### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ "2.7", "3.0", "3.1" ]
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Lint Ruby files
+        run: bin/rubocop
+      - name: Run tests
+        run: bin/test

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
-bundle exec rake "$@"
+if [[ 2 -eq $# ]]; then
+  bundle exec rake TEST="$1" TESTOPTS="-n='/$2/'"
+elif [[ 1 -eq $# ]]; then
+  bundle exec rake TEST="$1"
+else
+  bundle exec rake "$@"
+fi

--- a/dev.yml
+++ b/dev.yml
@@ -9,9 +9,9 @@ up:
 
 commands:
   server: exe/ruby-lsp
-  style: bundle exec rubocop
+  style: bin/rubocop
   test:
     syntax:
       argument: file
       optional: args...
-    run: bundle exec rake
+    run: bin/test


### PR DESCRIPTION
Add a CI script and change `bin/test` with the convenient workaround to accept arguments more easily. Mostly inspired by Tapioca's and Spoom's scripts.

For the time being, these will remain on `self-hosted`. When we are ready to open source, we should migrate all GH actions to `ubuntu-latest`.