### PR TITLE
Remove non existing visit methods from semantic highlighting

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -100,11 +100,6 @@ module RubyLsp
         @encoder.encode(@tokens)
       end
 
-      sig { params(node: SyntaxTree::ARefField).void }
-      def visit_a_ref_field(node)
-        add_token(node.collection.value.location, :variable)
-      end
-
       sig { params(node: SyntaxTree::Call).void }
       def visit_call(node)
         visit(node.receiver)
@@ -168,13 +163,6 @@ module RubyLsp
         case node.value
         when "self"
           add_token(node.location, :variable, [:default_library])
-        end
-      end
-
-      sig { params(node: SyntaxTree::MAssign).void }
-      def visit_m_assign(node)
-        node.target.parts.each do |var_ref|
-          add_token(var_ref.value.location, :variable)
         end
       end
 


### PR DESCRIPTION
### Motivation

We were using `visit_a_ref` and `visit_m_assign` as visit methods in semantic highlighting, but both of them don't actually exist and are never invoked. The right versions are `visit_aref` and `visit_massign`.

The reason this made no difference is because both nodes eventually come down to `visit_var_field` or `visit_var_ref` and we still push the right semantic tokens.

### Implementation

Removed the two unused methods.

### Automated Tests

These methods were not in use and so the current tests should just continue to pass.