### PR TITLE
Add Sorbet shims for debug gem

### DIFF
--- a/sorbet/rbi/shims/binding.rbi
+++ b/sorbet/rbi/shims/binding.rbi
@@ -1,0 +1,7 @@
+# typed: true
+
+class Binding
+  def b; end
+  def break; end
+  def debugger; end
+end


### PR DESCRIPTION
To prevent distracting typecheck errors during development.