### PR TITLE
Reduce noise in test output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,6 @@ Sorbet/StrictSigil:
     - "**/*.rake"
     - "test/**/*.rb"
     - "lib/ruby-lsp.rb"
+
+Style/StderrPuts:
+  Enabled: true

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For more visibility into which tests are running, use the `SpecReporter`:
 
 `SPEC_REPORTER=1 bin/test`
 
-By default the tests run with warnings disabled to reduce. To enable warnings, pass `VERBOSE=1`.
+By default the tests run with warnings disabled to reduce noise. To enable warnings, pass `VERBOSE=1`.
 Warnings are always shown when running in CI.
 
 ### Expectation testing

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ For more visibility into which tests are running, use the `SpecReporter`:
 
 `SPEC_REPORTER=1 bin/test`
 
+By default the tests run with warnings disabled to reduce. To enable warnings, pass `VERBOSE=1`.
+Warnings are always shown when running in CI.
+
 ### Expectation testing
 
 To simplify the way we run tests over different pieces of Ruby code, we use a custom expectations test framework against a set of Ruby fixtures.

--- a/lib/ruby_lsp/handler.rb
+++ b/lib/ruby_lsp/handler.rb
@@ -59,7 +59,7 @@ module RubyLsp
 
     sig { void }
     def start
-      $stderr.puts "Starting Ruby LSP..."
+      warn("Starting Ruby LSP...")
 
       @reader.read do |request|
         handler = @handlers[request[:method]]
@@ -94,7 +94,7 @@ module RubyLsp
 
     sig { void }
     def shutdown
-      $stderr.puts "Shutting down Ruby LSP..."
+      warn("Shutting down Ruby LSP...")
       @queue.shutdown
       store.clear
     end

--- a/lib/ruby_lsp/requests/support/rails_document_client.rb
+++ b/lib/ruby_lsp/requests/support/rails_document_client.rb
@@ -66,7 +66,7 @@ module RubyLsp
           private def build_search_index
             return unless RAILTIES_VERSION
 
-            $stderr.puts "Fetching Rails Documents..."
+            warn("Fetching Rails Documents...")
             # If the version's doc is not found, e.g. Rails main, it'll be redirected
             # In this case, we just fetch the latest doc
             response = if Gem::Version.new(RAILTIES_VERSION).prerelease?
@@ -78,11 +78,11 @@ module RubyLsp
             if response.code == "200"
               process_search_index(response.body)
             else
-              $stderr.puts("Response failed: #{response.inspect}")
+              warn("Response failed: #{response.inspect}")
               nil
             end
           rescue StandardError => e
-            $stderr.puts("Exception occurred when fetching Rails document index: #{e.inspect}")
+            warn("Exception occurred when fetching Rails document index: #{e.inspect}")
           end
 
           sig { params(js: String).returns(T::Hash[String, T::Array[T::Hash[Symbol, String]]]) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
-$VERBOSE = nil unless ENV["CI"]
+$VERBOSE = nil unless ENV["VERBOSE"] || ENV["CI"]
 
 require_relative "../lib/ruby_lsp/internal"
 require "minitest/autorun"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+$VERBOSE = nil unless ENV["CI"]
 
 require_relative "../lib/ruby_lsp/internal"
 require "minitest/autorun"


### PR DESCRIPTION
### Motivation

This is related to https://github.com/Shopify/ruby-lsp/issues/389 but taking a different approach.

The aim to reduce noise in the output when running tests.

### Implementation

If we use `warn` instead of `$stderr.puts` then we can selectively silence its output.

There is possibly a chance the hiding warnings could mask an underlying issue. To partly mitigate this, I'm only silencing the warnings in non-CI environments.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
