### PR TITLE
Start using standard token types (from LSP API)

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -4,8 +4,8 @@ module RubyLsp
   module Requests
     class SemanticHighlighting < BaseRequest
       TOKEN_TYPES = [
-        :local_variable,
-        :method_call,
+        :variable,
+        :method,
       ].freeze
       TOKEN_MODIFIERS = [].freeze
 
@@ -25,52 +25,52 @@ module RubyLsp
 
       def visit_m_assign(node)
         node.target.parts.each do |var_ref|
-          add_token(var_ref.value.location, :local_variable)
+          add_token(var_ref.value.location, :variable)
         end
       end
 
       def visit_var_field(node)
         case node.value
         when SyntaxTree::Ident
-          add_token(node.value.location, :local_variable)
+          add_token(node.value.location, :variable)
         end
       end
 
       def visit_var_ref(node)
         case node.value
         when SyntaxTree::Ident
-          add_token(node.value.location, :local_variable)
+          add_token(node.value.location, :variable)
         end
       end
 
       def visit_a_ref_field(node)
-        add_token(node.collection.value.location, :local_variable)
+        add_token(node.collection.value.location, :variable)
       end
 
       def visit_call(node)
         visit(node.receiver)
-        add_token(node.message.location, :method_call)
+        add_token(node.message.location, :method)
         visit(node.arguments)
       end
 
       def visit_command(node)
-        add_token(node.message.location, :method_call)
+        add_token(node.message.location, :method)
         visit(node.arguments)
       end
 
       def visit_command_call(node)
         visit(node.receiver)
-        add_token(node.message.location, :method_call)
+        add_token(node.message.location, :method)
         visit(node.arguments)
       end
 
       def visit_fcall(node)
-        add_token(node.value.location, :method_call)
+        add_token(node.value.location, :method)
         visit(node.arguments)
       end
 
       def visit_vcall(node)
-        add_token(node.value.location, :method_call)
+        add_token(node.value.location, :method)
       end
 
       def add_token(location, classification)


### PR DESCRIPTION
### Motivation

As part of this issue: https://github.com/Shopify/sorbet-issues/issues/557#issuecomment-1095619480

We found that we could reuse the standard token types outlined in the [LSP API ](https://microsoft.github.io/language-server-protocol/specification#textDocument_semanticTokens)and the themes would be able to capture it. 

For now, the goal is to remove ambiguity from the default VS Code behaviour. 

### Implementation

In this PR, we modify the token type output to be consistent with the standard token types. 

### Automated Tests

This change does not require any new tests because our old test covers the change. 

The way the tests are set up is token type agnostic - we only track them by index. 

### Manual Tests

1. Check out this branch
2. Restart/Run Ruby LSP
3. You should see now that instance variables and local variables are the same colour.

Before: 

<img width="353" alt="Screen Shot 2022-04-13 at 9 46 15 AM" src="https://user-images.githubusercontent.com/25471753/163194661-79eab63d-a603-4223-9ce8-36223b488e45.png">

After:

<img width="369" alt="Screen Shot 2022-04-13 at 9 45 51 AM" src="https://user-images.githubusercontent.com/25471753/163194578-1a6b83ab-8ded-4710-b34e-a64c47515ad8.png">
 
My theme's variable colour is very similar to the foreground colour - but notice that in the before picture, the variable is ambiguous (black), while after, it's coloured as a variable (blue) 