### PR TITLE
Avoid trying to parse document if there are no new edits

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -77,9 +77,9 @@ module RubyLsp
     def parse
       return if @unparsed_edits.empty?
 
+      @unparsed_edits.clear
       @tree = SyntaxTree.parse(@source)
       @syntax_error = false
-      @unparsed_edits.clear
     rescue SyntaxTree::Parser::ParseError
       @syntax_error = true
     end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -473,6 +473,18 @@ class DocumentTest < Minitest::Test
     assert_instance_of(SyntaxTree::CallNode, parent)
   end
 
+  def test_reparsing_without_new_edits_does_nothing
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///foo/bar.rb")
+    document.push_edits(
+      [{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }, text: "def foo" }],
+      version: 2,
+    )
+
+    document.parse
+    assert_predicate(document, :syntax_error?)
+    assert_empty(document.instance_variable_get(:@unparsed_edits))
+  end
+
   private
 
   def assert_error_edit(actual, error_range)


### PR DESCRIPTION
### Motivation

This is a tiny change, but that may provide considerable improvement. Before, we only cleared `@unparsed_edits` if we successfully parsed the document. What we actually want is to only try to parse the document if there are new edits we haven't tried parsing yet.

In the current approach, if someone types in a syntax error, we receive a bunch of requests from the editor (e.g.: folding range, document symbol, semantic highlighting...). Because trying to parse will fail and we won't clear `@unparsed_edits`, we'll actually try to parse again for each single one of these requests even though there's no possibility of successfully parsing. Parsing can only succeed after a new edit has been made.

### Implementation

The `@unparsed_edits` variable must indicate that there are edits waiting for a parse attempt. We should always clear the array even if parsing fails to prevent unnecessary parses.

### Automated Tests

Added a test that verifies the array is cleared even when there are syntax errors.