### PR TITLE
Add test for multiple single line method definitions

### DIFF
--- a/test/requests/folding_ranges_test.rb
+++ b/test/requests/folding_ranges_test.rb
@@ -49,6 +49,14 @@ class FoldingRangesTest < Minitest::Test
     RUBY
   end
 
+  def test_no_folding_for_single_line_method_definitions
+    assert_no_folding(<<~RUBY)
+      def foo; end
+      def bar; end
+      def baz; end
+    RUBY
+  end
+
   def test_folding_classes
     ranges = [
       { startLine: 0, endLine: 4, kind: "region" },


### PR DESCRIPTION
Just adding a test case that was missing. Because methods are all defined in a single line, no ranges should be emitted.