### PR TITLE
Add LSP integration tests

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -6,11 +6,9 @@ require "timeout"
 
 # Important integration test notes
 #
-# 1. If the request returns `nil`, use `send_request` and do not try to read the response or else we hang reading from
-# stdout
+# 1. If the request returns `nil`, use `send_request` and do not try to read the response or else it times out
 # 2. Make sure the request name is exactly the expected in CLI (e.g.: textDocument/foldingRange instead of
-# textDocument/foldingRanges). If the name is incorrect, the LSP won't return anything and the test will hang trying to
-# read from stdout
+# textDocument/foldingRanges). If the name is incorrect, the LSP won't return anything reading the response will timeout
 # 3. The goal is to verify that all parts are working together. Don't create extensive tests with long code examples -
 # those are meant for unit tests
 class IntegrationTest < Minitest::Test


### PR DESCRIPTION
Closes #69

### Motivation

We need to test `Cli` and `Handler` and make sure that all connections with store and request classes are working. This PR adds an integration test that makes requests to a real instance of the LSP running, so that we can see the full integration.

### Implementation

The relevant part of the implementation is what happens in `setup`, `teardown`, `make_request` and `send_request`. The rest is just adding some simple integration tests for the features we already have.

This is what we're doing for every test
- Create a new LSP instance and capture the stdout, stdin and stderr objects
- Set them to binary mode
- Use `make_request` or `send_request` to interact with the LSP
- On teardown, shutdown the LSP, close the IOs and make sure the child process finished successfully

### Automated Tests

That's the entire PR.

### Manual Tests

Not applicable.