### PR TITLE
Treat test name strings as document symbols

### DIFF
--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -112,7 +112,14 @@ module RubyLsp
 
         return unless node.call.message.value == "test" && node.call.arguments.is_a?(SyntaxTree::ArgParen)
 
-        full_name = node.call.arguments.arguments.parts.first.parts.map do |part|
+        arg_paren = node.call.arguments
+        args = arg_paren.arguments
+        return unless args
+
+        arg = args.parts.first
+        return unless arg.is_a?(SyntaxTree::StringLiteral)
+
+        full_name = arg.parts.map do |part|
           case part
           when SyntaxTree::TStringContent
             part.value

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -117,7 +117,6 @@ module RubyLsp
         name_node = args.parts.first
         return unless name_node.is_a?(SyntaxTree::StringLiteral)
 
-        # T.reveal_type(name_node)
         add_test(name_node, node)
       end
 

--- a/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
+++ b/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
@@ -1,0 +1,156 @@
+{
+    "result": [
+        {
+            "name": "WidgetTest",
+            "kind": 5,
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 0
+                },
+                "end": {
+                    "line": 40,
+                    "character": 3
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 0,
+                    "character": 6
+                },
+                "end": {
+                    "line": 0,
+                    "character": 16
+                }
+            },
+            "children": [
+                {
+                    "name": "it does something",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 1,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 4,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 1,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 1,
+                            "character": 25
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "interpolation before { } after",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 6,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 8,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 6,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 8,
+                            "character": 5
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "single line",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 10,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 10,
+                            "character": 37
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 10,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 10,
+                            "character": 37
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "interpolation before { } after",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 12,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 14,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 12,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 12,
+                            "character": 29
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "empty test",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 16,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 17,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 16,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 16,
+                            "character": 18
+                        }
+                    },
+                    "children": []
+                }
+            ]
+        }
+    ],
+    "params": []
+}

--- a/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
+++ b/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
@@ -40,11 +40,11 @@
                     "selectionRange": {
                         "start": {
                             "line": 1,
-                            "character": 8
+                            "character": 7
                         },
                         "end": {
                             "line": 1,
-                            "character": 25
+                            "character": 26
                         }
                     },
                     "children": []
@@ -65,11 +65,11 @@
                     "selectionRange": {
                         "start": {
                             "line": 6,
-                            "character": 2
+                            "character": 7
                         },
                         "end": {
-                            "line": 8,
-                            "character": 5
+                            "line": 6,
+                            "character": 42
                         }
                     },
                     "children": []
@@ -90,11 +90,11 @@
                     "selectionRange": {
                         "start": {
                             "line": 10,
-                            "character": 2
+                            "character": 7
                         },
                         "end": {
                             "line": 10,
-                            "character": 37
+                            "character": 20
                         }
                     },
                     "children": []
@@ -115,11 +115,11 @@
                     "selectionRange": {
                         "start": {
                             "line": 12,
-                            "character": 8
+                            "character": 7
                         },
                         "end": {
                             "line": 12,
-                            "character": 29
+                            "character": 42
                         }
                     },
                     "children": []
@@ -140,11 +140,11 @@
                     "selectionRange": {
                         "start": {
                             "line": 16,
-                            "character": 8
+                            "character": 7
                         },
                         "end": {
                             "line": 16,
-                            "character": 18
+                            "character": 19
                         }
                     },
                     "children": []

--- a/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
+++ b/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
@@ -9,7 +9,7 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 46,
+                    "line": 51,
                     "character": 3
                 }
             },

--- a/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
+++ b/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
@@ -9,7 +9,7 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 40,
+                    "line": 46,
                     "character": 3
                 }
             },

--- a/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
+++ b/test/expectations/document_symbol/activesupport_declarative_tests.exp.json
@@ -9,7 +9,7 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 51,
+                    "line": 50,
                     "character": 3
                 }
             },
@@ -25,7 +25,7 @@
             },
             "children": [
                 {
-                    "name": "it does something",
+                    "name": "empty test",
                     "kind": 6,
                     "range": {
                         "start": {
@@ -33,7 +33,7 @@
                             "character": 2
                         },
                         "end": {
-                            "line": 4,
+                            "line": 2,
                             "character": 5
                         }
                     },
@@ -44,107 +44,107 @@
                         },
                         "end": {
                             "line": 1,
+                            "character": 19
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "basic test",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 4,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 4,
+                            "character": 7
+                        },
+                        "end": {
+                            "line": 4,
+                            "character": 19
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "interpolation before { } after",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 8,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 10,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 8,
+                            "character": 7
+                        },
+                        "end": {
+                            "line": 8,
+                            "character": 42
+                        }
+                    },
+                    "children": []
+                },
+                {
+                    "name": "single line block",
+                    "kind": 6,
+                    "range": {
+                        "start": {
+                            "line": 12,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 12,
+                            "character": 43
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 12,
+                            "character": 7
+                        },
+                        "end": {
+                            "line": 12,
                             "character": 26
                         }
                     },
                     "children": []
                 },
                 {
-                    "name": "interpolation before { } after",
+                    "name": "interpolation with parens, before { } after",
                     "kind": 6,
                     "range": {
                         "start": {
-                            "line": 6,
+                            "line": 14,
                             "character": 2
                         },
                         "end": {
-                            "line": 8,
+                            "line": 16,
                             "character": 5
                         }
                     },
                     "selectionRange": {
                         "start": {
-                            "line": 6,
+                            "line": 14,
                             "character": 7
-                        },
-                        "end": {
-                            "line": 6,
-                            "character": 42
-                        }
-                    },
-                    "children": []
-                },
-                {
-                    "name": "single line",
-                    "kind": 6,
-                    "range": {
-                        "start": {
-                            "line": 10,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 10,
-                            "character": 37
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 10,
-                            "character": 7
-                        },
-                        "end": {
-                            "line": 10,
-                            "character": 20
-                        }
-                    },
-                    "children": []
-                },
-                {
-                    "name": "interpolation before { } after",
-                    "kind": 6,
-                    "range": {
-                        "start": {
-                            "line": 12,
-                            "character": 2
                         },
                         "end": {
                             "line": 14,
-                            "character": 5
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 12,
-                            "character": 7
-                        },
-                        "end": {
-                            "line": 12,
-                            "character": 42
-                        }
-                    },
-                    "children": []
-                },
-                {
-                    "name": "empty test",
-                    "kind": 6,
-                    "range": {
-                        "start": {
-                            "line": 16,
-                            "character": 2
-                        },
-                        "end": {
-                            "line": 17,
-                            "character": 5
-                        }
-                    },
-                    "selectionRange": {
-                        "start": {
-                            "line": 16,
-                            "character": 7
-                        },
-                        "end": {
-                            "line": 16,
-                            "character": 19
+                            "character": 55
                         }
                     },
                     "children": []

--- a/test/fixtures/activesupport_declarative_tests.rb
+++ b/test/fixtures/activesupport_declarative_tests.rb
@@ -31,6 +31,9 @@ class WidgetTest < ActiveSupport::TestCase
   test do
   end
 
+  test nil do
+  end
+
   test "a", "b" do
   end
 
@@ -38,6 +41,8 @@ class WidgetTest < ActiveSupport::TestCase
   end
 
   test "no block"
+
+  test
 
   test() { assert true }
 

--- a/test/fixtures/activesupport_declarative_tests.rb
+++ b/test/fixtures/activesupport_declarative_tests.rb
@@ -1,20 +1,19 @@
 class WidgetTest < ActiveSupport::TestCase
-  test "it does something" do
-    a = 1
-    assert true
+  test "empty test" do
   end
 
-  test("interpolation before #{1+1} after") do
+  test "basic test" do
     assert true
   end
-
-  test("single line") { assert true }
 
   test "interpolation before #{1+1} after" do
     assert true
   end
 
-  test "empty test" do
+  test("single line block") { assert true }
+
+  test("interpolation with parens, before #{1+1} after") do
+    assert true
   end
 
   # the remaining should not be treated as test methods

--- a/test/fixtures/activesupport_declarative_tests.rb
+++ b/test/fixtures/activesupport_declarative_tests.rb
@@ -1,0 +1,41 @@
+class WidgetTest < ActiveSupport::TestCase
+  test "it does something" do
+    a = 1
+    assert true
+  end
+
+  test("interpolation before #{1+1} after") do
+    assert true
+  end
+
+  test("single line") { assert true }
+
+  test "interpolation before #{1+1} after" do
+    assert true
+  end
+
+  test "empty test" do
+  end
+
+  # the remaining should not be treated as test methods
+
+  test "some" + "test" do
+  end
+
+  test :symbol_name do
+  end
+
+  it "does something" do
+  end
+
+  test do
+  end
+
+  test "a", "b" do
+  end
+
+  test "" do
+  end
+
+  test "no block"
+end

--- a/test/fixtures/activesupport_declarative_tests.rb
+++ b/test/fixtures/activesupport_declarative_tests.rb
@@ -38,4 +38,10 @@ class WidgetTest < ActiveSupport::TestCase
   end
 
   test "no block"
+
+  test() { assert true }
+
+  test(nil) { assert true }
+
+  test(foo) { assert true }
 end


### PR DESCRIPTION
### Motivation

When tests are defined as normal methods using the `def test_something` syntax, they are treated as document symbols, as any other method would be. But when using the `test "some string"` syntax provided by ActiveSupport, they are not detected. By adding support for those,  VS Code can show them in the Outline View, and list them you press `@` in the command palette.

<img width="565" alt="Screenshot 2023-02-26 at 9 46 30 AM" src="https://user-images.githubusercontent.com/13400/221419843-b481c3ae-e141-4d5d-b6c0-154d4723f1a6.png">

This uses some of the earlier exploratory work by @DeeChau in https://github.com/Shopify/ruby-lsp/pull/490

### Implementation

Currently this does not support other syntax such as RSpec, but I hope to add that in future.

### Automated Tests

I've added a new fixture and expectation.

### Manual Tests

Choose a large project which uses ActiveSupport tests, e.g. a Rails project. Ensure that each tests is listed in the Outline view.