### PR TITLE
Clear diagnostics after closing file

### DIFF
--- a/lib/ruby_lsp/cli.rb
+++ b/lib/ruby_lsp/cli.rb
@@ -41,6 +41,7 @@ module RubyLsp
         on("textDocument/didClose") do |request|
           uri = request.dig(:params, :textDocument, :uri)
           store.delete(uri)
+          clear_diagnostics(uri)
 
           RubyLsp::Handler::VOID
         end

--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -196,6 +196,14 @@ module RubyLsp
       )
     end
 
+    sig { params(uri: String).void }
+    def clear_diagnostics(uri)
+      @writer.write(
+        method: "textDocument/publishDiagnostics",
+        params: Interface::PublishDiagnosticsParams.new(uri: uri, diagnostics: [])
+      )
+    end
+
     sig do
       params(uri: String, range: T::Range[Integer]).returns(T::Array[LanguageServer::Protocol::Interface::CodeAction])
     end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -115,7 +115,14 @@ class IntegrationTest < Minitest::Test
   def test_document_did_close
     initialize_lsp([])
     open_file_with("class Foo\nend")
+
+    read_response("textDocument/publishDiagnostics")
+    assert_telemetry("textDocument/didOpen")
+
     assert(send_request("textDocument/didClose", { textDocument: { uri: "file://#{__FILE__}" } }))
+
+    diagnostics = read_response("textDocument/publishDiagnostics")
+    assert_empty(diagnostics.dig(:params, :diagnostics), "Did not clear diagnostics after closing file")
   end
 
   def test_document_did_change


### PR DESCRIPTION
### Motivation

Currently, we keep adding diagnostics to the problems tab and never clear it. This means that even after closing files, their violations still show up in that tab.

### Implementation

Send an empty diagnostics notification to clear the problems tab for the file being closed.

### Automated Tests

Added the assertions to the integration test.

### Manual Tests

1. Open the LSP on this branch
2. Open any file and make some violations
3. Save without formatting to keep the violations (CMD + SHIFT + P, save without formatting)
4. Close the file
5. Verify that the problems tab is cleared