### PR TITLE
Start processing method definitions with inline visibility modifiers

### DIFF
--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -108,7 +108,7 @@ module RubyLsp
 
       sig { override.params(node: SyntaxTree::Command).void }
       def visit_command(node)
-        return unless ATTR_ACCESSORS.include?(node.message.value)
+        return visit(node.arguments) unless ATTR_ACCESSORS.include?(node.message.value)
 
         node.arguments.parts.each do |argument|
           next unless argument.is_a?(SyntaxTree::SymbolLiteral)

--- a/test/expectations/document_symbol/def_with_decorators.exp.json
+++ b/test/expectations/document_symbol/def_with_decorators.exp.json
@@ -1,0 +1,88 @@
+{
+  "result": [
+    {
+      "name": "foo",
+      "kind": 6,
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 8
+        },
+        "end": {
+          "line": 2,
+          "character": 3
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 0,
+          "character": 12
+        },
+        "end": {
+          "line": 0,
+          "character": 15
+        }
+      },
+      "children": [
+
+      ]
+    },
+    {
+      "name": "bar",
+      "kind": 6,
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 11
+        },
+        "end": {
+          "line": 6,
+          "character": 3
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 4,
+          "character": 15
+        },
+        "end": {
+          "line": 4,
+          "character": 18
+        }
+      },
+      "children": [
+
+      ]
+    },
+    {
+      "name": "baz",
+      "kind": 6,
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 26
+        },
+        "end": {
+          "line": 10,
+          "character": 3
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 8,
+          "character": 30
+        },
+        "end": {
+          "line": 8,
+          "character": 33
+        }
+      },
+      "children": [
+
+      ]
+    }
+  ],
+  "params": [
+
+  ]
+}

--- a/test/fixtures/def_with_decorators.rb
+++ b/test/fixtures/def_with_decorators.rb
@@ -1,0 +1,11 @@
+private def foo
+  42
+end
+
+protected (def bar
+  1
+end)
+
+memoized internal private def baz
+  :baz
+end


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Fixes #548. We are currently missing constructs like `private def foo; end` and `protected def bar; end` when processing document symbols.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
The problem is because we do an early return for the `command` visitor if the node is not an attr accessor, and we do that without processing the child nodes of the `CommandNode`. This makes us miss a method definition like `private def foo; end`.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

Added a new expectation test named `def_with_visibility` that defines two methods with inline visibility with a command and a call syntax.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
