### PR TITLE
Respect RuboCop file exclusion

### DIFF
--- a/lib/ruby_lsp/requests/rubocop_request.rb
+++ b/lib/ruby_lsp/requests/rubocop_request.rb
@@ -15,6 +15,7 @@ module RubyLsp
 
       COMMON_RUBOCOP_FLAGS = T.let([
         "--stderr", # Print any output to stderr so that our stdout does not get polluted
+        "--force-exclusion",
         "--format",
         "RuboCop::Formatter::BaseFormatter", # Suppress any output by using the base formatter
       ].freeze, T::Array[String])


### PR DESCRIPTION
### Motivation

Closes #170

RuboCop doesn't respect the exclusion configuration if an excluded path is passed explicitly as an argument (which is what we do in diagnostics and formatting).

### Implementation

Pass the `--force-exclusion` flag to RuboCop, which makes it respect ignored paths even if requested explicitly.

### Manual Tests

1. Start the LSP on this branch
2. Open an included file, such as `diagnostics.rb`
3. Make some edits
4. Verify diagnostics and auto-formatting work
5. Open an excluded file, such as any Ruby file under `test/fixtures`
6. Make some edits
7. Verify neither diagnostics or formatting are available