### PR TITLE
Only fallback to Syntax Tree if part of the project's `Gemfile` or `gemspec`

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -74,6 +74,16 @@ module RubyLsp
       when "textDocument/formatting"
         begin
           formatting(uri)
+        rescue Requests::Formatter::NoFormatter => error
+          @notifications << Notification.new(
+            message: "window/statusUpdate",
+            params: Interface::ShowMessageParams.new(
+              type: Constant::MessageType::ERROR,
+              message: "hello from lsp",
+            ),
+          )
+
+          nil
         rescue Requests::Formatting::InvalidFormatter => error
           @notifications << Notification.new(
             message: "window/showMessage",

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -25,6 +25,10 @@ module RubyLsp
     # puts "Hello" # --> formatting: fixes the indentation on save
     # end
     # ```
+
+    SYNTAX_TREE_AS_DIRECT_DEPENDENCY = Bundler::LockfileParser.new(Bundler.read_file(Bundler.default_lockfile))
+      .dependencies.key?("syntax_tree")
+
     class Formatting < BaseRequest
       class Error < StandardError; end
       class InvalidFormatter < StandardError; end
@@ -40,7 +44,7 @@ module RubyLsp
           if formatter == "auto"
             if defined?(Support::RuboCopFormattingRunner)
               "rubocop"
-            elsif syntax_tree_as_direct_dependency?
+            elsif SYNTAX_TREE_AS_DIRECT_DEPENDENCY
               "syntax_tree"
             else
               "none"
@@ -90,11 +94,6 @@ module RubyLsp
         else
           raise InvalidFormatter, "Unknown formatter: #{@formatter}"
         end
-      end
-
-      sig { returns(T::Boolean) }
-      def syntax_tree_as_direct_dependency?
-        Bundler::LockfileParser.new(Bundler.read_file(Bundler.default_lockfile)).dependencies.key?("syntax_tree")
       end
     end
   end

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -26,10 +26,11 @@ module RubyLsp
     # end
     # ```
 
-    SYNTAX_TREE_AS_DIRECT_DEPENDENCY = Bundler::LockfileParser.new(Bundler.read_file(Bundler.default_lockfile))
-      .dependencies.key?("syntax_tree")
-
     class Formatting < BaseRequest
+
+      SYNTAX_TREE_AS_DIRECT_DEPENDENCY = Bundler::LockfileParser.new(Bundler.read_file(Bundler.default_lockfile))
+        .dependencies.key?("syntax_tree")
+
       class Error < StandardError; end
       class InvalidFormatter < StandardError; end
 

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -28,8 +28,7 @@ module RubyLsp
 
     class Formatting < BaseRequest
 
-      SYNTAX_TREE_AS_DIRECT_DEPENDENCY = Bundler::LockfileParser.new(Bundler.read_file(Bundler.default_lockfile))
-        .dependencies.key?("syntax_tree")
+      SYNTAX_TREE_AS_DIRECT_DEPENDENCY = Bundler.locked_gems.dependencies.key?("syntax_tree")
 
       class Error < StandardError; end
       class InvalidFormatter < StandardError; end

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -83,7 +83,6 @@ module RubyLsp
       sig { returns(T.nilable(String)) }
       def formatted_file
         case @formatter
-        when "none"
         when "rubocop"
           Support::RuboCopFormattingRunner.instance.run(@uri, @document)
         when "syntax_tree"

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -27,11 +27,11 @@ module RubyLsp
     # ```
 
     class Formatting < BaseRequest
-
       SYNTAX_TREE_AS_DIRECT_DEPENDENCY = Bundler.locked_gems.dependencies.key?("syntax_tree")
 
       class Error < StandardError; end
       class InvalidFormatter < StandardError; end
+      class NoFormatter < StandardError; end
 
       extend T::Sig
 
@@ -47,7 +47,7 @@ module RubyLsp
             elsif SYNTAX_TREE_AS_DIRECT_DEPENDENCY
               "syntax_tree"
             else
-              "none"
+              raise NoFormatter, "No formatter found. Please add RuboCop or Syntax Tree to the bundle"
             end
           else
             formatter

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -39,10 +39,8 @@ module RubyLsp
         @formatter = T.let(
           if formatter == "auto"
             if defined?(Support::RuboCopFormattingRunner)
-              warn("Using RuboCop for formatting")
               "rubocop"
             elsif syntax_tree_as_direct_dependency?
-              warn("Using Syntax Tree for formatting")
               "syntax_tree"
             else
               "none"

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -196,6 +196,6 @@ class FormattingTest < Minitest::Test
 
   def stub_syntax_tree(present:)
     result = present ? { "syntax_tree" => "..." } : {}
-    Bundler::locked_gems.stubs(:dependencies).returns(result)
+    Bundler.locked_gems.stubs(:dependencies).returns(result)
   end
 end

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -58,7 +58,7 @@ class FormattingTest < Minitest::Test
     stub_syntax_tree(present: false)
 
     with_uninstalled_rubocop do
-      assert_nil(formatted_document)
+      assert_raises(NoFormatter) { formatted_document }
     end
   end
 
@@ -96,7 +96,7 @@ class FormattingTest < Minitest::Test
     with_uninstalled_rubocop do
       require "ruby_lsp/requests"
       document = RubyLsp::Document.new(source: "def foo", version: 1, uri: "file://#{__FILE__}")
-      assert_nil(RubyLsp::Requests::Formatting.new(document).run)
+      assert_raises(NoFormatter) { RubyLsp::Requests::Formatting.new(document).run }
     end
   end
 

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -195,9 +195,7 @@ class FormattingTest < Minitest::Test
   end
 
   def stub_syntax_tree(present:)
-    parser = stub("lockfile_parser")
-    Bundler::LockfileParser.stubs(:new).returns(parser)
     result = present ? { "syntax_tree" => "..." } : {}
-    parser.stubs(:dependencies).returns(result)
+    Bundler::locked_gems.stubs(:dependencies).returns(result)
   end
 end


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/546 and https://github.com/Shopify/ruby-lsp/issues/384

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
There is a chance that auto-detection could be wrong in particular situations: If a gem has a runtime dependency on RuboCop, but the project using that gem uses `syntax_tree`, it will incorrectly default to using RuboCop. We could choose to mitigate this by:
- displaying an error if the correct formatter cannot be reliably determined.
- not applying any formatting unless a specific formatter is set

### Automated Tests

Included.

### Manual Tests

(in each case below, checkout this branch and add `ruby-lsp` to the Gemfile, with the appropriate `path`).

* Choose a project which has neither RuboCop or syntax_tree
* Attempt to format a Ruby file
* Ensure no formatting is performance
* Choose a project which uses RuboCop
* Attempt to format a Ruby file
* Ensure it's formatted using RuboCop (confirm via the logging in the LSP output panel)
* Choose a project which uses Syntax Tree
* Attempt to format a Ruby file
* Ensure it's formatted using Syntax Tree (confirm via the logging in the LSP output panel)