### PR TITLE
Add semantic token for keyword self

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -83,6 +83,14 @@ module RubyLsp
         visit(node.statement)
       end
 
+      sig { params(node: SyntaxTree::Kw).void }
+      def visit_kw(node)
+        case node.value
+        when "self"
+          add_token(node.location, :variable, [:default_library])
+        end
+      end
+
       sig { params(node: SyntaxTree::Defs).void }
       def visit_defs(node)
         visit(node.target)
@@ -112,6 +120,8 @@ module RubyLsp
         case node.value
         when SyntaxTree::Ident
           add_token(node.value.location, :variable)
+        else
+          visit(node.value)
         end
       end
 

--- a/test/expectations/semantic_highlighting/defs.exp
+++ b/test/expectations/semantic_highlighting/defs.exp
@@ -1,7 +1,14 @@
 [
   {
     "delta_line": 0,
-    "delta_start_char": 9,
+    "delta_start_char": 4,
+    "length": 4,
+    "token_type": 0,
+    "token_modifiers": 512
+  },
+  {
+    "delta_line": 0,
+    "delta_start_char": 5,
     "length": 3,
     "token_type": 1,
     "token_modifiers": 1

--- a/test/expectations/semantic_highlighting/sclass.exp
+++ b/test/expectations/semantic_highlighting/sclass.exp
@@ -1,0 +1,9 @@
+[
+  {
+    "delta_line": 1,
+    "delta_start_char": 11,
+    "length": 4,
+    "token_type": 0,
+    "token_modifiers": 512
+  }
+]


### PR DESCRIPTION
### Motivation

Add semantic token for keyword self

### Implementation

The same as usual, add a visitor method for the node

@vinistock and I discussed what token type to make `self`, and we landed on `:variable` with the token modifier `:default_library`. The default themes don't make use of the modifier, but we figure we could have it in case other themes use it. 

### Automated Tests

Yes, covered in an existing test (defs) and new test, sclass

### Manual Tests

Turn on VS Code's inspect editor token and scope mode

Note that the self keyword is now consistently coloured: 
<img width="512" alt="Screen Shot 2022-06-08 at 5 13 55 PM" src="https://user-images.githubusercontent.com/25471753/172718392-131c1e24-04a8-4ff1-b276-ece231342a79.png">

