### PR TITLE
Introduce a generic visitor pattern for requests handling

### DIFF
--- a/lib/ruby-lsp.rb
+++ b/lib/ruby-lsp.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "./ruby/lsp/cli"
 require "syntax_tree"
+
+require_relative "./ruby/lsp/cli"
+require_relative "./ruby/lsp/visitor"

--- a/lib/ruby/lsp/visitor.rb
+++ b/lib/ruby/lsp/visitor.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Ruby
+  module Lsp
+    class Visitor
+      def visit_all(nodes)
+        nodes.each do |node|
+          visit(node)
+        end
+      end
+
+      def visit(node)
+        return unless node
+
+        send("visit_#{self.class.class_to_visit_method(node.class.name)}", node)
+      end
+
+      def self.class_to_visit_method(string)
+        word = string.split("::").last
+        word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+        word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+        word.tr!("-", "_")
+        word.downcase!
+        word
+      end
+
+      SyntaxTree.constants.each do |constant|
+        class_eval(<<~EOS, __FILE__, __LINE__ + 1)
+          def visit_#{class_to_visit_method(constant.to_s)}(node)
+            visit_all(node.child_nodes)
+          end
+        EOS
+      end
+    end
+  end
+end

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class VisitorTest < Minitest::Test
+  def test_can_visit_all_nodes
+    visitor = Ruby::Lsp::Visitor.new
+
+    SyntaxTree.constants.each do |node|
+      assert_respond_to(visitor, "visit_#{Ruby::Lsp::Visitor.class_to_visit_method(node.to_s)}")
+    end
+  end
+
+  def test_class_to_visit_method
+    visit_method_name = Ruby::Lsp::Visitor.class_to_visit_method(SyntaxTree::TStringEnd.name)
+    assert_equal("t_string_end", visit_method_name)
+  end
+
+  def test_visit_tree
+    parsed_tree = Ruby::Lsp::Store::ParsedTree.new(<<~RUBY)
+      class Foo
+        def foo; end
+
+        class Bar
+          def bar; end
+        end
+      end
+
+      def baz; end
+    RUBY
+
+    visitor = DummyVisitor.new
+    visitor.visit(parsed_tree.tree)
+    assert_equal(["Foo", "foo", "Bar", "bar", "baz"], visitor.visited_nodes)
+  end
+
+  class DummyVisitor < Ruby::Lsp::Visitor
+    attr_reader :visited_nodes
+
+    def initialize
+      super
+      @visited_nodes = []
+    end
+
+    def visit_class_declaration(node)
+      @visited_nodes << node.constant.constant.value
+      super
+    end
+
+    def visit_def(node)
+      @visited_nodes << node.name.value
+    end
+  end
+end


### PR DESCRIPTION
This will make it easier to write custom visitors to implement LSP requests:

```ruby
  class ExampleVisitor < Ruby::Lsp::Visitor
    attr_reader :visited_nodes

    def initialize
      @visited_nodes = []
    end

    def visit_class_declaration(node)
      @visited_nodes << node.constant.constant.value
      super # Visit child nodes
    end

    def visit_def(node)
      @visited_nodes << node.name.value
      # super # Uncomment to visit child nodes
    end
  end
```