### PR TITLE
Fix completion on syntax error

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -21,9 +21,10 @@ module RubyLsp
       @encoding = T.let(encoding, String)
       @source = T.let(source, String)
       @unparsed_edits = T.let([], T::Array[EditShape])
+      @syntax_error = T.let(false, T::Boolean)
       @tree = T.let(SyntaxTree.parse(@source), T.nilable(SyntaxTree::Node))
     rescue SyntaxTree::Parser::ParseError
-      # Do not raise if we failed to parse
+      @syntax_error = true
     end
 
     sig { params(other: Document).returns(T::Boolean) }
@@ -68,14 +69,15 @@ module RubyLsp
       return if @unparsed_edits.empty?
 
       @tree = SyntaxTree.parse(@source)
+      @syntax_error = false
       @unparsed_edits.clear
     rescue SyntaxTree::Parser::ParseError
-      # Do nothing if we fail parse
+      @syntax_error = true
     end
 
     sig { returns(T::Boolean) }
     def syntax_error?
-      @unparsed_edits.any?
+      @syntax_error
     end
 
     sig { returns(T::Boolean) }

--- a/lib/ruby_lsp/requests/path_completion.rb
+++ b/lib/ruby_lsp/requests/path_completion.rb
@@ -24,7 +24,7 @@ module RubyLsp
         @position = position
       end
 
-      sig { override.returns(T.all(T::Array[LanguageServer::Protocol::Interface::CompletionItem], Object)) }
+      sig { override.returns(T.all(T::Array[Interface::CompletionItem], Object)) }
       def run
         # We can't verify if we're inside a require when there are syntax errors
         return [] if @document.syntax_error?
@@ -76,14 +76,12 @@ module RubyLsp
         end
       end
 
-      sig do
-        params(label: String, insert_text: String).returns(LanguageServer::Protocol::Interface::CompletionItem)
-      end
+      sig { params(label: String, insert_text: String).returns(Interface::CompletionItem) }
       def build_completion(label, insert_text)
-        LanguageServer::Protocol::Interface::CompletionItem.new(
+        Interface::CompletionItem.new(
           label: label,
           insert_text: insert_text,
-          kind: LanguageServer::Protocol::Constant::CompletionItemKind::REFERENCE,
+          kind: Constant::CompletionItemKind::REFERENCE,
         )
       end
     end

--- a/lib/ruby_lsp/requests/path_completion.rb
+++ b/lib/ruby_lsp/requests/path_completion.rb
@@ -21,17 +21,20 @@ module RubyLsp
         super(document)
 
         @tree = T.let(Support::PrefixTree.new(collect_load_path_files), Support::PrefixTree)
-
-        char_position = document.create_scanner.find_char_position(position)
-        @target = T.let(find(char_position), T.nilable(SyntaxTree::TStringContent))
+        @position = position
       end
 
       sig { override.returns(T.all(T::Array[LanguageServer::Protocol::Interface::CompletionItem], Object)) }
       def run
-        # no @target means the we are not inside a `require` call
-        return [] unless @target
+        # We can't verify if we're inside a require when there are syntax errors
+        return [] if @document.syntax_error?
 
-        text = @target.value
+        char_position = @document.create_scanner.find_char_position(@position)
+        target = T.let(find(char_position), T.nilable(SyntaxTree::TStringContent))
+        # no target means the we are not inside a `require` call
+        return [] unless target
+
+        text = target.value
         @tree.search(text).sort.map! do |path|
           build_completion(path, path.delete_prefix(text))
         end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -267,17 +267,29 @@ class DocumentTest < Minitest::Test
     RUBY
   end
 
-  def test_unparsed_edits_indicates_when_edits_are_present
+  def test_failing_to_parse_indicates_syntax_error
     document = RubyLsp::Document.new(+<<~RUBY)
       def foo
       end
     RUBY
 
-    refute(document.syntax_error?)
+    refute_predicate(document, :syntax_error?)
 
-    document.push_edits([{ range: { start: { line: 0, character: 7 }, end: { line: 0, character: 7 } }, text: "\n  " }])
+    document.push_edits([{
+      range: { start: { line: 0, character: 7 }, end: { line: 0, character: 7 } },
+      text: "\n  def",
+    }])
+    document.parse
 
-    assert(document.syntax_error?)
+    assert_predicate(document, :syntax_error?)
+  end
+
+  def test_files_opened_with_syntax_errors_are_properly_marked
+    document = RubyLsp::Document.new(+<<~RUBY)
+      def foo
+    RUBY
+
+    assert_predicate(document, :syntax_error?)
   end
 
   private

--- a/test/requests/path_completion_test.rb
+++ b/test/requests/path_completion_test.rb
@@ -46,6 +46,22 @@ class PathCompletionTest < Minitest::Test
     assert_equal(path_completions("ruby_lsp/requests/").to_json, result.to_json)
   end
 
+  def test_completion_does_not_fail_when_there_are_syntax_errors
+    document = RubyLsp::Document.new(+<<~RUBY)
+      require "ruby_lsp/requests/"
+
+      def foo
+    RUBY
+
+    position = {
+      line: 0,
+      character: 21,
+    }
+
+    result = RubyLsp::Requests::PathCompletion.new(document, position).run
+    assert_empty(result)
+  end
+
   private
 
   def path_completions(path_stem)


### PR DESCRIPTION
### Motivation

This PR fixes two issues that I noticed thanks to our telemetry. I recommend reviewing by commit. The issues were
1. We were using `@unparsed_edits` as the indication of whether a file had syntax errors or not, which is brittle. If a file is opened with syntax errors, `@unparsed_edits` is empty, but we still have a syntax error
2. We were trying to run completion when a syntax error existed, which resulted to passing `nil` to `locate` and then failed when invoking `child_nodes` on `nil`

### Implementation

1. Started using an instance variable to indicate the presence of syntax errors
2. Returned early from completion if the file is not properly parsed
3. Used the aliased language server constants to avoid very long constant names

### Automated Tests

Added a test for both fixes and adapted an existing test assumption.