### PR TITLE
Prevent older versions of Rubocop from breaking LSP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "debug", "~> 1.6", require: false
 gem "minitest", "~> 5.16"
 gem "minitest-reporters", "~> 1.5"
 gem "rake", "~> 13.0"
-gem "rubocop", ">= 1.0.0"
+gem "rubocop", "~> 1.33"
 gem "rubocop-shopify", "~> 2.10", require: false
 gem "rubocop-minitest", "~> 0.22.1", require: false
 gem "rubocop-rake", "~> 0.6.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       sorbet (>= 0.5.9204)
       sorbet-runtime (>= 0.5.9204)
       thor (>= 0.19.2)
-    syntax_tree (3.5.0)
+    syntax_tree (3.6.0)
       prettier_print
     tapioca (0.10.1)
       bundler (>= 1.17.3)
@@ -114,7 +114,7 @@ DEPENDENCIES
   minitest (~> 5.16)
   minitest-reporters (~> 1.5)
   rake (~> 13.0)
-  rubocop (>= 1.0.0)
+  rubocop (~> 1.33)
   rubocop-minitest (~> 0.22.1)
   rubocop-rake (~> 0.6.0)
   rubocop-shopify (~> 2.10)

--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -7,6 +7,12 @@ rescue LoadError
   return
 end
 
+begin
+  gem("rubocop", ">= 1.4.0")
+rescue LoadError
+  raise StandardError, "Incompatible RuboCop version. Ruby LSP requires >= 1.4.0"
+end
+
 module RubyLsp
   module Requests
     module Support


### PR DESCRIPTION
### Motivation

Closes #286 

### Implementation

- Successfully replicated the error with `rubocop` versions less than `1.4.0`.
- When testing, I noticed that `rubocop-shopify (~> 2.9)` needs `rubocop` to be `~> 1.33` so I went ahead and updated it in the gemfile for development.
- Added in logic to `rubocop_runner` so that the lsp would also run without `rubocop` if the version is less than `1.4.0`

### Tests

- Looked into writing a regression test to catch the error, but it ended up being difficult since it would involve running a test with a `rubocop` version that is different than the project's which meant the test would have to be written separately from the current `rubocop` testing.
