### PR TITLE
Move requires inside specific rake task

### DIFF
--- a/rakelib/check_docs.rake
+++ b/rakelib/check_docs.rake
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "language_server-protocol"
-require "syntax_tree"
-require "logger"
-require "ruby_lsp/requests/base_request"
-require "ruby_lsp/requests/rubocop_request"
-
 desc "Check if all LSP requests are documented"
 task :check_docs do
+  require "language_server-protocol"
+  require "syntax_tree"
+  require "logger"
+  require "ruby_lsp/requests/base_request"
+  require "ruby_lsp/requests/rubocop_request"
+
   Dir["#{Dir.pwd}/lib/ruby_lsp/requests/*.rb"].each do |file|
     require(file)
     YARD.parse(file, [], Logger::Severity::FATAL)


### PR DESCRIPTION
### Motivation

The publish action is breaking at requiring `syntax_tree` in the check_docs task which is not necessary for publishing the package. @paracycle pointed out that the default rake task loads everything in `rakelib`, so the requires in check_docs are being called every time rake loads, even when non-essential. So let's move them into the task that actually needs them.

### Implementation

copy paste
