### PR TITLE
Limit our Syntax Tree requirement to < 5.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ruby-lsp (0.3.5)
       language_server-protocol (~> 3.17.0)
       sorbet-runtime
-      syntax_tree (>= 4.0.2)
+      syntax_tree (>= 4.0.2, < 5.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("language_server-protocol", "~> 3.17.0")
   s.add_dependency("sorbet-runtime")
-  s.add_dependency("syntax_tree", ">= 4.0.2")
+  s.add_dependency("syntax_tree", ">= 4.0.2", "< 5.0.0")
 
   s.required_ruby_version = ">= 2.7.3"
 end


### PR DESCRIPTION
### Motivation

Limiting the requirement buys us some time to finish #356 and prevents people from upgrading it accidentally. Version 5.0.0 includes breaking changes that we're not ready to handle and many requests fail.