### PR TITLE
Add a convenience bin/console file

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# typed: strict
+# frozen_string_literal: true
+
+require "bundler/setup"
+require_relative "../lib/ruby_lsp/internal"
+require "irb"
+
+extend T::Sig
+
+sig { params(source: String).returns(RubyLsp::Document) }
+def new_doc(source)
+  RubyLsp::Document.new(source)
+end
+
+@source = T.let(File.read(File.expand_path("../lib/ruby_lsp/handler.rb", __dir__)), String)
+@document = T.let(new_doc(@source), RubyLsp::Document)
+
+IRB.start(__FILE__)


### PR DESCRIPTION
### Motivation

When testing things, I often find myself in an IRB session parsing sources and testing things out. This PR just adds a `bin/console` file that requires the basics for us, provides a `@document` variable that can be used out of the box and a convenience `new_doc` method to easily parse new sources.