### PR TITLE
Rescue any errors when trying to apply edits to the parsable source

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -95,12 +95,10 @@ module RubyLsp
         apply_edit(@parsable_source, edit[:range], edit[:text].gsub(/[^\r\n]/, " "))
       end
 
-      begin
-        @tree = SyntaxTree.parse(@parsable_source)
-      rescue StandardError
-        # Trying to maintain a parsable source when there are syntax errors is a best effort. If we fail to parse for
-        # any reason, just ignore it
-      end
+      @tree = SyntaxTree.parse(@parsable_source)
+    rescue StandardError
+      # Trying to maintain a parsable source when there are syntax errors is a best effort. If we fail to apply edits or
+      # parse, just ignore it
     end
 
     sig { params(source: String, range: RangeShape, text: String).void }


### PR DESCRIPTION
Correction to #352 

We sometimes get RangeError when applying the edits too, so we can't limit to just rescuing around parse, we want to ignore any errors when trying to modify the fake source.
