### PR TITLE
feat(benchmark): display missing requests

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,11 @@ jobs:
       # Fail the job based on the benchmark output
       - name: Finalize job
         run: |
-          if [[ "${{ steps.benchmark.outputs.REPORT }}" == *"At least one benchmark is slower than the main branch"* ]]; then
+          REPORT="${{ steps.benchmark.outputs.REPORT }}"
+          IS_SLOWER=$(grep "At least one benchmark is slower than the main branch" <<< "$REPORT")
+          IS_MISSING=$(grep "Missing benchmarks" <<< "$REPORT")
+
+          if [[ $IS_SLOWER || $IS_MISSING ]]; then
             exit 1
           else
             exit 0

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -314,6 +314,7 @@ if missing_benchmarks.any?
   puts "=" * 80
   puts "Missing benchmarks:\n\n"
   puts missing_benchmarks.map(&:to_s)
+  exit(1)
 end
 
 File.write(CACHE_FILE_PATH, results.to_json)


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/504

Display in benchmarks results if there is any missing request benchmark. 

### Implementation

The second option proposed here: https://github.com/Shopify/ruby-lsp/issues/504#issuecomment-1499068788

* Map all classes which inherit from `BaseRequest` or `Listener`
* Require everything under `ruby_lsp/requests`
* Re-map all classes which inherit from `BaseRequest` or `Listener`
* If a delta is present, display it. 

Two open questions: 

* Is the output OK this way? Should I format it like removing `RubyLsp::Requests` (or any other way)?

```bash
================================================================================
Missing benchmarks:

RubyLsp::Requests::PathCompletion
RubyLsp::Requests::CodeLens
RubyLsp::Requests::CodeActionResolve
```

* Should I edit `github/workflows/benchmark.yml` to make it fail if there are any missing requests?

### Automated Tests

I think there is no test on the task, but I may be wrong. Feel free to point it out if necessary.

### Manual Tests

There are already missing benchmarks so: 

* run `bin/benchmark` 
* output `PathCompletion`, `CodeLens` & `CodeActionResolve`
* comment an item in `requests` hash, re-run `bin/benchmark` it should be added on missing benchmarks