### PR TITLE
Add semantic tokens for heredoc identifiers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       language_server-protocol
       rubocop (>= 1.0)
       sorbet-runtime
-      syntax_tree (>= 2.4)
+      syntax_tree (>= 2.8)
 
 GEM
   remote: https://rubygems.org/
@@ -79,7 +79,7 @@ GEM
       sorbet (>= 0.5.9204)
       sorbet-runtime (>= 0.5.9204)
       thor (>= 0.19.2)
-    syntax_tree (2.7.1)
+    syntax_tree (2.8.0)
       prettier_print
     tapioca (0.8.1)
       bundler (>= 1.17.3)

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -129,6 +129,16 @@ module RubyLsp
         visit(node.arguments)
       end
 
+      sig { params(node: SyntaxTree::HeredocBeg).void }
+      def visit_heredoc_beg(node)
+        add_token(node.location, :variable, [:default_library])
+      end
+
+      sig { params(node: SyntaxTree::HeredocEnd).void }
+      def visit_heredoc_end(node)
+        add_token(node.location, :variable, [:default_library])
+      end
+
       sig { params(node: SyntaxTree::Kw).void }
       def visit_kw(node)
         case node.value

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency("language_server-protocol")
   s.add_dependency("rubocop", ">= 1.0")
   s.add_dependency("sorbet-runtime")
-  s.add_dependency("syntax_tree", ">= 2.4")
+  s.add_dependency("syntax_tree", ">= 2.8")
 end

--- a/sorbet/rbi/gems/syntax_tree@2.8.0.rbi
+++ b/sorbet/rbi/gems/syntax_tree@2.8.0.rbi
@@ -668,8 +668,6 @@ end
 # This is raised when you use the Visitor.visit_method method and it fails.
 # It is correctable to through DidYouMean.
 class SyntaxTree::BasicVisitor::VisitMethodError < ::StandardError
-  include ::DidYouMean::Correctable
-
   # @return [VisitMethodError] a new instance of VisitMethodError
   def initialize(visit_method); end
 
@@ -2275,7 +2273,7 @@ class SyntaxTree::Heredoc < ::SyntaxTree::Node
   # [Integer] how far to dedent the heredoc
   def dedent; end
 
-  # [String] the ending of the heredoc
+  # [HeredocEnd] the ending of the heredoc
   def ending; end
 
   def format(q); end
@@ -2307,6 +2305,31 @@ class SyntaxTree::HeredocBeg < ::SyntaxTree::Node
   def format(q); end
 
   # [String] the opening declaration of the heredoc
+  def value; end
+end
+
+# HeredocEnd represents the closing declaration of a heredoc.
+#
+#     <<~DOC
+#       contents
+#     DOC
+#
+# In the example above the HeredocEnd node represents the closing DOC.
+class SyntaxTree::HeredocEnd < ::SyntaxTree::Node
+  # @return [HeredocEnd] a new instance of HeredocEnd
+  def initialize(value:, location:, comments: T.unsafe(nil)); end
+
+  def accept(visitor); end
+  def child_nodes; end
+
+  # [Array[ Comment | EmbDoc ]] the comments attached to this node
+  def comments; end
+
+  def deconstruct; end
+  def deconstruct_keys(_keys); end
+  def format(q); end
+
+  # [String] the closing declaration of the heredoc
   def value; end
 end
 
@@ -5924,6 +5947,9 @@ class SyntaxTree::Visitor < ::SyntaxTree::BasicVisitor
   # Visit a HeredocBeg node.
   def visit_heredoc_beg(node); end
 
+  # Visit a HeredocEnd node.
+  def visit_heredoc_end(node); end
+
   # Visit a HshPtn node.
   def visit_hshptn(node); end
 
@@ -6327,6 +6353,7 @@ class SyntaxTree::Visitor::FieldVisitor < ::SyntaxTree::BasicVisitor
   def visit_hash(node); end
   def visit_heredoc(node); end
   def visit_heredoc_beg(node); end
+  def visit_heredoc_end(node); end
   def visit_hshptn(node); end
   def visit_ident(node); end
   def visit_if(node); end

--- a/test/expectations/semantic_highlighting/heredoc.exp
+++ b/test/expectations/semantic_highlighting/heredoc.exp
@@ -1,0 +1,18 @@
+{
+  "result": [
+    {
+      "delta_line": 0,
+      "delta_start_char": 0,
+      "length": 11,
+      "token_type": 0,
+      "token_modifiers": 512
+    },
+    {
+      "delta_line": 2,
+      "delta_start_char": 0,
+      "length": 9,
+      "token_type": 0,
+      "token_modifiers": 512
+    }
+  ]
+}


### PR DESCRIPTION
~**Blocked 🛑 Tests are failing because this PR is contingent on the next release of syntax_tree that [implements `SyntaxTree::HeredocEnd`](https://github.com/ruby-syntax-tree/syntax_tree/pull/95)**~

PR is ready to be merged and the syntax_tree gem bump is part of the PR. 

### Motivation

Add semantic tokens for HEREDOCS 

<img width="337" alt="Screen Shot 2022-06-20 at 2 51 07 PM" src="https://user-images.githubusercontent.com/25471753/174616553-2b5220f2-f322-4e39-a986-e3f23165f352.png">

<img width="317" alt="Screen Shot 2022-06-20 at 2 50 40 PM" src="https://user-images.githubusercontent.com/25471753/174616427-7f9ec661-7b2b-4d91-8b05-6ce0eca77cbc.png">

### Implementation

Add semantic tokens to ensure there's no ambiguity between the delimiters and the string value

The token type I chose to add was :variable and the modifier, `:default_library`. The reasoning is because we're trying to keep it simple for now and not add any more new tokens than we need to. It also aligns with how other themes highlight their HEREDOCs, e.g. in Ruby API this is the colouring used: 

<img width="610" alt="Screen Shot 2022-06-20 at 2 55 28 PM" src="https://user-images.githubusercontent.com/25471753/174617450-f1081005-186c-4dc9-ae80-3b185dc577ee.png">

### Automated Tests

I've added the appropriate tests for this case. 

### Manual Tests

Use this source code to test before and after applying this branch: 

```ruby
<<~HEREDOC
  some text
HEREDOC

foo = <<~HEREDOC
  some text
HEREDOC
```