### PR TITLE
Prevent excessive array allocations in `visit_all`

### DIFF
--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -28,6 +28,14 @@ module RubyLsp
       sig { abstract.returns(Object) }
       def run; end
 
+      # Syntax Tree implements `visit_all` using `map` instead of `each` for users who want to use the pattern
+      # `result = visitor.visit(tree)`. However, we don't use that pattern and should avoid producing a new array for
+      # every single node visited
+      sig { params(nodes: T::Array[SyntaxTree::Node]).void }
+      def visit_all(nodes)
+        nodes.each { |node| visit(node) }
+      end
+
       sig { params(node: SyntaxTree::Node).returns(LanguageServer::Protocol::Interface::Range) }
       def range_from_syntax_tree_node(node)
         loc = node.location


### PR DESCRIPTION
### Motivation

Syntax Tree implements `visit_all` using a `map` to allow users to use the following pattern
```ruby
visitor = MyVisitor.new
result = visitor.visit(tree)
```

Instead of using that pattern, we accumulate results in instance variables inside our visitors. This means that we're not actually doing anything with the arrays produced by this `map` - an that we're creating a superfluous array for every single node we visit, which in big files ends up accounting for a large number of arrays.

### Implementation

Simply override the default implementation and use `each` instead to prevent the creation of those arrays. The behaviour is exactly the same, we just avoid creating the arrays.