### PR TITLE
Avoid returning from on request blocks

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -110,15 +110,16 @@ module RubyLsp
         Requests::SelectionRanges.new(document).run
       end
 
-      return if ranges.nil?
-
       # Per the selection range request spec (https://microsoft.github.io/language-server-protocol/specification#textDocument_selectionRange),
       # every position in the positions array should have an element at the same index in the response
       # array. For positions without a valid selection range, the corresponding element in the response
       # array will be nil.
-      positions.map do |position|
-        ranges.find do |range|
-          range.cover?(position)
+
+      unless ranges.nil?
+        positions.map do |position|
+          ranges.find do |range|
+            range.cover?(position)
+          end
         end
       end
     end
@@ -143,9 +144,10 @@ module RubyLsp
 
     on("textDocument/documentHighlight") do |request|
       document = store.get(request.dig(:params, :textDocument, :uri))
-      return unless document.parsed?
 
-      Requests::DocumentHighlight.new(document, request.dig(:params, :position)).run
+      if document.parsed?
+        Requests::DocumentHighlight.new(document, request.dig(:params, :position)).run
+      end
     end
 
     on("textDocument/codeAction") do |request|

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -73,6 +73,21 @@ class IntegrationTest < Minitest::Test
     assert_equal(LanguageServer::Protocol::Constant::DocumentHighlightKind::WRITE, range[:kind])
   end
 
+  def test_document_highlight_with_syntax_error
+    initialize_lsp(["documentHighlights"])
+    open_file_with("class Foo")
+
+    read_response("textDocument/publishDiagnostics")
+
+    response = make_request(
+      "textDocument/documentHighlight",
+      { textDocument: { uri: "file://#{__FILE__}" }, position: { line: 0, character: 1 } }
+    )
+
+    assert_nil(response[:result])
+    assert_nil(response[:error])
+  end
+
   def test_semantic_highlighting
     initialize_lsp(["semanticHighlighting"])
     open_file_with("class Foo\nend")
@@ -226,6 +241,24 @@ class IntegrationTest < Minitest::Test
       { range: { start: { line: 0, character: 0 }, end: { line: 1, character: 3 } } },
       response[:result].first,
     )
+  end
+
+  def test_selection_ranges_with_syntax_error
+    initialize_lsp(["selectionRanges"])
+    open_file_with("class Foo")
+
+    read_response("textDocument/publishDiagnostics")
+
+    response = make_request(
+      "textDocument/selectionRange",
+      {
+        textDocument: { uri: "file://#{__FILE__}" },
+        positions: [{ line: 0, character: 0 }],
+      }
+    )
+
+    assert_nil(response[:result])
+    assert_nil(response[:error])
   end
 
   def test_incorrect_rubocop_configuration


### PR DESCRIPTION
### Motivation

Returning from the `on` blocks on the server configuration actually returns in a `LocalJumpError`. We need the block to return the value `nil`, but not explicitly `return` from it.

### Implementation

Just switched for a conditional.

### Automated Tests

Added two test examples that reproduce the `LocalJumpError` without the fix.