### PR TITLE
Move codebase to typed true

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,13 @@ AllCops:
 Naming/FileName:
   Exclude:
   - "lib/ruby-lsp.rb"
+
+Sorbet/FalseSigil:
+  Enabled: false
+
+Sorbet/TrueSigil:
+  Enabled: true
+  Include:
+    - "**/*.rb"
+  Exclude:
+    - "**/*.rake"

--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -1,6 +1,23 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
+begin
+  T::Configuration.default_checked_level = :never
+  # Suppresses call validation errors
+  T::Configuration.call_validation_error_handler = ->(*) {}
+  # Suppresses errors caused by T.cast, T.let, T.must, etc.
+  T::Configuration.inline_type_error_handler = ->(*) {}
+  # Suppresses errors caused by incorrect parameter ordering
+  T::Configuration.sig_validation_error_handler = ->(*) {}
+rescue
+  # Need this rescue so that if another gem has
+  # already set the checked level by the time we
+  # get to it, we don't fail outright.
+  nil
+end
+
 require_relative "../lib/internal"
 
 RubyLsp::Cli.start(ARGV)

--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -20,4 +20,4 @@ end
 
 require_relative "../lib/internal"
 
-RubyLsp::Cli.start(ARGV)
+RubyLsp::Cli.start

--- a/lib/ruby-lsp.rb
+++ b/lib/ruby-lsp.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/cli.rb
+++ b/lib/ruby_lsp/cli.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "language_server-protocol"
@@ -7,7 +7,10 @@ require_relative "handler"
 
 module RubyLsp
   module Cli
-    def self.start(_argv)
+    extend T::Sig
+
+    sig { void }
+    def self.start
       handler = RubyLsp::Handler.new
 
       handler.config do

--- a/lib/ruby_lsp/cli.rb
+++ b/lib/ruby_lsp/cli.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "language_server-protocol"

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "ruby_lsp/requests"

--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -128,7 +128,7 @@ module RubyLsp
     sig do
       params(
         uri: String,
-        positions: T::Array[{ line: Integer, character: Integer }]
+        positions: T::Array[Document::PositionShape]
       ).returns(T::Array[RubyLsp::Requests::Support::SelectionRange])
     end
     def respond_with_selection_ranges(uri, positions)
@@ -186,7 +186,7 @@ module RubyLsp
     sig do
       params(
         uri: String,
-        position: { line: Integer, character: Integer }
+        position: Document::PositionShape
       ).returns(T::Array[LanguageServer::Protocol::Interface::DocumentHighlight])
     end
     def respond_with_document_highlight(uri, position)

--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "ruby_lsp/requests"
@@ -7,21 +7,25 @@ require "benchmark"
 
 module RubyLsp
   class Handler
-    VOID = Object.new.freeze
+    extend T::Sig
+    VOID = T.let(Object.new.freeze, Object)
 
+    sig { returns(Store) }
     attr_reader :store
 
     Interface = LanguageServer::Protocol::Interface
     Constant = LanguageServer::Protocol::Constant
     Transport = LanguageServer::Protocol::Transport
 
+    sig { void }
     def initialize
-      @writer = Transport::Stdio::Writer.new
-      @reader = Transport::Stdio::Reader.new
-      @handlers = {}
-      @store = Store.new
+      @writer = T.let(Transport::Stdio::Writer.new, Transport::Stdio::Writer)
+      @reader = T.let(Transport::Stdio::Reader.new, Transport::Stdio::Reader)
+      @handlers = T.let({}, T::Hash[String, T.proc.params(request: T::Hash[Symbol, T.untyped]).returns(T.untyped)])
+      @store = T.let(Store.new, Store)
     end
 
+    sig { void }
     def start
       $stderr.puts "Starting Ruby LSP..."
       @reader.read do |request|
@@ -29,16 +33,24 @@ module RubyLsp
       end
     end
 
+    sig { params(blk: T.proc.bind(Handler).params(arg0: T.untyped).void).void }
     def config(&blk)
       instance_exec(&blk)
     end
 
     private
 
+    sig do
+      params(
+        msg: String,
+        blk: T.proc.bind(Handler).params(request: T::Hash[Symbol, T.untyped]).returns(T.untyped)
+      ).void
+    end
     def on(msg, &blk)
-      @handlers[msg.to_s] = blk
+      @handlers[msg] = blk
     end
 
+    sig { params(request: T::Hash[Symbol, T.untyped]).void }
     def handle(request)
       handler = @handlers[request[:method]]
       return unless handler
@@ -47,11 +59,13 @@ module RubyLsp
       @writer.write(id: request[:id], result: result) unless result == VOID
     end
 
+    sig { void }
     def shutdown
       $stderr.puts "Shutting down Ruby LSP..."
       store.clear
     end
 
+    sig { params(enabled_features: T::Array[String]).returns(Interface::InitializeResult) }
     def respond_with_capabilities(enabled_features)
       document_symbol_provider = if enabled_features.include?("documentSymbols")
         Interface::DocumentSymbolClientCapabilities.new(
@@ -97,18 +111,26 @@ module RubyLsp
       )
     end
 
+    sig { params(uri: String).returns(T::Array[LanguageServer::Protocol::Interface::DocumentSymbol]) }
     def respond_with_document_symbol(uri)
       store.cache_fetch(uri, :document_symbol) do |document|
         RubyLsp::Requests::DocumentSymbol.run(document)
       end
     end
 
+    sig { params(uri: String).returns(T::Array[LanguageServer::Protocol::Interface::FoldingRange]) }
     def respond_with_folding_ranges(uri)
       store.cache_fetch(uri, :folding_ranges) do |document|
         Requests::FoldingRanges.run(document)
       end
     end
 
+    sig do
+      params(
+        uri: String,
+        positions: T::Array[{ line: Integer, character: Integer }]
+      ).returns(T::Array[RubyLsp::Requests::Support::SelectionRange])
+    end
     def respond_with_selection_ranges(uri, positions)
       ranges = store.cache_fetch(uri, :selection_ranges) do |document|
         Requests::SelectionRanges.run(document)
@@ -125,16 +147,19 @@ module RubyLsp
       end
     end
 
+    sig { params(uri: String).returns(LanguageServer::Protocol::Interface::SemanticTokens) }
     def respond_with_semantic_highlighting(uri)
       store.cache_fetch(uri, :semantic_highlighting) do |document|
         Requests::SemanticHighlighting.new(document, encoder: Requests::Support::SemanticTokenEncoder.new).run
       end
     end
 
+    sig { params(uri: String).returns(T::Array[LanguageServer::Protocol::Interface::TextEdit]) }
     def respond_with_formatting(uri)
       Requests::Formatting.run(uri, store.get(uri))
     end
 
+    sig { params(uri: String).void }
     def send_diagnostics(uri)
       response = store.cache_fetch(uri, :diagnostics) do |document|
         Requests::Diagnostics.run(uri, document)
@@ -149,22 +174,32 @@ module RubyLsp
       )
     end
 
+    sig do
+      params(uri: String, range: T::Range[Integer]).returns(T::Array[LanguageServer::Protocol::Interface::Diagnostic])
+    end
     def respond_with_code_actions(uri, range)
       store.cache_fetch(uri, :code_actions) do |document|
         Requests::CodeActions.run(uri, document, range)
       end
     end
 
+    sig do
+      params(
+        uri: String,
+        position: { line: Integer, character: Integer }
+      ).returns(T::Array[LanguageServer::Protocol::Interface::DocumentHighlight])
+    end
     def respond_with_document_highlight(uri, position)
       Requests::DocumentHighlight.run(store.get(uri), position)
     end
 
-    def with_telemetry(request)
-      result = nil
-      error = nil
+    sig { params(request: T::Hash[Symbol, T.untyped], block: T.proc.void).returns(T.untyped) }
+    def with_telemetry(request, &block)
+      result = T.let(nil, T.untyped)
+      error = T.let(nil, T.nilable(StandardError))
 
       request_time = Benchmark.realtime do
-        result = yield
+        result = block.call
       rescue StandardError => e
         error = e
       end
@@ -173,6 +208,13 @@ module RubyLsp
       result
     end
 
+    sig do
+      params(
+        request: T::Hash[Symbol, T.untyped],
+        request_time: Float,
+        error: T.nilable(StandardError)
+      ).returns(T::Hash[Symbol, T.any(String, Float)])
+    end
     def telemetry_params(request, request_time, error)
       uri = request.dig(:params, :textDocument, :uri)
 

--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -149,7 +149,7 @@ module RubyLsp
       end
 
       def add_call_range(node)
-        receiver = node.receiver
+        receiver = T.let(node.receiver, SyntaxTree::Node)
         loop do
           case receiver
           when SyntaxTree::Call
@@ -185,7 +185,7 @@ module RubyLsp
       end
 
       def add_string_concat(node)
-        left = node.left
+        left = T.let(node.left, SyntaxTree::Node)
         left = left.left while left.is_a?(SyntaxTree::StringConcat)
 
         add_lines_range(left.location.start_line, node.right.location.end_line)

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/rubocop_request.rb
+++ b/lib/ruby_lsp/requests/rubocop_request.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocop"

--- a/lib/ruby_lsp/requests/selection_ranges.rb
+++ b/lib/ruby_lsp/requests/selection_ranges.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/support/selection_range.rb
+++ b/lib/ruby_lsp/requests/support/selection_range.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/support/semantic_token_encoder.rb
+++ b/lib/ruby_lsp/requests/support/semantic_token_encoder.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/support/syntax_error_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/syntax_error_diagnostic.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "cgi"
@@ -7,36 +7,51 @@ require "ruby_lsp/document"
 
 module RubyLsp
   class Store
+    extend T::Sig
+
+    sig { void }
     def initialize
-      @state = {}
+      @state = T.let({}, T::Hash[String, Document])
     end
 
+    sig { params(uri: String).returns(Document) }
     def get(uri)
       document = @state[uri]
       return document unless document.nil?
 
       set(uri, File.binread(CGI.unescape(URI.parse(uri).path)))
-      @state[uri]
+      T.must(@state[uri])
     end
 
+    sig { params(uri: String, content: String).void }
     def set(uri, content)
       @state[uri] = Document.new(content)
     rescue SyntaxTree::Parser::ParseError
       # Do not update the store if there are syntax errors
     end
 
+    sig { params(uri: String, edits: T::Array[Document::EditShape]).void }
     def push_edits(uri, edits)
-      @state[uri].push_edits(edits)
+      T.must(@state[uri]).push_edits(edits)
     end
 
+    sig { void }
     def clear
       @state.clear
     end
 
+    sig { params(uri: String).void }
     def delete(uri)
       @state.delete(uri)
     end
 
+    sig do
+      params(
+        uri: String,
+        request_name: Symbol,
+        block: T.proc.params(document: Document).returns(T.untyped)
+      ).returns(T.untyped)
+    end
     def cache_fetch(uri, request_name, &block)
       get(uri).cache_fetch(request_name, &block)
     end

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cgi"

--- a/sorbet/rbi/shims/hash.rbi
+++ b/sorbet/rbi/shims/hash.rbi
@@ -1,0 +1,6 @@
+# typed: true
+
+class Hash
+  sig { returns(String) }
+  def to_json; end
+end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/expectations/diagnostics/def_bad_formatting.exp
+++ b/test/expectations/diagnostics/def_bad_formatting.exp
@@ -11,9 +11,9 @@
       }
     },
     "severity": 3,
-    "code": "Sorbet/FalseSigil",
+    "code": "Sorbet/TrueSigil",
     "source": "RuboCop",
-    "message": "Sorbet/FalseSigil: No Sorbet sigil found in file. Try a `typed: false` to start (you can also use `rubocop -a` to automatically add this)."
+    "message": "Sorbet/TrueSigil: No Sorbet sigil found in file. Try a `typed: true` to start (you can also use `rubocop -a` to automatically add this)."
   },
   {
     "range": {

--- a/test/expectations/diagnostics/if_inside_else.exp
+++ b/test/expectations/diagnostics/if_inside_else.exp
@@ -2,6 +2,22 @@
   {
     "range": {
       "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 14
+      }
+    },
+    "severity": 3,
+    "code": "Sorbet/TrueSigil",
+    "source": "RuboCop",
+    "message": "Sorbet/TrueSigil: Sorbet sigil should be at least `true` got `false`."
+  },
+  {
+    "range": {
+      "start": {
         "line": 7,
         "character": 4
       },

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # TODO: how to pass arguments to the test runner? See for example `CodeActionsTest`

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -66,7 +66,7 @@ class ExpectationsTestRunner < Minitest::Test
       File.read(fixture_path)
         .lines
         .first
-        .match(/^#\s*required_ruby_version:\s*(?<version>\d+\.\d+(\.\d+)?)$/)
+        &.match(/^#\s*required_ruby_version:\s*(?<version>\d+\.\d+(\.\d+)?)$/)
         &.named_captures
         &.fetch("version")
     end

--- a/test/expectations/formatting/def_bad_formatting.exp
+++ b/test/expectations/formatting/def_bad_formatting.exp
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 def foo

--- a/test/expectations/formatting/string_multibytes.exp
+++ b/test/expectations/formatting/string_multibytes.exp
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 def foo

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -90,7 +90,7 @@ class IntegrationTest < Minitest::Test
 
     response = make_request("textDocument/formatting", { textDocument: { uri: "file://#{__FILE__}" } })
     assert_equal(<<~FORMATTED, response[:result].first[:newText])
-      # typed: false
+      # typed: true
       # frozen_string_literal: true
 
       class Foo

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/code_actions_test.rb
+++ b/test/requests/code_actions_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/code_actions_test.rb
+++ b/test/requests/code_actions_test.rb
@@ -31,14 +31,14 @@ class CodeActionsTest < Minitest::Test
 
   def assert_code_actions(source, code_actions, range)
     document = RubyLsp::Document.new(source)
-    result = nil
+    result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::Diagnostic]))
 
     stdout, _ = capture_io do
       result = RubyLsp::Requests::CodeActions.run("file://#{__FILE__}", document, range)
     end
 
     assert_empty(stdout)
-    assert_equal(map_diagnostics(code_actions).to_json, result.to_json)
+    assert_equal(map_diagnostics(code_actions).to_json, T.must(result).to_json)
   end
 
   def map_diagnostics(diagnostics)

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -13,7 +13,7 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
   end
 
   def assert_expectations(source, expected)
-    result = nil
+    result = T.let(nil, T.nilable(T::Array[RubyLsp::Requests::Support::RuboCopDiagnostic]))
 
     stdout, _ = capture_io do
       result = run_expectations(source)
@@ -22,7 +22,7 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
     assert_empty(stdout)
 
     diagnostics = json_expectations(expected)
-    assert_equal(map_diagnostics(diagnostics).to_json, result.map(&:to_lsp_diagnostic).to_json)
+    assert_equal(map_diagnostics(diagnostics).to_json, T.must(result).map(&:to_lsp_diagnostic).to_json)
   end
 
   def map_diagnostics(diagnostics)

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/document_highlight_test.rb
+++ b/test/requests/document_highlight_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/folding_ranges_expectations_test.rb
+++ b/test/requests/folding_ranges_expectations_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -13,7 +13,7 @@ class FormattingExpectationsTest < ExpectationsTestRunner
   end
 
   def assert_expectations(source, expected)
-    result = nil
+    result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::TextEdit]))
 
     stdout, _ = capture_io do
       result = run_expectations(source)

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/selection_ranges_test.rb
+++ b/test/requests/selection_ranges_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/support/semantic_token_encoder_test.rb
+++ b/test/requests/support/semantic_token_encoder_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/support/syntax_error_diagnostic_test.rb
+++ b/test/requests/support/syntax_error_diagnostic_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -20,8 +20,8 @@ class StoreTest < Minitest::Test
 
     assert_equal(RubyLsp::Document.new("def great_code; end"), @store.get(file.path))
   ensure
-    file.close
-    file.unlink
+    T.must(file).close
+    T.must(file).unlink
   end
 
   def test_store_ignores_syntax_errors

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -47,7 +47,7 @@ class StoreTest < Minitest::Test
     counter = 0
 
     5.times do
-      @store.cache_fetch("/foo/bar.rb", RubyLsp::Requests::FoldingRanges) do
+      @store.cache_fetch("/foo/bar.rb", :folding_ranges) do
         counter += 1
       end
     end
@@ -57,7 +57,7 @@ class StoreTest < Minitest::Test
     # After the entry in the storage is updated, the cache is invalidated
     @store.set("/foo/bar.rb", "def bar; end")
     5.times do
-      @store.cache_fetch("/foo/bar.rb", RubyLsp::Requests::FoldingRanges) do
+      @store.cache_fetch("/foo/bar.rb", :folding_ranges) do
         counter += 1
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))


### PR DESCRIPTION
### Motivation

Building on top of #119, we should leverage typing better by moving our files to typed true.

My desire is to make the most out of it and actually require `typed: strict`, but that should come in following PRs.

### Implementation

I highly recommend reviewing per commit.
1. Add runtime configuration similar to what we have in Tapioca to turn off runtime checks when running the server for real
2. Change the RuboCop rule to require typed true
3. Spoom bump force all files to typed true
4. Fix type checking errors caused by moving files to typed true
5. Move some fundamental files, like handler, document and store, to typed strict