### PR TITLE
Warn that the LSP is ready on initialized

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -37,6 +37,9 @@ module RubyLsp
       case request[:method]
       when "initialize"
         initialize_request(request.dig(:params))
+      when "initialized"
+        warn("Ruby LSP is ready")
+        VOID
       when "textDocument/didOpen"
         text_document_did_open(uri, request.dig(:params, :textDocument, :text))
       when "textDocument/didClose"

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -33,7 +33,7 @@ module RubyLsp
       # fall under the else branch which just pushes requests to the queue
       @reader.read do |request|
         case request[:method]
-        when "initialize", "textDocument/didOpen", "textDocument/didClose", "textDocument/didChange"
+        when "initialize", "initialized", "textDocument/didOpen", "textDocument/didClose", "textDocument/didChange"
           result = Executor.new(@store).execute(request)
           finalize_request(result, request)
         when "$/cancelRequest"


### PR DESCRIPTION
### Motivation

When we're initializing the LSP, we print `Starting Ruby LSP...`, but then we never print that it's ready, which is a minor source of confusion.

Also, after the refactor in #368, we automatically respond with `nil` even for notifications (which do not require a response). The only notification we receive without explicitly requesting in our capabilities is `initialized`, but it does print an error to the console saying `received response without id`.

### Implementation

Implement the `initialized` notification to avoid seeing the errors in the console and to let users know the LSP finished booting.