### PR TITLE
Use Runner#run instead of Runner#process_file in RuboCop runners

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_diagnostics_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostics_runner.rb
@@ -32,6 +32,7 @@ module RubyLsp
 
         sig { params(uri: String, document: Document).returns(T::Array[Support::RuboCopDiagnostic]) }
         def run(uri, document)
+          @diagnostics.clear
           @uri = uri
 
           file = CGI.unescape(URI.parse(uri).path)
@@ -39,7 +40,7 @@ module RubyLsp
           @options[:stdin] = document.source
 
           # Invoke RuboCop with just this file in `paths`
-          process_file(file)
+          super([file])
           @diagnostics
         end
 

--- a/lib/ruby_lsp/requests/support/rubocop_formatting_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_formatting_runner.rb
@@ -36,7 +36,7 @@ module RubyLsp
           @options[:stdin] = document.source
 
           # Invoke RuboCop with just this file in `paths`
-          process_file(file)
+          super([file])
           @options[:stdin]
         end
       end

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -21,6 +21,14 @@ class DiagnosticsTest < Minitest::Test
     assert_equal(syntax_error_diagnostics([error_edit]).to_json, result.map(&:to_lsp_diagnostic).to_json)
   end
 
+  def test_empty_diagnostics_for_ignored_file
+    fixture_path = File.expand_path("../fixtures/def_multiline_params.rb", __dir__)
+    document = RubyLsp::Document.new(File.read(fixture_path))
+
+    result = RubyLsp::Requests::Diagnostics.new("file://#{fixture_path}", document).run
+    assert_empty(result)
+  end
+
   private
 
   def syntax_error_diagnostics(edits)


### PR DESCRIPTION
### Motivation

In #183, I was playing around with some other refactors and accidentally left a change for using `process_file` instead of invoking `run`. However, `process_file` ignores some of the options we pass, in particular the `--force-exclusion`, which prevents excluded files from being formatted or receiving diagnostics.

### Implementation

Just switched back to the correct implementation.

### Automated Tests

Added a test that runs diagnostics against an ignored fixture to prevent regression.