### PR TITLE
Skip node locating when the document is not parsed

### DIFF
--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -27,11 +27,14 @@ module RubyLsp
 
       sig { params(document: Document, position: Document::PositionShape).void }
       def initialize(document, position)
+        super(document)
+
         @highlights = T.let([], T::Array[LanguageServer::Protocol::Interface::DocumentHighlight])
         position = Document::Scanner.new(document.source).find_position(position)
-        @target = T.let(find(T.must(document.tree), position), T.nilable(Support::HighlightTarget))
 
-        super(document)
+        return unless document.parsed?
+
+        @target = T.let(find(T.must(document.tree), position), T.nilable(Support::HighlightTarget))
       end
 
       sig { override.returns(T.all(T::Array[LanguageServer::Protocol::Interface::DocumentHighlight], Object)) }

--- a/test/requests/document_highlight_expectations_test.rb
+++ b/test/requests/document_highlight_expectations_test.rb
@@ -7,6 +7,13 @@ require "expectations/expectations_test_runner"
 class DocumentHighlightExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::DocumentHighlight, "document_highlight"
 
+  def test_when_document_is_not_parsed
+    broken_source = "class Foo"
+    document = RubyLsp::Document.new(broken_source)
+    result = RubyLsp::Requests::DocumentHighlight.new(document, { line: 0, character: 0 }).run
+    assert_empty(result)
+  end
+
   def default_args
     [{ character: 0, line: 0 }]
   end


### PR DESCRIPTION
### Motivation

Although `DocumentHighlight#run` skips `#visit` when the document is not parsed, `DocumentHighlight#initialize` doesn't skip node locating.

This means that `DocumentHighlight` will fail to initialize and cause error when the source code has syntax error.

Fixes #326 

### Implementation

Check if the document is parsed before trying to find the target node from `document.tree`.

### Automated Tests

Added a test to make sure the `DocumentHighlight` request can still be initialized with syntax-incorrect source code.

### Manual Tests

1. Create a file that has syntax error, like
    ```rb
    def foo(bar
      bar
    end
    ```
2. Switch to `OUTPUT` tab
3. Move cursor on `foo` to trigger `documentHighlight` requests
4.
    - On `main`, you'd see 
        ```
        Received response 'textDocument/documentHighlight - (40)' in 2ms. Request failed: #<NoMethodError: undefined method `child_nodes' for nil:NilClass
        
                matched = parent.child_nodes.compact.bsearch do |child|
                                ^^^^^^^^^^^^> (-32603).
        ```
    - On this branch, there should be no error
