### PR TITLE
Handle fields in semantic highlighting

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -189,6 +189,13 @@ module RubyLsp
         super
       end
 
+      sig { override.params(node: SyntaxTree::Field).void }
+      def visit_field(node)
+        add_token(node.name.location, :method)
+
+        super
+      end
+
       sig { override.params(node: SyntaxTree::VarField).void }
       def visit_var_field(node)
         value = node.value

--- a/test/expectations/semantic_highlighting/field_assignment.exp
+++ b/test/expectations/semantic_highlighting/field_assignment.exp
@@ -1,0 +1,18 @@
+{
+  "result": [
+    {
+      "delta_line": 0,
+      "delta_start_char": 0,
+      "length": 6,
+      "token_type": 13,
+      "token_modifiers": 0
+    },
+    {
+      "delta_line": 0,
+      "delta_start_char": 7,
+      "length": 3,
+      "token_type": 13,
+      "token_modifiers": 0
+    }
+  ]
+}

--- a/test/fixtures/field_assignment.rb
+++ b/test/fixtures/field_assignment.rb
@@ -1,0 +1,1 @@
+object.foo = "something"


### PR DESCRIPTION
### Motivation

I noticed that method invocations for assignments weren't being highlighted as so.

E.g.: `object.foo = "something"`, foo was not identified as a method, which is inconsistent.

### Implementation

Started handling field nodes and pushing semantic tokens for them.

### Automated Tests

Added a new example.

### Manual Tests

1. Start the LSP on this branch
2. Type `object.foo = 123`
3. Verify that both object and foo are highlighted the same
4. Alternatively, use the Inspect tokens command and verify that `foo` has the semantic token `method`