### PR TITLE
Update Diagnostics#run to not create errors if document didn't parse

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -15,13 +15,9 @@ module RubyLsp
     sig { returns(String) }
     attr_reader :source
 
-    sig { returns(T::Array[EditShape]) }
-    attr_reader :syntax_error_edits
-
     sig { params(source: String, encoding: String).void }
     def initialize(source, encoding = "utf-8")
       @cache = T.let({}, T::Hash[Symbol, T.untyped])
-      @syntax_error_edits = T.let([], T::Array[EditShape])
       @encoding = T.let(encoding, String)
       @source = T.let(source, String)
       @parsable_source = T.let(source.dup, String)
@@ -66,17 +62,15 @@ module RubyLsp
       return if @unparsed_edits.empty?
 
       @tree = SyntaxTree.parse(@source)
-      @syntax_error_edits.clear
       @unparsed_edits.clear
       @parsable_source = @source.dup
     rescue SyntaxTree::Parser::ParseError
-      @syntax_error_edits = @unparsed_edits
       update_parsable_source(@unparsed_edits)
     end
 
     sig { returns(T::Boolean) }
-    def syntax_errors?
-      @syntax_error_edits.any?
+    def syntax_error?
+      @unparsed_edits.any?
     end
 
     sig { returns(T::Boolean) }

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -37,17 +37,10 @@ module RubyLsp
         )
       end
       def run
-        return syntax_error_diagnostics if @document.syntax_errors?
+        return [] if @document.syntax_error?
         return [] unless defined?(Support::RuboCopDiagnosticsRunner)
 
         Support::RuboCopDiagnosticsRunner.instance.run(@uri, @document)
-      end
-
-      private
-
-      sig { returns(T::Array[Support::SyntaxErrorDiagnostic]) }
-      def syntax_error_diagnostics
-        @document.syntax_error_edits.map { |e| Support::SyntaxErrorDiagnostic.new(e) }
       end
     end
   end

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -46,13 +46,13 @@ module RubyLsp
       def run
         case @trigger_character
         when "{"
-          handle_curly_brace if @document.syntax_errors?
+          handle_curly_brace if @document.syntax_error?
         when "|"
-          handle_pipe if @document.syntax_errors?
+          handle_pipe if @document.syntax_error?
         when "\n"
           if (comment_match = @previous_line.match(/^#(\s*)/))
             handle_comment_line(T.must(comment_match[1]))
-          elsif @document.syntax_errors?
+          elsif @document.syntax_error?
             handle_statement_end
           end
         end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -211,28 +211,6 @@ class IntegrationTest < Minitest::Test
     assert_equal({ startLine: 0, endLine: 1, kind: "region" }, response[:result].first)
   end
 
-  def test_syntax_error_diagnostics
-    initialize_lsp([])
-    open_file_with("class Foo\nend")
-
-    assert_telemetry("textDocument/didOpen")
-
-    error_range = { start: { line: 1, character: 2 }, end: { line: 1, character: 3 } }
-
-    assert(send_request(
-      "textDocument/didChange",
-      {
-        textDocument: { uri: "file://#{__FILE__}" },
-        contentChanges: [{ text: "", range: error_range }],
-      },
-    ))
-    assert_telemetry("textDocument/didChange")
-    response = make_request("textDocument/diagnostic", { textDocument: { uri: "file://#{__FILE__}" } })
-
-    assert_equal("full", response.dig(:result, :kind))
-    assert_equal(error_range, response.dig(:result, :items)[0][:range])
-  end
-
   def test_request_with_telemetry
     initialize_lsp(["foldingRanges"], telemetry_enabled: true)
     open_file_with("class Foo\n\nend")

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -4,23 +4,6 @@
 require "test_helper"
 
 class DiagnosticsTest < Minitest::Test
-  def test_syntax_error_diagnostics
-    document = RubyLsp::Document.new(+<<~RUBY)
-      class Foo
-      end
-    RUBY
-
-    error_edit = {
-      range: { start: { line: 0, character: 10 }, end: { line: 0, character: 10 } },
-      text: "\n  end",
-    }
-
-    document.push_edits([error_edit])
-
-    result = RubyLsp::Requests::Diagnostics.new("file://#{__FILE__}", document).run
-    assert_equal(syntax_error_diagnostics([error_edit]).to_json, result.map(&:to_lsp_diagnostic).to_json)
-  end
-
   def test_empty_diagnostics_for_ignored_file
     fixture_path = File.expand_path("../fixtures/def_multiline_params.rb", __dir__)
     document = RubyLsp::Document.new(File.read(fixture_path))


### PR DESCRIPTION
### Motivation

Investigating this issue: https://github.com/Shopify/ruby-lsp/issues/426

Here is a video outlining the problem and some of the solutions: https://videobin.shopify.io/v/aGLgPv

The problem occurs because when a parse error occurs for a document we are storing the unparsed edits as syntax errors.

### Implementation

From the video, this PR implements the first solution of suppressing errors on unparsed edits. 

- Removed code to store unparsed edits as syntax errors. 
- Removed reference to syntax errors on document, replacing with `unparsed_edit?` helper.
  - Updated references to use new helper.
- Updated `Diagnostics` to return `[]` if there were unparsed edits instead of generating syntax error ranges.  

### Automated Tests

- Added unit test to validate that the diagnostics returns `[]` when unparsed edits present.
- Added unit test to validate behaviour of `unparsed_edits?`.
- Updated failing unit + integration tests.

### Manual Tests

To test these changes locally: 
- Create a file that contains a syntax error.
- Make new edits to the file.
- Validate that edits aren't being marked as syntax errors.
