### PR TITLE
Do not use the Sorbet runtime in the default load path

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,4 @@ Sorbet/StrictSigil:
   Exclude:
     - "**/*.rake"
     - "test/**/*.rb"
+    - "lib/ruby-lsp.rb"

--- a/lib/ruby-lsp.rb
+++ b/lib/ruby-lsp.rb
@@ -1,6 +1,6 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 module RubyLsp
-  VERSION = T.let(File.read(File.expand_path("../VERSION", __dir__)).strip, String)
+  VERSION = File.read(File.expand_path("../VERSION", __dir__)).strip
 end


### PR DESCRIPTION
### Motivation

If people forget to use `require: false` when adding the `ruby-lsp` to their `Gemfile`, then `lib/ruby-lsp.rb` will be required by Bundler.

We shouldn't use anything related to the Sorbet runtime in this file, because that would mean we have to require `sorbet-runtime` and possibly pollute the application in development mode.

This is currently breaking in apps that do not use `sorbet-runtime`, because `T.let` is not defined.

### Implementation

Ignored this file for the strict sigil cop and remove the `T.let`.