### PR TITLE
Increase the request time delta

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -211,7 +211,7 @@ class IntegrationTest < Minitest::Test
     assert_equal("file://#{__FILE__}", telemetry_response.dig(:params, :uri))
     assert_equal(RubyLsp::VERSION, telemetry_response.dig(:params, :lspVersion))
     assert_equal(request, telemetry_response.dig(:params, :request))
-    assert_in_delta(0.5, telemetry_response.dig(:params, :requestTime), 1)
+    assert_in_delta(0.5, telemetry_response.dig(:params, :requestTime), 2)
   end
 
   def make_request(request, params = nil)


### PR DESCRIPTION
### Motivation

Now that we added Sorbet, tests run slightly slower and we are getting random CI failures because the request time isn't within the 1 second delta we specified.

This PR just increases it to 2 seconds, since this still provides a similar experience in development and will prevent the CI failures.
