### PR TITLE
Add docs check to dev commands

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -8,6 +8,11 @@ up:
       gemfile: Gemfile
 
 commands:
+  docs:
+    run: bundle exec rake yard
+    subcommands:
+      check:
+        run: bundle exec rake check_docs
   server: exe/ruby-lsp
   style: bin/rubocop
   typecheck:


### PR DESCRIPTION
### Motivation

It feels like the doc check should be a `dev` command since it is checked on push and PR. Plus, these commands work with `minidev` for us external contributors and it's less to type than `bundle exec rake check_docs`.

I don't feel strongly about this, however hehe ❤️ 

### To test

- `dev docs` should run `bundle exec rake yard`
- `dev docs check` should run `bundle exec rake check_docs`