### PR TITLE
Update deprecated rubocop flag

### DIFF
--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -17,7 +17,7 @@ module RubyLsp
     class Formatting < RuboCopRequest
       extend T::Sig
 
-      RUBOCOP_FLAGS = T.let((COMMON_RUBOCOP_FLAGS + ["--auto-correct"]).freeze, T::Array[String])
+      RUBOCOP_FLAGS = T.let((COMMON_RUBOCOP_FLAGS + ["--autocorrect"]).freeze, T::Array[String])
 
       sig { params(uri: String, document: Document).void }
       def initialize(uri, document)


### PR DESCRIPTION
### Motivation

Update deprecated Rubocop flag (https://github.com/rubocop/rubocop/issues/10095) when `bin/test` runs 

<img width="836" alt="Screen Shot 2022-06-20 at 2 39 53 PM" src="https://user-images.githubusercontent.com/25471753/174614317-496dac72-c3b8-4f07-a793-a6eb50f821da.png">

### Implementation

Use new flag 

### Automated Tests

N/A 

### Manual Tests

Run `bin/test` before and after this branch  