### PR TITLE
Pass path to expectation tests instead of the file content

### DIFF
--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -7,9 +7,8 @@ require "expectations/expectations_test_runner"
 class DocumentLinkExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::DocumentLink, "document_link"
 
-  def assert_expectations(source, expected)
-    source = substitute_syntax_tree_version(source)
-    actual = T.cast(run_expectations(source), T::Array[LanguageServer::Protocol::Interface::DocumentLink])
+  def assert_expectations(path, expected)
+    actual = T.cast(run_expectations(path), T::Array[LanguageServer::Protocol::Interface::DocumentLink])
     assert_equal(map_expectations(json_expectations(expected)), JSON.parse(actual.to_json))
   end
 
@@ -20,9 +19,13 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
     end
   end
 
-  def run_expectations(source)
+  def run_expectations(path)
+    uri = "file://#{File.join(Dir.pwd, path)}"
+    source = File.read(path)
+    source = substitute_syntax_tree_version(source)
+
     document = RubyLsp::Document.new(source)
-    RubyLsp::Requests::DocumentLink.new("file://fake/path/without_version.rb", document).run
+    RubyLsp::Requests::DocumentLink.new(uri, document).run
   end
 
   private

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -7,16 +7,18 @@ require "expectations/expectations_test_runner"
 class FormattingExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Formatting, "formatting"
 
-  def run_expectations(source)
+  def run_expectations(path)
+    source = File.read(path)
     document = RubyLsp::Document.new(source)
+    # because we exclude fixture files in rubocop.yml, rubocop will ignore the file if we use the real fixture uri
     RubyLsp::Requests::Formatting.new("file://#{__FILE__}", document).run&.first&.new_text
   end
 
-  def assert_expectations(source, expected)
+  def assert_expectations(path, expected)
     result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::TextEdit]))
 
     stdout, _ = capture_io do
-      result = run_expectations(source)
+      result = run_expectations(path)
     end
 
     assert_empty(stdout)

--- a/test/requests/selection_ranges_expectations_test.rb
+++ b/test/requests/selection_ranges_expectations_test.rb
@@ -7,7 +7,8 @@ require "expectations/expectations_test_runner"
 class SelectionRangesExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::SelectionRanges, "selection_ranges"
 
-  def run_expectations(source)
+  def run_expectations(path)
+    source = File.read(path)
     document = RubyLsp::Document.new(source)
     actual = RubyLsp::Requests::SelectionRanges.new(document).run
     params = @__params&.any? ? @__params : default_args

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -7,7 +7,8 @@ require "expectations/expectations_test_runner"
 class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::SemanticHighlighting, "semantic_highlighting"
 
-  def run_expectations(source)
+  def run_expectations(path)
+    source = File.read(path)
     document = RubyLsp::Document.new(source)
     RubyLsp::Requests::SemanticHighlighting.new(
       document,
@@ -15,8 +16,8 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
     ).run
   end
 
-  def assert_expectations(source, expected)
-    actual = run_expectations(source).data
+  def assert_expectations(path, expected)
+    actual = run_expectations(path).data
     assert_equal(json_expectations(expected).to_json, decode_tokens(actual).to_json)
   end
 


### PR DESCRIPTION
### Motivation

When implementing #258, we'll decide whether to display links based on the file's path. And to test that mechanism, we need to pass real uri to the tests. But under the current testing structure, it's not possible to access that information in expectation tests.

It's also worth noting that **not** every test needs or can use real uri. For example, rubocop related tests can't use real uri because the fixture path is excluded in `.rubocop.yml`.

With that being said, I think tests should opt-in to real uri when possible so the testing setup can be more realistic.

### Implementation

Instead of passing `source` to `run_expectations`, passing the file's path instead. 

### Automated Tests

Existing tests

### Manual Tests


