### PR TITLE
Narrow local variable highlighting in variable references and assignments to just identifiers

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -41,11 +41,17 @@ module RubyLsp
       end
 
       def visit_var_field(node)
-        add_token(node.value.location, :local_variable)
+        case node.value
+        when SyntaxTree::Ident
+          add_token(node.value.location, :local_variable)
+        end
       end
 
       def visit_var_ref(node)
-        add_token(node.value.location, :local_variable)
+        case node.value
+        when SyntaxTree::Ident
+          add_token(node.value.location, :local_variable)
+        end
       end
 
       def visit_a_ref_field(node)

--- a/test/requests/semantic_highlighting_test.rb
+++ b/test/requests/semantic_highlighting_test.rb
@@ -62,6 +62,45 @@ class SemanticHighlightingTest < Minitest::Test
     RUBY
   end
 
+  def test_var_aref_variable
+    tokens = [
+      { delta_line: 1, delta_start_char: 2, length: 1, token_type: 0, token_modifiers: 0 },
+    ]
+
+    assert_tokens(tokens, <<~RUBY)
+      def my_method
+        a = :hello # local variable arefs should match
+        @my_ivar = true # ivar arefs should not match
+        $global_var = 1  # global arefs should not match
+        @@class_var = "hello" # cvar refs should not match
+      end
+      Foo = 3.14 # constant refs should not match
+    RUBY
+  end
+
+  def test_var_field_variable
+    tokens = [
+      { delta_line: 1, delta_start_char: 2, length: 1, token_type: 0, token_modifiers: 0 },
+      { delta_line: 1, delta_start_char: 2, length: 1, token_type: 0, token_modifiers: 0 },
+      { delta_line: 1, delta_start_char: 2, length: 1, token_type: 0, token_modifiers: 0 },
+      { delta_line: 1, delta_start_char: 2, length: 1, token_type: 0, token_modifiers: 0 },
+      { delta_line: 1, delta_start_char: 2, length: 1, token_type: 0, token_modifiers: 0 },
+      { delta_line: 1, delta_start_char: 2, length: 1, token_type: 0, token_modifiers: 0 },
+      { delta_line: 0, delta_start_char: 4, length: 1, token_type: 0, token_modifiers: 0 },
+    ]
+
+    assert_tokens(tokens, <<~RUBY)
+      def my_method
+        b = Foo # constant refs should not match
+        a = true # keyword refs should not match
+        a = @my_ivar # ivar refs should not match
+        a = $global_var # global refs should not match
+        a = @@class_var # cvar refs should not match
+        a = b # local variable refs should match
+      end
+    RUBY
+  end
+
   def test_command_invocation
     tokens = [
       { delta_line: 0, delta_start_char: 0, length: 4, token_type: 1, token_modifiers: 0 },


### PR DESCRIPTION
### Motivation

When testing the semantic highlighting in my editor, I noticed that it was matching constant references and other things as local variables as well, so I dug a little to understand why.

### Implementation

For `VarField` and `VarARef` nodes, the `value` field is documented to refer to many different kinds of nodes:
```ruby
  class VarField < Node
    # [nil | Const | CVar | GVar | Ident | IVar] the target of this node
    attr_reader :value
```
and
```ruby
  class VarRef < Node
    # [Const | CVar | GVar | Ident | IVar | Kw] the value of this node
    attr_reader :value
```

What we need to do is type match the `value` value to `Ident` for adding a `local_variable` token.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
Added tests that make sure constant, ivar, cvar, keyword and global variable references and assignments are not matched by semantic highlighting (to `local_variable` tokens, at least).

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Gives the step by step instructions. -->
Testing on this piece of code:
```ruby
def format(q)
  keyword = "alias "
  left_argument = AliasArgumentFormatter.new(left)
end
```
should not match `AliasArgumentFormatter` as a local variable. At least, that is where I first noticed this.
