### PR TITLE
Turn off new cops and extension suggestions for RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 AllCops:
+  NewCops: disable
+  SuggestExtensions: false
   TargetRubyVersion: 2.7
   Exclude:
   - "vendor/**/*"


### PR DESCRIPTION
### Motivation

Turn off new cops and extension suggestions from RuboCop. These keep printing a ton of stuff to the screen.

### Implementation

Just changed the config.

### Automated Tests

Not needed.

### Manual Tests

1. Run `bundle exec rubocop`
2. Verify you don't see the warnings about new cops