### PR TITLE
Add editors file with instructions on how to set up the Ruby LSP

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -1,0 +1,9 @@
+# Editors
+
+This file contains community driven instructions on how to set up the Ruby LSP in editors other than VS Code. For VS
+Code, use the official [Ruby LSP extension](https://github.com/Shopify/vscode-ruby-lsp).
+
+<!-- When adding a new editor to the list, either link directly to a website containing the instructions or link to a
+new H2 header in this file containing the instructions. -->
+
+- [Emacs LSP Mode](https://emacs-lsp.github.io/lsp-mode/page/lsp-ruby-lsp/)

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ group :development do
 end
 ```
 
-If using VS Code, install the [Ruby LSP extension](https://github.com/Shopify/vscode-ruby-lsp) to get the extra features in
-the editor.
+If using VS Code, install the [Ruby LSP extension](https://github.com/Shopify/vscode-ruby-lsp) to get the extra features
+in the editor. See [editors](https://github.com/Shopify/ruby-lsp/blob/main/EDITORS.md) for community instructions on
+setting up the Ruby LSP in different editors.
 
 See the [documentation](https://shopify.github.io/ruby-lsp) for more in-depth details about the
 [supported features](https://shopify.github.io/ruby-lsp/RubyLsp/Requests.html).


### PR DESCRIPTION
### Motivation

The community is adding instructions on how to set up the Ruby LSP in different editors. [Emacs](https://github.com/emacs-lsp/lsp-mode/pull/3984) was recently added and we have a long running discussion on how to configure NeoVim in #188.

We should add a list to make it easier to discover these instructions here in the repo.

### Implementation

Added an `EDITORS.md` file and linked it from the readme. I wanted to properly link it using YARD, so that `EDITORS.md` was treated like an actual page rather than a file in the repository, but I couldn't quite figure it out. Does anyone know how to do that?