### PR TITLE
Remove document reset on auto-formatting

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -18,14 +18,6 @@ module RubyLsp
       @source == other.source
     end
 
-    def reset(source)
-      @tree = SyntaxTree.parse(source)
-      @source = source
-      @parsable_source = source.dup
-      @cache.clear
-      @syntax_error_edits.clear
-    end
-
     def cache_fetch(request_name)
       cached = @cache[request_name]
       return cached if cached

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -27,8 +27,6 @@ module RubyLsp
         @formatted_text = @options[:stdin] # Rubocop applies the corrections on stdin
         return unless @formatted_text
 
-        @document.reset(@formatted_text)
-
         [
           LanguageServer::Protocol::Interface::TextEdit.new(
             range: LanguageServer::Protocol::Interface::Range.new(


### PR DESCRIPTION
### Motivation

Initially, we had thought that upon auto-formatting we would need to reset the internal state of the document to keep all features working as intended.

However, we were wrong. When auto-formatting, VS Code actually takes care of synchronizing the document for us. By resetting the document manually, we actually create weird bugs and behaviour.

### Implementation

Just remove the `reset` method definition and invocation inside the formatting request.

### Automated Tests

This is just a part of the code that is not needed.

### Manual Tests

#### On main
1. Make sure your Ruby formatter is the ruby lsp `"editor.defaultFormatter": "Shopify.ruby-lsp",`
2. Make some violations, like adding a bunch of unnecessary empty lines
3. Save the document
4. Verify that, because we reset the document ourselves and then receive text synchronization, we end up in a weird state, likely with syntax errors being incorrectly reported

#### On this branch
1. Repeat the same steps, but verify that no syntax errors show up and that features are not dislocated (like folding ranges showing up in incorrect lines)