### PR TITLE
Make the debugger skip Sorbet related frames

### DIFF
--- a/sorbet/rbi/shims/debug.rbi
+++ b/sorbet/rbi/shims/debug.rbi
@@ -1,0 +1,5 @@
+# typed: true
+
+module DEBUGGER__
+  CONFIG = T.untyped
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,9 @@ require "minitest/reporters"
 require "tempfile"
 require "debug"
 
+sorbet_paths = Gem.loaded_specs["sorbet-runtime"].full_require_paths.freeze
+DEBUGGER__::CONFIG[:skip_path] = Array(DEBUGGER__::CONFIG[:skip_path]) + sorbet_paths
+
 Minitest::Reporters.use!(Minitest::Reporters::DefaultReporter.new(color: true))
 
 module Minitest


### PR DESCRIPTION
### Motivation

Sorbet related frames are always a distraction when debugging.

![Screenshot 2022-10-19 at 17 21 16](https://user-images.githubusercontent.com/5079556/196749822-c9a8b103-76ac-4c5c-876f-912b52038728.png)

That's why we skip them for `shopify-types` users.

### Implementation

Use the debugger's `skip_path` config to skip them. This applies to both the `backtrace` command and stepping commands.

![Screenshot 2022-10-19 at 17 21 47](https://user-images.githubusercontent.com/5079556/196750077-f0cdeb80-931f-4f83-a24a-c3ac94aab599.png)
