### PR TITLE
Visit command blocks in semantic highlighting

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -160,6 +160,7 @@ module RubyLsp
           add_token(node.message.location, :method)
         end
         visit(node.arguments)
+        visit(node.block)
       end
 
       sig { override.params(node: SyntaxTree::CommandCall).void }
@@ -169,6 +170,7 @@ module RubyLsp
         visit(node.receiver)
         add_token(node.message.location, :method)
         visit(node.arguments)
+        visit(node.block)
       end
 
       sig { override.params(node: SyntaxTree::Const).void }

--- a/test/expectations/semantic_highlighting/command_with_block.exp.json
+++ b/test/expectations/semantic_highlighting/command_with_block.exp.json
@@ -1,0 +1,18 @@
+{
+    "result": [
+        {
+            "delta_line": 0,
+            "delta_start_char": 0,
+            "length": 3,
+            "token_type": 13,
+            "token_modifiers": 0
+        },
+        {
+            "delta_line": 1,
+            "delta_start_char": 2,
+            "length": 3,
+            "token_type": 13,
+            "token_modifiers": 0
+        }
+    ]
+}

--- a/test/fixtures/command_with_block.rb
+++ b/test/fixtures/command_with_block.rb
@@ -1,0 +1,3 @@
+foo 123 do
+  bar
+end


### PR DESCRIPTION
### Motivation

Blocks were added to command and command call in newer versions of syntax tree. We weren't visiting the blocks in semantic highlighting, which meant we didn't properly highlight anything inside of the blocks.

### Implementation

Started visiting the blocks.

### Automated Tests

Added a new test.