### PR TITLE
Use bugfix label for release automation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -16,7 +16,7 @@ changelog:
         - enhancement
     - title: 🐛 Bug Fixes
       labels:
-        - bug
+        - bugfix
     - title: 🛠 Other Changes
       labels:
         - "*"


### PR DESCRIPTION
### Motivation

In every other project, we always use `bug` for reports and `bugfix` for PRs that address issues.