### PR TITLE
Use DefaultReporter to get clearer failure reports

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ require "minitest/reporters"
 require "tempfile"
 require "debug"
 
-Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new(color: true))
+Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new(color: true))
 
 module Minitest
   class Test


### PR DESCRIPTION
### Motivation

The `SpecReporter` prints failures as they happen instead of all at once at the bottom. This means we need to scroll up to see test failures very often, which is annoying.

### Implementation

Just use a `DefaultReporter` instead. And now failures will be shown at the bottom :-)

![DefaultReporter](https://user-images.githubusercontent.com/5079556/196726190-b7c932a3-3614-488f-820f-af0f62eedc90.png)
