### PR TITLE
Update the doc -> docs in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /**/.yardoc
 /**/_yardoc/
 /**/coverage/
-/**/doc/
+/**/docs/
 /**/pkg/
 /**/spec/reports/
 /**/tmp/


### PR DESCRIPTION
`rake yard` puts documents under `/docs` instead of `/doc`. So we should ignore `/docs` instead.