### PR TITLE
Add missing open close capability

### DIFF
--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -49,7 +49,8 @@ module RubyLsp
       Interface::InitializeResult.new(
         capabilities: Interface::ServerCapabilities.new(
           text_document_sync: Interface::TextDocumentSyncOptions.new(
-            change: Constant::TextDocumentSyncKind::FULL
+            change: Constant::TextDocumentSyncKind::FULL,
+            open_close: true,
           ),
           document_symbol_provider: Interface::DocumentSymbolClientCapabilities.new(
             hierarchical_document_symbol_support: true,


### PR DESCRIPTION
We handle `didOpen` and `didClose` requests, but forgot to add it to the capabilities. Without this, we never actually receive those requests.