### PR TITLE
Bump syntax_tree from 2.7.1 to 2.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       language_server-protocol
       rubocop (>= 1.0)
       sorbet-runtime
-      syntax_tree (>= 2.4)
+      syntax_tree (>= 2.8)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       sorbet (>= 0.5.9204)
       sorbet-runtime (>= 0.5.9204)
       thor (>= 0.19.2)
-    syntax_tree (2.7.1)
+    syntax_tree (2.8.0)
       prettier_print
     tapioca (0.8.1)
       bundler (>= 1.17.3)

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency("language_server-protocol")
   s.add_dependency("rubocop", ">= 1.0")
   s.add_dependency("sorbet-runtime")
-  s.add_dependency("syntax_tree", ">= 2.4")
+  s.add_dependency("syntax_tree", ">= 2.8")
 end


### PR DESCRIPTION
### Motivation

Bumps [syntax_tree](https://github.com/kddnewton/syntax_tree) from 2.7.1 to 2.8.0

I need the changes for this PR - https://github.com/Shopify/ruby-lsp/pull/161

### Implementation

N/A 

### Automated Tests

N/A

### Manual Tests

N/A