### PR TITLE
Require bundler

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -72,7 +72,7 @@ module RubyLsp
           Module.instance_methods(false),
           Kernel.instance_methods(false),
           Kernel.methods(false),
-          *(Bundler::Dsl.instance_methods(false) if defined?(Bundler)),
+          Bundler::Dsl.instance_methods(false),
           Module.private_instance_methods(false),
         ].flatten.map(&:to_s),
         T::Array[String],


### PR DESCRIPTION
### Motivation

https://github.com/Shopify/ruby-lsp/issues/559

Bundler is referenced in SemanticHighlighting but when running `ruby-lsp` without bundle, it is not defined and throws an exception.

### Implementation

Explicitly require `bundler`

