### PR TITLE
Refactor locating nodes based on positions

### DIFF
--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -60,32 +60,6 @@ module RubyLsp
 
       sig do
         params(
-          parent: SyntaxTree::Node,
-          target_nodes: T::Array[T.class_of(SyntaxTree::Node)],
-          position: Integer,
-        ).returns(T::Array[SyntaxTree::Node])
-      end
-      def locate_node_and_parent(parent, target_nodes, position)
-        matched = parent.child_nodes.compact.bsearch do |child|
-          if (child.location.start_char...child.location.end_char).cover?(position)
-            0
-          else
-            position <=> child.location.start_char
-          end
-        end
-
-        case matched
-        when *target_nodes
-          [matched, parent]
-        when SyntaxTree::Node
-          locate_node_and_parent(matched, target_nodes, position)
-        else
-          []
-        end
-      end
-
-      sig do
-        params(
           node: SyntaxTree::Node,
           position: Integer,
         ).returns([T.nilable(SyntaxTree::Node), T.nilable(SyntaxTree::Node)])

--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -84,7 +84,7 @@ module RubyLsp
           # If the node's start character is already past the position, then we should've found the closest node already
           break if position < loc.start_char
 
-          # If the current node is narrower or equal than the previous closest node, than it is more precise
+          # If the current node is narrower than or equal to the previous closest node, then it is more precise
           closest_loc = closest.location
           if loc.end_char - loc.start_char <= closest_loc.end_char - closest_loc.start_char
             parent = T.let(closest, SyntaxTree::Node)

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -73,9 +73,10 @@ module RubyLsp
         ).returns(T.nilable(Support::HighlightTarget))
       end
       def find(node, position)
-        matched, parent = locate_node_and_parent(node, DIRECT_HIGHLIGHTS + [SyntaxTree::Ident], position)
+        matched, parent = locate(node, position)
 
         return unless matched && parent
+        return unless matched.is_a?(SyntaxTree::Ident) || DIRECT_HIGHLIGHTS.include?(matched.class)
 
         case matched
         when *DIRECT_HIGHLIGHTS

--- a/test/expectations/hover/model_active_record_constant.exp.json
+++ b/test/expectations/hover/model_active_record_constant.exp.json
@@ -18,7 +18,7 @@
   "params": [
     {
       "line": 0,
-      "character": 15
+      "character": 27
     }
   ]
 }

--- a/test/requests/base_request_test.rb
+++ b/test/requests/base_request_test.rb
@@ -1,0 +1,45 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+class BaseRequestTest < Minitest::Test
+  def setup
+    @document = RubyLsp::Document.new(<<~RUBY)
+      class Post < ActiveRecord::Base
+        scope :published do
+          # find posts that are published
+          where(published: true)
+        end
+      end
+    RUBY
+    @request_class = Class.new(RubyLsp::Requests::BaseRequest)
+    @fake_request = @request_class.new(@document)
+  end
+
+  def test_locate
+    # Locate the `ActiveRecord` module (19 is the position of the `R` character)
+    found, parent = @fake_request.locate(@document.tree, 19)
+    assert_instance_of(SyntaxTree::Const, found)
+    assert_equal("ActiveRecord", found.value)
+
+    assert_instance_of(SyntaxTree::VarRef, parent)
+    assert_equal("ActiveRecord", parent.value.value)
+
+    # Locate the `Base` class (27 is the position of the `B` character)
+    found, parent = @fake_request.locate(@document.tree, 27)
+    assert_instance_of(SyntaxTree::Const, found)
+    assert_equal("Base", found.value)
+
+    assert_instance_of(SyntaxTree::ConstPathRef, parent)
+    assert_equal("Base", parent.constant.value)
+    assert_equal("ActiveRecord", parent.parent.value.value)
+
+    # Locate the `where` invocation (94 is the position of the `w` character)
+    found, parent = @fake_request.locate(@document.tree, 94)
+    assert_instance_of(SyntaxTree::Ident, found)
+    assert_equal("where", found.value)
+
+    assert_instance_of(SyntaxTree::CallNode, parent)
+  end
+end


### PR DESCRIPTION
### Motivation

Closes #444 

When locating specific nodes on the AST, we were always returning the first node that matched a list of classes and covered the requested position. However, that is sometimes not precise enough.

For example, when hovering inside a block of a method call, we shouldn't consider it as the original invocation - but that was happening because the first node found `MethodAddBlock` already covered the position.
```ruby
scope :something do
  # hovering over this where should display information about `where`, but because the MethodAddBlock node
  # for scope was hit first, we always displayed the hover information for `scope`
  where(...)
end
```

### Implementation

I split it by commit to make it easier to review.
1. Create a new locate method and add a few tests for it. It keeps trying to find a node that has the narrowest range that still covers the requested position. I also removed the logic to match against specific node types, I think that belongs in the requests that are trying to find nodes
2. Migrate document highlight to the new locate method
3. Migrate hover to the new locate method. Now that we're finding more specific nodes, hovering over the ActiveRecord namespace doesn't trigger the request. It needs to be over the Base class, so I updated the test
4. Remove the old implementation of locate

### Automated Tests

Added new automated tests for base request.

### Manual Tests

1. Start the LSP on this branch
2. Open our fixture files for Rails apps
3. Play around with hovering over DSL methods, like `validates`
4. Verify hover information is displayed properly