### PR TITLE
Handle formatting errors in on_error block

### DIFF
--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -19,6 +19,8 @@ module RubyLsp
     # end
     # ```
     class Formatting < BaseRequest
+      class Error < StandardError; end
+
       extend T::Sig
 
       sig { params(uri: String, document: Document).void }

--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -48,6 +48,8 @@ module RubyLsp
           @options[:stdin] = contents
 
           super([path])
+        rescue RuboCop::Runner::InfiniteCorrectionLoop => error
+          raise Formatting::Error, error.message
         end
 
         sig { returns(String) }

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -160,9 +160,8 @@ module RubyLsp
       uri = request.dig(:params, :textDocument, :uri)
 
       Requests::Formatting.new(uri, store.get(uri)).run
-    rescue RuboCop::Runner::InfiniteCorrectionLoop => e
-      show_message(Constant::MessageType::ERROR, "Error from RuboCop: #{e.message}")
-      nil
+    end.on_error do |error|
+      show_message(Constant::MessageType::ERROR, "Formatting error: #{error.message}")
     end
 
     on("textDocument/onTypeFormatting", parallel: true) do |request|


### PR DESCRIPTION
### Motivation

Closes #277 

Everything inside of the `on` block is cancellable by our queue mechanism. Therefore, we cannot perform any IO operations inside of it. We were using `show_message` inside of a rescue, instead of using our `on_error` handler, which means we were writing to IO on a cancellable block.

### Implementation

Just switch to using `on_error`, which is guaranteed to run and cannot be cancelled in the middle of writing to IO.

### Automated Tests

I don't have any clever ideas for a test that will catch regression, but if you do let me know!