### PR TITLE
Upgrade bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "bundler", "~> 2.4.2"
 gem "debug", "~> 1.7", require: false
 gem "minitest", "~> 5.17"
 gem "minitest-reporters", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
+    mini_portile2 (2.8.1)
     minitest (5.17.0)
     minitest-reporters (1.5.0)
       ansi
@@ -55,11 +56,8 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     netrc (0.11.0)
-    nokogiri (1.13.10-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.2.0.0)
@@ -165,6 +163,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bundler (~> 2.4.2)
   debug (~> 1.7)
   minitest (~> 5.17)
   minitest-reporters (~> 1.5)
@@ -181,4 +180,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.3.7
+   2.4.2


### PR DESCRIPTION
We're seeing similar issues described in this issue:

https://github.com/dependabot/dependabot-core/issues/5917

And it looks like most of the issues came from bundler, not dependabot itself.

Given that

- ruby-lsp is using a relatively old version of bundler (2.3.7 was released in Feb 2022)
- dependabot now uses 2.3.25 by default

I think it's worth trying out a new bundler to see if it helps resolving the problem.

And if we compare this commit's change with https://github.com/Shopify/ruby-lsp/pull/410's, we can see that the new bundler already generates the entries we'd like to see. So I think the result is promising.
