### PR TITLE
Implement token modifiers in SemanticTokenEncoder

### DIFF
--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -85,7 +85,7 @@ module RubyLsp
           document_selector: { scheme: "file", language: "ruby" },
           legend: Interface::SemanticTokensLegend.new(
             token_types: Requests::SemanticHighlighting::TOKEN_TYPES,
-            token_modifiers: Requests::SemanticHighlighting::TOKEN_MODIFIERS
+            token_modifiers: Requests::SemanticHighlighting::TOKEN_MODIFIERS.keys
           ),
           range: false,
           full: {

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -21,7 +21,19 @@ module RubyLsp
         :variable,
         :method,
       ].freeze
-      TOKEN_MODIFIERS = [].freeze
+
+      TOKEN_MODIFIERS = {
+        declaration: 0,
+        definition: 1,
+        readonly: 2,
+        static: 3,
+        deprecated: 4,
+        abstract: 5,
+        async: 6,
+        modification: 7,
+        documentation: 8,
+        default_library: 9,
+      }.freeze
 
       SemanticToken = Struct.new(:location, :length, :type, :modifier)
 
@@ -90,9 +102,10 @@ module RubyLsp
         add_token(node.value.location, :method)
       end
 
-      def add_token(location, type)
+      def add_token(location, type, modifiers = [])
         length = location.end_char - location.start_char
-        @tokens.push(SemanticToken.new(location, length, TOKEN_TYPES.index(type), 0))
+        modifiers_indices = modifiers.map { |modifier| TOKEN_MODIFIERS[modifier] }
+        @tokens.push(SemanticToken.new(location, length, TOKEN_TYPES.index(type), modifiers_indices))
       end
     end
   end

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -104,7 +104,7 @@ module RubyLsp
 
       def add_token(location, type, modifiers = [])
         length = location.end_char - location.start_char
-        modifiers_indices = modifiers.map { |modifier| TOKEN_MODIFIERS[modifier] }
+        modifiers_indices = modifiers.filter_map { |modifier| TOKEN_MODIFIERS[modifier] }
         @tokens.push(SemanticToken.new(location, length, TOKEN_TYPES.index(type), modifiers_indices))
       end
     end

--- a/lib/ruby_lsp/requests/support/semantic_token_encoder.rb
+++ b/lib/ruby_lsp/requests/support/semantic_token_encoder.rb
@@ -51,8 +51,7 @@ module RubyLsp
         # to the token modifiers index map.
         def encode_modifiers(modifiers)
           modifiers.inject(0) do |encoded_modifiers, modifier|
-            encoded_modifiers |= (1 << modifier)
-            encoded_modifiers
+            encoded_modifiers | (1 << modifier)
           end
         end
       end

--- a/lib/ruby_lsp/requests/support/semantic_token_encoder.rb
+++ b/lib/ruby_lsp/requests/support/semantic_token_encoder.rb
@@ -39,10 +39,21 @@ module RubyLsp
           delta_column = column
           delta_column -= @current_column if delta_line == 0
 
-          [delta_line, delta_column, token.length, token.type, token.modifier]
+          [delta_line, delta_column, token.length, token.type, encode_modifiers(token.modifier)]
         ensure
           @current_row = row
           @current_column = column
+        end
+
+        # Encode an array of modifiers to positions onto a bit flag
+        # For example, [:default_library] will be encoded as
+        # 0b1000000000, as :default_library is the 10th bit according
+        # to the token modifiers index map.
+        def encode_modifiers(modifiers)
+          modifiers.inject(0) do |encoded_modifiers, modifier|
+            encoded_modifiers |= (1 << modifier)
+            encoded_modifiers
+          end
         end
       end
     end

--- a/test/requests/support/semantic_token_encoder_test.rb
+++ b/test/requests/support/semantic_token_encoder_test.rb
@@ -9,17 +9,17 @@ class SemanticTokenEncoderTest < Minitest::Test
 
   def test_tokens_encoded_to_relative_positioning
     tokens = [
-      TokenStub.new(LocationStub.new(1, 2), 1, 0, 0),
-      TokenStub.new(LocationStub.new(1, 4), 2, 9, 0),
-      TokenStub.new(LocationStub.new(2, 2), 3, 0, 6),
-      TokenStub.new(LocationStub.new(5, 6), 10, 4, 4),
+      TokenStub.new(LocationStub.new(1, 2), 1, 0, [0]),
+      TokenStub.new(LocationStub.new(1, 4), 2, 9, [0]),
+      TokenStub.new(LocationStub.new(2, 2), 3, 0, [6]),
+      TokenStub.new(LocationStub.new(5, 6), 10, 4, [4]),
     ]
 
     expected_encoding = [
-      0, 2, 1, 0, 0,
-      0, 2, 2, 9, 0,
-      1, 2, 3, 0, 6,
-      3, 6, 10, 4, 4,
+      0, 2, 1, 0, 1,
+      0, 2, 2, 9, 1,
+      1, 2, 3, 0, 64,
+      3, 6, 10, 4, 16,
     ]
 
     assert_equal(expected_encoding,
@@ -28,20 +28,35 @@ class SemanticTokenEncoderTest < Minitest::Test
 
   def test_tokens_sorted_before_encoded
     tokens = [
-      TokenStub.new(LocationStub.new(1, 2), 1, 0, 0),
-      TokenStub.new(LocationStub.new(5, 6), 10, 4, 4),
-      TokenStub.new(LocationStub.new(2, 2), 3, 0, 6),
-      TokenStub.new(LocationStub.new(1, 4), 2, 9, 0),
+      TokenStub.new(LocationStub.new(1, 2), 1, 0, [0]),
+      TokenStub.new(LocationStub.new(5, 6), 10, 4, [4]),
+      TokenStub.new(LocationStub.new(2, 2), 3, 0, [6]),
+      TokenStub.new(LocationStub.new(1, 4), 2, 9, [0]),
     ]
 
     expected_encoding = [
-      0, 2, 1, 0, 0,
-      0, 2, 2, 9, 0,
-      1, 2, 3, 0, 6,
-      3, 6, 10, 4, 4,
+      0, 2, 1, 0, 1,
+      0, 2, 2, 9, 1,
+      1, 2, 3, 0, 64,
+      3, 6, 10, 4, 16,
     ]
 
     assert_equal(expected_encoding,
       RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode(tokens).data)
+  end
+
+  def test_encoded_modifiers_with_no_modifiers
+    bit_flag = RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode_modifiers([])
+    assert_equal(0b0000000000, bit_flag)
+  end
+
+  def test_encoded_modifiers_with_one_modifier
+    bit_flag = RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode_modifiers([9])
+    assert_equal(0b1000000000, bit_flag)
+  end
+
+  def test_encoded_modifiers_with_some_modifiers
+    bit_flag = RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode_modifiers([1, 3, 9, 7, 5])
+    assert_equal(0b1010101010, bit_flag)
   end
 end


### PR DESCRIPTION
### Motivation

We want to utilize the token modifiers API from the LSP for better semantic highlighting. 

https://github.com/Shopify/ruby-dev-exp-issues/issues/518#issuecomment-1112681273

### Implementation

This is just implementing the code to encode the modifiers. We're not using it yet. 

The changes can be seen more clearly in the test cases. But essentially, we're encoding modifiers to each tokens. 

### ⭐️ Walk Through The Entire Flow! 

For example:

A token can be marked with the `:definition` and `:abstract` modifiers (maybe not in Ruby, lol). 

We first map these modifiers using `TOKENS_MODIFIERS` hash to get the indices of the each of the modifiers. This results in `[1, 5]`.

Using the array of indices, we pass that onto `SemanticTokenEncoder` which then encodes these indices into the appropriate bit map to be passed with the request.  

### Automated Tests

I've added the appropriate tests that covers all the cases. 

### Manual Tests

No manual tests yet because we aren't using the changes yet. 