### PR TITLE
Only show refactor action if range is not empty

### DIFF
--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -49,7 +49,9 @@ module RubyLsp
           code_action if diagnostic.dig(:data, :correctable) && cover?(range)
         end
 
-        code_actions << refactor_code_action(@range, @uri)
+        # Only add refactor actions if there's a non empty selection in the editor
+        code_actions << refactor_code_action(@range, @uri) unless @range.dig(:start) == @range.dig(:end)
+        code_actions
       end
 
       private

--- a/test/expectations/code_actions/aref_field.exp.json
+++ b/test/expectations/code_actions/aref_field.exp.json
@@ -1,0 +1,40 @@
+{
+    "params": {
+        "range": {
+            "start": {
+                "line": 2,
+                "character": 9
+            },
+            "end": {
+                "line": 2,
+                "character": 13
+            }
+        },
+        "textDocument": {
+            "uri": "file:///fake",
+            "version": null
+        },
+        "context": {
+            "diagnostics": []
+        }
+    },
+    "result": [
+        {
+            "title": "Refactor: Extract Variable",
+            "kind": "refactor.extract",
+            "data": {
+                "range": {
+                    "start": {
+                        "line": 2,
+                        "character": 9
+                    },
+                    "end": {
+                        "line": 2,
+                        "character": 13
+                    }
+                },
+                "uri": "file:///fake"
+            }
+        }
+    ]
+}

--- a/test/expectations/code_actions/def_bad_formatting.exp.json
+++ b/test/expectations/code_actions/def_bad_formatting.exp.json
@@ -1,8 +1,14 @@
 {
     "params": {
         "range": {
-            "start": { "line": 3, "character": 0 },
-            "end": { "line": 3, "character": 0 }
+            "start": {
+                "line": 3,
+                "character": 0
+            },
+            "end": {
+                "line": 3,
+                "character": 0
+            }
         },
         "textDocument": {
             "uri": "file:///fake",
@@ -116,23 +122,6 @@
         }
     },
     "result": [
-        {
-            "title": "Refactor: Extract Variable",
-            "kind": "refactor.extract",
-            "data": {
-                "range": {
-                    "start": {
-                        "line": 3,
-                        "character": 0
-                    },
-                    "end": {
-                        "line": 3,
-                        "character": 0
-                    }
-                },
-                "uri": "file:///fake"
-            }
-        },
         {
             "title": "Autocorrect Layout/IndentationWidth",
             "kind": "quickfix",


### PR DESCRIPTION
### Motivation

Closes #594

We're not checking if the range is empty, so we always show refactor code actions everywhere all the time. This is not a great experience and we should only show if the range is not empty.

**Note**

We should not perform any more elaborate checks in the code actions request. More complex processing, like figuring out if the selection is a complete node, must be done in code actions resolve to prevent performance bottlenecks.

### Implementation

Stopped adding the refactor action if the `start` matches the `end` of the requested range.

### Automated Tests

Changed tests to reflect the new behaviour.

### Manual Tests

1. Open any file using this branch of the LSP
2. You should not see the lightbulb for refactors unless you explicitly make a selection in the editor