### PR TITLE
Make it easier to configure enabled features

### DIFF
--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -1,0 +1,60 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ExecutorTest < Minitest::Test
+  def setup
+    store = RubyLsp::Store.new
+    @executor = RubyLsp::Executor.new(store)
+  end
+
+  def test_initialize_enabled_features_with_array
+    response = @executor.execute({
+      method: "initialize",
+      params: {
+        initializationOptions: { enabledFeatures: ["semanticHighlighting"] },
+        capabilities: { general: { positionEncodings: "utf-8" } },
+      },
+    }).response
+
+    hash = JSON.parse(response.to_json)
+    capabitilies = hash["capabilities"]
+
+    # TextSynchronization + semanticHighlighting
+    assert_equal(2, capabitilies.length)
+    assert_includes(capabitilies, "semanticTokensProvider")
+  end
+
+  def test_initialize_enabled_features_with_hash
+    response = @executor.execute({
+      method: "initialize",
+      params: {
+        initializationOptions: { enabledFeatures: { "semanticHighlighting" => false } },
+        capabilities: { general: { positionEncodings: "utf-8" } },
+      },
+    }).response
+
+    hash = JSON.parse(response.to_json)
+    capabitilies = hash["capabilities"]
+
+    # Only semantic highlighting is turned off because all others default to true when configuring with a hash
+    refute_includes(capabitilies, "semanticTokensProvider")
+  end
+
+  def test_initialize_enabled_features_with_no_configuration
+    response = @executor.execute({
+      method: "initialize",
+      params: {
+        initializationOptions: {},
+        capabilities: { general: { positionEncodings: "utf-8" } },
+      },
+    }).response
+
+    hash = JSON.parse(response.to_json)
+    capabitilies = hash["capabilities"]
+
+    # All features are enabled by default
+    assert_includes(capabitilies, "semanticTokensProvider")
+  end
+end


### PR DESCRIPTION
### Motivation

Reflecting on this comment https://github.com/Shopify/ruby-lsp/issues/559#issuecomment-1472254321, it is weird indeed that our features are all opt-in instead of opt-out. And that the server has very little control over which features are enabled.

This makes it difficult for clients other than VS Code (which we control the extension's configuration defaults) to set up the Ruby LSP. In retrospect, using an array to configure enabled features was a mistake.

### Implementation

This PR maintains backwards compatibility with clients that are already using arrays to configure features, but also adds the possibility to use a hash or nothing at all.
- Array: because the absence of the feature name indicates it's disabled, we use a hash with `false` as the default and turn all present items to `true`
- Hash: with a hash, clients have full control over what's enabled or disabled, so we should default to all features enabled unless explicitly disabled
- Not passing the config: if clients don't send `enabledFeatures`, then we default to all features enabled

### Automated Tests

Added a test for Executor to verify that we're returning the right capabilities for the different initialization parameters.