### PR TITLE
Refactor to support codeAction/Resolve

### DIFF
--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -29,6 +29,7 @@ module RubyLsp
     autoload :OnTypeFormatting, "ruby_lsp/requests/on_type_formatting"
     autoload :Diagnostics, "ruby_lsp/requests/diagnostics"
     autoload :CodeActions, "ruby_lsp/requests/code_actions"
+    autoload :CodeActionResolve, "ruby_lsp/requests/code_action_resolve"
     autoload :DocumentHighlight, "ruby_lsp/requests/document_highlight"
     autoload :InlayHints, "ruby_lsp/requests/inlay_hints"
 

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -1,0 +1,50 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Requests
+    # ![Code actions demo](../../misc/code_actions.gif)
+    #
+    # The [code actions](https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction)
+    # request informs the editor of RuboCop quick fixes that can be applied. These are accesible by hovering over a
+    # specific diagnostic.
+    #
+    # # Example
+    #
+    # ```ruby
+    # def say_hello
+    # puts "Hello" # --> code action: quick fix indentation
+    # end
+    # ```
+    class CodeActionResolve < BaseRequest
+      extend T::Sig
+
+      sig do
+        params(document: Document,
+          code_action: { title: String, kind: String, data: T::Hash[Symbol, T.untyped], isPreferred: T::Boolean })
+          .void
+      end
+      def initialize(document, code_action)
+        super(document)
+        @code_action = code_action
+      end
+
+      sig { override.returns(Interface::CodeAction) }
+      def run
+        to_quick_fix
+      end
+
+      private
+
+      sig { returns(Interface::CodeAction) }
+      def to_quick_fix
+        Interface::CodeAction.new(
+          title: @code_action[:title],
+          kind: @code_action[:kind],
+          is_preferred: @code_action[:isPreferred],
+          edit: @code_action.dig(:data, :edit),
+        )
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -44,18 +44,21 @@ module RubyLsp
           LanguageServer::Protocol::Interface::CodeAction.new(
             title: "Autocorrect #{@offense.cop_name}",
             kind: LanguageServer::Protocol::Constant::CodeActionKind::QUICK_FIX,
-            edit: LanguageServer::Protocol::Interface::WorkspaceEdit.new(
-              document_changes: [
-                LanguageServer::Protocol::Interface::TextDocumentEdit.new(
-                  text_document: LanguageServer::Protocol::Interface::OptionalVersionedTextDocumentIdentifier.new(
-                    uri: @uri,
-                    version: nil,
-                  ),
-                  edits: @replacements,
-                ),
-              ],
-            ),
             is_preferred: true,
+            data: {
+              uri: @uri,
+              edit: LanguageServer::Protocol::Interface::WorkspaceEdit.new(
+                document_changes: [
+                  LanguageServer::Protocol::Interface::TextDocumentEdit.new(
+                    text_document: LanguageServer::Protocol::Interface::OptionalVersionedTextDocumentIdentifier.new(
+                      uri: @uri,
+                      version: nil,
+                    ),
+                    edits: @replacements,
+                  ),
+                ],
+              ),
+            },
           )
         end
 


### PR DESCRIPTION
Previously we were using the textDocument/codeAction only for Rubocop Where the edits are available and sent back in the response.

To be able to support refactorings, we would need to use the codeAction/resolve

This refactor adds code action resolve, and uses it for the rubocop edits.

Co-authored-by: Vinicius Stock <vinicius.stock@shopify.com>
Co-authored-by: Jenny Shih <jenny.shih@shopify.com>

### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
