### PR TITLE
Bump syntax_tree

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    prettier_print (0.1.0)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.4.0)
@@ -52,7 +53,8 @@ GEM
     rubocop-shopify (2.6.0)
       rubocop (~> 1.29)
     ruby-progressbar (1.11.0)
-    syntax_tree (2.3.1)
+    syntax_tree (2.7.1)
+      prettier_print
     unicode-display_width (2.1.0)
     webrick (1.7.0)
     yard (0.9.27)

--- a/test/requests/selection_ranges_test.rb
+++ b/test/requests/selection_ranges_test.rb
@@ -1121,8 +1121,8 @@ class SelectionRangesTest < Minitest::Test
         },
         parent: {
           range: {
-            start: { line: 1, character: 5 },
-            end: { line: 1, character: 9 },
+            start: { line: 1, character: 3 },
+            end: { line: 1, character: 11 },
           },
           parent: {
             range: {


### PR DESCRIPTION
### Motivation

I tried to bump to 0.0.3 but the `syntax_tree` jump meant a test was failing and I had to [revert that](https://github.com/Shopify/ruby-lsp/commit/b6dd4971117efdaa4e0347f8f2f91698045b041c), luckily before anything was published.

So I cut this branch to investigate.
ALSO: Curiously, during publish, I got an exception I can't reproduce which was very confusing to me:

```rb
NameError: uninitialized constant SyntaxTree::BasicVisitor::VisitMethodChecker::DidYouMean
<...>/syntax_tree-2.7.1/lib/syntax_tree/basic_visitor.rb:36:in `<class:VisitMethodChecker>'
```

I'm not sure why this would come up. Can't reproduce locally.

### Implementation

The change in the test seems to be legit.
Given the following Ruby program:

```rb
case foo
in { a: 1 }
  puts "a"
else
  puts "nothing"
end
```

The test previously was written to match the characters inside the pattern matching block, in this case starting at the `a` and ending at the `1`. Since the syntax_tree bump, it appears that it now starts at the `{` and ends at the `}` which seems to make sense. From what I can tell, this seems to have changed in [2.4.0](https://github.com/ruby-syntax-tree/syntax_tree/blob/main/CHANGELOG.md#240---2022-05-07) but it's not obvious (to me at least) where.

### Automated Tests

See tests
