### PR TITLE
Fetch latest doc for Rails versions that do not have their own docs

### DIFF
--- a/lib/ruby_lsp/requests/support/rails_document_client.rb
+++ b/lib/ruby_lsp/requests/support/rails_document_client.rb
@@ -67,12 +67,13 @@ module RubyLsp
             return unless RAILTIES_VERSION
 
             warn("Fetching Rails Documents...")
-            # If the version's doc is not found, e.g. Rails main, it'll be redirected
-            # In this case, we just fetch the latest doc
-            response = if Gem::Version.new(RAILTIES_VERSION).prerelease?
-              Net::HTTP.get_response(URI("#{RAILS_DOC_HOST}/js/search_index.js"))
-            else
-              Net::HTTP.get_response(URI("#{RAILS_DOC_HOST}/v#{RAILTIES_VERSION}/js/search_index.js"))
+
+            response = Net::HTTP.get_response(URI("#{RAILS_DOC_HOST}/v#{RAILTIES_VERSION}/js/search_index.js"))
+
+            if response.code == "302"
+              # If the version's doc is not found, e.g. Rails main, it'll be redirected
+              # In this case, we just fetch the latest doc
+              response = Net::HTTP.get_response(URI("#{RAILS_DOC_HOST}/js/search_index.js"))
             end
 
             if response.code == "200"


### PR DESCRIPTION
### Motivation

Closes #558 

### Implementation

Currently, the code assumes that any released version of Rails has corresponding documentation that can be accessed at `https://api.rubyonrails.org/<version>js/search_index.js`. However, Rails 7.0.4.3 was released two weeks ago and the link `https://api.rubyonrails.org/v7.0.4.3/js/search_index.js` redirects to `https://edgeapi.rubyonrails.org/js/search_index.js`. By the current logic of the code, `7.0.4.3` should have documentation and since it does not, it assumes the response failed. To fix this, we can just check if the response status code is `302` instead of if the version is pre-released and then fetch the latest docs.

### Automated Tests

There currently aren't any tests for this part of the code so there was nothing to update. 

### Manual Tests

1. Debug the main branch on a Rails project
    - Change the `rails` version to `7.0.4.3` and observe the error in the `Ruby LSP` output:
    
       ```
        Fetching Rails Documents...
        Response failed: #<Net::HTTPFound 302 Moved Temporarily readbody=true>
       ```
    - Change the `rails` version to a release version `>= 7.0.4.2`; there should be no error
    - Change the `rails` version to `gem 'rails', github: 'rails/rails', branch: 'main'` to get the latest pre-release version; there should be no error
2. Debug this branch on a Rails project
    - Repeat the steps from step 1 and none of these steps should produce errors
