### PR TITLE
Update texts for refactor: extract variable

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -255,7 +255,7 @@ module RubyLsp
           message: "window/showMessage",
           params: Interface::ShowMessageParams.new(
             type: Constant::MessageType::ERROR,
-            message: "Invalid selection for extract refactor",
+            message: "Invalid selection for Extract Variable refactor",
           ),
         )
         raise Requests::CodeActionResolve::CodeActionError

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -13,7 +13,7 @@ module RubyLsp
     #
     # ```ruby
     # # Before:
-    # 1 + 1 # Select the text and use Refactor: Extract variable
+    # 1 + 1 # Select the text and use Refactor: Extract Variable
     #
     # # After:
     # new_variable = 1 + 1
@@ -52,7 +52,7 @@ module RubyLsp
         source_line_indentation = T.must(T.must(@document.source.lines[source_range.dig(:start, :line)])[/\A */]).size
 
         Interface::CodeAction.new(
-          title: "Refactor: Extract variable",
+          title: "Refactor: Extract Variable",
           edit: Interface::WorkspaceEdit.new(
             document_changes: [
               Interface::TextDocumentEdit.new(

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -65,7 +65,7 @@ module RubyLsp
       sig { params(range: Document::RangeShape, uri: String).returns(Interface::CodeAction) }
       def refactor_code_action(range, uri)
         Interface::CodeAction.new(
-          title: "Refactor: Extract variable",
+          title: "Refactor: Extract Variable",
           kind: Constant::CodeActionKind::REFACTOR_EXTRACT,
           data: {
             range: range,

--- a/test/expectations/code_action_resolve/def_extract_variable.exp.json
+++ b/test/expectations/code_action_resolve/def_extract_variable.exp.json
@@ -10,7 +10,7 @@
         }
     },
     "result": {
-        "title": "Refactor: Extract variable",
+        "title": "Refactor: Extract Variable",
         "edit": {
             "documentChanges": [
                 {

--- a/test/expectations/code_actions/def_bad_formatting.exp.json
+++ b/test/expectations/code_actions/def_bad_formatting.exp.json
@@ -117,7 +117,7 @@
     },
     "result": [
         {
-            "title": "Refactor: Extract variable",
+            "title": "Refactor: Extract Variable",
             "kind": "refactor.extract",
             "data": {
                 "range": {

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -227,7 +227,7 @@ class IntegrationTest < Minitest::Test
         },
       },
     )
-    assert_equal("Refactor: Extract variable", response[:result][:title])
+    assert_equal("Refactor: Extract Variable", response[:result][:title])
   end
 
   def test_document_did_close


### PR DESCRIPTION
### Motivation

Addressing the two comments ([this](https://github.com/Shopify/ruby-lsp/pull/491#discussion_r1112212682) and [this](https://github.com/Shopify/ruby-lsp/pull/491#discussion_r1112217153)) from @andyw8 in https://github.com/Shopify/ruby-lsp/pull/491 that I didn't get to before merging.


### Implementation

Two text/copy changes:
1. "Invalid selection for extract refactor" -> "Invalid selection for Extract Variable refactor"
2. "Refactor: Extract variable" -> "Refactor: Extract Variable"

### Automated Tests

No changes

### Manual Tests

No changes