### PR TITLE
Regenerate Gemfile.lock on CI to fix failures on Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v3
+
+      - if: ${{ matrix.ruby == '3.2' }}
+        run: "rm -f Gemfile.lock"
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
### Motivation

Every dependabot PR is currently failing CI on Ruby 3.2. Dependabot messes with the way nokogiri is entered into Gemfile.lock, which causes errors because nokogiri does not have a pre-compiled binary for Ruby 3.2 on those platforms. We need a workaround to get CI passing on Ruby 3.2 until this issue is fixed.

### Implementation

I originally tried to add "ruby" as a platform to Gemfile.lock (similar to [Mike's tapioca PR here](https://github.com/Shopify/tapioca/pull/1237)), but that didn't fix the issue.

So, based on [Mike's follow-up PR to tapioca](https://github.com/Shopify/tapioca/pull/1238), I added something to the CI pipeline that deletes Gemfile.lock when running on Ruby 3.2. This causes the lockfile to be regenerated when the gems are installed, which gets around the issue with nokogiri.

### Automated Tests

CI is now passing on Ruby 3.2.