### PR TITLE
Treat .exp files as JSON

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "ruby lsp.trace.server": "messages",
   "[ruby]": {
     "editor.defaultFormatter": "Shopify.ruby-lsp",
-  }
+  },
+  "files.associations": {
+    "*.exp": "json"
+  },
 }


### PR DESCRIPTION
Treat `.exp` as JSON so that we benefit from syntax highlighting and auto-formatting.