### PR TITLE
Test helper improvements

### DIFF
--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -85,10 +85,10 @@ class ExpectationsTestRunner < Minitest::Test
 
     begin
       # If the values are JSON we want to pretty print them
-      expected_obj = { "result" => JSON.parse(expected) }
+      expected_obj = { "result" => expected }
       expected_obj["params"] = @__params if @__params
 
-      actual_obj = { "result" => JSON.parse(actual) }
+      actual_obj = { "result" => actual }
       actual_obj["params"] = @__params if @__params
 
       $stderr.puts "########## Expected ##########"


### PR DESCRIPTION
### Motivation

1. We should pass file and line number when calling `class_eval` so the methods generated inside can get proper location for debugging.
2. The `diff` method's logic is incorrect so it never prints `expected` and `actual` value in JSON format. This makes copy and pasting the `actual` value to new `.exp` file impossible. See the 2nd commit's message for more information.

**Before**

```
DocumentLinkExpectationsTest
########## Expected ##########
{"range"=>{"start"=>{"line"=>0, "character"=>0}, "end"=>{"line"=>0, "character"=>50}}, "target"=>"file:///Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39", "tooltip"=>"Jump to /Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39"}
{"range"=>{"start"=>{"line"=>4, "character"=>0}, "end"=>{"line"=>4, "character"=>32}}, "target"=>"file:///opt/rubies/3.1.2/lib/ruby/3.1.0/mutex_m.rb#1", "tooltip"=>"Jump to /opt/rubies/3.1.2/lib/ruby/3.1.0/mutex_m.rb#1"}
##########  Actual  ##########
{"range"=>{"start"=>{"line"=>0, "character"=>0}, "end"=>{"line"=>0, "character"=>50}}, "target"=>"file:///Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39", "tooltip"=>"Jump to /Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39"}
{"range"=>{"start"=>{"line"=>4, "character"=>0}, "end"=>{"line"=>4, "character"=>32}}, "target"=>"file:///opt/rubies/3.1.2/lib/ruby/3.1.0/mutex_m.rb#1", "tooltip"=>"Jump to /opt/rubies/3.1.2/lib/ruby/3.1.0/mutex_m.rb#1"}
{"range"=>{"start"=>{"line"=>8, "character"=>0}, "end"=>{"line"=>8, "character"=>45}}, "target"=>"file:///Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39", "tooltip"=>"Jump to /Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39"}
```

**After**

```
########## Expected ##########
{
  "result": [
    {
      "range": {
        "start": {
          "line": 0,
          "character": 0
        },
        "end": {
          "line": 0,
          "character": 50
        }
      },
      "target": "file:///Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39",
      "tooltip": "Jump to /Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39"
    },
    {
      "range": {
        "start": {
          "line": 4,
          "character": 0
        },
        "end": {
          "line": 4,
          "character": 32
        }
      },
      "target": "file:///opt/rubies/3.1.2/lib/ruby/3.1.0/mutex_m.rb#1",
      "tooltip": "Jump to /opt/rubies/3.1.2/lib/ruby/3.1.0/mutex_m.rb#1"
    }
  ],
  "params": [

  ]
}
##########  Actual  ##########
{
  "result": [
    {
      "range": {
        "start": {
          "line": 0,
          "character": 0
        },
        "end": {
          "line": 0,
          "character": 50
        }
      },
      "target": "file:///Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39",
      "tooltip": "Jump to /Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39"
    },
    {
      "range": {
        "start": {
          "line": 4,
          "character": 0
        },
        "end": {
          "line": 4,
          "character": 32
        }
      },
      "target": "file:///opt/rubies/3.1.2/lib/ruby/3.1.0/mutex_m.rb#1",
      "tooltip": "Jump to /opt/rubies/3.1.2/lib/ruby/3.1.0/mutex_m.rb#1"
    },
    {
      "range": {
        "start": {
          "line": 8,
          "character": 0
        },
        "end": {
          "line": 8,
          "character": 45
        }
      },
      "target": "file:///Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39",
      "tooltip": "Jump to /Users/hung-wulo/.gem/ruby/3.1.2/gems/syntax_tree-3.5.0/lib/syntax_tree.rb#39"
    }
  ],
  "params": [

  ]
}
```


### Implementation

See the commit messages.

### Automated Tests

All the existing tests should provide enough coverage.

### Manual Tests

1. Make an expectation test fail by changing its content (but keep it a valid json)
2. Run the test
3. The expected/actual output should be json instead of Ruby Hash