### PR TITLE
Display an error message if the RuboCop config is invalid

### DIFF
--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -195,7 +195,7 @@ module RubyLsp
         )
       )
     rescue RuboCop::ValidationError => e
-      show_message(Constant::MessageType::ERROR, "RuboCop configuration error: #{e.message}")
+      show_message(Constant::MessageType::ERROR, "Error in RuboCop configuration file: #{e.message}")
     end
 
     sig { params(uri: String).void }

--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -194,6 +194,8 @@ module RubyLsp
           diagnostics: response.map(&:to_lsp_diagnostic)
         )
       )
+    rescue RuboCop::ValidationError => e
+      show_message(Constant::MessageType::ERROR, "RuboCop configuration error: #{e.message}")
     end
 
     sig { params(uri: String).void }
@@ -201,6 +203,14 @@ module RubyLsp
       @writer.write(
         method: "textDocument/publishDiagnostics",
         params: Interface::PublishDiagnosticsParams.new(uri: uri, diagnostics: [])
+      )
+    end
+
+    sig { params(type: Integer, message: String).void }
+    def show_message(type, message)
+      @writer.write(
+        method: "window/showMessage",
+        params: Interface::ShowMessageParams.new(type: type, message: message)
       )
     end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -226,7 +226,7 @@ class IntegrationTest < Minitest::Test
     assert_equal("window/showMessage", response.dig(:method))
     assert_equal(LanguageServer::Protocol::Constant::MessageType::ERROR, response.dig(:params, :type))
     assert_equal(
-      "RuboCop configuration error: unrecognized cop or department InvalidCop found in .rubocop.yml",
+      "Error in RuboCop configuration file: unrecognized cop or department InvalidCop found in .rubocop.yml",
       response.dig(:params, :message)
     )
   ensure

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -212,6 +212,29 @@ class IntegrationTest < Minitest::Test
     )
   end
 
+  def test_incorrect_rubocop_configuration
+    initialize_lsp([])
+    open_file_with("class Foo\nend")
+
+    # Add an invalid cop to the configuration, but save a backup since we're modifying the real file
+    FileUtils.cp(".rubocop.yml", ".rubocop.yml.bak")
+    File.write(".rubocop.yml", "\nInvalidCop:\n  Enabled: true", mode: "a")
+
+    response = read_response("textDocument/publishDiagnostics")
+    assert_telemetry("textDocument/didOpen")
+
+    assert_equal("window/showMessage", response.dig(:method))
+    assert_equal(LanguageServer::Protocol::Constant::MessageType::ERROR, response.dig(:params, :type))
+    assert_equal(
+      "RuboCop configuration error: unrecognized cop or department InvalidCop found in .rubocop.yml",
+      response.dig(:params, :message)
+    )
+  ensure
+    # Restore the original configuration file
+    FileUtils.rm(".rubocop.yml")
+    FileUtils.mv(".rubocop.yml.bak", ".rubocop.yml")
+  end
+
   private
 
   def assert_telemetry(request)


### PR DESCRIPTION
### Motivation

Closes #225

If a project using the LSP has invalid RuboCop configuration, like using a cop that no longer exists, diagnostics and formatting break. While this is not an error of the LSP itself, it would be nice to alert users and prompt them to fix their configuration.

### Implementation

Rescue RuboCop's validation error when trying to run diagnostics and send a show message notification. This makes VS Code display an error notification if the configuration is invalid.

### Automated Tests

Added a new integration example.

### Manual Tests

1. Start the LSP on this branch
2. Change `.rubocop.yml` to make it invalid. For example, add
```yml
InvalidCop:
  Enabled: true
```
3. Verify you get a notification about the invalid configuration