### PR TITLE
Let clients pull diagnostics instead of pushing on edits

### DIFF
--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -87,25 +87,6 @@ module RubyLsp
     end
 
     sig { params(uri: String).void }
-    def send_diagnostics(uri)
-      response = store.cache_fetch(uri, :diagnostics) do |document|
-        Requests::Diagnostics.new(uri, document).run
-      end
-
-      return if response.nil?
-
-      @writer.write(
-        method: "textDocument/publishDiagnostics",
-        params: Interface::PublishDiagnosticsParams.new(
-          uri: uri,
-          diagnostics: response.map(&:to_lsp_diagnostic)
-        )
-      )
-    rescue RuboCop::ValidationError => e
-      show_message(Constant::MessageType::ERROR, "Error in RuboCop configuration file: #{e.message}")
-    end
-
-    sig { params(uri: String).void }
     def clear_diagnostics(uri)
       @writer.write(
         method: "textDocument/publishDiagnostics",


### PR DESCRIPTION
### Motivation

While working on #238 to improve performance, I noticed one expensive operation is computing diagnostics on every file change and bumped on this new feature exposed in the 3.17 of the specification.

Computing RuboCop diagnostics on a file can be pretty expensive - especially if the file is too large. In the latest version of the [specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics), support for pulling diagnostics from the client has been added.

This means that, besides from the server being able to push diagnostics, we can also broadcast that the server can handle `textDocument/diagnostic` to compute diagnostics for a file.

I believe switching to pulling diagnostics will reduce some pressure on the server for large files, since we can decouple `textDocument/didChange` from computing diagnostics and just let VS Code figure out the best time to request them. 

This also opens up the possibility of using a middleware in the extension to add debounce and avoid computing diagnostics while the developer is still typing.

### Implementation

- Stop sending diagnostics through the `textDocument/publishDiagnostics` notification
- Start handling the `textDocument/diagnostic` request (which does exactly the same thing as the notification)

Note: the languageserver gem is not updated for the 3.17 version of the specification yet, so it doesn't include this new request in its objects. I changed our capabilities response to use a hash, so that we can use the new specs immediately, but added todos to fix them once the gem supports the latest spec.

### Automated Tests

Updated existing integration tests (which no longer publish diagnostics every time) and added one specific to diagnostics.

### Manual Tests

1. Start the LSP on this branch
2. Make some violations on a file, like incorrect indentation
3. Verify that diagnostics show up in the file (squiggly yellow/blue lines)