### PR TITLE
Allow specifying a formatter

### DIFF
--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -12,10 +12,14 @@ module RubyLsp
     sig { params(encoding: String).void }
     attr_writer :encoding
 
+    sig { returns(String) }
+    attr_accessor :formatter
+
     sig { void }
     def initialize
       @state = T.let({}, T::Hash[String, Document])
       @encoding = T.let("utf-8", String)
+      @formatter = T.let("auto", String)
     end
 
     sig { params(uri: String).returns(Document) }

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -66,6 +66,17 @@ class FormattingTest < Minitest::Test
     assert_nil(RubyLsp::Requests::Formatting.new("file:///some/other/folder/file.rb", @document).run)
   end
 
+  def test_allows_specifying_formatter
+    SyntaxTree.expects(:format).with(@document.source).once
+    formatted_document("syntax_tree")
+  end
+
+  def test_raises_on_invalid_formatter
+    assert_raises(RubyLsp::Requests::Formatting::InvalidFormatter) do
+      formatted_document("invalid")
+    end
+  end
+
   private
 
   def with_uninstalled_rubocop(&block)
@@ -89,8 +100,8 @@ class FormattingTest < Minitest::Test
     # Constants are already unloaded
   end
 
-  def formatted_document
+  def formatted_document(formatter = "auto")
     require "ruby_lsp/requests"
-    RubyLsp::Requests::Formatting.new("file://#{__FILE__}", @document).run&.first&.new_text
+    RubyLsp::Requests::Formatting.new("file://#{__FILE__}", @document, formatter: formatter).run&.first&.new_text
   end
 end


### PR DESCRIPTION
### Motivation

Part of https://github.com/Shopify/vscode-ruby-lsp/issues/430

We want to allow users to be able to configure which formatter they want to use. In order to do so for every editor, the server must accept the formatter option when being initialized and then decide what to do based on it.

### Implementation

- Save the formatter option in store
- Always pass it along to the formatting request
- Decide what to do based on the option

### Automated Tests

Added a test where we select Syntax Tree despite RuboCop being present.