### PR TITLE
Fix text synchronization for multibyte characters

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "strscan"
-
 module RubyLsp
   class Document
     attr_reader :tree, :source, :syntax_error_edits
@@ -71,19 +69,19 @@ module RubyLsp
 
     class Scanner
       def initialize(source)
-        @source = source
-        @scanner = StringScanner.new(source)
         @current_line = 0
+        @pos = 0
+        @chars = source.chars
       end
 
       def find_position(position)
-        # Move the string scanner counting line breaks until we reach the right line
         until @current_line == position[:line]
-          @scanner.scan_until(/\R/)
+          @pos += 1 until /\R/.match?(@chars[@pos])
+          @pos += 1
           @current_line += 1
         end
 
-        @scanner.pos + position[:character]
+        @pos + position[:character]
       end
     end
   end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -222,6 +222,28 @@ class DocumentTest < Minitest::Test
     RUBY
   end
 
+  def test_pushing_edits_to_document_with_unicode
+    document = RubyLsp::Document.new(+<<~RUBY)
+      chars = ["億"]
+    RUBY
+
+    # Write puts 'a' in incremental edits
+    document.push_edits([{ range: { start: { line: 0, character: 13 }, end: { line: 0, character: 13 } }, text: "\n" }])
+    document.push_edits([{ range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } }, text: "p" }])
+    document.push_edits([{ range: { start: { line: 1, character: 1 }, end: { line: 1, character: 1 } }, text: "u" }])
+    document.push_edits([{ range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } }, text: "t" }])
+    document.push_edits([{ range: { start: { line: 1, character: 3 }, end: { line: 1, character: 3 } }, text: "s" }])
+    document.push_edits([{ range: { start: { line: 1, character: 4 }, end: { line: 1, character: 4 } }, text: " " }])
+    document.push_edits([{ range: { start: { line: 1, character: 5 }, end: { line: 1, character: 5 } }, text: "'" }])
+    document.push_edits([{ range: { start: { line: 1, character: 6 }, end: { line: 1, character: 6 } }, text: "a" }])
+    document.push_edits([{ range: { start: { line: 1, character: 7 }, end: { line: 1, character: 7 } }, text: "'" }])
+
+    assert_equal(<<~RUBY, document.source)
+      chars = ["億"]
+      puts 'a'
+    RUBY
+  end
+
   private
 
   def assert_error_edit(actual, error_range)

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -21,6 +21,24 @@ class FormattingTest < Minitest::Test
     RUBY
   end
 
+  def test_formatting_with_multibyte_characters
+    original = <<~RUBY
+      def foo
+
+
+      puts "億"
+      end
+    RUBY
+
+    assert_formatted(original, <<~RUBY)
+      # frozen_string_literal: true
+
+      def foo
+        puts "億"
+      end
+    RUBY
+  end
+
   private
 
   def assert_formatted(original, formatted)


### PR DESCRIPTION
### Motivation

Our previous approach to finding character positions in the source was counting bytes - not characters. This causes a bug with multibyte characters, where we apply the edits in the wrong index, messing up the entire document.

### Implementation

A simple solution would be to replace `scanner.pos` with `scanner.charpos`. The first one returns the byte position of the string scanner and the second returns the character position (which is what we want).

However, I played around a bit and benchmarked rolling out our own loop vs using the string scanner. On benchmark-ips, rolling out our own loop was 11x faster than using string scanner, so I switched the implementation.

We now split the source we're analyzing in characters and then keep track of the position ourselves.

### Automated Tests

Added a test for pushing edits and for auto-formatting as well.

### Manual Tests

1. Using this branch, open up a file
2. Add any multibyte character
3. Continue editing the file, like adding more method definitions
4. Verify that diagnostics don't show up unexpectedly
5. Verify that auto-formatting doesn't mess up the file with incorrect text