### PR TITLE
Prevent breaking on nameless keyword rest parameters

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -179,7 +179,8 @@ module RubyLsp
           add_token(location_without_colon(location), :variable)
         end
 
-        add_token(node.keyword_rest.name.location, :variable) if node.keyword_rest
+        name = node.keyword_rest&.name
+        add_token(node.keyword_rest.name.location, :variable) if name
       end
 
       sig { params(node: SyntaxTree::VarField).void }

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -180,7 +180,7 @@ module RubyLsp
         end
 
         name = node.keyword_rest&.name
-        add_token(node.keyword_rest.name.location, :variable) if name
+        add_token(name.location, :variable) if name
       end
 
       sig { params(node: SyntaxTree::VarField).void }

--- a/test/fixtures/nameless_keyword_rest.rb
+++ b/test/fixtures/nameless_keyword_rest.rb
@@ -1,0 +1,2 @@
+def foo(**)
+end


### PR DESCRIPTION
### Motivation

Keyword rest parameters can be nameless, which means trying to access `keyword_rest.name.location` may try to invoke a method on `nil` and break.

### Implementation

Improve the guard clause and added a new test fixture to make sure it does not break requests.