### PR TITLE
Upgrade syntax_tree requirement to >= 3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ruby-lsp (0.2.0)
       language_server-protocol
       sorbet-runtime
-      syntax_tree (>= 2.4)
+      syntax_tree (>= 3.4)
 
 GEM
   remote: https://rubygems.org/
@@ -81,7 +81,7 @@ GEM
       sorbet (>= 0.5.9204)
       sorbet-runtime (>= 0.5.9204)
       thor (>= 0.19.2)
-    syntax_tree (3.3.0)
+    syntax_tree (3.4.0)
       prettier_print
     tapioca (0.9.2)
       bundler (>= 1.17.3)

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("language_server-protocol")
   s.add_dependency("sorbet-runtime")
-  s.add_dependency("syntax_tree", ">= 2.4")
+  s.add_dependency("syntax_tree", ">= 3.4")
 
   s.required_ruby_version = ">= 2.7.3"
 end


### PR DESCRIPTION
### Motivation

Upgrade our syntax_tree requirement to higher than 3.4 since it includes some important bug fixes.