### PR TITLE
Refactor ParsedTree into Document

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RubyLsp
+  class Document
+    attr_reader :tree, :parser, :source
+
+    def initialize(source)
+      @source = source
+      @parser = SyntaxTree::Parser.new(source)
+      @tree = @parser.parse
+      @cache = {}
+    end
+
+    def ==(other)
+      @source == other.source
+    end
+
+    def cache_fetch(request_name)
+      cached = @cache[request_name]
+      return cached if cached
+
+      result = yield(self)
+      @cache[request_name] = result
+      result
+    end
+  end
+end

--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -3,12 +3,12 @@
 module RubyLsp
   module Requests
     class BaseRequest < SyntaxTree::Visitor
-      def self.run(parsed_tree)
-        new(parsed_tree).run
+      def self.run(document)
+        new(document).run
       end
 
-      def initialize(parsed_tree)
-        @parsed_tree = parsed_tree
+      def initialize(document)
+        @document = document
 
         super()
       end

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -42,7 +42,7 @@ module RubyLsp
         end
       end
 
-      def initialize(parsed_tree)
+      def initialize(document)
         super
 
         @root = SymbolHierarchyRoot.new
@@ -50,7 +50,7 @@ module RubyLsp
       end
 
       def run
-        visit(@parsed_tree.tree)
+        visit(@document.tree)
         @root.children
       end
 

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -31,7 +31,7 @@ module RubyLsp
         SyntaxTree::When,
       ].freeze
 
-      def initialize(parsed_tree)
+      def initialize(document)
         super
 
         @ranges = []
@@ -39,7 +39,7 @@ module RubyLsp
       end
 
       def run
-        visit(@parsed_tree.tree)
+        visit(@document.tree)
         emit_partial_range
         @ranges
       end

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -5,7 +5,7 @@ module RubyLsp
     class Formatting < RuboCopRequest
       RUBOCOP_FLAGS = (COMMON_RUBOCOP_FLAGS + ["--auto-correct"]).freeze
 
-      def initialize(uri, parsed_tree)
+      def initialize(uri, document)
         super
         @formatted_text = nil
       end

--- a/lib/ruby_lsp/requests/rubocop_request.rb
+++ b/lib/ruby_lsp/requests/rubocop_request.rb
@@ -14,13 +14,13 @@ module RubyLsp
 
       attr_reader :file, :text
 
-      def self.run(uri, parsed_tree)
-        new(uri, parsed_tree).run
+      def self.run(uri, document)
+        new(uri, document).run
       end
 
-      def initialize(uri, parsed_tree)
+      def initialize(uri, document)
         @file = CGI.unescape(URI.parse(uri).path)
-        @text = parsed_tree.source
+        @text = document.source
         @uri = uri
 
         super(

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -9,11 +9,11 @@ module RubyLsp
       ].freeze
       TOKEN_MODIFIERS = [].freeze
 
-      def initialize(parsed_tree)
+      def initialize(document)
         super
 
         @tokens = []
-        @tree = parsed_tree.tree
+        @tree = document.tree
         @current_row = 0
         @current_column = 0
       end

--- a/test/requests/code_actions_test.rb
+++ b/test/requests/code_actions_test.rb
@@ -29,11 +29,11 @@ class CodeActionsTest < Minitest::Test
   private
 
   def assert_code_actions(source, code_actions, range)
-    parsed_tree = RubyLsp::Store::ParsedTree.new(source)
+    document = RubyLsp::Document.new(source)
     result = nil
 
     stdout, _ = capture_io do
-      result = RubyLsp::Requests::CodeActions.run("file://#{__FILE__}", parsed_tree, range)
+      result = RubyLsp::Requests::CodeActions.run("file://#{__FILE__}", document, range)
     end
 
     assert_empty(stdout)

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -24,11 +24,11 @@ class DiagnosticsTest < Minitest::Test
   private
 
   def assert_diagnostics(source, diagnostics)
-    parsed_tree = RubyLsp::Store::ParsedTree.new(source)
+    document = RubyLsp::Document.new(source)
     result = nil
 
     stdout, _ = capture_io do
-      result = RubyLsp::Requests::Diagnostics.run("file://#{__FILE__}", parsed_tree)
+      result = RubyLsp::Requests::Diagnostics.run("file://#{__FILE__}", document)
     end
 
     assert_empty(stdout)

--- a/test/requests/document_symbols_test.rb
+++ b/test/requests/document_symbols_test.rb
@@ -238,8 +238,8 @@ class DocumentSymbolsTest < Minitest::Test
   private
 
   def assert_symbols(source, expected_symbols, print_result: false)
-    parsed_tree = RubyLsp::Store::ParsedTree.new(source)
-    actual = RubyLsp::Requests::DocumentSymbol.run(parsed_tree)
+    document = RubyLsp::Document.new(source)
+    actual = RubyLsp::Requests::DocumentSymbol.run(document)
     actual_json = JSON.parse(actual.to_json, symbolize_names: true)
     simplified_symbol = simplified_symbols(actual_json)
 

--- a/test/requests/folding_ranges_test.rb
+++ b/test/requests/folding_ranges_test.rb
@@ -499,14 +499,14 @@ class FoldingRangesTest < Minitest::Test
   private
 
   def assert_no_folding(source)
-    parsed_tree = RubyLsp::Store::ParsedTree.new(source)
-    actual = RubyLsp::Requests::FoldingRanges.run(parsed_tree)
+    document = RubyLsp::Document.new(source)
+    actual = RubyLsp::Requests::FoldingRanges.run(document)
     assert_empty(JSON.parse(actual.to_json, symbolize_names: true))
   end
 
   def assert_ranges(source, expected_ranges)
-    parsed_tree = RubyLsp::Store::ParsedTree.new(source)
-    actual = RubyLsp::Requests::FoldingRanges.run(parsed_tree)
+    document = RubyLsp::Document.new(source)
+    actual = RubyLsp::Requests::FoldingRanges.run(document)
     assert_equal(expected_ranges, JSON.parse(actual.to_json, symbolize_names: true))
   end
 end

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -24,11 +24,11 @@ class FormattingTest < Minitest::Test
   private
 
   def assert_formatted(original, formatted)
-    parsed_tree = RubyLsp::Store::ParsedTree.new(original)
+    document = RubyLsp::Document.new(original)
     result = nil
 
     stdout, _ = capture_io do
-      result = RubyLsp::Requests::Formatting.run("file://#{__FILE__}", parsed_tree).first.new_text
+      result = RubyLsp::Requests::Formatting.run("file://#{__FILE__}", document).first.new_text
     end
 
     assert_empty(stdout)

--- a/test/requests/semantic_highlighting_test.rb
+++ b/test/requests/semantic_highlighting_test.rb
@@ -222,10 +222,10 @@ class SemanticHighlightingTest < Minitest::Test
   private
 
   def assert_tokens(expected, source_code)
-    parsed_tree = RubyLsp::Store::ParsedTree.new(source_code)
+    document = RubyLsp::Document.new(source_code)
     assert_equal(
       inline_tokens(expected),
-      RubyLsp::Requests::SemanticHighlighting.run(parsed_tree).data
+      RubyLsp::Requests::SemanticHighlighting.run(document).data
     )
   end
 

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -9,7 +9,7 @@ class StoreTest < Minitest::Test
   end
 
   def test_get
-    assert_equal(RubyLsp::Store::ParsedTree.new("def foo; end"), @store.get("/foo/bar.rb"))
+    assert_equal(RubyLsp::Document.new("def foo; end"), @store.get("/foo/bar.rb"))
   end
 
   def test_reads_from_file_if_missing_in_store
@@ -17,7 +17,7 @@ class StoreTest < Minitest::Test
     file.write("def great_code; end")
     file.rewind
 
-    assert_equal(RubyLsp::Store::ParsedTree.new("def great_code; end"), @store.get(file.path))
+    assert_equal(RubyLsp::Document.new("def great_code; end"), @store.get(file.path))
   ensure
     file.close
     file.unlink
@@ -26,7 +26,7 @@ class StoreTest < Minitest::Test
   def test_store_ignores_syntax_errors
     @store.set("/foo/bar.rb", "def bar; end; end")
 
-    assert_equal(RubyLsp::Store::ParsedTree.new("def foo; end"), @store.get("/foo/bar.rb"))
+    assert_equal(RubyLsp::Document.new("def foo; end"), @store.get("/foo/bar.rb"))
   end
 
   def test_clear


### PR DESCRIPTION
Step towards #52 for better syntax error resliiency

### Motivation

In order to accept incremental text changes and handle syntax errors better, we'll need to add considerably more logic into the concept we now call `ParsedTree`.

I believe there are two issues with this right now
- the name won't match the concept very well
- the class is growing too much to be nested under `Store`

### Implementation

- Rename `ParsedTree` to `Document`, since the concept keeps information about the source code, the tree it produces and the cache for LSP requests for that particular document
- Move the class into its own file

### Automated Tests

The existing tests should cover this refactor.

### Manual Tests

1. Start the plugin on this branch
2. Open and change files
3. Verify that nothing breaks