### PR TITLE
Add release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+# release.yml
+
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - chore
+    authors:
+      - dependabot
+  categories:
+    - title: 🚧 Breaking Changes
+      labels:
+        - breaking-change
+    - title: ✨ Enhancements
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 🛠 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
### Motivation

To make GH smarter at generating release notes.

### Implementation

Replicate [`Tapioca`'s `release.yml`](https://github.com/Shopify/tapioca/blob/main/.github/release.yml#L2) with slightly different label names.

### Automated Tests

N/A

### Manual Tests

Need to wait for a couple of new PRs to be merged before we can test it.
