### PR TITLE
Take client encoding into consideration when applying text edits

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -18,10 +18,11 @@ module RubyLsp
     sig { returns(T::Array[EditShape]) }
     attr_reader :syntax_error_edits
 
-    sig { params(source: String).void }
-    def initialize(source)
+    sig { params(source: String, encoding: String).void }
+    def initialize(source, encoding = "utf-8")
       @cache = T.let({}, T::Hash[Symbol, T.untyped])
       @syntax_error_edits = T.let([], T::Array[EditShape])
+      @encoding = T.let(encoding, String)
       @source = T.let(source, String)
       @parsable_source = T.let(source.dup, String)
       @unparsed_edits = T.let([], T::Array[EditShape])
@@ -83,6 +84,11 @@ module RubyLsp
       !@tree.nil?
     end
 
+    sig { returns(Scanner) }
+    def create_scanner
+      Scanner.new(@source, @encoding)
+    end
+
     private
 
     sig { params(edits: T::Array[EditShape]).void }
@@ -103,9 +109,9 @@ module RubyLsp
 
     sig { params(source: String, range: RangeShape, text: String).void }
     def apply_edit(source, range, text)
-      scanner = Scanner.new(source)
-      start_position = scanner.find_position(range[:start])
-      end_position = scanner.find_position(range[:end])
+      scanner = Scanner.new(source, @encoding)
+      start_position = scanner.find_char_position(range[:start])
+      end_position = scanner.find_char_position(range[:end])
 
       source[start_position...end_position] = text
     end
@@ -113,22 +119,49 @@ module RubyLsp
     class Scanner
       extend T::Sig
 
-      sig { params(source: String).void }
-      def initialize(source)
+      LINE_BREAK = T.let(0x0A, Integer)
+      # After character 0xFFFF, UTF-16 considers characters to have length 2 and we have to account for that
+      SURROGATE_PAIR_START = T.let(0xFFFF, Integer)
+
+      sig { params(source: String, encoding: String).void }
+      def initialize(source, encoding)
         @current_line = T.let(0, Integer)
         @pos = T.let(0, Integer)
-        @source = source
+        @source = T.let(source.codepoints, T::Array[Integer])
+        @encoding = encoding
       end
 
+      # Finds the character index inside the source string for a given line and column
       sig { params(position: PositionShape).returns(Integer) }
-      def find_position(position)
+      def find_char_position(position)
+        # Find the character index for the beginning of the requested line
         until @current_line == position[:line]
-          @pos += 1 until /\R/.match?(@source[@pos])
+          @pos += 1 until LINE_BREAK == @source[@pos]
           @pos += 1
           @current_line += 1
         end
 
-        @pos + position[:character]
+        # The final position is the beginning of the line plus the requested column. If the encoding is UTF-16, we also
+        # need to adjust for surrogate pairs
+        requested_position = @pos + position[:character]
+        requested_position -= utf_16_character_position_correction(@pos, requested_position) if @encoding == "utf-16"
+        requested_position
+      end
+
+      # Subtract 1 for each character after 0xFFFF in the current line from the column position, so that we hit the
+      # right character in the UTF-8 representation
+      sig { params(current_position: Integer, requested_position: Integer).returns(Integer) }
+      def utf_16_character_position_correction(current_position, requested_position)
+        utf16_unicode_correction = 0
+
+        until current_position == requested_position
+          codepoint = @source[current_position]
+          utf16_unicode_correction += 1 if codepoint && codepoint > SURROGATE_PAIR_START
+
+          current_position += 1
+        end
+
+        utf16_unicode_correction
       end
     end
   end

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -30,10 +30,9 @@ module RubyLsp
         super(document)
 
         @highlights = T.let([], T::Array[LanguageServer::Protocol::Interface::DocumentHighlight])
-        position = Document::Scanner.new(document.source).find_position(position)
-
         return unless document.parsed?
 
+        position = document.create_scanner.find_char_position(position)
         @target = T.let(find(T.must(document.tree), position), T.nilable(Support::HighlightTarget))
       end
 

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -24,7 +24,7 @@ module RubyLsp
       def initialize(document, position)
         super(document)
 
-        @position = T.let(Document::Scanner.new(document.source).find_position(position), Integer)
+        @position = T.let(document.create_scanner.find_char_position(position), Integer)
       end
 
       sig { override.returns(T.nilable(LanguageServer::Protocol::Interface::Hover)) }

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -27,9 +27,9 @@ module RubyLsp
       def initialize(document, position, trigger_character)
         super(document)
 
-        scanner = Document::Scanner.new(document.source)
-        line_begin = position[:line] == 0 ? 0 : scanner.find_position({ line: position[:line] - 1, character: 0 })
-        line_end = scanner.find_position(position)
+        scanner = document.create_scanner
+        line_begin = position[:line] == 0 ? 0 : scanner.find_char_position({ line: position[:line] - 1, character: 0 })
+        line_end = scanner.find_char_position(position)
         line = T.must(@document.source[line_begin..line_end])
 
         @indentation = T.let(find_indentation(line), Integer)

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -7,6 +7,8 @@ module RubyLsp
   Handler.start do
     on("initialize") do |request|
       store.clear
+      store.encoding = request.dig(:params, :capabilities, :general, :positionEncodings)
+
       initialization_options = request.dig(:params, :initializationOptions)
       enabled_features = initialization_options.fetch(:enabledFeatures, [])
 

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -9,9 +9,13 @@ module RubyLsp
   class Store
     extend T::Sig
 
+    sig { params(encoding: String).void }
+    attr_writer :encoding
+
     sig { void }
     def initialize
       @state = T.let({}, T::Hash[String, Document])
+      @encoding = T.let("utf-8", String)
     end
 
     sig { params(uri: String).returns(Document) }
@@ -25,7 +29,7 @@ module RubyLsp
 
     sig { params(uri: String, content: String).void }
     def set(uri, content)
-      document = Document.new(content)
+      document = Document.new(content, @encoding)
       @state[uri] = document
     end
 


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/1494

VS Code (and possibly other clients) [use UTF-16 to represent internal strings because of NodeJS](https://github.com/microsoft/vscode/issues/20170). In UTF-16, 4 byte unicode characters (like emojis) have length 2, whereas in UTF-8 they have length 1.

When editing a line that includes an emoji, this means that VS Code will send us the `character` part of the position offset by +1 for each 4 bytes unicode character, which messes up our internal document state.

After doing some research, it appears that LSP clients broadcast their encodings to the servers so that they can adjust `character` positions for when there are 4 bytes characters. In fact, Rust Analyzer does exactly this, by checking UTF-16 lengths when the client is using that encoding.

### Implementation

I split the fix by commit.
1. Started saving the encoding coming from the client capabilities in the global store
2. Started passing the encoding to `Document::Scanner` so that we have that information accessible
3. Started making `character` adjustments when the encoding is UTF-16. The adjustment is simply to subtract 1 for each 4 byte character we find

### Automated Tests

Added a test including emojis.

### Manual Tests

**Check the problem in main first**
1. In the main branch, start the LSP
2. Open any Ruby file with emojis
3. Make edits on the same line and around the emoji
4. Verify that the Ruby LSP's internal state gets completely messes up (you should see incorrectly reported syntax errors, non functioning undo...)

**On this branch**
1. Verify that doing the same as above does not error and all LSP functionality continues to work with emojis present