### PR TITLE
Test and handle the situation where RailsDocumentClient#search_index being nil

### DIFF
--- a/lib/ruby_lsp/requests/support/rails_document_client.rb
+++ b/lib/ruby_lsp/requests/support/rails_document_client.rb
@@ -28,7 +28,7 @@ module RubyLsp
             params(name: String).returns(T::Array[String])
           end
           def generate_rails_document_urls(name)
-            docs = T.must(search_index)[name]
+            docs = search_index&.fetch(name, nil)
 
             return [] unless docs
 

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -14,6 +14,14 @@ class HoverExpectationsTest < ExpectationsTestRunner
     assert_equal(json_expectations(substitute(expected)), actual_json)
   end
 
+  def test_search_index_being_nil
+    document = RubyLsp::Document.new("belongs_to :foo")
+
+    RubyLsp::Requests::Support::RailsDocumentClient.stub(:search_index, nil) do
+      RubyLsp::Requests::Hover.new(document, { character: 0, line: 0 }).run
+    end
+  end
+
   class FakeHTTPResponse
     attr_reader :code, :body
 


### PR DESCRIPTION
### Motivation

Fixes #327

### Implementation

Test and handle the case where `search_Index` being `nil`.

### Automated Tests

Added

### Manual Tests

- Comment out `gem "railties" in `Gemfile`
- Run `Reload Window` to restart the LSP
- Open the `OUTPUT` tab 
- Hover some DSL calls, like `expectations_tests` of `expectations_tests RubyLsp::Requests::Hover, "hover"`
    - On `main`, this should produce 
        ```
        Request failed: #<NoMethodError: undefined method `[]' for nil:NilClass
        
                    docs = T.must(search_index)[name]
                                               ^^^^^^> (-32603).
        ```
    - On this branch, it should not cause any error