### PR TITLE
Use document.uri instead of passing uri around

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -146,7 +146,7 @@ module RubyLsp
     sig { params(uri: String).returns(T::Array[Interface::DocumentLink]) }
     def document_link(uri)
       @store.cache_fetch(uri, :document_link) do |document|
-        RubyLsp::Requests::DocumentLink.new(uri, document).run
+        RubyLsp::Requests::DocumentLink.new(document).run
       end
     end
 
@@ -215,7 +215,7 @@ module RubyLsp
 
     sig { params(uri: String).returns(T.nilable(T::Array[Interface::TextEdit])) }
     def formatting(uri)
-      Requests::Formatting.new(uri, @store.get(uri), formatter: @store.formatter).run
+      Requests::Formatting.new(@store.get(uri), formatter: @store.formatter).run
     end
 
     sig do
@@ -258,7 +258,7 @@ module RubyLsp
     def code_action(uri, range, context)
       document = @store.get(uri)
 
-      Requests::CodeActions.new(uri, document, range, context).run
+      Requests::CodeActions.new(document, range, context).run
     end
 
     sig { params(params: T::Hash[Symbol, T.untyped]).returns(Interface::CodeAction) }
@@ -294,7 +294,7 @@ module RubyLsp
     sig { params(uri: String).returns(T.nilable(Interface::FullDocumentDiagnosticReport)) }
     def diagnostic(uri)
       response = @store.cache_fetch(uri, :diagnostics) do |document|
-        Requests::Diagnostics.new(uri, document).run
+        Requests::Diagnostics.new(document).run
       end
 
       Interface::FullDocumentDiagnosticReport.new(kind: "full", items: response.map(&:to_lsp_diagnostic)) if response

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -21,16 +21,15 @@ module RubyLsp
 
       sig do
         params(
-          uri: String,
           document: Document,
           range: Document::RangeShape,
           context: T::Hash[Symbol, T.untyped],
         ).void
       end
-      def initialize(uri, document, range, context)
+      def initialize(document, range, context)
         super(document)
 
-        @uri = uri
+        @uri = T.let(document.uri, String)
         @range = range
         @context = context
       end

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -21,11 +21,11 @@ module RubyLsp
     class Diagnostics < BaseRequest
       extend T::Sig
 
-      sig { params(uri: String, document: Document).void }
-      def initialize(uri, document)
+      sig { params(document: Document).void }
+      def initialize(document)
         super(document)
 
-        @uri = uri
+        @uri = T.let(document.uri, String)
       end
 
       sig { override.returns(T.nilable(T.all(T::Array[Support::RuboCopDiagnostic], Object))) }

--- a/lib/ruby_lsp/requests/document_link.rb
+++ b/lib/ruby_lsp/requests/document_link.rb
@@ -69,13 +69,13 @@ module RubyLsp
         end
       end
 
-      sig { params(uri: String, document: Document).void }
-      def initialize(uri, document)
+      sig { params(document: Document).void }
+      def initialize(document)
         super(document)
 
         # Match the version based on the version in the RBI file name. Notice that the `@` symbol is sanitized to `%40`
         # in the URI
-        version_match = /(?<=%40)[\d.]+(?=\.rbi$)/.match(uri)
+        version_match = /(?<=%40)[\d.]+(?=\.rbi$)/.match(document.uri)
         @gem_version = T.let(version_match && version_match[0], T.nilable(String))
         @links = T.let([], T::Array[Interface::DocumentLink])
       end

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -27,11 +27,11 @@ module RubyLsp
 
       extend T::Sig
 
-      sig { params(uri: String, document: Document, formatter: String).void }
-      def initialize(uri, document, formatter: "auto")
+      sig { params(document: Document, formatter: String).void }
+      def initialize(document, formatter: "auto")
         super(document)
 
-        @uri = uri
+        @uri = T.let(document.uri, String)
         @formatter = T.let(
           if formatter == "auto"
             defined?(Support::RuboCopFormattingRunner) ? "rubocop" : "syntax_tree"

--- a/test/requests/code_actions_expectations_test.rb
+++ b/test/requests/code_actions_expectations_test.rb
@@ -14,7 +14,6 @@ class CodeActionsExpectationsTest < ExpectationsTestRunner
 
     stdout, _ = capture_io do
       result = RubyLsp::Requests::CodeActions.new(
-        "file:///fake",
         document,
         params[:range],
         params[:context],

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -8,13 +8,13 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Diagnostics, "diagnostics"
 
   def run_expectations(source)
-    document = RubyLsp::Document.new(source: source, version: 1, uri: "file:///fake.rb")
-    RubyLsp::Requests::Diagnostics.new("file://#{__FILE__}", document).run
+    document = RubyLsp::Document.new(source: source, version: 1, uri: "file://#{__FILE__}")
+    RubyLsp::Requests::Diagnostics.new(document).run
     result = T.let(nil, T.nilable(T::Array[RubyLsp::Requests::Support::RuboCopDiagnostic]))
 
     stdout, _ = capture_io do
       result = T.cast(
-        RubyLsp::Requests::Diagnostics.new("file://#{__FILE__}", document).run,
+        RubyLsp::Requests::Diagnostics.new(document).run,
         T::Array[RubyLsp::Requests::Support::RuboCopDiagnostic],
       )
     end

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -8,7 +8,7 @@ class DiagnosticsTest < Minitest::Test
     fixture_path = File.expand_path("../fixtures/def_multiline_params.rb", __dir__)
     document = RubyLsp::Document.new(source: File.read(fixture_path), version: 1, uri: "file://#{fixture_path}")
 
-    result = RubyLsp::Requests::Diagnostics.new("file://#{fixture_path}", document).run
+    result = RubyLsp::Requests::Diagnostics.new(document).run
     assert_empty(result)
   end
 
@@ -19,6 +19,6 @@ class DiagnosticsTest < Minitest::Test
       end
     RUBY
 
-    assert_nil(RubyLsp::Requests::Diagnostics.new("file:///some/other/folder/file.rb", document).run)
+    assert_nil(RubyLsp::Requests::Diagnostics.new(document).run)
   end
 end

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -22,7 +22,7 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::Document.new(source: source, version: 1, uri: "file://#{@_path}")
-    RubyLsp::Requests::DocumentLink.new(@_path, document).run
+    RubyLsp::Requests::DocumentLink.new(document).run
   end
 
   private

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -9,7 +9,7 @@ class FormattingExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::Document.new(source: source, version: 1, uri: "file://#{__FILE__}")
-    RubyLsp::Requests::Formatting.new("file://#{__FILE__}", document).run&.first&.new_text
+    RubyLsp::Requests::Formatting.new(document).run&.first&.new_text
   end
 
   def assert_expectations(source, expected)


### PR DESCRIPTION
### Motivation

Second step in trying to fix #535

Now that we have the URI in the document instances, there's no need to pass it around as arguments.

### Implementation

Removed URI arguments in every request that used it and read it from the document instead.