### PR TITLE
Upgrade syntax_tree requirement to 2.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ruby-lsp (0.1.0)
       language_server-protocol
       rubocop (>= 1.0)
-      syntax_tree (>= 2.1)
+      syntax_tree (>= 2.3)
 
 GEM
   remote: https://rubygems.org/

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency("language_server-protocol")
   s.add_dependency("rubocop", ">= 1.0")
-  s.add_dependency("syntax_tree", ">= 2.1")
+  s.add_dependency("syntax_tree", ">= 2.3")
 end


### PR DESCRIPTION
### Motivation

This new version contains an important bug fix that causes the LSP to crash.
