### PR TITLE
Remove the running variable

### DIFF
--- a/lib/ruby/lsp/handler.rb
+++ b/lib/ruby/lsp/handler.rb
@@ -16,15 +16,12 @@ module Ruby
         @writer = Transport::Stdio::Writer.new
         @reader = Transport::Stdio::Reader.new
         @handlers = {}
-        @running = true
         @store = Store.new
       end
 
       def start
         $stderr.puts "Starting Ruby LSP..."
         @reader.read do |request|
-          break unless @running
-
           handle(request)
         end
       end
@@ -47,7 +44,6 @@ module Ruby
       def shutdown
         $stderr.puts "Shutting down Ruby LSP..."
         store.clear
-        @running = false
       end
 
       def respond_with_capabilities


### PR DESCRIPTION
This is not only not necessary, since the language server gem handles shutdown requests by killing the process, it actually breaks the functionality by not allowing the gem to do its thing.

Tophat instructions here https://github.com/Shopify/vscode-ruby-lsp/pull/26.