### PR TITLE
Add test for argument forwarding (`...`)

### DIFF
--- a/test/expectations/document_highlight/argument_forwarding.exp
+++ b/test/expectations/document_highlight/argument_forwarding.exp
@@ -1,0 +1,23 @@
+{
+    "params": [
+        {
+            "line": 0,
+            "character": 5
+        }
+    ],
+    "result": [
+        {
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 4
+                },
+                "end": {
+                    "line": 0,
+                    "character": 7
+                }
+            },
+            "kind": 3
+        }
+    ]
+}


### PR DESCRIPTION
### Motivation

Closes #393

When working on https://github.com/Shopify/ruby-lsp/pull/376 I discovered there was no highlighting test covering `SyntaxTree::ArgsForward`.

It seems that although we had `test/fixtures/argument_forwarding.rb`, there was no corresponding `.exp` - does that mean the fixture was essentially unused? If so, might there be other 'gaps' like this, and could we catch those programatically? 🤔

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
