### PR TITLE
Properly fold nested multiline invocations

### DIFF
--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -56,6 +56,8 @@ module RubyLsp
 
       def visit_arg_paren(node)
         add_simple_range(node)
+
+        visit_all(node.arguments.parts) if node.arguments
       end
 
       def visit_array_literal(node)

--- a/test/requests/folding_ranges_test.rb
+++ b/test/requests/folding_ranges_test.rb
@@ -273,6 +273,21 @@ class FoldingRangesTest < Minitest::Test
     RUBY
   end
 
+  def test_folding_nested_multiline_method_invocation
+    ranges = [
+      { startLine: 0, endLine: 5, kind: "region" },
+      { startLine: 1, endLine: 4, kind: "region" },
+    ]
+    assert_ranges(<<~RUBY, ranges)
+      foo.invocation(
+        another_invocation(
+          1,
+          2
+        )
+      )
+    RUBY
+  end
+
   def test_folding_heredoc
     ranges = [
       { startLine: 0, endLine: 2, kind: "region" },


### PR DESCRIPTION
We weren't visiting the arguments of multiline invocations, which means we missed any folding that could exist in the parameters. This PR simply visits the method arguments so that we can fold whatever is inside.