### PR TITLE
Fix document highlight documentation example

### DIFF
--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -18,7 +18,7 @@ module RubyLsp
     # def foo
     #   FOO # should be highlighted as "read"
     # end
-    # ````
+    # ```
     class DocumentHighlight < BaseRequest
       def self.run(document, position)
         new(document, position).run


### PR DESCRIPTION
There was an extra character in the example, making it not render as code.