### PR TITLE
Add runtime dependency on version 3.17.x of LSP gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ruby-lsp (0.3.0)
-      language_server-protocol
+      language_server-protocol (~> 3.17.0)
       sorbet-runtime
       syntax_tree (>= 3.4)
 

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables = ["ruby-lsp"]
   s.require_paths = ["lib"]
 
-  s.add_dependency("language_server-protocol")
+  s.add_dependency("language_server-protocol", "~> 3.17.0")
   s.add_dependency("sorbet-runtime")
   s.add_dependency("syntax_tree", ">= 3.4")
 


### PR DESCRIPTION
### Motivation

Since we are currently supporting v3.17 of the spec, made the runtime dependency to only consider 3.17.x.y versions of the LSP gem, in case there are breaking changes to the protocol with the 3.18 version of the spec.
