### PR TITLE
Add test for if inside else diagnostic

### DIFF
--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -38,6 +38,31 @@ class DiagnosticsTest < Minitest::Test
     assert_equal(syntax_error_diagnostics([error_edit]).to_json, result.map(&:to_lsp_diagnostic).to_json)
   end
 
+  def test_if_inside_else_diagnostics
+    diagnostics = [
+      start: { line: 6, character: 4 },
+      end: { line: 6, character: 6 },
+      severity: :info,
+      code: "Style/IfInsideElse",
+      message: "Style/IfInsideElse: Convert `if` nested inside `else` to `elsif`.",
+    ]
+
+    assert_diagnostics(<<~RUBY, diagnostics)
+      # frozen_string_literal: true
+
+      def my_method
+        if a
+          do_thing_0
+        else
+          if b
+            do_thing_1
+            do_thing_2
+          end
+        end
+      end
+    RUBY
+  end
+
   private
 
   def assert_diagnostics(source, diagnostics)


### PR DESCRIPTION
### Motivation

Closes #98

We had a report of `Style/IfInsideElse` violations incorrectly reporting non-existing `Layout/IndentationConsistency` violations as well.

I was not able to reproduce it either in VS Code or in tests, but I think it's worth adding the example to make sure we don't regress for any reason.

### Automated Tests

Added a new test for the scenario that was reported.

### Manual Tests

Not really necessary, but if you'd like to verify that the scenario indeed doesn't trigger incorrect violations:
1. While using the `ruby-lsp`, create a new Ruby file
2. Add the contents reported in #98
3. Verify no `Layout/IndentationConsistency` violations are reported