### PR TITLE
[RFC] Constant/method indexing and go to definition

### DIFF
--- a/lib/ruby_lsp/indexer.rb
+++ b/lib/ruby_lsp/indexer.rb
@@ -1,0 +1,68 @@
+# typed: true
+# frozen_string_literal: true
+
+class Indexer
+  VM_DEFINECLASS_TYPE_CLASS           = 0x00
+  VM_DEFINECLASS_TYPE_SINGLETON_CLASS = 0x01
+  VM_DEFINECLASS_TYPE_MODULE          = 0x02
+  VM_DEFINECLASS_FLAG_SCOPED          = 0x08
+  VM_DEFINECLASS_FLAG_HAS_SUPERCLASS  = 0x10
+
+  def initialize(root)
+    @root = root
+    @index = {
+      constant: (Hash.new { |h,k| h[k] = [] }),
+      method: (Hash.new { |h,k| h[k] = [] })
+    }
+  end
+
+  def run
+    Dir["#{@root}/**/*.rb"].each do |file|
+      index_file(file)
+    end
+  end
+
+  def locs_for_symbol(symbol, kind)
+    $stderr.puts "--- Looking for #{symbol} of kind #{kind}"
+    index.dig(kind, symbol)
+  end
+
+  private
+
+  attr_reader :root, :index
+
+  def index_file(file)
+    iseq = RubyVM::InstructionSequence.compile(File.read(file)).to_a
+    index_iseq(iseq) do |line, event, message|
+      index[event][message] << [File.absolute_path(file), line]
+    end
+  end
+
+  def index_iseq(iseq, nesting = [], &blk)
+    line = iseq[9]
+    iseq[13].each_with_index do |insn, index|
+      case insn
+      in Integer
+        line = insn
+      in [:defineclass, name, class_iseq, ^(VM_DEFINECLASS_TYPE_SINGLETON_CLASS)]
+        # if iseq[13][index - 2] == [:putself]
+        #   index_iseq(iseq, nesting + [name], &blk)
+        # else
+        #   raise NotImplementedError, "singleton class with non-self receiver"
+        # end
+      in [:defineclass, name, class_iseq, flags] if flags & VM_DEFINECLASS_TYPE_MODULE > 0
+        blk.call(line, :constant, (nesting + [name]).join("::"))
+        index_iseq(class_iseq, nesting + [name], &blk)
+      in [:defineclass, name, class_iseq, flags]
+        blk.call(line, :constant, (nesting + [name]).join("::"))
+        index_iseq(class_iseq, nesting + [name], &blk)
+      in [:definemethod, name, method_iseq]
+        blk.call(line, :method, "#{name}")
+      in [:definesmethod, name, method_iseq]
+        blk.call(line, :method, "#{name}")
+      else
+        # skip other instructions
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -31,7 +31,7 @@ module RubyLsp
     autoload :CodeActions, "ruby_lsp/requests/code_actions"
     autoload :DocumentHighlight, "ruby_lsp/requests/document_highlight"
     autoload :InlayHints, "ruby_lsp/requests/inlay_hints"
-
+    autoload :GoToDefinition, "ruby_lsp/requests/go_to_definition"
     # :nodoc:
     module Support
       autoload :RuboCopDiagnostic, "ruby_lsp/requests/support/rubocop_diagnostic"

--- a/lib/ruby_lsp/requests/go_to_definition.rb
+++ b/lib/ruby_lsp/requests/go_to_definition.rb
@@ -1,0 +1,88 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Requests
+    class GoToDefinition < BaseRequest
+      extend T::Sig
+
+      sig { params(indexer: Indexer, uri: String, document: Document, position: Document::PositionShape).void }
+      def initialize(indexer, uri, document, position)
+        super(document)
+        @uri = uri
+        @indexer = T.let(indexer, Indexer)
+        @position = T.let(document.create_scanner.find_char_position(position), Integer)
+      end
+
+      sig { override.returns(T::Array[LanguageServer::Protocol::Interface::Location]) }
+      def run
+        return [] unless @document.parsed?
+
+        $stderr.puts "====== Here.... Document is parsed"
+
+        target, _ = locate_node_and_parent(
+          T.must(@document.tree), [SyntaxTree::ConstPathRef], @position
+        )
+
+        $stderr.puts "====== Here.... Target is found #{target.class}"
+
+        locs = case target
+        when SyntaxTree::Command
+          message = target.message
+          indexer.locs_for_symbol(message, :method)
+        when SyntaxTree::CallNode
+          return [] if target.message == :call
+
+          indexer.locs_for_symbol(target.message.value, :method)
+        when SyntaxTree::ConstPathRef
+          constant_name = full_constant_name(target)
+          $stderr.puts "====== Here.... Constant #{constant_name}"
+          indexer.locs_for_symbol(constant_name, :constant)
+        end
+
+        $stderr.puts "====== Here.... Got locs #{locs}"
+
+        return [] unless locs
+
+        locs.map do |file, line|
+          LanguageServer::Protocol::Interface::Location.new(
+            uri: "file://#{file}",
+            range: LanguageServer::Protocol::Interface::Range.new(
+              start: LanguageServer::Protocol::Interface::Position.new(
+                line: line - 1,
+                character: 0,
+              ),
+              end: LanguageServer::Protocol::Interface::Position.new(
+                line: line - 1,
+                character: 0,
+              ),
+            ),
+          )
+        end
+      end
+
+      private
+
+      sig { returns(Indexer) }
+      attr_reader :indexer
+
+      sig do
+        params(name: String, node: SyntaxTree::Node).returns(T.nilable(LanguageServer::Protocol::Interface::Hover))
+      end
+      def generate_rails_document_link_hover(name, node)
+        urls = Support::RailsDocumentClient.generate_rails_document_urls(name)
+
+        return if urls.empty?
+
+        contents = LanguageServer::Protocol::Interface::MarkupContent.new(
+          kind: "markdown",
+          value: urls.join("\n\n"),
+        )
+        LanguageServer::Protocol::Interface::Hover.new(
+          range: range_from_syntax_tree_node(node),
+          contents: contents,
+        )
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -81,8 +81,22 @@ module RubyLsp
           document_on_type_formatting_provider: on_type_formatting_provider,
           diagnostic_provider: diagnostics_provider,
           inlay_hint_provider: inlay_hint_provider,
+          definition_provider: true,
         ),
       )
+    end
+
+    on("textDocument/definition") do |request|
+      uri = request.dig(:params, :textDocument, :uri)
+      position = request.dig(:params, :position)
+
+      $stderr.puts "====== Here...."
+      store.cache_fetch(uri, :definition) do |document|
+        $stderr.puts "====== Inside cache...."
+        RubyLsp::Requests::GoToDefinition.new(indexer, uri, document, position).run.tap do |response|
+          $stderr.puts(response.inspect)
+        end
+      end
     end
 
     on("textDocument/didChange") do |request|


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
This is a quick-and-dirty, first-cut implementation of constant/method definition indexing based on the prototype code supplied by @kddnewton. An example "Go to definition" request implementation that only works for fully-qualified constants is also included.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The indexer is based on scanning the compiled instruction sequences that correspond to all project Ruby files (all files under the folder that contains the `Gemfile`). This technique was suggested by @kddnewton and can compile and process all files in Core in about 30s on my M1 Pro machine.

In its current form, the indexer runs serially before the Ruby LSP starts, which is obviously not the best way to do this, but is fast enough for this RFC.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
None

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
None