### PR TITLE
Fix on type formatting pipe completion for regular or expressions

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -61,7 +61,7 @@ module RubyLsp
 
       sig { void }
       def handle_pipe
-        return unless /".*|/.match?(@previous_line)
+        return unless /((?<=do)|(?<={))\s+\|/.match?(@previous_line)
 
         add_edit_with_text("|")
         move_cursor_to(@position[:line], @position[:character])

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -70,6 +70,18 @@ class OnTypeFormattingTest < Minitest::Test
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
 
+  def test_pipe_is_not_added_in_regular_or_pipe
+    document = RubyLsp::Document.new(+"")
+
+    document.push_edits([{
+      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+      text: "|",
+    }])
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 11 }, "|").run
+    assert_empty(T.must(edits))
+  end
+
   def test_comment_continuation
     document = RubyLsp::Document.new(+"")
 


### PR DESCRIPTION
### Motivation

We were always automatically adding another pipe if the user typed in one. However, that's not correct, we only want to duplicate the pipe for block arguments (pipes that are preceded with `do` or a curly brace). Always adding two pipes is an odd experience.

### Implementation

Started checking if `do` or a curly brace is present in the same line of the original pipe.

### Automated Tests

Added a test that fails on the original implementation.