### PR TITLE
Add test for SemanticTokenEncoder

### DIFF
--- a/test/requests/support/semantic_token_encoder_test.rb
+++ b/test/requests/support/semantic_token_encoder_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SemanticTokenEncoderTest < Minitest::Test
+  TokenStub = RubyLsp::Requests::SemanticHighlighting::SemanticToken
+  LocationStub = Struct.new(:start_line, :start_column)
+
+  def test_tokens_encoded_to_relative_positioning
+    tokens = [
+      TokenStub.new(LocationStub.new(1, 2), 1, 0, 0),
+      TokenStub.new(LocationStub.new(1, 4), 2, 9, 0),
+      TokenStub.new(LocationStub.new(2, 2), 3, 0, 6),
+      TokenStub.new(LocationStub.new(5, 6), 10, 4, 4),
+    ]
+
+    expected_encoding = [
+      0, 2, 1, 0, 0,
+      0, 2, 2, 9, 0,
+      1, 2, 3, 0, 6,
+      3, 6, 10, 4, 4,
+    ]
+
+    assert_equal(expected_encoding,
+      RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode(tokens).data)
+  end
+
+  def test_tokens_sorted_before_encoded
+    tokens = [
+      TokenStub.new(LocationStub.new(1, 2), 1, 0, 0),
+      TokenStub.new(LocationStub.new(5, 6), 10, 4, 4),
+      TokenStub.new(LocationStub.new(2, 2), 3, 0, 6),
+      TokenStub.new(LocationStub.new(1, 4), 2, 9, 0),
+    ]
+
+    expected_encoding = [
+      0, 2, 1, 0, 0,
+      0, 2, 2, 9, 0,
+      1, 2, 3, 0, 6,
+      3, 6, 10, 4, 4,
+    ]
+
+    assert_equal(expected_encoding,
+      RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode(tokens).data)
+  end
+end


### PR DESCRIPTION
### Motivation

Add tests for `SemanticTokenEncoder`

Part of: https://github.com/Shopify/ruby-dev-exp-issues/issues/518

### Implementation

`SemanticTokenEncoder` does two things: sort the tokens, then encodes them into relative positioning. I created two test cases: 

- The first one ensures that tokens are in the correct relative positioning. I've included tokens that are in the same row, and in the same column, and token modifiers and types. 
- The second test passes in tokens whose location are not sorted. We expect the tokens to be sorted then encoded the same way. 

### Automated Tests

This PR adds tests. 

### Manual Tests

N/A - no changes to implementation. 