### PR TITLE
Improve error handling + fix formatting hanging issue

### DIFF
--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -28,9 +28,7 @@ module RubyLsp
     sig { void }
     def start
       $stderr.puts "Starting Ruby LSP..."
-      @reader.read do |request|
-        with_telemetry(request) { handle(request) }
-      end
+      @reader.read { |request| handle(request) }
     end
 
     sig { params(blk: T.proc.bind(Handler).params(arg0: T.untyped).void).void }
@@ -50,29 +48,25 @@ module RubyLsp
       @handlers[msg] = blk
     end
 
-    sig do
-      params(
-        request: T::Hash[Symbol, T.untyped]
-      ).returns(
-        T::Array[T.any(T.untyped, T.nilable(StandardError))]
-      )
-    end
+    sig { params(request: T::Hash[Symbol, T.untyped]).void }
     def handle(request)
       result = T.let(nil, T.untyped)
       error = T.let(nil, T.nilable(StandardError))
       handler = @handlers[request[:method]]
 
-      if handler
-        begin
-          result = handler.call(request)
-        rescue StandardError => e
-          error = e
-        end
+      request_time = Benchmark.realtime do
+        if handler
+          begin
+            result = handler.call(request)
+          rescue StandardError => e
+            error = e
+          end
 
-        @writer.write(id: request[:id], result: result) unless result == VOID
+          @writer.write(id: request[:id], result: result) unless result == VOID
+        end
       end
 
-      [result, error]
+      @writer.write(method: "telemetry/event", params: telemetry_params(request, request_time, error))
     end
 
     sig { void }
@@ -210,25 +204,6 @@ module RubyLsp
     end
     def respond_with_document_highlight(uri, position)
       Requests::DocumentHighlight.new(store.get(uri), position).run
-    end
-
-    sig do
-      type_parameters(:T)
-        .params(
-          request: T::Hash[Symbol, T.untyped],
-          block: T.proc.returns(T.type_parameter(:T))
-        ).returns(T.type_parameter(:T))
-    end
-    def with_telemetry(request, &block)
-      result = T.let(nil, T.untyped)
-      error = T.let(nil, T.nilable(StandardError))
-
-      request_time = Benchmark.realtime do
-        result, error = block.call
-      end
-
-      @writer.write(method: "telemetry/event", params: telemetry_params(request, request_time, error))
-      result
     end
 
     sig do

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -17,7 +17,7 @@ module RubyLsp
     class Formatting < RuboCopRequest
       extend T::Sig
 
-      RUBOCOP_FLAGS = T.let((COMMON_RUBOCOP_FLAGS + ["--autocorrect"]).freeze, T::Array[String])
+      RUBOCOP_FLAGS = T.let((COMMON_RUBOCOP_FLAGS + ["--auto-correct"]).freeze, T::Array[String])
 
       sig { params(uri: String, document: Document).void }
       def initialize(uri, document)


### PR DESCRIPTION
### Motivation

This fixes https://github.com/Shopify/ruby-lsp/issues/146. 

The issue is caused by a sequence of events:
1. `--autocorrect` flag isn't recognized by Rubocop versions <= `1.29` and will trigger a `OptionParser::InvalidOption` exception.
2. The exception will interrupt `Handler#handle`, so the result (response) is never sent. That's why VS Code hangs.
3. And because the error will be rescued in `#with_telemetry`, we don't see anything at the surface.


### Implementation

1. Update the flag to be `--auto-correct` instead.
2. Move exception handling into `Handler#handle` to make sure responses will always be returned.
3. Because `#with_telemetry` also needs to be aware of the error, it's highly dependant on with how `#handle` returns result + error (re-raise isn't a good options imo). So I think the separation between `#with_telemetry` and `#handle` becomes redundant after change 2.

### Automated Tests

This is the hard part because from my understanding, the only tests that cover `Handler#handle` are integration tests. But it's ran in a separate process so we can't use stubbing/mocking to raise an exception intentionally.

IMO, we should also have handler level tests so we can check error handling situation, which we currently don't have.

### Manual Tests

1. Remove `rubocop-shopify`'s version restriction in Gemfile.
2. Add `gem "rubocop", "1.29", require: false` to Gemfile
4. Run `bundle update`
5. Restart LSP
6. Open a Ruby file, mess up indentations, and save
7. See if the file is formatted

And to test error handling:

1. Change the `--auto-correct` flag in `formatting.rb` to something like `--foo`
2. Restart LSP
3. Open a Ruby file, mess up indentations, and save
4. The file will **not** be formatted but VS Code won't hang either

### Questions

- Are you agree with having handler level tests, mainly for testing error handling situations?