### PR TITLE
Handle required parameters in semantic highlighting

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -185,6 +185,10 @@ module RubyLsp
           add_token(location_without_colon(location), :variable)
         end
 
+        node.requireds.each do |required|
+          add_token(required.location, :variable)
+        end
+
         rest = node.keyword_rest
         return if rest.nil? || rest.is_a?(SyntaxTree::ArgsForward)
 

--- a/test/expectations/semantic_highlighting/lambdas.exp
+++ b/test/expectations/semantic_highlighting/lambdas.exp
@@ -1,0 +1,18 @@
+{
+  "result": [
+    {
+      "delta_line": 0,
+      "delta_start_char": 10,
+      "length": 4,
+      "token_type": 8,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 1,
+      "delta_start_char": 7,
+      "length": 4,
+      "token_type": 8,
+      "token_modifiers": 0
+    }
+  ]
+}

--- a/test/expectations/semantic_highlighting/method_params.exp
+++ b/test/expectations/semantic_highlighting/method_params.exp
@@ -9,7 +9,14 @@
     },
     {
       "delta_line": 0,
-      "delta_start_char": 21,
+      "delta_start_char": 4,
+      "length": 1,
+      "token_type": 8,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 17,
       "length": 1,
       "token_type": 8,
       "token_modifiers": 0

--- a/test/expectations/semantic_highlighting/numbered_parameters.exp
+++ b/test/expectations/semantic_highlighting/numbered_parameters.exp
@@ -1,0 +1,11 @@
+{
+  "result": [
+    {
+      "delta_line": 1,
+      "delta_start_char": 7,
+      "length": 2,
+      "token_type": 8,
+      "token_modifiers": 0
+    }
+  ]
+}

--- a/test/expectations/semantic_highlighting/single_line_lambda.exp
+++ b/test/expectations/semantic_highlighting/single_line_lambda.exp
@@ -1,0 +1,18 @@
+{
+  "result": [
+    {
+      "delta_line": 0,
+      "delta_start_char": 4,
+      "length": 3,
+      "token_type": 8,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 12,
+      "length": 3,
+      "token_type": 8,
+      "token_modifiers": 0
+    }
+  ]
+}

--- a/test/fixtures/numbered_parameters.rb
+++ b/test/fixtures/numbered_parameters.rb
@@ -1,0 +1,3 @@
+lambda {
+  puts _1
+}

--- a/test/fixtures/single_line_lambda.rb
+++ b/test/fixtures/single_line_lambda.rb
@@ -1,0 +1,1 @@
+-> (var) { puts var }


### PR DESCRIPTION
### Motivation

I noticed that the arguments of single line lambdas weren't being highlighted as local variables (e.g.: `->(var) { var }`). This is because we weren't pushing semantic tokens for required arguments when visiting params.

### Implementation

Started pushing local variable tokens for required parameters.

### Automated Tests

Added a few extra test cases.