### PR TITLE
Substitute all T::Struct usage for plain Objects

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -78,11 +78,28 @@ module RubyLsp
         T::Array[String],
       )
 
-      class SemanticToken < T::Struct
-        const :location, SyntaxTree::Location
-        const :length, Integer
-        const :type, Integer
-        const :modifier, T::Array[Integer]
+      class SemanticToken
+        extend T::Sig
+
+        sig { returns(SyntaxTree::Location) }
+        attr_reader :location
+
+        sig { returns(Integer) }
+        attr_reader :length
+
+        sig { returns(Integer) }
+        attr_reader :type
+
+        sig { returns(T::Array[Integer]) }
+        attr_reader :modifier
+
+        sig { params(location: SyntaxTree::Location, length: Integer, type: Integer, modifier: T::Array[Integer]).void }
+        def initialize(location:, length:, type:, modifier:)
+          @location = location
+          @length = length
+          @type = type
+          @modifier = modifier
+        end
       end
 
       sig do

--- a/lib/ruby_lsp/requests/support/highlight_target.rb
+++ b/lib/ruby_lsp/requests/support/highlight_target.rb
@@ -10,9 +10,20 @@ module RubyLsp
         READ = LanguageServer::Protocol::Constant::DocumentHighlightKind::READ
         WRITE = LanguageServer::Protocol::Constant::DocumentHighlightKind::WRITE
 
-        class HighlightMatch < T::Struct
-          const :type, Integer
-          const :node, SyntaxTree::Node
+        class HighlightMatch
+          extend T::Sig
+
+          sig { returns(Integer) }
+          attr_reader :type
+
+          sig { returns(SyntaxTree::Node) }
+          attr_reader :node
+
+          sig { params(type: Integer, node: SyntaxTree::Node).void }
+          def initialize(type:, node:)
+            @type = type
+            @node = node
+          end
         end
 
         sig { params(node: SyntaxTree::Node).void }

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -6,29 +6,73 @@ module RubyLsp
   VOID = T.let(Object.new.freeze, Object)
 
   # A notification to be sent to the client
-  class Notification < T::Struct
-    const :message, String
-    const :params, Object
+  class Notification
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :message
+
+    sig { returns(Object) }
+    attr_reader :params
+
+    sig { params(message: String, params: Object).void }
+    def initialize(message:, params:)
+      @message = message
+      @params = params
+    end
   end
 
   # The final result of running a request before its IO is finalized
-  class Result < T::Struct
-    const :response, T.untyped # rubocop:disable Sorbet/ForbidUntypedStructProps
-    const :error, T.nilable(Exception)
-    const :request_time, T.nilable(Float)
-    const :notifications, T::Array[Notification]
+  class Result
+    extend T::Sig
+
+    sig { returns(T.untyped) }
+    attr_reader :response
+
+    sig { returns(T::Array[Notification]) }
+    attr_reader :notifications
+
+    sig { returns(T.nilable(Exception)) }
+    attr_reader :error
+
+    sig { returns(T.nilable(Float)) }
+    attr_reader :request_time
+
+    sig do
+      params(
+        response: T.untyped,
+        notifications: T::Array[Notification],
+        error: T.nilable(Exception),
+        request_time: T.nilable(Float),
+      ).void
+    end
+    def initialize(response:, notifications:, error: nil, request_time: nil)
+      @response = response
+      @notifications = notifications
+      @error = error
+      @request_time = request_time
+    end
   end
 
   # A request that will sit in the queue until it's executed
-  class Job < T::Struct
+  class Job
     extend T::Sig
 
-    const :request, T::Hash[Symbol, T.untyped]
-    prop :cancelled, T::Boolean
+    sig { returns(T::Hash[Symbol, T.untyped]) }
+    attr_reader :request
+
+    sig { returns(T::Boolean) }
+    attr_reader :cancelled
+
+    sig { params(request: T::Hash[Symbol, T.untyped], cancelled: T::Boolean).void }
+    def initialize(request:, cancelled:)
+      @request = request
+      @cancelled = cancelled
+    end
 
     sig { void }
     def cancel
-      self.cancelled = true
+      @cancelled = true
     end
   end
 end


### PR DESCRIPTION
### Motivation

I wanted to get a more complete understanding of the LSP's performance on a long running session, so I added the following to `server.rb` to generate profile data.
```ruby
def start
  # ...
  when "initialized"
    StackProf.start(mode: :cpu, raw: true)

  when "shutdown"
    StackProf.stop
    data = StackProf.results
    File.write("profile.json", JSON.pretty_generate(data))
  # ...
end
```

I edited and saved files for 2 minutes to triggered as many requests as possible. To my surprise, of the 120 seconds we spent 30 of them just initializing `T::Struct` objects (specifically, running the construct with defaults thing and performing runtime typechecks with `is_a?`).

Other than the desire to have very compact class definitions, we really have no other requirement for using `T::Struct` and it doesn't seem like a good trade off for the performance penalty.

Using benchmark IPS to check the difference on a single request, not counting objects created for queueing, there's a 7% performance difference.
```
Warming up --------------------------------------
                 new    15.350k i/100ms
Calculating -------------------------------------
                 new    154.727k (± 1.1%) i/s -    782.850k in   5.060214s

Comparison:
                 new:   154727.1 i/s
                 old:   144077.7 i/s - 1.07x  (± 0.00) slower
```

This also benefits YJIT, which in my local machine goes from 1.24 -> 1.32 interp / yjit ratio.

### Implementation

Switched all `T::Struct` to regular classes.