### PR TITLE
Fix keyword recognition for on-type formatting

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -80,6 +80,10 @@ module RubyLsp
 
       sig { void }
       def handle_statement_end
+        # If a keyword occurs in a line which appears be a comment or a string, we will not try to format it, since
+        # it could be a coincidental match. This approach is not perfect, but it should cover most cases.
+        return if @previous_line.start_with?(/["'#]/)
+
         return unless END_REGEXES.any? { |regex| regex.match?(@previous_line) }
 
         indents = " " * @indentation

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -119,6 +119,21 @@ class OnTypeFormattingTest < Minitest::Test
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
 
+  def test_keyword_handling
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "\"def\"g\"",
+      }],
+      version: 2,
+    )
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 5 }, "\n").run
+    assert_empty(edits)
+  end
+
   def test_comment_continuation_with_other_line_break_matches
     document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
 


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/608

### Implementation

We will skip on-type formatting if a line begins with a string, or a comment. This may not be perfect, but it should cover most cases. We can't parse the code to be fully confident because it may include invalid syntax. (This may become feasible in future if we move to YARP).

### Automated Tests

Included

### Manual Tests

Verify against the example in https://github.com/Shopify/ruby-lsp/issues/608
