### PR TITLE
Fix server encoding registration and prefer UTF-8

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -6,14 +6,4 @@ require "bundler/setup"
 require_relative "../lib/ruby_lsp/internal"
 require "irb"
 
-extend T::Sig
-
-sig { params(source: String).returns(RubyLsp::Document) }
-def new_doc(source)
-  RubyLsp::Document.new(source)
-end
-
-@source = T.let(File.read(File.expand_path("../lib/ruby_lsp/server.rb", __dir__)), String)
-@document = T.let(new_doc(@source), RubyLsp::Document)
-
 IRB.start(__FILE__)

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -22,7 +22,7 @@ module RubyLsp
     attr_reader :uri
 
     sig { params(source: String, version: Integer, uri: String, encoding: String).void }
-    def initialize(source:, version:, uri:, encoding: "utf-8")
+    def initialize(source:, version:, uri:, encoding: Constant::PositionEncodingKind::UTF8)
       @cache = T.let({}, T::Hash[Symbol, T.untyped])
       @encoding = T.let(encoding, String)
       @source = T.let(source, String)
@@ -182,7 +182,11 @@ module RubyLsp
         # The final position is the beginning of the line plus the requested column. If the encoding is UTF-16, we also
         # need to adjust for surrogate pairs
         requested_position = @pos + position[:character]
-        requested_position -= utf_16_character_position_correction(@pos, requested_position) if @encoding == "utf-16"
+
+        if @encoding == Constant::PositionEncodingKind::UTF16
+          requested_position -= utf_16_character_position_correction(@pos, requested_position)
+        end
+
         requested_position
       end
 

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -9,8 +9,8 @@ module RubyLsp
   class Store
     extend T::Sig
 
-    sig { params(encoding: String).void }
-    attr_writer :encoding
+    sig { returns(String) }
+    attr_accessor :encoding
 
     sig { returns(String) }
     attr_accessor :formatter
@@ -18,7 +18,7 @@ module RubyLsp
     sig { void }
     def initialize
       @state = T.let({}, T::Hash[String, Document])
-      @encoding = T.let("utf-8", String)
+      @encoding = T.let(Constant::PositionEncodingKind::UTF8, String)
       @formatter = T.let("auto", String)
     end
 

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -14,15 +14,15 @@ class ExecutorTest < Minitest::Test
       method: "initialize",
       params: {
         initializationOptions: { enabledFeatures: ["semanticHighlighting"] },
-        capabilities: { general: { positionEncodings: "utf-8" } },
+        capabilities: { general: { positionEncodings: ["utf-8"] } },
       },
     }).response
 
     hash = JSON.parse(response.to_json)
     capabilities = hash["capabilities"]
 
-    # TextSynchronization + semanticHighlighting
-    assert_equal(2, capabilities.length)
+    # TextSynchronization + encodings + semanticHighlighting
+    assert_equal(3, capabilities.length)
     assert_includes(capabilities, "semanticTokensProvider")
   end
 
@@ -31,7 +31,7 @@ class ExecutorTest < Minitest::Test
       method: "initialize",
       params: {
         initializationOptions: { enabledFeatures: { "semanticHighlighting" => false } },
-        capabilities: { general: { positionEncodings: "utf-8" } },
+        capabilities: { general: { positionEncodings: ["utf-8"] } },
       },
     }).response
 
@@ -47,7 +47,7 @@ class ExecutorTest < Minitest::Test
       method: "initialize",
       params: {
         initializationOptions: {},
-        capabilities: { general: { positionEncodings: "utf-8" } },
+        capabilities: { general: { positionEncodings: ["utf-8"] } },
       },
     }).response
 
@@ -56,5 +56,50 @@ class ExecutorTest < Minitest::Test
 
     # All features are enabled by default
     assert_includes(capabilities, "semanticTokensProvider")
+  end
+
+  def test_initialize_defaults_to_utf_8_if_present
+    response = @executor.execute({
+      method: "initialize",
+      params: {
+        initializationOptions: {},
+        capabilities: { general: { positionEncodings: ["utf-8", "utf-16"] } },
+      },
+    }).response
+
+    hash = JSON.parse(response.to_json)
+
+    # All features are enabled by default
+    assert_includes("utf-8", hash.dig("capabilities", "positionEncoding"))
+  end
+
+  def test_initialize_uses_utf_16_if_utf_8_is_not_present
+    response = @executor.execute({
+      method: "initialize",
+      params: {
+        initializationOptions: {},
+        capabilities: { general: { positionEncodings: ["utf-16"] } },
+      },
+    }).response
+
+    hash = JSON.parse(response.to_json)
+
+    # All features are enabled by default
+    assert_includes("utf-16", hash.dig("capabilities", "positionEncoding"))
+  end
+
+  def test_initialize_uses_utf_16_if_no_encodings_are_specified
+    response = @executor.execute({
+      method: "initialize",
+      params: {
+        initializationOptions: {},
+        capabilities: { general: { positionEncodings: [] } },
+      },
+    }).response
+
+    hash = JSON.parse(response.to_json)
+
+    # All features are enabled by default
+    assert_includes("utf-16", hash.dig("capabilities", "positionEncoding"))
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -426,7 +426,7 @@ class IntegrationTest < Minitest::Test
     end
 
     enabled_providers = enabled_features.map { |feature| FEATURE_TO_PROVIDER[feature] }
-    assert_equal([:textDocumentSync, *enabled_providers], response[:capabilities].keys)
+    assert_equal([:positionEncoding, :textDocumentSync, *enabled_providers], response[:capabilities].keys)
   end
 
   def open_file_with(content)


### PR DESCRIPTION
### Motivation

Our client encoding reading was wrong. The `positionEncodings` field is actually an array of encodings that the editor supports and not a single one. This means that our UTF-16 corrections weren't being properly applied.

The server must look into the list and select out of the possible ones its preference. Because Ripper doesn't support anything but UTF-8, we should always prefer that.

### Implementation

- If UTF-8 is a possible encoding, we pick that
- Otherwise, we try to use whatever encoding we received

### Automated Tests

Added positional encodings to the expected initialization capabilities.