### PR TITLE
Add missing argument visit

### DIFF
--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -78,6 +78,8 @@ module RubyLsp
         end_line = node.location.end_line - 1
         receiver = node.receiver
 
+        visit_all(node.arguments.arguments.parts) if node.arguments
+
         while receiver.is_a?(SyntaxTree::Call) || receiver.is_a?(SyntaxTree::MethodAddBlock)
           if receiver.is_a?(SyntaxTree::Call)
             visit(receiver.arguments) if receiver.arguments

--- a/test/requests/folding_ranges_test.rb
+++ b/test/requests/folding_ranges_test.rb
@@ -275,8 +275,8 @@ class FoldingRangesTest < Minitest::Test
 
   def test_folding_nested_multiline_method_invocation
     ranges = [
-      { startLine: 0, endLine: 5, kind: "region" },
       { startLine: 1, endLine: 4, kind: "region" },
+      { startLine: 0, endLine: 5, kind: "region" },
     ]
     assert_ranges(<<~RUBY, ranges)
       foo.invocation(
@@ -284,6 +284,19 @@ class FoldingRangesTest < Minitest::Test
           1,
           2
         )
+      )
+    RUBY
+  end
+
+  def test_folding_nested_multiline_invocation_no_parenthesis
+    ranges = [
+      { startLine: 1, endLine: 2, kind: "region" },
+      { startLine: 0, endLine: 3, kind: "region" },
+    ]
+    assert_ranges(<<~RUBY, ranges)
+      foo.invocation(
+        another_invocation 1,
+          2
       )
     RUBY
   end


### PR DESCRIPTION
After merging all of the remaining folding PRs, we ended up missing a visit to the node arguments for calls. This PR just adds the visit and an extra test case.