### PR TITLE
Do not fail on LoadError

### DIFF
--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -20,13 +20,13 @@ module RubyLsp
       const :action, T.proc.params(request: T::Hash[Symbol, T.untyped]).returns(T.untyped)
       const :parallel, T::Boolean
       prop :error_handler,
-        T.nilable(T.proc.params(error: StandardError, request: T::Hash[Symbol, T.untyped]).void)
+        T.nilable(T.proc.params(error: Exception, request: T::Hash[Symbol, T.untyped]).void)
 
       # A proc that runs in case a request has errored. Receives the error and the original request as arguments. Useful
       # for displaying window messages on errors
       sig do
         params(
-          block: T.proc.bind(Handler).params(error: StandardError, request: T::Hash[Symbol, T.untyped]).void
+          block: T.proc.bind(Handler).params(error: Exception, request: T::Hash[Symbol, T.untyped]).void
         ).void
       end
       def on_error(&block)

--- a/lib/ruby_lsp/queue.rb
+++ b/lib/ruby_lsp/queue.rb
@@ -11,7 +11,7 @@ module RubyLsp
 
     class Result < T::Struct
       const :response, T.untyped # rubocop:disable Sorbet/ForbidUntypedStructProps
-      const :error, T.nilable(StandardError)
+      const :error, T.nilable(Exception)
       const :request_time, T.nilable(Float)
     end
 
@@ -88,13 +88,13 @@ module RubyLsp
     sig { params(request: T::Hash[Symbol, T.untyped]).returns(Queue::Result) }
     def execute(request)
       response = T.let(nil, T.untyped)
-      error = T.let(nil, T.nilable(StandardError))
+      error = T.let(nil, T.nilable(Exception))
 
       request_time = Benchmark.realtime do
         response = T.must(@handlers[request[:method]]).action.call(request)
       rescue Cancelled
         raise
-      rescue StandardError => e
+      rescue StandardError, LoadError => e
         error = e
       end
 
@@ -169,7 +169,7 @@ module RubyLsp
       params(
         request: T::Hash[Symbol, T.untyped],
         request_time: Float,
-        error: T.nilable(StandardError)
+        error: T.nilable(Exception)
       ).returns(T::Hash[Symbol, T.any(String, Float)])
     end
     def telemetry_params(request, request_time, error)


### PR DESCRIPTION
### Motivation

Closes #291

The ticket explains why this is needed.

Concerning the discussion about rescuing all `Exception` or `LoadError` specifically, this is the list I came up for exceptions after listing descendants.
```
 SystemStackError,                                                                                                                            
 NoMemoryError,                                                                                                                               
 SecurityError,                                                                                                                               
 NotImplementedError,                                                                                                                         
 LoadError,                                                                                                                                   
 SyntaxError,                                                                                                                                 
 ScriptError,                                                                                                                                 
 StandardError,                                                                                                                               
 Interrupt,                                                                                                                                   
 SignalException
```
I think it's okay to rescue `LoadError` exclusively. The other exceptions are either interrupt related or seem quite catastrophic and we might not want to rescue those.

### Implementation

Started rescuing `LoadError` and changed all error related types to `Exception`, which is a parent of `StandardError`.

### Automated Tests

Added an example that raises `LoadError`.