### PR TITLE
Visit method invocation related nodes in order 

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -69,6 +69,12 @@ module RubyLsp
         visit(node.arguments)
       end
 
+      def visit_command_call(node)
+        visit(node.receiver)
+        add_token(node.message.location, :method_call)
+        visit(node.arguments)
+      end
+
       def visit_f_call(node)
         add_token(node.value.location, :method_call)
         visit(node.arguments)

--- a/test/requests/semantic_highlighting_test.rb
+++ b/test/requests/semantic_highlighting_test.rb
@@ -124,6 +124,20 @@ class SemanticHighlightingTest < Minitest::Test
     RUBY
   end
 
+  def test_command_call
+    tokens = [
+      { delta_line: 0, delta_start_char: 0, length: 3, token_type: 0, token_modifiers: 0 },
+      { delta_line: 1, delta_start_char: 0, length: 6, token_type: 1, token_modifiers: 0 },
+      { delta_line: 0, delta_start_char: 7, length: 10, token_type: 1, token_modifiers: 0 },
+      { delta_line: 0, delta_start_char: 11, length: 3, token_type: 0, token_modifiers: 0 },
+    ]
+
+    assert_tokens(tokens, <<~RUBY)
+      var = "Hello"
+      object.invocation var
+    RUBY
+  end
+
   def test_call_invocation
     tokens = [
       { delta_line: 0, delta_start_char: 8, length: 6, token_type: 1, token_modifiers: 0 },


### PR DESCRIPTION
### Motivation

When visiting method calls for semantic highlighting, we aren't visiting the receiver, method call and arguments in proper order, resulting in an `InvalidTokenRowError`. This change ensures that the receiver, method call and arguments are visited in order. 

### Implementation

Introduce order-specific node visiting for each of the call nodes: `Call`, `CommandCall`, `FCall`, `VCall`

### Automated Tests

I've added the tests along with each atomic change. 

Go through each of the commit for a clearer review on which tests are related to which change. 

### Manual Tests

1. Create a new file
2. Paste this code snippet into it. This code snippet contains all the relevant changes in this PR 

```
def pr_changes
  var, arg = "Hello"

  puts var # Command
  object.invocation var # CommandCall
  var.upcase(arg) # Call
  invocation(var) # FCall

  invocation(
    var,
    var,
    var
  ) # Multiline
end
```
3. 👀 Method calls and local arguments should be highlighted as expected 

<img width="509" alt="Screen Shot 2022-04-06 at 1 36 30 PM" src="https://user-images.githubusercontent.com/25471753/162034707-e7572bbb-b9b2-486c-886b-a97c726612f7.png">

# Additional Notes

I plan on cleaning up the test file more in my next PR