### PR TITLE
Disable verbose tracing by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
-  "ruby lsp.trace.server": "verbose",
-  "editor.defaultFormatter": "Shopify.ruby-lsp"
+  // Set this value to `verbose` to see the full JSON content of LSP requests and responses
+  "ruby lsp.trace.server": "messages",
+  "editor.defaultFormatter": "Shopify.ruby-lsp",
 }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ are expected to adhere to the
 [Contributor Covenant](https://github.com/Shopify/ruby-lsp/blob/main/CODE_OF_CONDUCT.md)
 code of conduct.
 
+## Debugging
+
+### Tracing LSP requests and responses
+
+LSP server tracing can be controlled through the `ruby lsp.trace.server` config key in the `.vscode/settings.json` config file.
+
+Possible values are:
+
+* `off`: no tracing
+* `messages`: display requests and responses notifications
+* `verbose`: display each request and response as JSON
+
 ## License
 
 The gem is available as open source under the terms of the


### PR DESCRIPTION
This was introduced in #37 but it's _very_ verbose as we add new files/features to the project.

I left it commented so we can easily enable it if we need to debug anything related to it but in most cases it just clutters the extension output window and hide the stacktraces and debugging instructions.