### PR TITLE
Fix aref_field var bug and add test

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -49,7 +49,7 @@ module RubyLsp
       end
 
       def visit_a_ref_field(node)
-        add_token(node.target.collection.value.location, :local_variable)
+        add_token(node.collection.value.location, :local_variable)
       end
 
       def visit_call(node)

--- a/test/requests/semantic_highlighting_test.rb
+++ b/test/requests/semantic_highlighting_test.rb
@@ -48,6 +48,20 @@ class SemanticHighlightingTest < Minitest::Test
     RUBY
   end
 
+  def test_aref_field
+    tokens = [
+      { delta_line: 1, delta_start_char: 2, length: 1, token_type: 0, token_modifiers: 0 },
+      { delta_line: 1, delta_start_char: 2, length: 1, token_type: 0, token_modifiers: 0 },
+    ]
+
+    assert_tokens(tokens, <<~RUBY)
+      def my_method
+        a = []
+        a[1] = "foo"
+      end
+    RUBY
+  end
+
   def test_command_invocation
     tokens = [
       { delta_line: 0, delta_start_char: 0, length: 4, token_type: 1, token_modifiers: 0 },


### PR DESCRIPTION
## Issue 

Previously, test were not technically covering `aref_field` nodes. When it was actually being used, `node.target` was nil, so the server was crashing. 

I've fixed the issue and add a test case for it. 

There is still another issue that's causing `folding_ranges.rb` to break and I'm investigating that now. 