### PR TITLE
Add missing rest in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
-            await github.repos.createRelease({
+            await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: "${{ github.ref }}",


### PR DESCRIPTION
### Motivation

I just tried to run our action by pushing a fake tag and it [failed](https://github.com/Shopify/ruby-lsp/actions/runs/3114526623/jobs/5050465668) because `github.repos` was undefined.

I guess we needed the `rest` part.