### PR TITLE
Make the diagnostic request parallel

### DIFF
--- a/lib/ruby_lsp/queue.rb
+++ b/lib/ruby_lsp/queue.rb
@@ -139,9 +139,8 @@ module RubyLsp
         # Thread::Queue#pop is thread safe and will wait until an item is available
         loop do
           job = T.let(@job_queue.pop, T.nilable(Job))
-          break if job.nil?
-
           # The only time when the job is nil is when the queue is closed and we can then terminate the thread
+          break if job.nil?
 
           request = job.request
           @mutex.synchronize do

--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -14,6 +14,8 @@ module RubyLsp
       class RuboCopRunner < RuboCop::Runner
         extend T::Sig
 
+        class ConfigurationError < StandardError; end
+
         sig { returns(T::Array[RuboCop::Cop::Offense]) }
         attr_reader :offenses
 
@@ -50,6 +52,8 @@ module RubyLsp
           super([path])
         rescue RuboCop::Runner::InfiniteCorrectionLoop => error
           raise Formatting::Error, error.message
+        rescue RuboCop::ValidationError => error
+          raise ConfigurationError, error.message
         end
 
         sig { returns(String) }

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -207,7 +207,7 @@ module RubyLsp
       Handler::VOID
     end
 
-    on("textDocument/diagnostic") do |request|
+    on("textDocument/diagnostic", parallel: true) do |request|
       uri = request.dig(:params, :textDocument, :uri)
       response = store.cache_fetch(uri, :diagnostics) do |document|
         Requests::Diagnostics.new(uri, document).run
@@ -215,9 +215,7 @@ module RubyLsp
 
       { kind: "full", items: response.map(&:to_lsp_diagnostic) } if response
     end.on_error do |error|
-      if error.is_a?(RuboCop::ValidationError)
-        show_message(Constant::MessageType::ERROR, "Error in RuboCop configuration file: #{error.message}")
-      end
+      show_message(Constant::MessageType::ERROR, "Error running diagnostics: #{error.message}")
     end
 
     on("shutdown") { shutdown }

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -275,7 +275,7 @@ class IntegrationTest < Minitest::Test
     assert_equal("window/showMessage", response.dig(:method))
     assert_equal(LanguageServer::Protocol::Constant::MessageType::ERROR, response.dig(:params, :type))
     assert_equal(
-      "Error in RuboCop configuration file: unrecognized cop or department InvalidCop found in .rubocop.yml",
+      "Error running diagnostics: unrecognized cop or department InvalidCop found in .rubocop.yml",
       response.dig(:params, :message)
     )
   ensure


### PR DESCRIPTION
### Motivation

Make the diagnostic request parallel and avoid referencing RuboCop classes in `server.rb`, given that it's an optional dependency.

### Implementation

Added `parallel: true`, moved a comment that was accidentally misplaced in `queue.rb` and create a custom error class similar to the one for `Formatting::Error`.

### Automated Tests

This is a refactor and the existing test for displaying RuboCop validation errors should continue to pass.