### PR TITLE
Add inlay hint for hash arguments with no braces

### DIFF
--- a/lib/ruby_lsp/requests/inlay_hints.rb
+++ b/lib/ruby_lsp/requests/inlay_hints.rb
@@ -17,6 +17,9 @@ module RubyLsp
     # rescue # Label "StandardError" goes here as a bare rescue implies rescuing StandardError
     #   puts "handle some rescue"
     # end
+    #
+    # foo(positional_arg, key: value)
+    # #                  ^          ^ these two locations will have brace labels added
     # ```
     class InlayHints < BaseRequest
       RESCUE_STRING_LENGTH = T.let("rescue".length, Integer)
@@ -40,7 +43,7 @@ module RubyLsp
         return unless node.exception.nil?
 
         loc = node.location
-        return unless @range.cover?(loc.start_line - 1) && @range.cover?(loc.end_line - 1)
+        return unless visible?(loc)
 
         @hints << LanguageServer::Protocol::Interface::InlayHint.new(
           position: { line: loc.start_line - 1, character: loc.start_column + RESCUE_STRING_LENGTH },
@@ -50,6 +53,44 @@ module RubyLsp
         )
 
         super
+      end
+
+      sig { params(node: SyntaxTree::Args).void }
+      def visit_args(node)
+        bare_assoc_hash = node.parts.find { |x| x.is_a?(SyntaxTree::BareAssocHash) }
+        return unless bare_assoc_hash
+
+        loc = bare_assoc_hash.location
+        return unless visible?(loc)
+
+        @hints << LanguageServer::Protocol::Interface::InlayHint.new(
+          position: {
+            line: bare_assoc_hash.assocs.first.location.start_line - 1,
+            character: bare_assoc_hash.assocs.first.location.start_column,
+          },
+          label: "{",
+          padding_right: true,
+          tooltip: "Braces are implied, this is where the left brace would be",
+        )
+
+        @hints << LanguageServer::Protocol::Interface::InlayHint.new(
+          position: {
+            line: bare_assoc_hash.assocs.last.location.end_line - 1,
+            character: bare_assoc_hash.assocs.last.location.end_column,
+          },
+          label: "}",
+          padding_left: true,
+          tooltip: "Braces are implied, this is where the right brace would be",
+        )
+
+        super
+      end
+
+      private
+
+      sig { params(loc: SyntaxTree::Location).returns(T::Boolean) }
+      def visible?(loc)
+        @range.cover?(loc.start_line - 1) && @range.cover?(loc.end_line - 1)
       end
     end
   end

--- a/test/expectations/inlay_hints/method_call_hash_args.exp
+++ b/test/expectations/inlay_hints/method_call_hash_args.exp
@@ -1,0 +1,94 @@
+{
+  "result": [
+    {
+      "position": {
+        "line": 0,
+        "character": 18
+      },
+      "label": "{",
+      "tooltip": "Braces are implied, this is where the left brace would be",
+      "paddingRight": true
+    },
+    {
+      "position": {
+        "line": 0,
+        "character": 40
+      },
+      "label": "}",
+      "tooltip": "Braces are implied, this is where the right brace would be",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 4,
+        "character": 2
+      },
+      "label": "{",
+      "tooltip": "Braces are implied, this is where the left brace would be",
+      "paddingRight": true
+    },
+    {
+      "position": {
+        "line": 5,
+        "character": 13
+      },
+      "label": "}",
+      "tooltip": "Braces are implied, this is where the right brace would be",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 8,
+        "character": 18
+      },
+      "label": "{",
+      "tooltip": "Braces are implied, this is where the left brace would be",
+      "paddingRight": true
+    },
+    {
+      "position": {
+        "line": 9,
+        "character": 12
+      },
+      "label": "}",
+      "tooltip": "Braces are implied, this is where the right brace would be",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 11,
+        "character": 5
+      },
+      "label": "{",
+      "tooltip": "Braces are implied, this is where the left brace would be",
+      "paddingRight": true
+    },
+    {
+      "position": {
+        "line": 11,
+        "character": 15
+      },
+      "label": "}",
+      "tooltip": "Braces are implied, this is where the right brace would be",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 13,
+        "character": 18
+      },
+      "label": "{",
+      "tooltip": "Braces are implied, this is where the left brace would be",
+      "paddingRight": true
+    },
+    {
+      "position": {
+        "line": 13,
+        "character": 40
+      },
+      "label": "}",
+      "tooltip": "Braces are implied, this is where the right brace would be",
+      "paddingLeft": true
+    }
+  ]
+}

--- a/test/fixtures/method_call_hash_args.rb
+++ b/test/fixtures/method_call_hash_args.rb
@@ -1,0 +1,14 @@
+foo("positional", bar: "one", baz: "two")
+
+foo(
+  "positional",
+  bar: "three",
+  baz: "four",
+)
+
+foo("positional", bar: "five",
+  baz: "six")
+
+puts bar: "one"
+
+foo "positional", bar: "one", baz: "two"


### PR DESCRIPTION
### Motivation

I like this inlay hint, at least in theory. It makes it clear what's actually going on when you can sometimes omit braces from method calls. Could be helpful for newer ruby users too.

Definitely feel free to boot this one up and have a look at it. As it is, these will also be added in sorbet signatures because `params` is called with BareAssocHash arguments. Maybe this could be refined to only add the hint if there's a mix of positional arguments and hash arguments? I'm open to suggestions.

### Implementation

When visiting arguments, if it has a child BareAssocHash, process the inlay hints around that hash.

**Note:** I still need to get a gif of it working for docs. Or maybe the StandardError example is sufficient to demonstrate inlay hints? Your call.

### Automated Tests

Added a bunch of different expectation tests. Any cases I'm missing?

### Manual Tests

- I modified the gemfile of a local project (Tapioca) to point to my local copy of Ruby-LSP
- I opened Tapioca when running the client in debug mode so it was using my branch LSP version
- I typed the following code to ensure the inlay hint popped up and get a clearer idea of what it looks like and how it `feels` to use it.

```ruby
  def foo(positional, **args)
    puts positional
    puts args
  end

  foo("positional", bar: "one", baz: "two")

  foo(
    "positional",
    bar: "three",
    baz: "four",
  )

  foo("positional", bar: "five",
    baz: "six")

  puts bar: "one"

  foo "positional", bar: "one", baz: "two"
``` 