### PR TITLE
Handle class/module declarations as a `class` token with `declaration` modifier

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -217,6 +217,19 @@ module RubyLsp
         add_token(node.value.location, :method) unless special_method?(node.value.value)
       end
 
+      sig { params(node: SyntaxTree::ClassDeclaration).void }
+      def visit_class(node)
+        add_token(node.constant.location, :class, [:declaration])
+        add_token(node.superclass.location, :class) if node.superclass
+        visit(node.bodystmt)
+      end
+
+      sig { params(node: SyntaxTree::ModuleDeclaration).void }
+      def visit_module(node)
+        add_token(node.constant.location, :class, [:declaration])
+        visit(node.bodystmt)
+      end
+
       sig { params(location: SyntaxTree::Location, type: Symbol, modifiers: T::Array[Symbol]).void }
       def add_token(location, type, modifiers = [])
         length = location.end_char - location.start_char

--- a/test/expectations/semantic_highlighting/class_declaration_with_superclass.exp
+++ b/test/expectations/semantic_highlighting/class_declaration_with_superclass.exp
@@ -1,0 +1,18 @@
+{
+  "result": [
+    {
+      "delta_line": 0,
+      "delta_start_char": 6,
+      "length": 3,
+      "token_type": 2,
+      "token_modifiers": 1
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 6,
+      "length": 10,
+      "token_type": 2,
+      "token_modifiers": 0
+    }
+  ]
+}

--- a/test/expectations/semantic_highlighting/sclass.exp
+++ b/test/expectations/semantic_highlighting/sclass.exp
@@ -4,8 +4,8 @@
       "delta_line": 0,
       "delta_start_char": 6,
       "length": 3,
-      "token_type": 0,
-      "token_modifiers": 0
+      "token_type": 2,
+      "token_modifiers": 1
     },
     {
       "delta_line": 1,

--- a/test/expectations/semantic_highlighting/special_ruby_methods.exp
+++ b/test/expectations/semantic_highlighting/special_ruby_methods.exp
@@ -4,8 +4,8 @@
       "delta_line": 5,
       "delta_start_char": 6,
       "length": 3,
-      "token_type": 0,
-      "token_modifiers": 0
+      "token_type": 2,
+      "token_modifiers": 1
     },
     {
       "delta_line": 1,

--- a/test/fixtures/class_declaration_with_superclass.rb
+++ b/test/fixtures/class_declaration_with_superclass.rb
@@ -1,0 +1,2 @@
+class Foo < Superclass
+end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -92,7 +92,7 @@ class IntegrationTest < Minitest::Test
     assert_telemetry("textDocument/didOpen")
 
     response = make_request("textDocument/semanticTokens/full", { textDocument: { uri: "file://#{__FILE__}" } })
-    assert_equal([0, 6, 3, 0, 0], response[:result][:data])
+    assert_equal([0, 6, 3, 2, 1], response[:result][:data])
   end
 
   def test_document_link


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The current semantic highlighting was not handling `class Foo < Bar` or `module Baz` constructs and skipping them in semantic highlighting. This PR makes them semantic `class` tokens with the `declaration` modifier.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Handle `visit_class` and `visit_module` callbacks and emit the correct tokens.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated automated tests.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
