### PR TITLE
Extract document highlight target to allow more granular handling

### DIFF
--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -29,6 +29,7 @@ module RubyLsp
       autoload :SelectionRange, "ruby_lsp/requests/support/selection_range"
       autoload :SemanticTokenEncoder, "ruby_lsp/requests/support/semantic_token_encoder"
       autoload :SyntaxErrorDiagnostic, "ruby_lsp/requests/support/syntax_error_diagnostic"
+      autoload :HighlightTarget, "ruby_lsp/requests/support/highlight_target"
     end
   end
 end

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -29,7 +29,7 @@ module RubyLsp
       def initialize(document, position)
         @highlights = T.let([], T::Array[LanguageServer::Protocol::Interface::DocumentHighlight])
         position = Document::Scanner.new(document.source).find_position(position)
-        @target = T.let(find(T.must(document.tree), position), T.nilable(VarNodes))
+        @target = T.let(find(T.must(document.tree), position), T.nilable(Support::HighlightTarget))
 
         super(document)
       end

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -79,7 +79,8 @@ module RubyLsp
              SyntaxTree::VarField
           Support::HighlightTarget.new(matched)
         when SyntaxTree::Ident
-          Support::HighlightTarget.new(node)
+          relevant_node = node.is_a?(SyntaxTree::Params) ? matched : node
+          Support::HighlightTarget.new(relevant_node)
         when SyntaxTree::Node
           find(matched, position)
         end

--- a/lib/ruby_lsp/requests/support/highlight_target.rb
+++ b/lib/ruby_lsp/requests/support/highlight_target.rb
@@ -1,0 +1,69 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Requests
+    module Support
+      class HighlightTarget
+        extend T::Sig
+
+        READ = LanguageServer::Protocol::Constant::DocumentHighlightKind::READ
+        WRITE = LanguageServer::Protocol::Constant::DocumentHighlightKind::WRITE
+
+        sig { params(node: SyntaxTree::Node).void }
+        def initialize(node)
+          @node = node
+          @value = T.let(value(node), T.nilable(String))
+        end
+
+        sig { params(other: SyntaxTree::Node).returns(T.nilable(Integer)) }
+        def highlight_type(other)
+          matched_highlight(other) if @value == value(other)
+        end
+
+        private
+
+        sig { params(other: SyntaxTree::Node).returns(T.nilable(Integer)) }
+        def matched_highlight(other)
+          case @node
+          when SyntaxTree::VCall
+            if other.is_a?(SyntaxTree::VCall)
+              READ
+            elsif other.is_a?(SyntaxTree::Def)
+              WRITE
+            end
+          when SyntaxTree::GVar,
+               SyntaxTree::IVar,
+               SyntaxTree::Const,
+               SyntaxTree::CVar,
+               SyntaxTree::VarField,
+               SyntaxTree::VarRef
+            if other.is_a?(SyntaxTree::VarField)
+              WRITE
+            elsif other.is_a?(SyntaxTree::VarRef)
+              READ
+            end
+          end
+        end
+
+        sig { params(node: SyntaxTree::Node).returns(T.nilable(String)) }
+        def value(node)
+          case node
+          when SyntaxTree::GVar, SyntaxTree::IVar, SyntaxTree::Const, SyntaxTree::CVar
+            node.value
+          when SyntaxTree::Assign
+            value(node.target)
+          when SyntaxTree::ConstPathField, SyntaxTree::TopConstField
+            node.constant.value
+          when SyntaxTree::Field
+            node.name.value
+          when SyntaxTree::VarField, SyntaxTree::VarRef
+            node.value&.value
+          when SyntaxTree::Ident
+            node.value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/requests/support/highlight_target.rb
+++ b/lib/ruby_lsp/requests/support/highlight_target.rb
@@ -33,6 +33,7 @@ module RubyLsp
         sig { params(other: SyntaxTree::Node).returns(T.nilable(HighlightMatch)) }
         def matched_highlight(other)
           case @node
+          # Method definitions and invocations
           when SyntaxTree::VCall, SyntaxTree::FCall, SyntaxTree::Call, SyntaxTree::Command,
                SyntaxTree::CommandCall, SyntaxTree::Def, SyntaxTree::Defs, SyntaxTree::DefEndless
             case other
@@ -41,6 +42,7 @@ module RubyLsp
             when SyntaxTree::Def, SyntaxTree::Defs, SyntaxTree::Defs
               HighlightMatch.new(type: WRITE, node: other.name)
             end
+          # Variables, parameters and constants
           when SyntaxTree::GVar, SyntaxTree::IVar, SyntaxTree::Const, SyntaxTree::CVar, SyntaxTree::VarField,
                SyntaxTree::VarRef, SyntaxTree::Ident
             case other

--- a/lib/ruby_lsp/requests/support/highlight_target.rb
+++ b/lib/ruby_lsp/requests/support/highlight_target.rb
@@ -10,38 +10,48 @@ module RubyLsp
         READ = LanguageServer::Protocol::Constant::DocumentHighlightKind::READ
         WRITE = LanguageServer::Protocol::Constant::DocumentHighlightKind::WRITE
 
+        class HighlightMatch < T::Struct
+          const :type, Integer
+          const :node, SyntaxTree::Node
+        end
+
         sig { params(node: SyntaxTree::Node).void }
         def initialize(node)
           @node = node
           @value = T.let(value(node), T.nilable(String))
         end
 
-        sig { params(other: SyntaxTree::Node).returns(T.nilable(Integer)) }
+        sig { params(other: SyntaxTree::Node).returns(T.nilable(HighlightMatch)) }
         def highlight_type(other)
           matched_highlight(other) if @value == value(other)
         end
 
         private
 
-        sig { params(other: SyntaxTree::Node).returns(T.nilable(Integer)) }
+        # Match the target type (where the cursor is positioned) with the `other` type (the node we're currently
+        # visiting)
+        sig { params(other: SyntaxTree::Node).returns(T.nilable(HighlightMatch)) }
         def matched_highlight(other)
           case @node
-          when SyntaxTree::VCall
-            if other.is_a?(SyntaxTree::VCall)
-              READ
-            elsif other.is_a?(SyntaxTree::Def)
-              WRITE
+          when SyntaxTree::VCall, SyntaxTree::FCall, SyntaxTree::Call, SyntaxTree::Command,
+               SyntaxTree::CommandCall, SyntaxTree::Def, SyntaxTree::Defs, SyntaxTree::DefEndless
+            case other
+            when SyntaxTree::VCall, SyntaxTree::FCall, SyntaxTree::Call, SyntaxTree::Command, SyntaxTree::CommandCall
+              HighlightMatch.new(type: READ, node: other)
+            when SyntaxTree::Def, SyntaxTree::Defs, SyntaxTree::Defs
+              HighlightMatch.new(type: WRITE, node: other.name)
             end
-          when SyntaxTree::GVar,
-               SyntaxTree::IVar,
-               SyntaxTree::Const,
-               SyntaxTree::CVar,
-               SyntaxTree::VarField,
+          when SyntaxTree::GVar, SyntaxTree::IVar, SyntaxTree::Const, SyntaxTree::CVar, SyntaxTree::VarField,
                SyntaxTree::VarRef
-            if other.is_a?(SyntaxTree::VarField)
-              WRITE
-            elsif other.is_a?(SyntaxTree::VarRef)
-              READ
+            case other
+            when SyntaxTree::VarField
+              HighlightMatch.new(type: WRITE, node: other)
+            when SyntaxTree::VarRef
+              HighlightMatch.new(type: READ, node: other)
+            when SyntaxTree::ClassDeclaration, SyntaxTree::ModuleDeclaration
+              HighlightMatch.new(type: WRITE, node: other.constant)
+            when SyntaxTree::ConstPathRef
+              HighlightMatch.new(type: READ, node: other.constant)
             end
           end
         end
@@ -49,18 +59,18 @@ module RubyLsp
         sig { params(node: SyntaxTree::Node).returns(T.nilable(String)) }
         def value(node)
           case node
-          when SyntaxTree::GVar, SyntaxTree::IVar, SyntaxTree::Const, SyntaxTree::CVar
-            node.value
-          when SyntaxTree::Assign
-            value(node.target)
-          when SyntaxTree::ConstPathField, SyntaxTree::TopConstField
+          when SyntaxTree::ConstPathRef, SyntaxTree::ConstPathField, SyntaxTree::TopConstField
             node.constant.value
-          when SyntaxTree::Field
-            node.name.value
-          when SyntaxTree::VarField, SyntaxTree::VarRef
-            node.value&.value
-          when SyntaxTree::Ident
+          when SyntaxTree::GVar, SyntaxTree::IVar, SyntaxTree::Const, SyntaxTree::CVar, SyntaxTree::Ident
             node.value
+          when SyntaxTree::Field, SyntaxTree::Def, SyntaxTree::Defs, SyntaxTree::DefEndless
+            node.name.value
+          when SyntaxTree::VarField, SyntaxTree::VarRef, SyntaxTree::VCall, SyntaxTree::FCall
+            node.value&.value
+          when SyntaxTree::Call, SyntaxTree::Command, SyntaxTree::CommandCall
+            node.message.value
+          when SyntaxTree::ClassDeclaration, SyntaxTree::ModuleDeclaration
+            node.constant.constant.value
           end
         end
       end

--- a/lib/ruby_lsp/requests/support/highlight_target.rb
+++ b/lib/ruby_lsp/requests/support/highlight_target.rb
@@ -23,7 +23,7 @@ module RubyLsp
 
         sig { params(other: SyntaxTree::Node).returns(T.nilable(HighlightMatch)) }
         def highlight_type(other)
-          matched_highlight(other) if other.is_a?(SyntaxTree::Params) || @value == value(other)
+          matched_highlight(other) if other.is_a?(SyntaxTree::Params) || (@value && @value == value(other))
         end
 
         private

--- a/test/expectations/document_highlight/class_and_reference.exp
+++ b/test/expectations/document_highlight/class_and_reference.exp
@@ -1,0 +1,36 @@
+{
+    "params": [
+        {
+            "line": 3,
+            "character": 0
+        }
+    ],
+    "result": [
+        {
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 6
+                },
+                "end": {
+                    "line": 0,
+                    "character": 9
+                }
+            },
+            "kind": 3
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 0
+                },
+                "end": {
+                    "line": 3,
+                    "character": 3
+                }
+            },
+            "kind": 2
+        }
+    ]
+}

--- a/test/expectations/document_highlight/def_and_reference.exp
+++ b/test/expectations/document_highlight/def_and_reference.exp
@@ -1,0 +1,36 @@
+{
+    "params": [
+        {
+            "line": 3,
+            "character": 0
+        }
+    ],
+    "result": [
+        {
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 4
+                },
+                "end": {
+                    "line": 0,
+                    "character": 7
+                }
+            },
+            "kind": 3
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 0
+                },
+                "end": {
+                    "line": 3,
+                    "character": 3
+                }
+            },
+            "kind": 2
+        }
+    ]
+}

--- a/test/expectations/document_highlight/def_multiline_params.exp
+++ b/test/expectations/document_highlight/def_multiline_params.exp
@@ -1,0 +1,36 @@
+{
+    "params": [
+        {
+            "line": 4,
+            "character": 2
+        }
+    ],
+    "result": [
+        {
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 2
+                },
+                "end": {
+                    "line": 1,
+                    "character": 3
+                }
+            },
+            "kind": 3
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 4,
+                    "character": 2
+                },
+                "end": {
+                    "line": 4,
+                    "character": 3
+                }
+            },
+            "kind": 3
+        }
+    ]
+}

--- a/test/expectations/document_highlight/defs_multiline_params.exp
+++ b/test/expectations/document_highlight/defs_multiline_params.exp
@@ -1,0 +1,36 @@
+{
+    "params": [
+        {
+            "line": 1,
+            "character": 2
+        }
+    ],
+    "result": [
+        {
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 2
+                },
+                "end": {
+                    "line": 1,
+                    "character": 3
+                }
+            },
+            "kind": 3
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 4,
+                    "character": 2
+                },
+                "end": {
+                    "line": 4,
+                    "character": 3
+                }
+            },
+            "kind": 3
+        }
+    ]
+}

--- a/test/expectations/document_highlight/full_name_highlight.exp
+++ b/test/expectations/document_highlight/full_name_highlight.exp
@@ -1,0 +1,49 @@
+{
+    "params": [
+        {
+            "line": 3,
+            "character": 5
+        }
+    ],
+    "result": [
+        {
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 6
+                },
+                "end": {
+                    "line": 0,
+                    "character": 14
+                }
+            },
+            "kind": 3
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 11
+                },
+                "end": {
+                    "line": 0,
+                    "character": 14
+                }
+            },
+            "kind": 2
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 5
+                },
+                "end": {
+                    "line": 3,
+                    "character": 8
+                }
+            },
+            "kind": 2
+        }
+    ]
+}

--- a/test/expectations/document_highlight/module_and_reference.exp
+++ b/test/expectations/document_highlight/module_and_reference.exp
@@ -1,0 +1,36 @@
+{
+    "params": [
+        {
+            "line": 3,
+            "character": 0
+        }
+    ],
+    "result": [
+        {
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 7
+                },
+                "end": {
+                    "line": 0,
+                    "character": 10
+                }
+            },
+            "kind": 3
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 0
+                },
+                "end": {
+                    "line": 3,
+                    "character": 3
+                }
+            },
+            "kind": 2
+        }
+    ]
+}

--- a/test/fixtures/class_and_reference.rb
+++ b/test/fixtures/class_and_reference.rb
@@ -1,0 +1,4 @@
+class Foo
+end
+
+Foo

--- a/test/fixtures/def_and_reference.rb
+++ b/test/fixtures/def_and_reference.rb
@@ -1,0 +1,4 @@
+def foo
+end
+
+foo

--- a/test/fixtures/full_name_highlight.rb
+++ b/test/fixtures/full_name_highlight.rb
@@ -1,0 +1,4 @@
+class Foo::Bar
+end
+
+Foo::Bar

--- a/test/fixtures/module_and_reference.rb
+++ b/test/fixtures/module_and_reference.rb
@@ -1,0 +1,4 @@
+module Foo
+end
+
+Foo


### PR DESCRIPTION
### Motivation

Closes #165

In the previous structure, it was difficult to account for highlights that needed to happen between different nodes (e.g.: a method invocation and definition). This refactor aims at making it more flexible.

### Implementation

This refactor extracts a supporting class `HighlightTarget`, which knows how to extract the string value of each node of interest as well as matching the target with nodes that should be highlighted.

For example, if the target is a method invocation, then we want to highlight other invocations of the same method plus the definition.

After that extraction, the request class now only overrides the `visit` method and delegates to `HighlightTarget` to determine whether to highlight a piece of syntax depending on the target type.

### Automated Tests

Added a few tests that were missing.

### Manual Tests

Use the added fixture files to test.

1. Start the LSP on this branch
2. Put the cursor on a method invocation
3. Verify that the invocation and definition are highlighted
4. Put the cursor on a class
5. Verify that the reference and definition are highlighted