### PR TITLE
Warn user that --debug flag requires the debug gem

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -28,7 +28,11 @@ if ARGV.include?("--debug")
   socket_identifier = "ruby-debug-#{ENV["USER"]}-#{File.basename(Dir.pwd)}.sock"
   ENV["RUBY_DEBUG_SOCK_PATH"] = "#{sockets_dir}/#{socket_identifier}"
 
-  require "debug/open_nonstop"
+  begin
+    require "debug/open_nonstop"
+  rescue LoadError
+    warn("You need to install the debug gem to use the --debug flag")
+  end
 end
 
 RubyLsp::Server.new.start


### PR DESCRIPTION
### Motivation

Fixes #592 

### Implementation

Rescue `LoadError` if the `debug` gem is not in the target project's bundle.

### Automated Tests

We don't have tests for the `--debug` atm.

### Manual Tests

1. Add `gem "ruby-lsp", github: "Shopify/ruby-lsp", branch: "fix-#592"` in a Ruby project's `Gemfile`
2. Remove `gem "debug"` from the `Gemfile` if it's present
3. Run `bundle`
4. Run `bundle exec ruby-lsp --debug`
5. See the text:

    > You need to install the debug gem to use the --debug flag
    Starting Ruby LSP...
