### PR TITLE
Add Slack and VS Code extension badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://github.com/Shopify/ruby-lsp/workflows/CI/badge.svg)
+[![Build Status](https://github.com/Shopify/ruby-lsp/workflows/CI/badge.svg)](https://github.com/Shopify/ruby-lsp/actions/workflows/ci.yml)
 [![Ruby LSP extension](https://img.shields.io/badge/VS%20Code-Ruby%20LSP-success?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
 [![Ruby DX Slack](https://img.shields.io/badge/Slack-Ruby%20DX-success?logo=slack)](https://join.slack.com/t/ruby-dx/shared_invite/zt-1s6f4y15t-v9jedZ9YUPQLM91TEJ4Gew)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 ![Build Status](https://github.com/Shopify/ruby-lsp/workflows/CI/badge.svg)
+[![Ruby LSP extension](https://img.shields.io/badge/VS%20Code-Ruby%20LSP-success?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
+[![Ruby DX Slack](https://img.shields.io/badge/Slack-Ruby%20DX-success?logo=slack)](https://join.slack.com/t/ruby-dx/shared_invite/zt-1s6f4y15t-v9jedZ9YUPQLM91TEJ4Gew)
+
 
 # Ruby LSP
 


### PR DESCRIPTION
### Motivation

I think badges are generally good at catching people's eyes. And using them to emphasise the link to the VS Code extension and the Ruby DX Slack workspace should be helpful.

I didn't add a badge to the rubygems because in most cases we don't want users to install it manually.

### Implementation

I generated badges through https://shields.io and use them for the links.
I also added a link to the CI badge as clicking it now will visit the badge file in a new tab, which isn't helpful.