### PR TITLE
Add semantic token for keywords and keyword rest parameters

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -148,19 +148,7 @@ module RubyLsp
       def visit_params(node)
         node.keywords.each do |keyword,|
           location = keyword.location
-
-          # We exclude the ":" symbol from the keyword
-          # for consistency with the rest of the parameters
-          modified_location = SyntaxTree::Location.new(
-            start_line: location.start_line,
-            start_column: location.start_column,
-            start_char: location.start_char,
-            end_char: location.end_char - 1,
-            end_column: location.end_column - 1,
-            end_line: location.end_line,
-          )
-
-          add_token(modified_location, :variable)
+          add_token(location_without_colon(location), :variable)
         end
 
         add_token(node.keyword_rest.name.location, :variable) if node.keyword_rest
@@ -202,6 +190,23 @@ module RubyLsp
             type: T.must(TOKEN_TYPES.index(type)),
             modifier: modifiers_indices
           )
+        )
+      end
+
+      private
+
+      # Exclude the ":" symbol at the end of a location
+      # We use it on keyword parameters to be consistent
+      # with the rest of the parameters
+      sig { params(location: T.untyped).returns(SyntaxTree::Location) }
+      def location_without_colon(location)
+        SyntaxTree::Location.new(
+          start_line: location.start_line,
+          start_column: location.start_column,
+          start_char: location.start_char,
+          end_char: location.end_char - 1,
+          end_column: location.end_column - 1,
+          end_line: location.end_line,
         )
       end
     end

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -144,6 +144,15 @@ module RubyLsp
         end
       end
 
+      sig { params(node: SyntaxTree::Params).void }
+      def visit_params(node)
+        node.keywords.each do |keyword,|
+          add_token(keyword.location, :variable)
+        end
+
+        add_token(node.keyword_rest.name.location, :variable) if node.keyword_rest
+      end
+
       sig { params(node: SyntaxTree::VarField).void }
       def visit_var_field(node)
         case node.value

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -147,7 +147,20 @@ module RubyLsp
       sig { params(node: SyntaxTree::Params).void }
       def visit_params(node)
         node.keywords.each do |keyword,|
-          add_token(keyword.location, :variable)
+          location = keyword.location
+
+          # We exclude the ":" symbol from the keyword
+          # for consistency with the rest of the parameters
+          modified_location = SyntaxTree::Location.new(
+            start_line: location.start_line,
+            start_column: location.start_column,
+            start_char: location.start_char,
+            end_char: location.end_char - 1,
+            end_column: location.end_column - 1,
+            end_line: location.end_line,
+          )
+
+          add_token(modified_location, :variable)
         end
 
         add_token(node.keyword_rest.name.location, :variable) if node.keyword_rest

--- a/test/expectations/semantic_highlighting/method_params.exp
+++ b/test/expectations/semantic_highlighting/method_params.exp
@@ -1,0 +1,81 @@
+{
+  "result": [
+    {
+      "delta_line": 0,
+      "delta_start_char": 4,
+      "length": 3,
+      "token_type": 1,
+      "token_modifiers": 1
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 21,
+      "length": 2,
+      "token_type": 0,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 8,
+      "length": 1,
+      "token_type": 0,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 1,
+      "delta_start_char": 2,
+      "length": 4,
+      "token_type": 1,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 5,
+      "length": 1,
+      "token_type": 0,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 3,
+      "length": 1,
+      "token_type": 0,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 3,
+      "length": 1,
+      "token_type": 0,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 3,
+      "length": 1,
+      "token_type": 0,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 3,
+      "length": 1,
+      "token_type": 0,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 3,
+      "length": 1,
+      "token_type": 0,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 3,
+      "length": 3,
+      "token_type": 0,
+      "token_modifiers": 0
+    }
+  ]
+}

--- a/test/expectations/semantic_highlighting/method_params.exp
+++ b/test/expectations/semantic_highlighting/method_params.exp
@@ -10,7 +10,7 @@
     {
       "delta_line": 0,
       "delta_start_char": 21,
-      "length": 2,
+      "length": 1,
       "token_type": 0,
       "token_modifiers": 0
     },

--- a/test/fixtures/method_params.rb
+++ b/test/fixtures/method_params.rb
@@ -1,0 +1,3 @@
+def foo(a, b = 1, *c, d, e: 1, **f, &blk)
+  puts a, b, c, d, e, f, blk
+end


### PR DESCRIPTION
### Motivation

Add semantic token for keyword and keyword rest to make it consistent between other params in the method definition 

### Implementation

Add a visitor method for `SyntaxTree::Params` 

### Automated Tests

Yes. I added a new test fixture for method parameters. 

### Manual Tests

A visual test (or you can use the Developer Inspect Editor Scope mode) 

Before:
<img width="380" alt="Screen Shot 2022-06-10 at 2 41 01 PM" src="https://user-images.githubusercontent.com/25471753/173129991-c53c62df-ec42-4e34-b168-e4476fa5b31f.png">

After: 
<img width="364" alt="Screen Shot 2022-06-10 at 2 40 45 PM" src="https://user-images.githubusercontent.com/25471753/173129949-e34be9fd-2812-4830-bd7e-9fdcd8b9a8f6.png">