### PR TITLE
Add semantic token for name in a method definition

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -52,6 +52,12 @@ module RubyLsp
         @encoder.encode(@tokens)
       end
 
+      def visit_def(node)
+        add_token(node.name.location, :method, [:declaration])
+        visit(node.params)
+        visit(node.bodystmt)
+      end
+
       def visit_m_assign(node)
         node.target.parts.each do |var_ref|
           add_token(var_ref.value.location, :variable)

--- a/test/expectations/semantic_highlighting/aref_field.exp
+++ b/test/expectations/semantic_highlighting/aref_field.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 9,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 1,

--- a/test/expectations/semantic_highlighting/aref_variable.exp
+++ b/test/expectations/semantic_highlighting/aref_variable.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 9,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 1,

--- a/test/expectations/semantic_highlighting/call_invocation_with_variable_receiver.exp
+++ b/test/expectations/semantic_highlighting/call_invocation_with_variable_receiver.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 11,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 3,

--- a/test/expectations/semantic_highlighting/call_invocation_with_variable_receiver_and_arguments.exp
+++ b/test/expectations/semantic_highlighting/call_invocation_with_variable_receiver_and_arguments.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 11,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 3,

--- a/test/expectations/semantic_highlighting/fcall_invocation.exp
+++ b/test/expectations/semantic_highlighting/fcall_invocation.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 11,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 10,

--- a/test/expectations/semantic_highlighting/fcall_invocation_variable_arguments.exp
+++ b/test/expectations/semantic_highlighting/fcall_invocation_variable_arguments.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 11,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 3,

--- a/test/expectations/semantic_highlighting/local_variables.exp
+++ b/test/expectations/semantic_highlighting/local_variables.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 9,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 3,

--- a/test/expectations/semantic_highlighting/multi_assignment.exp
+++ b/test/expectations/semantic_highlighting/multi_assignment.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 9,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 1,

--- a/test/expectations/semantic_highlighting/var_aref_variable.exp
+++ b/test/expectations/semantic_highlighting/var_aref_variable.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 9,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 1,

--- a/test/expectations/semantic_highlighting/var_field_variable.exp
+++ b/test/expectations/semantic_highlighting/var_field_variable.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 9,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 1,

--- a/test/expectations/semantic_highlighting/vcall_invocation.exp
+++ b/test/expectations/semantic_highlighting/vcall_invocation.exp
@@ -1,5 +1,12 @@
 [
   {
+    "delta_line": 0,
+    "delta_start_char": 4,
+    "length": 11,
+    "token_type": 1,
+    "token_modifiers": 1
+  },
+  {
     "delta_line": 1,
     "delta_start_char": 2,
     "length": 10,


### PR DESCRIPTION
### Motivation

Define a new semantic token for method names using the modifiers implemented in https://github.com/Shopify/ruby-lsp/pull/112

### Implementation

Similar to the previous semantic tokens, add a visit method for it. 

### Automated Tests

Most of the tests contain a method definition, which means an additional token is added to the array of expected tokens. 

### Manual Tests

- Check out this branch and use the tool `Inspect Editor Token and Scope`. 
- Click on a method name

<img width="598" alt="Screen Shot 2022-06-07 at 2 01 55 PM" src="https://user-images.githubusercontent.com/25471753/172451684-bcec897e-af02-4e9f-829a-3e2728e99501.png">
