### PR TITLE
Properly place `end` when there's extra content after keyword

### DIFF
--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -152,4 +152,27 @@ class OnTypeFormattingTest < Minitest::Test
     ]
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
+
+  def test_breaking_line_between_keyword_and_more_content
+    document = RubyLsp::Document.new(+"")
+
+    document.push_edits([{
+      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+      text: "if something\n",
+    }])
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
+    expected_edits = [
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: " \nend",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "$0",
+      },
+    ]
+
+    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
 end


### PR DESCRIPTION
### Motivation

The original functionality for completing the `end` tokens on keywords didn't take into account breaking the line in the middle, which resulted in weird behaviour. For example
```ruby
if something
# ^ If you break the line here it results in

if
endsomething
```
which is of course not the experience we want. We should make sure the extra content after the line break is properly placed in the middle like this
```ruby
if
  something
end
```

### Implementation

- If the `@previous_line` includes a line break, that means there's content **after** the line break that triggered this on type formatting completion
- In that case, we want to place the `end` token one line below the extra content
- The only corner case is that, if the document does not have enough lines (e.g.: a single line document with an if statement), then we need to insert an extra line break ourselves

### Automated Tests

Added a new example.

### Manual Tests

1. Start the LSP on this branch
2. Open any file or create a new one
3. Type `if something`
4. Break the line right before `something`
5. Verify that the `end` token is inserted in the right place
6. Verify that the cursor is moved back into the conditional of the if statement

Play around with other keywords and scenarios.