### PR TITLE
Implement the exit life cycle request

### DIFF
--- a/lib/ruby_lsp/cli.rb
+++ b/lib/ruby_lsp/cli.rb
@@ -81,6 +81,11 @@ module RubyLsp
         end
 
         on("shutdown") { shutdown }
+
+        on("exit") do
+          status = store.empty? ? 0 : 1
+          exit(status)
+        end
       end
 
       handler.start

--- a/lib/ruby_lsp/cli.rb
+++ b/lib/ruby_lsp/cli.rb
@@ -83,6 +83,8 @@ module RubyLsp
         on("shutdown") { shutdown }
 
         on("exit") do
+          # We return zero if shutdown has already been received or one otherwise as per the recommendation in the spec
+          # https://microsoft.github.io/language-server-protocol/specification/#exit
           status = store.empty? ? 0 : 1
           exit(status)
         end

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -40,6 +40,11 @@ module RubyLsp
       @state.clear
     end
 
+    sig { returns(T::Boolean) }
+    def empty?
+      @state.empty?
+    end
+
     sig { params(uri: String).void }
     def delete(uri)
       @state.delete(uri)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -31,6 +31,7 @@ class IntegrationTest < Minitest::Test
   def teardown
     # Tell the LSP to shutdown
     make_request("shutdown")
+    make_request("exit")
 
     # Make sure IOs are closed
     @stdin.close
@@ -39,6 +40,7 @@ class IntegrationTest < Minitest::Test
 
     # Make sure the exit status is zero
     assert_equal(0, @wait_thr.value)
+    refute_predicate(@wait_thr, :alive?)
   end
 
   def test_document_symbol

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -36,6 +36,13 @@ class StoreTest < Minitest::Test
     assert_empty(@store.instance_variable_get(:@state))
   end
 
+  def test_empty?
+    refute_empty(@store)
+
+    @store.clear
+    assert_empty(@store)
+  end
+
   def test_delete
     @store.delete("/foo/bar.rb")
 


### PR DESCRIPTION
### Motivation

Closes #196

We forgot to handle the `exit` lifecycle request, which is different than `shutdown`. According to the [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown), shutdown is used to "turn off the server without exiting the process".

Exit on the [other hand](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#exit), should exit the process using status code 0 if the server was shutdown previously or 1 otherwise.

I'm not 100% sure why this wasn't a problem for VS Code, but I assume it probably just force kills the server if the `exit` request doesn't respond.

### Implementation

1. Add an `empty?` method to `Store` to use it as an indicator that we already shutdown the server
2. Implement the `exit` request

### Automated Tests

Added a test for `empty?` and improved the integration test to make sure that the process has been terminated.