### PR TITLE
Adjust Gemfile.lock platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     minitest-reporters (1.5.0)
       ansi
@@ -55,9 +56,8 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     netrc (0.11.0)
-    nokogiri (1.13.10-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
@@ -151,8 +151,9 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
+  arm64-darwin
+  ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
### Motivation

With the recent changes to fix CI, we now can't bundle install in our dev laptops. I'm hoping adding arm64-darwin, x86-darwin and x86-linux will fix the issue.