### PR TITLE
Make requests that handle text edits non concurrent

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -35,7 +35,8 @@ module RubyLsp
       # fall under the else branch which just pushes requests to the queue
       @reader.read do |request|
         case request[:method]
-        when "initialize", "initialized", "textDocument/didOpen", "textDocument/didClose", "textDocument/didChange"
+        when "initialize", "initialized", "textDocument/didOpen", "textDocument/didClose", "textDocument/didChange",
+              "textDocument/formatting", "textDocument/onTypeFormatting", "codeAction/resolve"
           result = Executor.new(@store).execute(request)
           finalize_request(result, request)
         when "$/cancelRequest"


### PR DESCRIPTION
### Motivation

Closes #535 

Note: this issue is very hard to reproduce and debug, but I believe this is a good solution.

When typing fast in a large file, sometimes we return text edits for old versions of the document which gets us in an inconsistent state. This happens because the thread switches and ends up allowing `textDocument/didChange` requests to come in before we return other text edits.

I believe a good solution for this is to run all requests that require text edits in the main thread, which should avoid more text edits coming in between and taking us to an inconsistent state.

My suggestion is to roll with this and check our metrics to see if the errors go away.

### Implementation

Moved the requests that return text edits to run in the main thread. Because those aren't placed in the queue, the order of operations is guaranteed.