### PR TITLE
Add RuboCop quick fixes code actions

### DIFF
--- a/lib/ruby_lsp/cli.rb
+++ b/lib/ruby_lsp/cli.rb
@@ -56,6 +56,13 @@ module RubyLsp
           respond_with_formatting(request.dig(:params, :textDocument, :uri))
         end
 
+        on("textDocument/codeAction") do |request|
+          range = request.dig(:params, :range)
+          start_line = range.dig(:start, :line)
+          end_line = range.dig(:end, :line)
+          respond_with_code_actions(request.dig(:params, :textDocument, :uri), (start_line..end_line))
+        end
+
         on("shutdown") { shutdown }
       end
 

--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -72,7 +72,8 @@ module RubyLsp
               delta: true,
             }
           ),
-          document_formatting_provider: true
+          document_formatting_provider: true,
+          code_action_provider: true
         )
       )
     end
@@ -108,9 +109,15 @@ module RubyLsp
         method: "textDocument/publishDiagnostics",
         params: Interface::PublishDiagnosticsParams.new(
           uri: uri,
-          diagnostics: response
+          diagnostics: response.map(&:to_lsp_diagnostic)
         )
       )
+    end
+
+    def respond_with_code_actions(uri, range)
+      store.cache_fetch(uri, :code_actions) do |parsed_tree|
+        Requests::CodeActions.run(uri, parsed_tree, range)
+      end
     end
   end
 end

--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -9,5 +9,6 @@ module RubyLsp
     autoload :RuboCopRequest, "ruby_lsp/requests/rubocop_request"
     autoload :Formatting, "ruby_lsp/requests/formatting"
     autoload :Diagnostics, "ruby_lsp/requests/diagnostics"
+    autoload :CodeActions, "ruby_lsp/requests/code_actions"
   end
 end

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RubyLsp
+  module Requests
+    class CodeActions
+      def self.run(uri, parsed_tree, range)
+        new(uri, parsed_tree, range).run
+      end
+
+      def initialize(uri, parsed_tree, range)
+        @parsed_tree = parsed_tree
+        @uri = uri
+        @range = range
+      end
+
+      def run
+        diagnostics = Diagnostics.run(@uri, @parsed_tree)
+        corrections = diagnostics.select { |diagnostic| diagnostic.correctable? && diagnostic.in_range?(@range) }
+        return if corrections.empty?
+
+        corrections.map!(&:to_lsp_code_action)
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -19,23 +19,77 @@ module RubyLsp
       end
 
       def file_finished(_file, offenses)
-        @diagnostics = offenses.map do |offense|
+        @diagnostics = offenses.map { |offense| Diagnostic.new(offense, @uri) }
+      end
+
+      class Diagnostic
+        attr_reader :replacements
+
+        def initialize(offense, uri)
+          @offense = offense
+          @uri = uri
+          @replacements = offense.correctable? ? offense_replacements : []
+        end
+
+        def correctable?
+          @offense.correctable?
+        end
+
+        def in_range?(range)
+          range.cover?(@offense.line - 1)
+        end
+
+        def to_lsp_code_action
+          LanguageServer::Protocol::Interface::CodeAction.new(
+            title: "Autocorrect #{@offense.cop_name}",
+            kind: LanguageServer::Protocol::Constant::CodeActionKind::QUICK_FIX,
+            edit: LanguageServer::Protocol::Interface::WorkspaceEdit.new(
+              document_changes: [
+                LanguageServer::Protocol::Interface::TextDocumentEdit.new(
+                  text_document: LanguageServer::Protocol::Interface::OptionalVersionedTextDocumentIdentifier.new(
+                    uri: @uri,
+                    version: nil
+                  ),
+                  edits: @replacements
+                ),
+              ]
+            ),
+            is_preferred: true,
+          )
+        end
+
+        def to_lsp_diagnostic
           LanguageServer::Protocol::Interface::Diagnostic.new(
-            message: offense.message,
+            message: @offense.message,
             source: "RuboCop",
-            code: offense.cop_name,
-            severity: RUBOCOP_TO_LSP_SEVERITY[offense.severity.name],
+            code: @offense.cop_name,
+            severity: RUBOCOP_TO_LSP_SEVERITY[@offense.severity.name],
             range: LanguageServer::Protocol::Interface::Range.new(
               start: LanguageServer::Protocol::Interface::Position.new(
-                line: offense.line - 1,
-                character: offense.column
+                line: @offense.line - 1,
+                character: @offense.column
               ),
               end: LanguageServer::Protocol::Interface::Position.new(
-                line: offense.last_line - 1,
-                character: offense.last_column
+                line: @offense.last_line - 1,
+                character: @offense.last_column
               )
             )
           )
+        end
+
+        private
+
+        def offense_replacements
+          @offense.corrector.as_replacements.map do |range, replacement|
+            LanguageServer::Protocol::Interface::TextEdit.new(
+              range: LanguageServer::Protocol::Interface::Range.new(
+                start: LanguageServer::Protocol::Interface::Position.new(line: range.line - 1, character: range.column),
+                end: LanguageServer::Protocol::Interface::Position.new(line: range.last_line - 1,
+                  character: range.last_column)
+              ),
+              new_text: replacement
+            )
+          end
         end
       end
     end

--- a/lib/ruby_lsp/requests/rubocop_request.rb
+++ b/lib/ruby_lsp/requests/rubocop_request.rb
@@ -12,7 +12,7 @@ module RubyLsp
         "RuboCop::Formatter::BaseFormatter", # Suppress any output by using the base formatter
       ].freeze
 
-      attr_reader :uri, :file, :text
+      attr_reader :file, :text
 
       def self.run(uri, parsed_tree)
         new(uri, parsed_tree).run
@@ -21,6 +21,7 @@ module RubyLsp
       def initialize(uri, parsed_tree)
         @file = CGI.unescape(URI.parse(uri).path)
         @text = parsed_tree.source
+        @uri = uri
 
         super(
           ::RuboCop::Options.new.parse(rubocop_flags).first,

--- a/test/requests/code_actions_test.rb
+++ b/test/requests/code_actions_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CodeActionsTest < Minitest::Test
+  def test_code_actions
+    actions = [
+      title: "Autocorrect Layout/IndentationWidth",
+      replacements: [
+        {
+          range: {
+            start: { line: 3, character: 0 },
+            end: { line: 3, character: 0 },
+          },
+          newText: "  ",
+        },
+      ],
+    ]
+
+    assert_code_actions(<<~RUBY, actions, (3..4))
+      # frozen_string_literal: true
+
+      def foo
+      puts "Hello, world!"
+      end
+    RUBY
+  end
+
+  private
+
+  def assert_code_actions(source, code_actions, range)
+    parsed_tree = RubyLsp::Store::ParsedTree.new(source)
+    result = nil
+
+    stdout, _ = capture_io do
+      result = RubyLsp::Requests::CodeActions.run("file://#{__FILE__}", parsed_tree, range)
+    end
+
+    assert_empty(stdout)
+    assert_equal(map_diagnostics(code_actions).to_json, result.to_json)
+  end
+
+  def map_diagnostics(diagnostics)
+    diagnostics.map do |diagnostic|
+      LanguageServer::Protocol::Interface::CodeAction.new(
+        title: diagnostic[:title],
+        kind: LanguageServer::Protocol::Constant::CodeActionKind::QUICK_FIX,
+        edit: LanguageServer::Protocol::Interface::WorkspaceEdit.new(
+          document_changes: [
+            LanguageServer::Protocol::Interface::TextDocumentEdit.new(
+              text_document: LanguageServer::Protocol::Interface::OptionalVersionedTextDocumentIdentifier.new(
+                uri: "file://#{__FILE__}",
+                version: nil
+              ),
+              edits: diagnostic[:replacements]
+            ),
+          ]
+        ),
+        is_preferred: true,
+      )
+    end
+  end
+end

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -32,7 +32,7 @@ class DiagnosticsTest < Minitest::Test
     end
 
     assert_empty(stdout)
-    assert_equal(map_diagnostics(diagnostics).to_json, result.to_json)
+    assert_equal(map_diagnostics(diagnostics).to_json, result.map(&:to_lsp_diagnostic).to_json)
   end
 
   def map_diagnostics(diagnostics)


### PR DESCRIPTION
### Motivation

Add Rubocop quick fixes as code actions. This is the last step to merge the `rubocop-lsp` into the `ruby-lsp`. This allows us to hover over an offense on the editor and get a button to apply a quick fix, which then solves the issue.

### Implementation

Because the fixes are based on diagnostics, I created a helper class `Diagnostic` to keep track of some extra information. The `CodeActions` request simply runs the diagnostics request to collect all of them and then filters based on whether the diagnostics is correctable and is on the range for the cursor.

### Automated Tests

Added some tests, but these will probably change once the test fixtures go in.

### Manual Tests

1. Start the plugin on this branch (F5)
2. Make some bad edits, like extra blank lines or incorrect indentation
3. Hover over the blue diagnostic line
4. Verify a quick fix button shows up
5. Click the quick fix button
6. Verify the offense is resolved