### PR TITLE
Sanitize home directory from telemetry URI

### DIFF
--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -227,7 +227,7 @@ module RubyLsp
         params[:errorMessage] = error.message
       end
 
-      params[:uri] = uri if uri
+      params[:uri] = uri.sub(%r{.*://#{Dir.home}}, "~") if uri
       params
     end
   end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -207,8 +207,9 @@ class IntegrationTest < Minitest::Test
 
   def assert_telemetry(request)
     telemetry_response = read_response("telemetry/event")
+    expected_uri = __FILE__.sub(Dir.home, "~")
 
-    assert_equal("file://#{__FILE__}", telemetry_response.dig(:params, :uri))
+    assert_equal(expected_uri, telemetry_response.dig(:params, :uri))
     assert_equal(RubyLsp::VERSION, telemetry_response.dig(:params, :lspVersion))
     assert_equal(request, telemetry_response.dig(:params, :request))
     assert_in_delta(0.5, telemetry_response.dig(:params, :requestTime), 2)


### PR DESCRIPTION
### Motivation

We were sending the full URI for telemetry, which includes `file:///Users/myusername/....`. We don't really care (and it makes harder to analyze the data) about the beginning of the URI.

### Implementation

This PR just removes the `file://$HOME_DIR` part of the URI.

Before: `file:///Users/john/path/to/project/my_file.rb`
After: `~/path/to/project/my_file.rb`

### Automated Tests

Adapted the integration test.