### PR TITLE
Alert users about non auto-correctable diagnostics

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -61,11 +61,18 @@ module RubyLsp
 
         sig { returns(LanguageServer::Protocol::Interface::Diagnostic) }
         def to_lsp_diagnostic
+          if @offense.correctable?
+            severity = RUBOCOP_TO_LSP_SEVERITY[@offense.severity.name]
+            message = @offense.message
+          else
+            severity = LanguageServer::Protocol::Constant::DiagnosticSeverity::WARNING
+            message = "#{@offense.message}\n\nThis offense is not auto-correctable.\n"
+          end
           LanguageServer::Protocol::Interface::Diagnostic.new(
-            message: @offense.message,
+            message: message,
             source: "RuboCop",
             code: @offense.cop_name,
-            severity: RUBOCOP_TO_LSP_SEVERITY[@offense.severity.name],
+            severity: severity,
             range: LanguageServer::Protocol::Interface::Range.new(
               start: LanguageServer::Protocol::Interface::Position.new(
                 line: @offense.line - 1,

--- a/test/expectations/diagnostics/if_inside_else.exp
+++ b/test/expectations/diagnostics/if_inside_else.exp
@@ -11,10 +11,10 @@
           "character": 14
         }
       },
-      "severity": 3,
+      "severity": 2,
       "code": "Sorbet/TrueSigil",
       "source": "RuboCop",
-      "message": "Sorbet/TrueSigil: Sorbet sigil should be at least `true` got `false`."
+      "message": "Sorbet/TrueSigil: Sorbet sigil should be at least `true` got `false`.\n\nThis offense is not auto-correctable.\n"
     },
     {
       "range": {


### PR DESCRIPTION
### Motivation

Closes #215 

### Implementation
 
If the offense is not correctable, 
- changes severity so that the squiggle underneath is red and 
- includes `"This offense is not auto-correctable."` at the top of the offense message.

### Automated Tests

Updated existing unit tests. All tests passing.

### Manual Tests

1. Open the Ruby LSP repo on this branch
2. Create a new file in `lib/ruby_lsp`
3. Create a non auto-correctable issue (e.g., `RubyLsp.constants`)
4. Check that the offense appears red and the error message includes `"This offense is not auto-correctable."`
