### PR TITLE
Avoid switching branches in publish_docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -22,11 +22,6 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-      - name: Reset gh-pages branch
-        run: |
-          git switch gh-pages
-          git reset --hard origin/main
-
       - name: Generate documentation
         run: bundle exec rake yard
 
@@ -34,4 +29,4 @@ jobs:
         run: |
           git add docs
           git commit -m "Publish website $(git log --format=format:%h -1)"
-          git push origin +gh-pages
+          git push --force origin main:gh-pages


### PR DESCRIPTION
### Motivation

Our action is [failing](https://github.com/Shopify/ruby-lsp/runs/6428844612?check_suite_focus=true), this time when trying to switch branches.

### Implementation

I've tried simplifying the action a little further. Instead of switching to the `gh-pages` branch and resetting, we just create the commit locally in `main`, but push it to a different branch.