### PR TITLE
Store the parsed tree to avoid unnecessary re-parsing

### DIFF
--- a/lib/ruby/lsp/requests/folding_ranges.rb
+++ b/lib/ruby/lsp/requests/folding_ranges.rb
@@ -4,12 +4,12 @@ module Ruby
   module Lsp
     module Requests
       class FoldingRanges
-        def self.run(item)
-          new(item).run
+        def self.run(parsed_tree)
+          new(parsed_tree).run
         end
 
-        def initialize(item)
-          @queue = [item.tree]
+        def initialize(parsed_tree)
+          @queue = [parsed_tree.tree]
           @ranges = []
         end
 

--- a/lib/ruby/lsp/store.rb
+++ b/lib/ruby/lsp/store.rb
@@ -11,15 +11,15 @@ module Ruby
       end
 
       def [](uri)
-        item = @state[uri]
-        return item unless item.nil?
+        parsed_tree = @state[uri]
+        return parsed_tree unless parsed_tree.nil?
 
         self[uri] = File.binread(CGI.unescape(URI.parse(uri).path))
         @state[uri]
       end
 
       def []=(uri, content)
-        @state[uri] = Item.new(content)
+        @state[uri] = ParsedTree.new(content)
       rescue SyntaxTree::ParseError
         # Do not update the store if there are syntax errors
       end
@@ -32,7 +32,7 @@ module Ruby
         @state.delete(uri)
       end
 
-      class Item
+      class ParsedTree
         attr_reader :tree, :parser, :source
 
         def initialize(source)

--- a/test/requests/folding_ranges_test.rb
+++ b/test/requests/folding_ranges_test.rb
@@ -16,8 +16,8 @@ class FoldingRangesTest < Minitest::Test
   private
 
   def assert_ranges(source, expected_ranges)
-    item = Ruby::Lsp::Store::Item.new(source)
-    actual = Ruby::Lsp::Requests::FoldingRanges.run(item)
+    parsed_tree = Ruby::Lsp::Store::ParsedTree.new(source)
+    actual = Ruby::Lsp::Requests::FoldingRanges.run(parsed_tree)
     assert_equal(expected_ranges, JSON.parse(actual.to_json, symbolize_names: true))
   end
 end

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -7,7 +7,7 @@ class StoreTest < Minitest::Test
     store = Ruby::Lsp::Store.new
     store["/foo/bar.rb"] = "def foo; end"
 
-    assert_equal(Ruby::Lsp::Store::Item.new("def foo; end"), store["/foo/bar.rb"])
+    assert_equal(Ruby::Lsp::Store::ParsedTree.new("def foo; end"), store["/foo/bar.rb"])
   end
 
   def test_reads_from_file_if_missing_in_store
@@ -17,7 +17,7 @@ class StoreTest < Minitest::Test
     file.write("def great_code; end")
     file.rewind
 
-    assert_equal(Ruby::Lsp::Store::Item.new("def great_code; end"), store[file.path])
+    assert_equal(Ruby::Lsp::Store::ParsedTree.new("def great_code; end"), store[file.path])
   ensure
     file.close
     file.unlink
@@ -28,7 +28,7 @@ class StoreTest < Minitest::Test
     store["/foo/bar.rb"] = "def foo; end"
     store["/foo/bar.rb"] = "def bar; end; end"
 
-    assert_equal(Ruby::Lsp::Store::Item.new("def foo; end"), store["/foo/bar.rb"])
+    assert_equal(Ruby::Lsp::Store::ParsedTree.new("def foo; end"), store["/foo/bar.rb"])
   end
 
   def test_clear


### PR DESCRIPTION
Reflecting on @paracycle's [comment](https://github.com/Shopify/ruby-lsp/pull/10#discussion_r831555120), I think delivering this refactor partially will make the transition easier in the future.

This PR changes our storage to store a new helper class `Item` (let me know if you have better naming suggestions), which keeps the parsed tree and source. For the time being, it must also keep the parser instance so that we can figure out absolute column positions. Once the limitation is addressed in syntax_tree, we can drop the parser and keep only tree and source.

This will probably make it easier to refactor requests later when we can drop the parser. Additionally, it makes it easier to handle syntax errors in a single place in the code (currently the LSP breaks every time you start typing something).

After this, we will only re-parse files when we receive `didOpen` and `didChange` requests. For every other request, we just re-use the existing tree.