### PR TITLE
Remove unnecessary file

### DIFF
--- a/lib/ruby-lsp.rb
+++ b/lib/ruby-lsp.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require_relative "./lsp"
+require_relative "./ruby/lsp/cli"

--- a/lib/ruby/lsp.rb
+++ b/lib/ruby/lsp.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "./lsp/cli"

--- a/lib/ruby/lsp/handler.rb
+++ b/lib/ruby/lsp/handler.rb
@@ -18,6 +18,7 @@ module Ruby
         $stderr.puts "Starting Ruby LSP..."
         @reader.read do |request|
           break unless @running
+
           handle(request)
         end
       end


### PR DESCRIPTION
Because the name of the gem is `ruby-lsp`, then bundler should require `lib/ruby/lsp` and not `lib/ruby-lsp`. I don't believe we need this file.

I also corrected a rubocop offense.

EDIT: sorry I got it the wrong way around. Bundler will require `lib/ruby-lsp` because that's the gem's name and not `lib/ruby/lsp`.