### PR TITLE
Use ref_name for release title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: "${{ github.ref }}",
-              name: "${{ github.ref }}",
+              name: "${{ github.ref_name }}",
               generate_release_notes: true
             })


### PR DESCRIPTION
### Motivation

Our releases are working, but they are being created with the title `refs/tags/vX.X.X`. I think using `ref_name` should give us just the `vX.X.X`.