### PR TITLE
Ignore `SyntaxTree::ArgsForward` in `HighlightTarget`

### DIFF
--- a/lib/ruby_lsp/requests/support/highlight_target.rb
+++ b/lib/ruby_lsp/requests/support/highlight_target.rb
@@ -67,8 +67,7 @@ module RubyLsp
           case node
           when SyntaxTree::ConstPathRef, SyntaxTree::ConstPathField, SyntaxTree::TopConstField
             node.constant.value
-          when SyntaxTree::GVar, SyntaxTree::IVar, SyntaxTree::Const, SyntaxTree::CVar, SyntaxTree::Ident,
-               SyntaxTree::ArgsForward
+          when SyntaxTree::GVar, SyntaxTree::IVar, SyntaxTree::Const, SyntaxTree::CVar, SyntaxTree::Ident
             node.value
           when SyntaxTree::Field, SyntaxTree::Def, SyntaxTree::Defs, SyntaxTree::DefEndless, SyntaxTree::RestParam,
                SyntaxTree::KwRestParam, SyntaxTree::BlockArg


### PR DESCRIPTION
### Motivation

As mentioned in https://github.com/Shopify/ruby-lsp/issues/393, there's not really much value in having document highlighting on `...` since it has no name, so we'll remove that node type from the match list. This will simplify the syntax_tree v5 upgrade.

### Manual Tests

* Reload ruby-lsp on this branch
* Open `test/fixtures/argument_forwarding.rb`
* Click around the `...` tokens and ensure no errors in the Output tab.