### PR TITLE
Improve worker stability

### DIFF
--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -72,42 +72,6 @@ class QueueTest < Minitest::Test
     end
   end
 
-  def test_cancel_while_processing
-    capture_subprocess_io do
-      @running_job_signal = Thread::Queue.new
-      @running_job_response = Thread::Queue.new
-
-      @queue.push({ id: "job_to_cancel", method: "cancelled_in_the_middle" })
-
-      assert_equal(:started, @running_job_response.pop)
-      @queue.cancel("job_to_cancel")
-      @running_job_signal.push(:unblock)
-
-      @queue.shutdown
-
-      assert_empty(@running_job_response)
-    end
-  end
-
-  def test_cancel_while_finalization
-    capture_subprocess_io do
-      @running_job_response = Thread::Queue.new
-      @blocking_job_signal = Thread::Queue.new
-
-      @queue.push({ id: "job_to_cancel", method: "with_error_handler" })
-      assert_equal(:started, @running_job_response.pop)
-
-      @queue.cancel("job_to_cancel")
-
-      @blocking_job_signal.push(:unblock)
-      assert_equal(:finished, @running_job_response.pop)
-
-      @queue.shutdown
-    end
-  rescue Exception => e # rubocop:disable Lint/RescueException
-    raise "error handler during finalization was cancelled. Error: #{e.message}"
-  end
-
   def test_cancel_after_processing
     capture_subprocess_io do
       @cancelled_run = Thread::Queue.new


### PR DESCRIPTION
### Motivation

We have been receiving reports of the LSP being unstable when performing edits. After debugging, it looks like the issue is that the thread worker is being killed when trying to cancel requests midway of processing.

I believe we should remove the ability to cancel requests while they are already being processed. We can keep request cancellation to remove items from the queue if processing has not started, but trying to stop the thread worker midway has proven difficult and flaky.

### Implementation

I split the changes in 2 commits
- Added a mutex synchronization block when writing to IO to guarantee that we won't try to concurrently perform IO
- Removed the functionality for cancelling requests midway. We will no longer try to raise on the thread and rescue

### Automated Tests

Removed tests that were related to cancelling requests as they were being processed.

### Manual Tests

Basically a smoke test on this branch.
1. Start the LSP on this branch
2. Edit files and play around
3. Verify that the LSP does not get in a state of hanging. For example, if the thread worker was accidentally killed, the formatting pop up created by VS Code would never go away (it only closes when it receives a response)