### PR TITLE
Skip formatting if the document is not valid

### DIFF
--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -37,6 +37,8 @@ module RubyLsp
         # Don't try to format files outside the current working directory
         return unless @uri.sub("file://", "").start_with?(Dir.pwd)
 
+        return if @document.syntax_error?
+
         formatted_text = formatted_file
         return unless formatted_text
 

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -36,6 +36,19 @@ class FormattingTest < Minitest::Test
     end
   end
 
+  def test_syntax_tree_formatting_ignores_syntax_invalid_documents
+    with_uninstalled_rubocop do
+      require "ruby_lsp/requests"
+      document = RubyLsp::Document.new("def foo")
+      assert_nil(RubyLsp::Requests::Formatting.new("file://#{__FILE__}", document).run)
+    end
+  end
+
+  def test_rubocop_formatting_ignores_syntax_invalid_documents
+    document = RubyLsp::Document.new("def foo")
+    assert_nil(RubyLsp::Requests::Formatting.new("file://#{__FILE__}", document).run)
+  end
+
   def test_returns_nil_if_document_is_already_formatted
     document = RubyLsp::Document.new(+<<~RUBY)
       # typed: strict


### PR DESCRIPTION
Closes #477 

### Implementation

Check if the document's syntax is valid before passing it for formatting.

### Manual Tests

1. Comment out all `rubocop` gems in Gemfile
2. Restart LSP server
3. Save
    ```rb
    # test.rb
    def foo
    ewrwerew
    ```
4. 
    - On `main` it'll cause this dialog
    ![Screenshot 2023-02-17 at 12 22 55](https://user-images.githubusercontent.com/5079556/219652667-e5cc82de-c07d-468f-a9f9-49ee32adc4fe.png)
    - On this branch there should be no dialog


