### PR TITLE
Ignore errors when trying to parse our parsable source

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -95,9 +95,12 @@ module RubyLsp
         apply_edit(@parsable_source, edit[:range], edit[:text].gsub(/[^\r\n]/, " "))
       end
 
-      @tree = SyntaxTree.parse(@parsable_source)
-    rescue SyntaxTree::Parser::ParseError
-      # If we can't parse the source even after emptying the edits, then just fallback to the previous source
+      begin
+        @tree = SyntaxTree.parse(@parsable_source)
+      rescue StandardError
+        # Trying to maintain a parsable source when there are syntax errors is a best effort. If we fail to parse for
+        # any reason, just ignore it
+      end
     end
 
     sig { params(source: String, range: RangeShape, text: String).void }


### PR DESCRIPTION
### Motivation

Most of the errors we are getting in telemetry are related to parsing the fake source we keep around while there are syntax errors. However, maintaining that parsable source is just a best effort to keep features working while developers are typing. If we fail to do so, features come back as soon as the syntax is valid again. Therefore, we should prevent any errors from trying to parse the fake source from bubbling up to our telemetry (or worse breaking the LSP).

### Implementation

Wrapped the parse invocation in a standard error rescue.