### PR TITLE
Include Kernel.methods as part of special Ruby methods

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -60,10 +60,13 @@ module RubyLsp
         default_library: 9,
       }.freeze, T::Hash[Symbol, Integer])
 
-      SPECIAL_RUBY_METHODS = T.let((Module.instance_methods(false) +
-        Kernel.methods(false) + Bundler::Dsl.instance_methods(false) +
-        Module.private_instance_methods(false))
-        .map(&:to_s), T::Array[String])
+      SPECIAL_RUBY_METHODS = T.let((
+        Module.instance_methods(false) +
+        Kernel.instance_methods(false) +
+        Kernel.methods(false) +
+        Bundler::Dsl.instance_methods(false) +
+        Module.private_instance_methods(false)
+      ).map(&:to_s), T::Array[String])
 
       class SemanticToken < T::Struct
         const :location, SyntaxTree::Location

--- a/test/expectations/semantic_highlighting/special_ruby_methods.exp
+++ b/test/expectations/semantic_highlighting/special_ruby_methods.exp
@@ -16,14 +16,7 @@
     },
     {
       "delta_line": 4,
-      "delta_start_char": 2,
-      "length": 6,
-      "token_type": 13,
-      "token_modifiers": 0
-    },
-    {
-      "delta_line": 0,
-      "delta_start_char": 7,
+      "delta_start_char": 9,
       "length": 3,
       "token_type": 0,
       "token_modifiers": 0


### PR DESCRIPTION
### Motivation

The method `extend` and others are actually present in `Kernel.methods` instead of `Kernel.instance_methods`. This means that we were accidentally pushing semantic tokens for `extend` when we didn't mean to.

Our test expectation was actually asserting the wrong behaviour and that's why the test passed.

### Implementation

Just added `Kernel.methods(false)` to the list and split it into multiple lines.

### Automated Tests

Fixed the expectation for special Ruby methods.