### PR TITLE
Fix the code action cache level

### DIFF
--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -35,7 +35,7 @@ module RubyLsp
 
       sig { override.returns(T.all(T::Array[LanguageServer::Protocol::Interface::CodeAction], Object)) }
       def run
-        diagnostics = Diagnostics.new(@uri, @document).run
+        diagnostics = @document.cache_fetch(:diagnostics) { Diagnostics.new(@uri, @document).run }
         corrections = diagnostics.select do |diagnostic|
           diagnostic.correctable? && T.cast(diagnostic, Support::RuboCopDiagnostic).in_range?(@range)
         end

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -205,13 +205,12 @@ module RubyLsp
 
     on("textDocument/codeAction", parallel: true) do |request|
       uri = request.dig(:params, :textDocument, :uri)
+      document = store.get(uri)
       range = request.dig(:params, :range)
       start_line = range.dig(:start, :line)
       end_line = range.dig(:end, :line)
 
-      store.cache_fetch(uri, :code_actions) do |document|
-        Requests::CodeActions.new(uri, document, start_line..end_line).run
-      end
+      Requests::CodeActions.new(uri, document, start_line..end_line).run
     end
 
     on("textDocument/inlayHint", parallel: true) do |request|


### PR DESCRIPTION
### Motivation

While pairing on #381, I noticed that we had our `cache_fetch` invocation at the wrong place for code actions. We want to cache the diagnostics response, so that we don't have to run RuboCop more than once, but we do not want to cache the code actions response since it may change depending on which range is visible in the editor.

### Implementation

Removed the cache from the server part, which depends on the range, and wrapped the diagnostics call in the cache.