### PR TITLE
Fix path completions when partial path is typed

### DIFF
--- a/lib/ruby_lsp/requests/path_completion.rb
+++ b/lib/ruby_lsp/requests/path_completion.rb
@@ -80,7 +80,13 @@ module RubyLsp
       def build_completion(label, insert_text)
         Interface::CompletionItem.new(
           label: label,
-          insert_text: insert_text,
+          text_edit: Interface::TextEdit.new(
+            range: Interface::Range.new(
+              start: @position,
+              end: @position,
+            ),
+            new_text: insert_text,
+          ),
           kind: Constant::CompletionItemKind::REFERENCE,
         )
       end

--- a/test/requests/path_completion_test.rb
+++ b/test/requests/path_completion_test.rb
@@ -88,6 +88,31 @@ class PathCompletionTest < Minitest::Test
     assert_equal(expected.to_json, result.to_json)
   end
 
+  def test_completion_with_partial_path
+    prefix = "foo/suppo"
+
+    document = RubyLsp::Document.new(+<<~RUBY)
+      require "#{prefix}"
+    RUBY
+
+    position = {
+      line: 0,
+      character: document.source.rindex('"') || 0,
+    }
+
+    result = with_file_structure do
+      RubyLsp::Requests::PathCompletion.new(document, position).run
+    end
+
+    expected = [
+      path_completion("foo/support/bar", prefix, position),
+      path_completion("foo/support/baz", prefix, position),
+      path_completion("foo/support/quux", prefix, position),
+    ]
+
+    assert_equal(expected.to_json, result.to_json)
+  end
+
   def test_completion_does_not_fail_when_there_are_syntax_errors
     document = RubyLsp::Document.new(+<<~RUBY)
       require "ruby_lsp/requests/"

--- a/test/requests/path_completion_test.rb
+++ b/test/requests/path_completion_test.rb
@@ -5,45 +5,87 @@ require "test_helper"
 
 class PathCompletionTest < Minitest::Test
   def test_completion_command
-    document = RubyLsp::Document.new(+<<~RUBY)
-      require "ruby_lsp/requests/"
+    prefix = "foo/"
+
+    document = RubyLsp::Document.new(<<~RUBY)
+      require "#{prefix}"
     RUBY
 
     position = {
       line: 0,
-      character: 21,
+      character: document.source.rindex('"') || 0,
     }
 
-    result = RubyLsp::Requests::PathCompletion.new(document, position).run
-    assert_equal(path_completions("ruby_lsp/requests/").to_json, result.to_json)
+    result = with_file_structure do
+      RubyLsp::Requests::PathCompletion.new(document, position).run
+    end
+
+    expected = [
+      path_completion("foo/bar", prefix, position),
+      path_completion("foo/baz", prefix, position),
+      path_completion("foo/quux", prefix, position),
+      path_completion("foo/support/bar", prefix, position),
+      path_completion("foo/support/baz", prefix, position),
+      path_completion("foo/support/quux", prefix, position),
+    ]
+
+    assert_equal(expected.to_json, result.to_json)
   end
 
   def test_completion_call
+    prefix = "foo/"
+
     document = RubyLsp::Document.new(+<<~RUBY)
-      require("ruby_lsp/requests/")
+      require("#{prefix}")
     RUBY
 
     position = {
       line: 0,
-      character: 21,
+      character: document.source.rindex('"') || 0,
     }
 
-    result = RubyLsp::Requests::PathCompletion.new(document, position).run
-    assert_equal(path_completions("ruby_lsp/requests/").to_json, result.to_json)
+    result = with_file_structure do
+      RubyLsp::Requests::PathCompletion.new(document, position).run
+    end
+
+    expected = [
+      path_completion("foo/bar", prefix, position),
+      path_completion("foo/baz", prefix, position),
+      path_completion("foo/quux", prefix, position),
+      path_completion("foo/support/bar", prefix, position),
+      path_completion("foo/support/baz", prefix, position),
+      path_completion("foo/support/quux", prefix, position),
+    ]
+
+    assert_equal(expected.to_json, result.to_json)
   end
 
   def test_completion_command_call
+    prefix = "foo/"
+
     document = RubyLsp::Document.new(+<<~RUBY)
-      Kernel.require "ruby_lsp/requests/"
+      Kernel.require "#{prefix}"
     RUBY
 
     position = {
       line: 0,
-      character: 28,
+      character: document.source.rindex('"') || 0,
     }
 
-    result = RubyLsp::Requests::PathCompletion.new(document, position).run
-    assert_equal(path_completions("ruby_lsp/requests/").to_json, result.to_json)
+    result = with_file_structure do
+      RubyLsp::Requests::PathCompletion.new(document, position).run
+    end
+
+    expected = [
+      path_completion("foo/bar", prefix, position),
+      path_completion("foo/baz", prefix, position),
+      path_completion("foo/quux", prefix, position),
+      path_completion("foo/support/bar", prefix, position),
+      path_completion("foo/support/baz", prefix, position),
+      path_completion("foo/support/quux", prefix, position),
+    ]
+
+    assert_equal(expected.to_json, result.to_json)
   end
 
   def test_completion_does_not_fail_when_there_are_syntax_errors
@@ -64,16 +106,47 @@ class PathCompletionTest < Minitest::Test
 
   private
 
-  def path_completions(path_stem)
-    root = File.dirname(Bundler.default_gemfile) + "/lib"
+  def with_file_structure(&block)
+    Dir.mktmpdir("path_completion_test") do |tmpdir|
+      $LOAD_PATH << tmpdir
 
-    Dir["#{path_stem}**/*.rb", base: root].sort.map do |path|
-      path.delete_suffix!(".rb")
-      LanguageServer::Protocol::Interface::CompletionItem.new(
-        label: path,
-        insert_text: path.delete_prefix(path_stem),
-        kind: LanguageServer::Protocol::Constant::CompletionItemKind::REFERENCE,
-      )
+      # Set up folder structure like this
+      # <tmpdir>
+      # |-- foo
+      # |   |-- bar.rb
+      # |   |-- baz.rb
+      # |   |-- quux.rb
+      # |   |-- support
+      # |       |-- bar.rb
+      # |       |-- baz.rb
+      # |       |-- quux.rb
+      FileUtils.mkdir_p(tmpdir + "/foo/support")
+      FileUtils.touch([
+        tmpdir + "/foo/bar.rb",
+        tmpdir + "/foo/baz.rb",
+        tmpdir + "/foo/quux.rb",
+        tmpdir + "/foo/support/bar.rb",
+        tmpdir + "/foo/support/baz.rb",
+        tmpdir + "/foo/support/quux.rb",
+      ])
+
+      return block.call
+    ensure
+      $LOAD_PATH.delete(tmpdir)
     end
+  end
+
+  def path_completion(path, prefix, position)
+    LanguageServer::Protocol::Interface::CompletionItem.new(
+      label: path,
+      text_edit: LanguageServer::Protocol::Interface::TextEdit.new(
+        range: LanguageServer::Protocol::Interface::Range.new(
+          start: position,
+          end: position,
+        ),
+        new_text: path.delete_prefix(prefix),
+      ),
+      kind: LanguageServer::Protocol::Constant::CompletionItemKind::REFERENCE,
+    )
   end
 end


### PR DESCRIPTION
### Motivation

With the current implementation when a completion request is received with the require string like `"ruby_lsp/reque"`, the completion suggestions are returned correctly, but when the user selects one of the suggestions, for example, `ruby_lsp/requests/base_request`, then their require string becomes `"ruby_lsp/sts/base_request"`.

Apparently, this happens because [the contents of `insert_text` is open to interpretation by the client](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem):

> The `insertText` is subject to interpretation by the client side.
> Some tools might not take the string literally. For example
> VS Code when code complete is requested in this example
> `con<cursor position>` and a completion item with an `insertText` of
> `console` is provided it will only insert `sole`. Therefore it is
> recommended to use `textEdit` instead since it avoids additional client
> side interpretation.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This PR changes the implementation to use `text_edit` instead of `insert_text` for completion items.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
Updates existing tests to be more resilient and added a new test case for partial path completion.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
