### PR TITLE
Avoid unnecessary String#sub in diagnostic

### DIFF
--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -34,7 +34,7 @@ module RubyLsp
         return unless defined?(Support::RuboCopDiagnosticsRunner)
 
         # Don't try to run RuboCop diagnostics for files outside the current working directory
-        return unless @uri.sub("file://", "").start_with?(Dir.pwd)
+        return unless @uri.start_with?(WORKSPACE_URI)
 
         Support::RuboCopDiagnosticsRunner.instance.run(@uri, @document)
       end

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -5,6 +5,9 @@ module RubyLsp
   # Used to indicate that a request shouldn't return a response
   VOID = T.let(Object.new.freeze, Object)
 
+  # This freeze is not redundant since the interpolated string is mutable
+  WORKSPACE_URI = T.let("file://#{Dir.pwd}".freeze, String) # rubocop:disable Style/RedundantFreeze
+
   # A notification to be sent to the client
   class Notification
     extend T::Sig


### PR DESCRIPTION
### Motivation

Instead of doing `sub` and then `start_with?`, we can do a single operation to check if we're inside the current workspace.

### Implementation

Moved the workspace URI into a constant since it might be useful for other requests. Removed the `sub`.