### PR TITLE
Change dependabot reviewer to ruby-dev-exp

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     reviewers:
-      - "Shopify/sorbet"
+      - "Shopify/ruby-dev-exp"
     labels:
       - "dependencies"
       - "ruby"


### PR DESCRIPTION
### Motivation

We were still using the Sorbet team for dependabot reviews, but `ruby-dev-exp` is more appropriate.