### PR TITLE
Include all token types in legend

### DIFF
--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -103,7 +103,7 @@ module RubyLsp
         Interface::SemanticTokensRegistrationOptions.new(
           document_selector: { scheme: "file", language: "ruby" },
           legend: Interface::SemanticTokensLegend.new(
-            token_types: Requests::SemanticHighlighting::TOKEN_TYPES,
+            token_types: Requests::SemanticHighlighting::TOKEN_TYPES.keys,
             token_modifiers: Requests::SemanticHighlighting::TOKEN_MODIFIERS.keys
           ),
           range: false,

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -21,11 +21,31 @@ module RubyLsp
     class SemanticHighlighting < BaseRequest
       extend T::Sig
 
-      TOKEN_TYPES = T.let([
-        :variable,
-        :method,
-        :namespace,
-      ].freeze, T::Array[Symbol])
+      TOKEN_TYPES = T.let({
+        namespace: 0,
+        type: 1,
+        class: 2,
+        enum: 3,
+        interface: 4,
+        struct: 5,
+        typeParameter: 6,
+        parameter: 7,
+        variable: 8,
+        property: 9,
+        enumMember: 10,
+        event: 11,
+        function: 12,
+        method: 13,
+        macro: 14,
+        keyword: 15,
+        modifier: 16,
+        comment: 17,
+        string: 18,
+        number: 19,
+        regexp: 20,
+        operator: 21,
+        decorator: 22,
+      }.freeze, T::Hash[Symbol, Integer])
 
       TOKEN_MODIFIERS = T.let({
         declaration: 0,
@@ -195,7 +215,7 @@ module RubyLsp
           SemanticToken.new(
             location: location,
             length: length,
-            type: T.must(TOKEN_TYPES.index(type)),
+            type: T.must(TOKEN_TYPES[type]),
             modifier: modifiers_indices
           )
         )

--- a/test/expectations/semantic_highlighting/aref_field.exp
+++ b/test/expectations/semantic_highlighting/aref_field.exp
@@ -4,21 +4,21 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 9,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/aref_variable.exp
+++ b/test/expectations/semantic_highlighting/aref_variable.exp
@@ -4,21 +4,21 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 9,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/call_invocation.exp
+++ b/test/expectations/semantic_highlighting/call_invocation.exp
@@ -4,7 +4,7 @@
       "delta_line": 0,
       "delta_start_char": 8,
       "length": 6,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/call_invocation_with_variable_receiver.exp
+++ b/test/expectations/semantic_highlighting/call_invocation_with_variable_receiver.exp
@@ -4,28 +4,28 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 11,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 6,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/call_invocation_with_variable_receiver_and_arguments.exp
+++ b/test/expectations/semantic_highlighting/call_invocation_with_variable_receiver_and_arguments.exp
@@ -4,42 +4,42 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 11,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 5,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 6,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 7,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/command_call.exp
+++ b/test/expectations/semantic_highlighting/command_call.exp
@@ -4,28 +4,28 @@
       "delta_line": 0,
       "delta_start_char": 0,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 0,
       "length": 6,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 7,
       "length": 10,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 11,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/command_invocation.exp
+++ b/test/expectations/semantic_highlighting/command_invocation.exp
@@ -4,7 +4,7 @@
       "delta_line": 1,
       "delta_start_char": 0,
       "length": 3,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/command_invocation_variable.exp
+++ b/test/expectations/semantic_highlighting/command_invocation_variable.exp
@@ -4,14 +4,14 @@
       "delta_line": 0,
       "delta_start_char": 0,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 5,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/const.exp
+++ b/test/expectations/semantic_highlighting/const.exp
@@ -4,42 +4,42 @@
       "delta_line": 0,
       "delta_start_char": 0,
       "length": 2,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 2,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 0,
       "length": 3,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 5,
       "length": 2,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 3,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 5,
       "length": 2,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/def_endless.exp
+++ b/test/expectations/semantic_highlighting/def_endless.exp
@@ -4,7 +4,7 @@
       "delta_line": 2,
       "delta_start_char": 4,
       "length": 3,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     }
   ]

--- a/test/expectations/semantic_highlighting/defs.exp
+++ b/test/expectations/semantic_highlighting/defs.exp
@@ -4,21 +4,21 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 4,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 512
     },
     {
       "delta_line": 0,
       "delta_start_char": 5,
       "length": 3,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/fcall_invocation.exp
+++ b/test/expectations/semantic_highlighting/fcall_invocation.exp
@@ -4,14 +4,14 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 11,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 10,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/fcall_invocation_variable_arguments.exp
+++ b/test/expectations/semantic_highlighting/fcall_invocation_variable_arguments.exp
@@ -4,28 +4,28 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 11,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 10,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 11,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/local_variables.exp
+++ b/test/expectations/semantic_highlighting/local_variables.exp
@@ -4,21 +4,21 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 9,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/method_params.exp
+++ b/test/expectations/semantic_highlighting/method_params.exp
@@ -4,70 +4,70 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 3,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 0,
       "delta_start_char": 21,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 8,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 7,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 3,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 3,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 3,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 3,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 3,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 3,
       "length": 3,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/multi_assignment.exp
+++ b/test/expectations/semantic_highlighting/multi_assignment.exp
@@ -4,35 +4,35 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 9,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 3,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/sclass.exp
+++ b/test/expectations/semantic_highlighting/sclass.exp
@@ -4,14 +4,14 @@
       "delta_line": 0,
       "delta_start_char": 6,
       "length": 3,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 11,
       "length": 4,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 512
     }
   ]

--- a/test/expectations/semantic_highlighting/special_ruby_methods.exp
+++ b/test/expectations/semantic_highlighting/special_ruby_methods.exp
@@ -4,56 +4,56 @@
       "delta_line": 5,
       "delta_start_char": 6,
       "length": 3,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 10,
       "length": 3,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 4,
       "delta_start_char": 2,
       "length": 6,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 7,
       "length": 3,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 4,
       "delta_start_char": 6,
       "length": 3,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 4,
       "length": 3,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 3,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 4,
       "length": 11,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/var_aref_variable.exp
+++ b/test/expectations/semantic_highlighting/var_aref_variable.exp
@@ -4,21 +4,21 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 9,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 5,
       "delta_start_char": 0,
       "length": 3,
-      "token_type": 2,
+      "token_type": 0,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/var_field_variable.exp
+++ b/test/expectations/semantic_highlighting/var_field_variable.exp
@@ -4,27 +4,20 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 9,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 3,
-      "token_type": 2,
-      "token_modifiers": 0
-    },
-    {
-      "delta_line": 1,
-      "delta_start_char": 2,
-      "length": 1,
       "token_type": 0,
       "token_modifiers": 0
     },
@@ -32,35 +25,42 @@
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 1,
+      "delta_start_char": 2,
+      "length": 1,
+      "token_type": 8,
       "token_modifiers": 0
     },
     {
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 1,
-      "token_type": 0,
+      "token_type": 8,
       "token_modifiers": 0
     }
   ]

--- a/test/expectations/semantic_highlighting/vcall_invocation.exp
+++ b/test/expectations/semantic_highlighting/vcall_invocation.exp
@@ -4,14 +4,14 @@
       "delta_line": 0,
       "delta_start_char": 4,
       "length": 11,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 1
     },
     {
       "delta_line": 1,
       "delta_start_char": 2,
       "length": 10,
-      "token_type": 1,
+      "token_type": 13,
       "token_modifiers": 0
     }
   ]

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -78,7 +78,7 @@ class IntegrationTest < Minitest::Test
     assert_telemetry("textDocument/didOpen")
 
     response = make_request("textDocument/semanticTokens/full", { textDocument: { uri: "file://#{__FILE__}" } })
-    assert_equal([0, 6, 3, 2, 0], response[:result][:data])
+    assert_equal([0, 6, 3, 0, 0], response[:result][:data])
   end
 
   def test_formatting


### PR DESCRIPTION
### Motivation

Add all token types from the LSP specification in our legend, similar to what we're doing for modifiers and for symbol types in document symbol. This is mostly for consistency, but also so that we have the full list available when handling new tokens.

### Implementation

- Added the full list
- Changed the array to be a hash, so that we don't have to find items in an array for every token and can just access it
- Updated tests to reflect the change in token indices

### Automated Tests

Updated tests to reflect the change in token indices.

### Manual Tests

There shouldn't be any functional change.