### PR TITLE
Ignore comment continuation for magic comment

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -25,6 +25,7 @@ module RubyLsp
         ],
         T::Array[Regexp],
       )
+      FROZEN_STRING = "frozen_string_literal: true"
 
       sig { params(document: Document, position: Document::PositionShape, trigger_character: String).void }
       def initialize(document, position, trigger_character)
@@ -50,7 +51,7 @@ module RubyLsp
         when "|"
           handle_pipe if @document.syntax_error?
         when "\n"
-          if (comment_match = @previous_line.match(/^#(\s*)/))
+          if (comment_match = @previous_line.match(/^#(\s*)/)) && !@previous_line.include?(FROZEN_STRING)
             handle_comment_line(T.must(comment_match[1]))
           elsif @document.syntax_error?
             handle_statement_end

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -174,6 +174,21 @@ class OnTypeFormattingTest < Minitest::Test
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
 
+  def test_comment_continuation_when_inserting_new_line_after_magic_comment
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "# frozen_string_literal: true",
+      }],
+      version: 2,
+    )
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 29 }, "\n").run
+    assert_empty(edits)
+  end
+
   def test_breaking_line_between_keyword_and_more_content
     document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
 


### PR DESCRIPTION
### Motivation

Hey! I had become more interested in editor tooling in the past month. With the ability to use it at a work now thanks to not needing the gem in bundle, I've had an opportunity to use this tool a lot more. I'm currently writing some greenfield code and find myself creating a lot of new files. As part of that, I end up typing out the magic comment to freeze string literals fairly often.

I find myself typing out the magic comment fairly often and having to remove the extra comment line it adds after hitting enter. Given that the literal freeze comment is like a method invocation (sort of), I figured it might make sense t exclude it from comment continuation logic. This PR puts that in place.
### Implementation

I added a condition to the on-type formatter to ensure that the frozen string isn't included. If it might be useful to add this for other magic comments as well, we could also use a Regex instead and check for matches.

### Automated Tests

Test added.

### Manual Tests

* Add a `frozen_string_literal: true` comment to the top of the document and hit enter.

As a note, I've never worked with Sorbet or dev tooling like this. I tried my best with getting some of this stuff right, but I'm still a bit confused on how to appropriately get the edited version of the gem running locally with the VSCode extension. I was also surprised to see the type annotation for the return of `run` accept an empty array as a valid input. I come purely from Ruby land, so my type knowledge is limited. I'm not sure if the extension can accept an empty response either.

Please do let me know what I can do better. I'd love to improve my skills with this tooling, so all criticism is welcome.