### PR TITLE
Upgrade rubocop requirement to 1.30.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-lsp (0.0.4)
       language_server-protocol
-      rubocop (>= 1.0)
+      rubocop (>= 1.30)
       sorbet-runtime
       syntax_tree (>= 2.3)
 

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("language_server-protocol")
-  s.add_dependency("rubocop", ">= 1.0")
+  s.add_dependency("rubocop", ">= 1.30")
   s.add_dependency("sorbet-runtime")
   s.add_dependency("syntax_tree", ">= 2.3")
 end


### PR DESCRIPTION
### Motivation
From version 0.0.4, formatting uses `--autocorrect` for RuboCop. This was added in RuboCop [1.30.0](https://github.com/rubocop/rubocop/releases/tag/v1.30.0) (https://github.com/rubocop/rubocop/pull/10547). Therefore, `textDocument/formatting` will not work with RuboCop versions less than 1.30.0.

### Implementation
Upgraded requirement version in gemspec.

### Automated Tests
I think it is not needed to add test. CI has been passed with RuboCop 1.30.1.

### Manual Tests
There is no change in behavior.
