### PR TITLE
Autoload RailsDocumentClient

### DIFF
--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -39,6 +39,7 @@ module RubyLsp
       autoload :SemanticTokenEncoder, "ruby_lsp/requests/support/semantic_token_encoder"
       autoload :SyntaxErrorDiagnostic, "ruby_lsp/requests/support/syntax_error_diagnostic"
       autoload :HighlightTarget, "ruby_lsp/requests/support/highlight_target"
+      autoload :RailsDocumentClient, "ruby_lsp/requests/support/rails_document_client"
     end
   end
 end

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "ruby_lsp/requests/support/rails_document_client"
-
 module RubyLsp
   module Requests
     # ![Hover demo](../../misc/rails_document_link_hover.gif)

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "net/http" # for stubbing
 require "expectations/expectations_test_runner"
 
 class HoverExpectationsTest < ExpectationsTestRunner


### PR DESCRIPTION
The build became flaky after https://github.com/Shopify/ruby-lsp/pull/328, which is likely caused by `RailsDocumentClient` now being autoloadable. 