### PR TITLE
Show error message when there's a InfiniteCorrectionLoop exception

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -148,6 +148,9 @@ module RubyLsp
       uri = request.dig(:params, :textDocument, :uri)
 
       Requests::Formatting.new(uri, store.get(uri)).run
+    rescue RuboCop::Runner::InfiniteCorrectionLoop => e
+      show_message(Constant::MessageType::ERROR, "Error from RuboCop: #{e.message}")
+      nil
     end
 
     on("textDocument/documentHighlight") do |request|


### PR DESCRIPTION
### Motivation

Resolves: https://github.com/Shopify/ruby-lsp/issues/249

When RuboCop raises this error, any formatting runners just halt without any errors. If the users aren't looking at the output, they won't notice it - making the entire experience confusing.  

This change makes it obvious to the user that there's an infinite loop error from RuboCop through a windowed error so they can investigate. 

### Implementation

This rescue must be in two requests, `/formatting` and `/diagnostic`. Both these requests use a support runner that inherit from RuboCop::Runner module (i.e. the [format runner](https://github.com/Shopify/ruby-lsp/blob/a404a0809d9a175c21d7adffe1223c5a3d16e844/lib/ruby_lsp/requests/support/rubocop_formatting_runner.rb#L17) and [diagnostics runner](https://github.com/Shopify/ruby-lsp/blob/a404a0809d9a175c21d7adffe1223c5a3d16e844/lib/ruby_lsp/requests/support/rubocop_diagnostics_runner.rb#L17)). 

The [RuboCop::Runner::InfiniteCorrectionLoop exception](https://github.com/rubocop/rubocop/blob/89b5599d5d9d1527613cc79596ebded65404e0d4/lib/rubocop/runner.rb#L11
) may be raised in any of those runs.

### Automated Tests

Unfortunately it isn't easy to reproduce this error. I've looked into how we test another instance of a rescued exception in Server where the Rubocop config file isn't valid - that exception is simple to replicate. Would be open to ideas on how we can test this. 

### Manual Tests

Same 