### PR TITLE
Return nil if document is already formatted

### DIFF
--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -33,7 +33,7 @@ module RubyLsp
         formatted_text = formatted_file
         return unless formatted_text
 
-        return if formatted_text == @document.source
+        return if formatted_text.size == @document.source.size && formatted_text == @document.source
 
         size = @document.source.size
 

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -33,9 +33,8 @@ module RubyLsp
         formatted_text = formatted_file
         return unless formatted_text
 
-        return if formatted_text.size == @document.source.size && formatted_text == @document.source
-
         size = @document.source.size
+        return if formatted_text.size == size && formatted_text == @document.source
 
         [
           LanguageServer::Protocol::Interface::TextEdit.new(

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -33,6 +33,8 @@ module RubyLsp
         formatted_text = formatted_file
         return unless formatted_text
 
+        return if formatted_text == @document.source
+
         size = @document.source.size
 
         [

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -36,6 +36,19 @@ class FormattingTest < Minitest::Test
     end
   end
 
+  def test_returns_nil_if_document_is_already_formatted
+    document = RubyLsp::Document.new(+<<~RUBY)
+      # typed: strict
+      # frozen_string_literal: true
+
+      class Foo
+        def foo
+        end
+      end
+    RUBY
+    assert_nil(RubyLsp::Requests::Formatting.new("file://#{__FILE__}", document).run)
+  end
+
   private
 
   def with_uninstalled_rubocop(&block)


### PR DESCRIPTION
### Motivation

If the documented is already formatted, we should not return text edits to VS Code as it may delay saving the file.

### Implementation

If the formatted text matches the source, then return early.

### Automated Tests

Added an example.