### PR TITLE
Set the minimum syntax_tree version to 2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       language_server-protocol
       rubocop (>= 1.0)
       sorbet-runtime
-      syntax_tree (>= 2.3)
+      syntax_tree (>= 2.4)
 
 GEM
   remote: https://rubygems.org/

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency("language_server-protocol")
   s.add_dependency("rubocop", ">= 1.0")
   s.add_dependency("sorbet-runtime")
-  s.add_dependency("syntax_tree", ">= 2.3")
+  s.add_dependency("syntax_tree", ">= 2.4")
 end


### PR DESCRIPTION
### Motivation

Some older versions of syntax_tree use trailing argument forwarding but don't have an explicit lower-bound for Ruby versions. [The minimum Ruby version appears to have been added in 2.4](https://github.com/ruby-syntax-tree/syntax_tree/compare/v2.3.1...v2.4.0#diff-4c28749b7a3b36b36dc7a63af5ddfd2941a337389e40b76b99590f37d1ead153R22) so we'll set that as the minimum accepted syntax_tree version.

