### PR TITLE
Avoid running RuboCop outside of project folder

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -223,7 +223,7 @@ module RubyLsp
       Requests::InlayHints.new(document, start_line..end_line).run
     end
 
-    sig { params(uri: String, range: Document::RangeShape).returns(T::Array[Interface::CodeAction]) }
+    sig { params(uri: String, range: Document::RangeShape).returns(T.nilable(T::Array[Interface::CodeAction])) }
     def code_action(uri, range)
       start_line = range.dig(:start, :line)
       end_line = range.dig(:end, :line)

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -33,9 +33,11 @@ module RubyLsp
         @range = range
       end
 
-      sig { override.returns(T.all(T::Array[LanguageServer::Protocol::Interface::CodeAction], Object)) }
+      sig { override.returns(T.nilable(T.all(T::Array[LanguageServer::Protocol::Interface::CodeAction], Object))) }
       def run
         diagnostics = @document.cache_fetch(:diagnostics) { Diagnostics.new(@uri, @document).run }
+        return if diagnostics.nil?
+
         corrections = diagnostics.select do |diagnostic|
           diagnostic.correctable? && T.cast(diagnostic, Support::RuboCopDiagnostic).in_range?(@range)
         end

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -30,15 +30,20 @@ module RubyLsp
 
       sig do
         override.returns(
-          T.any(
-            T.all(T::Array[Support::RuboCopDiagnostic], Object),
-            T.all(T::Array[Support::SyntaxErrorDiagnostic], Object),
+          T.nilable(
+            T.any(
+              T.all(T::Array[Support::RuboCopDiagnostic], Object),
+              T.all(T::Array[Support::SyntaxErrorDiagnostic], Object),
+            ),
           ),
         )
       end
       def run
-        return [] if @document.syntax_error?
-        return [] unless defined?(Support::RuboCopDiagnosticsRunner)
+        return if @document.syntax_error?
+        return unless defined?(Support::RuboCopDiagnosticsRunner)
+
+        # Don't try to run RuboCop diagnostics for files outside the current working directory
+        return unless @uri.sub("file://", "").start_with?(Dir.pwd)
 
         Support::RuboCopDiagnosticsRunner.instance.run(@uri, @document)
       end

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -32,8 +32,11 @@ module RubyLsp
         @uri = uri
       end
 
-      sig { override.returns(T.nilable(T.all(T::Array[LanguageServer::Protocol::Interface::TextEdit], Object))) }
+      sig { override.returns(T.nilable(T.all(T::Array[Interface::TextEdit], Object))) }
       def run
+        # Don't try to format files outside the current working directory
+        return unless @uri.sub("file://", "").start_with?(Dir.pwd)
+
         formatted_text = formatted_file
         return unless formatted_text
 
@@ -41,10 +44,10 @@ module RubyLsp
         return if formatted_text.size == size && formatted_text == @document.source
 
         [
-          LanguageServer::Protocol::Interface::TextEdit.new(
-            range: LanguageServer::Protocol::Interface::Range.new(
-              start: LanguageServer::Protocol::Interface::Position.new(line: 0, character: 0),
-              end: LanguageServer::Protocol::Interface::Position.new(line: size, character: size),
+          Interface::TextEdit.new(
+            range: Interface::Range.new(
+              start: Interface::Position.new(line: 0, character: 0),
+              end: Interface::Position.new(line: size, character: size),
             ),
             new_text: formatted_text,
           ),

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -12,6 +12,16 @@ class DiagnosticsTest < Minitest::Test
     assert_empty(result)
   end
 
+  def test_returns_nil_if_document_is_not_in_project_folder
+    document = RubyLsp::Document.new(<<~RUBY)
+      def foo
+      wrong_indent
+      end
+    RUBY
+
+    assert_nil(RubyLsp::Requests::Diagnostics.new("file:///some/other/folder/file.rb", document).run)
+  end
+
   private
 
   def syntax_error_diagnostics(edits)

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -49,6 +49,10 @@ class FormattingTest < Minitest::Test
     assert_nil(RubyLsp::Requests::Formatting.new("file://#{__FILE__}", document).run)
   end
 
+  def test_returns_nil_if_document_is_not_in_project_folder
+    assert_nil(RubyLsp::Requests::Formatting.new("file:///some/other/folder/file.rb", @document).run)
+  end
+
   private
 
   def with_uninstalled_rubocop(&block)


### PR DESCRIPTION
### Motivation

Closes #401 

If a user has the LSP open a project and decides to open an external file that belongs to a different project, RuboCop will try to load the `.rubocop.yml` configuration from the folder where that external file exists.

This will always fail if there are RuboCop plugins in that configuration since Bundler configured the load paths using the current project's `Gemfile` and not the one where the external file is. For example:
- Bundler sets up load paths for the `Gemfile` in the main project (includes rubocop and rubocop-performance)
- User opens external file in different folder. This other folder's configuration requires rubocop-rails
- Because rubocop-rails is not present in the main project's bundle, it is not in the load paths and requiring it fails

This is not a major issue in the experience, but it fills our telemetry with error reports that aren't very useful.

### Implementation

We wouldn't be able to re-configure load paths with Bundler just for the external file, so I don't believe there's any practical way of making RuboCop functionality simply work in them.

The approach here is to just return `nil` if the file URI doesn't belong to the same folder where the LSP process is running (`Dir.pwd`).

**Note**

This is a RuboCop specific issue, because it tries to load configurations found in any folder. Other requests can continue to work normally in external files, such as semantic highlighting.

### Automated Tests

Added one for diagnostics and one for formatting.

### Manual Tests

1. Start the LSP for this branch on another project `gem "ruby-lsp", require: false, path: "ruby-lsp/folder/here"`
2. Verify diagnostics and formatting work on any file that belongs to the project
3. Open a file that belongs to a different project that also uses RuboCop
4. Verify diagnostics and formatting do not work