### PR TITLE
Allow configuring desired LSP features

### DIFF
--- a/lib/ruby_lsp/cli.rb
+++ b/lib/ruby_lsp/cli.rb
@@ -10,9 +10,9 @@ module RubyLsp
       handler = RubyLsp::Handler.new
 
       handler.config do
-        on("initialize") do
+        on("initialize") do |request|
           store.clear
-          respond_with_capabilities
+          respond_with_capabilities(request.dig(:params, :initializationOptions).fetch(:enabledFeatures, []))
         end
 
         on("textDocument/didChange") do |request|


### PR DESCRIPTION
### Motivation

It's beneficial for our users to be able to configure which features they would like to enable or disable on the LSP - especially as we're working actively on getting things implemented.

The option with the most flexibility is accepting initialization options from the LSP plugin, so that individuals can configure their VS Code instance as they prefer (or share it in a workspace settings.json).

### Implementation

- Receive the enabled features on the initialization parameters
- Broadcast capabilities based on which features are enabled, so that we don't receive requests for things that are turned off

### Automated Tests

I considered adding some tests for the handler, but in its current implementation, everything is private. Also, testing that the capabilities match what we configured felt a bit too much.

### Manual Tests

Follow the steps here https://github.com/Shopify/vscode-ruby-lsp/pull/54.