### PR TITLE
Remove capabilities we don't actually support

### DIFF
--- a/lib/ruby/lsp/handler.rb
+++ b/lib/ruby/lsp/handler.rb
@@ -49,11 +49,6 @@ module Ruby
             text_document_sync: Interface::TextDocumentSyncOptions.new(
               change: Constant::TextDocumentSyncKind::FULL
             ),
-            completion_provider: Interface::CompletionOptions.new(
-              resolve_provider: true,
-              trigger_characters: ["."]
-            ),
-            definition_provider: true
           )
         )
       end


### PR DESCRIPTION
Our LSP doesn't actually support go to definition or completion, so we shouldn't include those in our capabilities.