### PR TITLE
Add README content and move CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-# ruby-lsp
+![Build Status](https://github.com/Shopify/ruby-lsp/workflows/CI/badge.svg)
+
+# Ruby LSP
+
+This gem is an implementation of the language server protocol specification for Ruby, used to improve editor features.
+
+## Usage
+
+Install the gem. There's no need to require it, since the server is used as a standalone executable.
+
+```ruby
+group :development do
+  gem "ruby-lsp", require: false
+end
+```
+
+If using VS Code, install the [Ruby LSP plugin](https://github.com/Shopify/vscode-ruby-lsp) to get the extra features in
+the editor.
 
 ## Contributing
 


### PR DESCRIPTION
### Motivation

In preparation to open source the repo, move the CI to `ubuntu-latest` and add some README content.