### PR TITLE
Use the correct path for reading the VERSION file

### DIFF
--- a/lib/ruby-lsp.rb
+++ b/lib/ruby-lsp.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RubyLsp
-  VERSION = File.read("VERSION").strip
+  VERSION = File.read(File.expand_path("../VERSION", __dir__)).strip
 end


### PR DESCRIPTION
### Motivation

When the gem is installed and used in projects, trying to read `VERSION` without making it relative to the gem file paths will attempt to read the incorrect path.