### PR TITLE
Avoid trying to access name if the rest parameter is an ArgsForward

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -179,7 +179,10 @@ module RubyLsp
           add_token(location_without_colon(location), :variable)
         end
 
-        name = node.keyword_rest&.name
+        rest = node.keyword_rest
+        return if rest.nil? || rest.is_a?(SyntaxTree::ArgsForward)
+
+        name = rest.name
         add_token(name.location, :variable) if name
       end
 

--- a/test/fixtures/argument_forwarding.rb
+++ b/test/fixtures/argument_forwarding.rb
@@ -1,0 +1,5 @@
+def foo(...)
+end
+
+def bar(a, ...)
+end


### PR DESCRIPTION
### Motivation

The `keyword_rest` method can return `ArgsForward` as well, which does not have a `name` method and causes the semantic highlighting request to break.

### Implementation

Return early if the rest parameter doesn't exist (is `nil`) or if it's an `ArgsForward` (since no special highlighting is necessary for the three dots).

### Automated Tests

Added the fixtures that trigger the exception.