### PR TITLE
Add documentation publish workflow

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,39 @@
+name: Publish docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Publish documentation website
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1.1
+          bundler-cache: true
+
+      - name: Configure git
+        run:
+          - git config user.name github-actions
+          - git config user.email github-actions@github.com
+
+      - name: Reset gh-pages branch
+        run:
+          - git switch gh-pages
+          - git reset --hard origin/main
+
+      - name: Generate documentation
+        run:
+          - bundle exec rake yard
+          - mv doc docs
+
+      - name: Commit to gh-pages
+        run:
+          - git add docs
+          - git commit -m "Publish website $(git log --format=format:%h -1)"
+          - git push origin +gh-pages

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Generate documentation
         run:
           - bundle exec rake yard
-          - mv doc docs
 
       - name: Commit to gh-pages
         run:

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Rake::TestTask.new(:test) do |t|
 end
 
 YARD::Rake::YardocTask.new do |t|
-  t.options = ["--markup", "markdown"]
+  t.options = ["--markup", "markdown", "--output-dir", "docs"]
 end
 
 require "rubocop/rake_task"


### PR DESCRIPTION
### Motivation

Closes #89

Add GitHub action automation to publish our website to GH pages.

### Implementation

According to the [checkout action documentation](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token), we should be able to push new commits using this mechanism. The action does the following:
1. Configures the git user and email
2. Resets the gh-pages branch to match main
3. Generates the documentation and moves it to a folder that is not ignored by git
4. Commits the folder using the message `Publish website LAST_SHA`
5. Pushes to gh-pages

If this action works and we're able to push the generates docs to the branch, getting the website up should just be a matter of changing the repo's settings.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

N/A.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

N/A.