### PR TITLE
Add folding support for pattern matching and chained invocations

### DIFF
--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -72,6 +72,24 @@ module RubyLsp
         super
       end
 
+      def visit_call(node)
+        end_line = node.location.end_line - 1
+        receiver = node.receiver
+
+        while receiver.is_a?(SyntaxTree::Call) || receiver.is_a?(SyntaxTree::MethodAddBlock)
+          if receiver.is_a?(SyntaxTree::Call)
+            visit(receiver.arguments) if receiver.arguments
+            receiver = receiver.receiver
+          else
+            visit(receiver.block)
+            receiver = receiver.call.receiver
+          end
+        end
+
+        start_line = receiver.location.start_line - 1
+        add_range(start_line, end_line) if start_line < end_line
+      end
+
       def visit_def(node)
         params_location = node.params.location
 

--- a/test/requests/folding_ranges_test.rb
+++ b/test/requests/folding_ranges_test.rb
@@ -423,6 +423,28 @@ class FoldingRangesTest < Minitest::Test
     RUBY
   end
 
+  def test_folding_chained_invocations
+    ranges = [
+      { startLine: 1, endLine: 7, kind: "region" },
+      { startLine: 2, endLine: 6, kind: "region" },
+      { startLine: 4, endLine: 5, kind: "region" },
+      { startLine: 0, endLine: 10, kind: "region" },
+    ]
+    assert_ranges(<<~RUBY, ranges)
+      []
+        .select do |x|
+          if x.odd?
+            x + 2
+          else
+            x + 1
+          end
+        end
+        .map { |x| x }
+        .drop(1)
+        .sort
+    RUBY
+  end
+
   private
 
   def assert_no_folding(source)


### PR DESCRIPTION
Add support for folding these two structures

```ruby
case foo
in { a: 1 } # start
  puts "a" # end
end

[] # start
  .select ...
  .map ...
  .uniq
  .sort # end
```

For figuring out the chained invocation range, we begin at the last invocation (`sort` in our example) and recursively try to find the initial receiver to identify the start line.