### PR TITLE
Add comment continuation via on type `on_type_formatting`

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -41,7 +41,9 @@ module RubyLsp
 
       sig { override.returns(T.nilable(T.all(T::Array[Interface::TextEdit], Object))) }
       def run
-        return unless @document.syntax_errors?
+        handle_comment_line
+
+        return @edits unless @document.syntax_errors?
 
         case @trigger_character
         when "{"
@@ -81,6 +83,18 @@ module RubyLsp
 
         add_edit_with_text(" \n#{indents}end")
         move_cursor_to(@position[:line], @indentation + 2)
+      end
+
+      sig { void }
+      def handle_comment_line
+        return unless @trigger_character == "\n"
+
+        is_comment_match = @previous_line.match(/^#(\s*)/)
+        return unless is_comment_match
+
+        spaces = T.must(is_comment_match[1])
+        add_edit_with_text("##{spaces}")
+        move_cursor_to(@position[:line], @indentation + spaces.size + 1)
       end
 
       sig { params(text: String).void }

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -69,4 +69,26 @@ class OnTypeFormattingTest < Minitest::Test
     ]
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
+
+  def test_comment_continuation
+    document = RubyLsp::Document.new(+"")
+
+    document.push_edits([{
+      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+      text: "    #    something",
+    }])
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").run
+    expected_edits = [
+      {
+        range: { start: { line: 0, character: 14 }, end: { line: 0, character: 14 } },
+        newText: "#    ",
+      },
+      {
+        range: { start: { line: 0, character: 9 }, end: { line: 0, character: 9 } },
+        newText: "$0",
+      },
+    ]
+    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
 end


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
One of my pet peeves is that when I am trying to write a comment block on top of a method or class, hitting enter does not continue the comment block but instead starts a new line for me. That is a huge hurdle for me to write documentation comments.

On type formatting can be helpful here by continuing the comment block and provide the indentation that the previous line of the comment block message had.

This is especially helpful when one is writing code example inside a comment block like:
```
  # This method acts in the following way:
  # ````
  # def foo
  #    puts "Hello World"
```
pressing `Enter` at this point should continue the comment block and indent the next line of the comment block as much as the previous line:
```
  #   |
      ^ cursor position
```

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Since the existing on type formatting only work inside a malformed document, I added handling for the comment block before that check, since it should be working on well-formed documents only.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
Added an automated test.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
