### PR TITLE
Move codebase to typed strict

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,15 @@ Sorbet/FalseSigil:
 Sorbet/TrueSigil:
   Enabled: true
   Include:
-    - "**/*.rb"
+    - "test/**/*.rb"
   Exclude:
     - "**/*.rake"
+    - "lib/**/*.rb"
+
+Sorbet/StrictSigil:
+  Enabled: true
+  Include:
+    - "lib/**/*.rb"
+  Exclude:
+    - "**/*.rake"
+    - "test/**/*.rb"

--- a/lib/internal.rb
+++ b/lib/internal.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/lib/ruby-lsp.rb
+++ b/lib/ruby-lsp.rb
@@ -1,6 +1,6 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
-  VERSION = File.read(File.expand_path("../VERSION", __dir__)).strip
+  VERSION = T.let(File.read(File.expand_path("../VERSION", __dir__)).strip, String)
 end

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -32,7 +32,13 @@ module RubyLsp
       @source == other.source
     end
 
-    sig { params(request_name: Symbol, block: T.proc.params(document: Document).returns(T.untyped)).returns(T.untyped) }
+    sig do
+      type_parameters(:T)
+        .params(
+          request_name: Symbol,
+          block: T.proc.params(document: Document).returns(T.type_parameter(:T))
+        ).returns(T.type_parameter(:T))
+    end
     def cache_fetch(request_name, &block)
       cached = @cache[request_name]
       return cached if cached

--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -154,7 +154,7 @@ module RubyLsp
       end
     end
 
-    sig { params(uri: String).returns(T::Array[LanguageServer::Protocol::Interface::TextEdit]) }
+    sig { params(uri: String).returns(T.nilable(T::Array[LanguageServer::Protocol::Interface::TextEdit])) }
     def respond_with_formatting(uri)
       Requests::Formatting.run(uri, store.get(uri))
     end

--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp

--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -1,24 +1,31 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
   module Requests
     # :nodoc:
     class BaseRequest < SyntaxTree::Visitor
+      extend T::Sig
+      extend T::Helpers
+
+      abstract!
+
+      sig { overridable.params(document: Document).returns(T.untyped) }
       def self.run(document)
         new(document).run
       end
 
+      sig { params(document: Document).void }
       def initialize(document)
         @document = document
 
         super()
       end
 
-      def run
-        raise NotImplementedError, "#{self.class}#run must be implemented"
-      end
+      sig { abstract.returns(T.untyped) }
+      def run; end
 
+      sig { params(node: SyntaxTree::Node).returns(LanguageServer::Protocol::Interface::Range) }
       def range_from_syntax_tree_node(node)
         loc = node.location
 

--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -7,10 +7,13 @@ module RubyLsp
     class BaseRequest < SyntaxTree::Visitor
       extend T::Sig
       extend T::Helpers
+      extend T::Generic
+
+      Response = type_template { { upper: T.untyped } }
 
       abstract!
 
-      sig { overridable.params(document: Document).returns(T.untyped) }
+      sig { overridable.params(document: Document).returns(Response) }
       def self.run(document)
         new(document).run
       end

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
@@ -15,16 +15,33 @@ module RubyLsp
     # end
     # ```
     class CodeActions
+      extend T::Sig
+
+      sig do
+        params(
+          uri: String,
+          document: Document,
+          range: T::Range[Integer]
+        ).returns(T::Array[LanguageServer::Protocol::Interface::CodeAction])
+      end
       def self.run(uri, document, range)
         new(uri, document, range).run
       end
 
+      sig do
+        params(
+          uri: String,
+          document: Document,
+          range: T::Range[Integer]
+        ).void
+      end
       def initialize(uri, document, range)
         @document = document
         @uri = uri
         @range = range
       end
 
+      sig { returns(T::Array[LanguageServer::Protocol::Interface::CodeAction]) }
       def run
         diagnostics = Diagnostics.run(@uri, @document)
         corrections = diagnostics.select { |diagnostic| diagnostic.correctable? && diagnostic.in_range?(@range) }

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -44,10 +44,12 @@ module RubyLsp
       sig { returns(T::Array[LanguageServer::Protocol::Interface::CodeAction]) }
       def run
         diagnostics = Diagnostics.run(@uri, @document)
-        corrections = diagnostics.select { |diagnostic| diagnostic.correctable? && diagnostic.in_range?(@range) }
+        corrections = diagnostics.select do |diagnostic|
+          diagnostic.correctable? && T.cast(diagnostic, Support::RuboCopDiagnostic).in_range?(@range)
+        end
         return [] if corrections.empty?
 
-        corrections.map!(&:to_lsp_code_action)
+        T.cast(corrections, T::Array[Support::RuboCopDiagnostic]).map!(&:to_lsp_code_action)
       end
     end
   end

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -16,6 +16,16 @@ module RubyLsp
     # ```
     class Diagnostics < RuboCopRequest
       extend T::Sig
+      extend T::Generic
+
+      Response = type_template do
+        {
+          fixed: T.any(
+            T::Array[Support::RuboCopDiagnostic],
+            T::Array[Support::SyntaxErrorDiagnostic],
+          ),
+        }
+      end
 
       sig do
         override.returns(

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
@@ -15,6 +15,16 @@ module RubyLsp
     # end
     # ```
     class Diagnostics < RuboCopRequest
+      extend T::Sig
+
+      sig do
+        override.returns(
+          T.any(
+            T::Array[Support::RuboCopDiagnostic],
+            T::Array[Support::SyntaxErrorDiagnostic],
+          )
+        )
+      end
       def run
         return syntax_error_diagnostics if @document.syntax_errors?
 
@@ -23,12 +33,14 @@ module RubyLsp
         @diagnostics
       end
 
+      sig { params(_file: String, offenses: T::Array[RuboCop::Cop::Offense]).void }
       def file_finished(_file, offenses)
         @diagnostics = offenses.map { |offense| Support::RuboCopDiagnostic.new(offense, @uri) }
       end
 
       private
 
+      sig { returns(T::Array[Support::SyntaxErrorDiagnostic]) }
       def syntax_error_diagnostics
         @document.syntax_error_edits.map { |e| Support::SyntaxErrorDiagnostic.new(e) }
       end

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -22,6 +22,9 @@ module RubyLsp
     # ```
     class DocumentHighlight < BaseRequest
       extend T::Sig
+      extend T::Generic
+
+      Response = type_template { { fixed: T::Array[LanguageServer::Protocol::Interface::DocumentHighlight] } }
 
       VarNodes = T.type_alias do
         T.any(
@@ -37,7 +40,7 @@ module RubyLsp
         override(allow_incompatible: true).params(
           document: Document,
           position: Document::PositionShape
-        ).returns(T::Array[LanguageServer::Protocol::Interface::DocumentHighlight])
+        ).returns(Response)
       end
       def self.run(document, position)
         new(document, position).run

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -26,6 +26,9 @@ module RubyLsp
     # ```
     class DocumentSymbol < BaseRequest
       extend T::Sig
+      extend T::Generic
+
+      Response = type_template { { fixed: T::Array[LanguageServer::Protocol::Interface::DocumentSymbol] } }
 
       SYMBOL_KIND = T.let({
         file: 1,

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -14,6 +14,9 @@ module RubyLsp
     # ```
     class FoldingRanges < BaseRequest
       extend T::Sig
+      extend T::Generic
+
+      Response = type_template { { fixed: T::Array[LanguageServer::Protocol::Interface::FoldingRange] } }
 
       SIMPLE_FOLDABLES = T.let([
         SyntaxTree::ArrayLiteral,

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
@@ -15,13 +15,16 @@ module RubyLsp
     # end
     # ```
     class Formatting < RuboCopRequest
-      RUBOCOP_FLAGS = (COMMON_RUBOCOP_FLAGS + ["--autocorrect"]).freeze
+      extend T::Sig
+      RUBOCOP_FLAGS = T.let((COMMON_RUBOCOP_FLAGS + ["--autocorrect"]).freeze, T::Array[String])
 
+      sig { params(uri: String, document: Document).void }
       def initialize(uri, document)
         super
-        @formatted_text = nil
+        @formatted_text = T.let(nil, T.nilable(String))
       end
 
+      sig { override.returns(T.nilable(T::Array[LanguageServer::Protocol::Interface::TextEdit])) }
       def run
         super
 
@@ -44,6 +47,7 @@ module RubyLsp
 
       private
 
+      sig { returns(T::Array[String]) }
       def rubocop_flags
         RUBOCOP_FLAGS
       end

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -16,6 +16,10 @@ module RubyLsp
     # ```
     class Formatting < RuboCopRequest
       extend T::Sig
+      extend T::Generic
+
+      Response = type_template { { fixed: T.nilable(T::Array[LanguageServer::Protocol::Interface::TextEdit]) } }
+
       RUBOCOP_FLAGS = T.let((COMMON_RUBOCOP_FLAGS + ["--autocorrect"]).freeze, T::Array[String])
 
       sig { params(uri: String, document: Document).void }

--- a/lib/ruby_lsp/requests/rubocop_request.rb
+++ b/lib/ruby_lsp/requests/rubocop_request.rb
@@ -10,6 +10,9 @@ module RubyLsp
     class RuboCopRequest < RuboCop::Runner
       extend T::Sig
       extend T::Helpers
+      extend T::Generic
+
+      Response = type_template { { upper: T.untyped } }
 
       abstract!
 
@@ -25,7 +28,7 @@ module RubyLsp
       sig { returns(String) }
       attr_reader :text
 
-      sig { overridable.params(uri: String, document: Document).returns(T.untyped) }
+      sig { overridable.params(uri: String, document: Document).returns(Response) }
       def self.run(uri, document)
         new(uri, document).run
       end

--- a/lib/ruby_lsp/requests/rubocop_request.rb
+++ b/lib/ruby_lsp/requests/rubocop_request.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocop"
@@ -8,23 +8,36 @@ module RubyLsp
   module Requests
     # :nodoc:
     class RuboCopRequest < RuboCop::Runner
-      COMMON_RUBOCOP_FLAGS = [
+      extend T::Sig
+      extend T::Helpers
+
+      abstract!
+
+      COMMON_RUBOCOP_FLAGS = T.let([
         "--stderr", # Print any output to stderr so that our stdout does not get polluted
         "--format",
         "RuboCop::Formatter::BaseFormatter", # Suppress any output by using the base formatter
-      ].freeze
+      ].freeze, T::Array[String])
 
-      attr_reader :file, :text
+      sig { returns(String) }
+      attr_reader :file
 
+      sig { returns(String) }
+      attr_reader :text
+
+      sig { overridable.params(uri: String, document: Document).returns(T.untyped) }
       def self.run(uri, document)
         new(uri, document).run
       end
 
+      sig { params(uri: String, document: Document).void }
       def initialize(uri, document)
-        @file = CGI.unescape(URI.parse(uri).path)
+        @file = T.let(CGI.unescape(URI.parse(uri).path), String)
         @document = document
-        @text = document.source
+        @text = T.let(document.source, String)
         @uri = uri
+        @options = T.let({}, T::Hash[Symbol, T.untyped])
+        @diagnostics = T.let([], T::Array[Support::RuboCopDiagnostic])
 
         super(
           ::RuboCop::Options.new.parse(rubocop_flags).first,
@@ -32,6 +45,7 @@ module RubyLsp
         )
       end
 
+      sig { returns(T.untyped) }
       def run
         # We communicate with Rubocop via stdin
         @options[:stdin] = text
@@ -42,6 +56,7 @@ module RubyLsp
 
       private
 
+      sig { returns(T::Array[String]) }
       def rubocop_flags
         COMMON_RUBOCOP_FLAGS
       end

--- a/lib/ruby_lsp/requests/selection_ranges.rb
+++ b/lib/ruby_lsp/requests/selection_ranges.rb
@@ -18,6 +18,10 @@ module RubyLsp
     # ```
     class SelectionRanges < BaseRequest
       extend T::Sig
+      extend T::Generic
+
+      Response = type_template { { fixed: T::Array[Support::SelectionRange] } }
+
       NODES_THAT_CAN_BE_PARENTS = T.let([
         SyntaxTree::Assign,
         SyntaxTree::ArrayLiteral,

--- a/lib/ruby_lsp/requests/selection_ranges.rb
+++ b/lib/ruby_lsp/requests/selection_ranges.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
@@ -17,7 +17,8 @@ module RubyLsp
     # end
     # ```
     class SelectionRanges < BaseRequest
-      NODES_THAT_CAN_BE_PARENTS = [
+      extend T::Sig
+      NODES_THAT_CAN_BE_PARENTS = T.let([
         SyntaxTree::Assign,
         SyntaxTree::ArrayLiteral,
         SyntaxTree::Begin,
@@ -54,15 +55,17 @@ module RubyLsp
         SyntaxTree::VCall,
         SyntaxTree::When,
         SyntaxTree::While,
-      ].freeze
+      ].freeze, T::Array[T.class_of(SyntaxTree::Node)])
 
+      sig { params(document: Document).void }
       def initialize(document)
         super(document)
 
-        @ranges = []
-        @stack = []
+        @ranges = T.let([], T::Array[Support::SelectionRange])
+        @stack = T.let([], T::Array[Support::SelectionRange])
       end
 
+      sig { override.returns(T::Array[Support::SelectionRange]) }
       def run
         visit(@document.tree)
         @ranges.reverse!
@@ -70,6 +73,7 @@ module RubyLsp
 
       private
 
+      sig { params(node: T.nilable(SyntaxTree::Node)).void }
       def visit(node)
         return if node.nil?
 
@@ -83,6 +87,12 @@ module RubyLsp
         @stack.pop if NODES_THAT_CAN_BE_PARENTS.include?(node.class)
       end
 
+      sig do
+        params(
+          location: SyntaxTree::Location,
+          parent: T.nilable(Support::SelectionRange)
+        ).returns(Support::SelectionRange)
+      end
       def create_selection_range(location, parent = nil)
         RubyLsp::Requests::Support::SelectionRange.new(
           range: LanguageServer::Protocol::Interface::Range.new(

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -18,6 +18,11 @@ module RubyLsp
     # ```
     class SemanticHighlighting < BaseRequest
       extend T::Sig
+      extend T::Generic
+
+      Response = type_template do
+        { fixed: T.any(LanguageServer::Protocol::Interface::SemanticTokens, T::Array[SemanticToken]) }
+      end
 
       TOKEN_TYPES = T.let([
         :variable,

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
@@ -17,22 +17,31 @@ module RubyLsp
     # end
     # ```
     class SemanticHighlighting < BaseRequest
-      TOKEN_TYPES = [
+      extend T::Sig
+
+      TOKEN_TYPES = T.let([
         :variable,
         :method,
-      ].freeze
-      TOKEN_MODIFIERS = [].freeze
+      ].freeze, T::Array[Symbol])
+      TOKEN_MODIFIERS = T.let([].freeze, T::Array[Symbol])
 
-      SemanticToken = Struct.new(:location, :length, :type, :modifier)
+      class SemanticToken < T::Struct
+        const :location, SyntaxTree::Location
+        const :length, Integer
+        const :type, Integer
+        const :modifier, Integer
+      end
 
+      sig { params(document: Document, encoder: T.nilable(Support::SemanticTokenEncoder)).void }
       def initialize(document, encoder: nil)
         super(document)
 
         @encoder = encoder
-        @tokens = []
-        @tree = document.tree
+        @tokens = T.let([], T::Array[SemanticToken])
+        @tree = T.let(document.tree, SyntaxTree::Node)
       end
 
+      sig { override.returns(T.any(LanguageServer::Protocol::Interface::SemanticTokens, T::Array[SemanticToken])) }
       def run
         visit(@tree)
         return @tokens unless @encoder
@@ -40,12 +49,14 @@ module RubyLsp
         @encoder.encode(@tokens)
       end
 
+      sig { params(node: SyntaxTree::MAssign).void }
       def visit_m_assign(node)
         node.target.parts.each do |var_ref|
           add_token(var_ref.value.location, :variable)
         end
       end
 
+      sig { params(node: SyntaxTree::VarField).void }
       def visit_var_field(node)
         case node.value
         when SyntaxTree::Ident
@@ -53,6 +64,7 @@ module RubyLsp
         end
       end
 
+      sig { params(node: SyntaxTree::VarRef).void }
       def visit_var_ref(node)
         case node.value
         when SyntaxTree::Ident
@@ -60,39 +72,53 @@ module RubyLsp
         end
       end
 
+      sig { params(node: SyntaxTree::ARefField).void }
       def visit_a_ref_field(node)
         add_token(node.collection.value.location, :variable)
       end
 
+      sig { params(node: SyntaxTree::Call).void }
       def visit_call(node)
         visit(node.receiver)
         add_token(node.message.location, :method)
         visit(node.arguments)
       end
 
+      sig { params(node: SyntaxTree::Command).void }
       def visit_command(node)
         add_token(node.message.location, :method)
         visit(node.arguments)
       end
 
+      sig { params(node: SyntaxTree::CommandCall).void }
       def visit_command_call(node)
         visit(node.receiver)
         add_token(node.message.location, :method)
         visit(node.arguments)
       end
 
+      sig { params(node: SyntaxTree::FCall).void }
       def visit_fcall(node)
         add_token(node.value.location, :method)
         visit(node.arguments)
       end
 
+      sig { params(node: SyntaxTree::VCall).void }
       def visit_vcall(node)
         add_token(node.value.location, :method)
       end
 
+      sig { params(location: SyntaxTree::Location, type: Symbol).void }
       def add_token(location, type)
         length = location.end_char - location.start_char
-        @tokens.push(SemanticToken.new(location, length, TOKEN_TYPES.index(type), 0))
+        @tokens.push(
+          SemanticToken.new(
+            location: location,
+            length: length,
+            type: T.must(TOKEN_TYPES.index(type)),
+            modifier: 0
+          )
+        )
       end
     end
   end

--- a/lib/ruby_lsp/requests/support/selection_range.rb
+++ b/lib/ruby_lsp/requests/support/selection_range.rb
@@ -1,10 +1,13 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
   module Requests
     module Support
       class SelectionRange < LanguageServer::Protocol::Interface::SelectionRange
+        extend T::Sig
+
+        sig { params(position: Document::PositionShape).returns(T::Boolean) }
         def cover?(position)
           line_range = (range.start.line..range.end.line)
           character_range = (range.start.character..range.end.character)

--- a/lib/ruby_lsp/requests/support/semantic_token_encoder.rb
+++ b/lib/ruby_lsp/requests/support/semantic_token_encoder.rb
@@ -1,15 +1,23 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
   module Requests
     module Support
       class SemanticTokenEncoder
+        extend T::Sig
+
+        sig { void }
         def initialize
-          @current_row = 0
-          @current_column = 0
+          @current_row = T.let(0, Integer)
+          @current_column = T.let(0, Integer)
         end
 
+        sig do
+          params(
+            tokens: T::Array[SemanticHighlighting::SemanticToken]
+          ).returns(LanguageServer::Protocol::Interface::SemanticTokens)
+        end
         def encode(tokens)
           delta = tokens
             .sort_by do |token|
@@ -31,6 +39,7 @@ module RubyLsp
 
         # For more information on how each number is calculated, read:
         # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_semanticTokens
+        sig { params(token: SemanticHighlighting::SemanticToken).returns(T::Array[Integer]) }
         def compute_delta(token)
           row = token.location.start_line - 1
           column = token.location.start_column

--- a/lib/ruby_lsp/requests/support/syntax_error_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/syntax_error_diagnostic.rb
@@ -1,18 +1,23 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module RubyLsp
   module Requests
     module Support
       class SyntaxErrorDiagnostic
+        extend T::Sig
+
+        sig { params(edit: Document::EditShape).void }
         def initialize(edit)
           @edit = edit
         end
 
+        sig { returns(FalseClass) }
         def correctable?
           false
         end
 
+        sig { returns(LanguageServer::Protocol::Interface::Diagnostic) }
         def to_lsp_diagnostic
           LanguageServer::Protocol::Interface::Diagnostic.new(
             message: "Syntax error",

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -46,11 +46,12 @@ module RubyLsp
     end
 
     sig do
-      params(
-        uri: String,
-        request_name: Symbol,
-        block: T.proc.params(document: Document).returns(T.untyped)
-      ).returns(T.untyped)
+      type_parameters(:T)
+        .params(
+          uri: String,
+          request_name: Symbol,
+          block: T.proc.params(document: Document).returns(T.type_parameter(:T))
+        ).returns(T.type_parameter(:T))
     end
     def cache_fetch(uri, request_name, &block)
       get(uri).cache_fetch(request_name, &block)

--- a/rakelib/check_docs.rake
+++ b/rakelib/check_docs.rake
@@ -3,6 +3,7 @@
 
 desc "Check if all LSP requests are documented"
 task :check_docs do
+  require "sorbet-runtime"
   require "language_server-protocol"
   require "syntax_tree"
   require "logger"

--- a/sorbet/tapioca/require.rb
+++ b/sorbet/tapioca/require.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 # Add your extra requires here (`bin/tapioca require` can be used to boostrap this list)

--- a/test/requests/code_actions_test.rb
+++ b/test/requests/code_actions_test.rb
@@ -31,7 +31,7 @@ class CodeActionsTest < Minitest::Test
 
   def assert_code_actions(source, code_actions, range)
     document = RubyLsp::Document.new(source)
-    result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::Diagnostic]))
+    result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::CodeAction]))
 
     stdout, _ = capture_io do
       result = RubyLsp::Requests::CodeActions.run("file://#{__FILE__}", document, range)

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/folding_ranges_expectations_test.rb
+++ b/test/requests/folding_ranges_expectations_test.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "test_helper"

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -9,7 +9,7 @@ class FormattingExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::Document.new(source)
-    RubyLsp::Requests::Formatting.run("file://#{__FILE__}", document).first.new_text
+    RubyLsp::Requests::Formatting.run("file://#{__FILE__}", document)&.first&.new_text
   end
 
   def assert_expectations(source, expected)

--- a/test/requests/support/semantic_token_encoder_test.rb
+++ b/test/requests/support/semantic_token_encoder_test.rb
@@ -4,15 +4,12 @@
 require "test_helper"
 
 class SemanticTokenEncoderTest < Minitest::Test
-  TokenStub = RubyLsp::Requests::SemanticHighlighting::SemanticToken
-  LocationStub = Struct.new(:start_line, :start_column)
-
   def test_tokens_encoded_to_relative_positioning
     tokens = [
-      TokenStub.new(LocationStub.new(1, 2), 1, 0, 0),
-      TokenStub.new(LocationStub.new(1, 4), 2, 9, 0),
-      TokenStub.new(LocationStub.new(2, 2), 3, 0, 6),
-      TokenStub.new(LocationStub.new(5, 6), 10, 4, 4),
+      stub_token(1, 2, 1, 0, 0),
+      stub_token(1, 4, 2, 9, 0),
+      stub_token(2, 2, 3, 0, 6),
+      stub_token(5, 6, 10, 4, 4),
     ]
 
     expected_encoding = [
@@ -28,10 +25,10 @@ class SemanticTokenEncoderTest < Minitest::Test
 
   def test_tokens_sorted_before_encoded
     tokens = [
-      TokenStub.new(LocationStub.new(1, 2), 1, 0, 0),
-      TokenStub.new(LocationStub.new(5, 6), 10, 4, 4),
-      TokenStub.new(LocationStub.new(2, 2), 3, 0, 6),
-      TokenStub.new(LocationStub.new(1, 4), 2, 9, 0),
+      stub_token(1, 2, 1, 0, 0),
+      stub_token(5, 6, 10, 4, 4),
+      stub_token(2, 2, 3, 0, 6),
+      stub_token(1, 4, 2, 9, 0),
     ]
 
     expected_encoding = [
@@ -43,5 +40,23 @@ class SemanticTokenEncoderTest < Minitest::Test
 
     assert_equal(expected_encoding,
       RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode(tokens).data)
+  end
+
+  private
+
+  def stub_token(start_line, start_column, length, type, modifier)
+    RubyLsp::Requests::SemanticHighlighting::SemanticToken.new(
+      location: SyntaxTree::Location.new(
+        start_line: start_line,
+        start_column: start_column,
+        start_char: 0,
+        end_char: 0,
+        end_column: 0,
+        end_line: 0,
+      ),
+      length: length,
+      type: type,
+      modifier: modifier
+    )
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))


### PR DESCRIPTION
### Motivation

The final PR in our efforts to adopt Sorbet. This PR enforces typed strict in our files (except for test files, which are enforced as typed true).

### Implementation

Split by commit
1. Move the codebase to typed strict
2. Add generic for response type in RuboCopRequest
3. Add generic for response type in BaseRequest
4. Enhance some block related types

Let me know what you think about the generics. I don't love it, but they did improve typing and actually helped me find an incorrect signature in `Handler`.