### PR TITLE
Add fixture for a return with multiple statements in parens

### DIFF
--- a/test/fixtures/return_multiple_statements.rb
+++ b/test/fixtures/return_multiple_statements.rb
@@ -1,0 +1,8 @@
+def foo
+  return(
+    1
+    2
+  )
+end
+
+foo


### PR DESCRIPTION
### Motivation

While working on `return` node for YARP, this syntax was pointed out to me. Seemed like a good candidate for a fixture: 
```ruby
def foo 
  return (
    1
    2
  ) 
end

foo 
> 2
```