### PR TITLE
Separate server notifications and requests

### DIFF
--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -9,8 +9,11 @@ module RubyLsp
   WORKSPACE_URI = T.let("file://#{Dir.pwd}".freeze, String) # rubocop:disable Style/RedundantFreeze
 
   # A notification to be sent to the client
-  class Notification
+  class Message
     extend T::Sig
+    extend T::Helpers
+
+    abstract!
 
     sig { returns(String) }
     attr_reader :message
@@ -25,6 +28,9 @@ module RubyLsp
     end
   end
 
+  class Notification < Message; end
+  class Request < Message; end
+
   # The final result of running a request before its IO is finalized
   class Result
     extend T::Sig
@@ -32,8 +38,8 @@ module RubyLsp
     sig { returns(T.untyped) }
     attr_reader :response
 
-    sig { returns(T::Array[Notification]) }
-    attr_reader :notifications
+    sig { returns(T::Array[Message]) }
+    attr_reader :messages
 
     sig { returns(T.nilable(Exception)) }
     attr_reader :error
@@ -44,14 +50,14 @@ module RubyLsp
     sig do
       params(
         response: T.untyped,
-        notifications: T::Array[Notification],
+        messages: T::Array[Message],
         error: T.nilable(Exception),
         request_time: T.nilable(Float),
       ).void
     end
-    def initialize(response:, notifications:, error: nil, request_time: nil)
+    def initialize(response:, messages:, error: nil, request_time: nil)
       @response = response
-      @notifications = notifications
+      @messages = messages
       @error = error
       @request_time = request_time
     end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -337,6 +337,7 @@ class IntegrationTest < Minitest::Test
     File.write(".rubocop.yml", "\nInvalidCop:\n  Enabled: true", mode: "a")
 
     make_request("textDocument/diagnostic", { textDocument: { uri: "file://#{__FILE__}" } })
+    read_response("textDocument/diagnostic")
     response = read_response("window/showMessage")
 
     assert_equal("window/showMessage", response.dig(:method))


### PR DESCRIPTION
### Motivation

The server can send both requests and notifications to the client, but our model only took notifications into account. We need to be able to use requests to register for dynamic features, which is necessary for #199.

This PR allows us to decide whether to send a Notification or a Request message to the client.

### Implementation

1. Renamed notifications to messages everywhere
2. Created two subclasses of `Message`: `Request` and `Notification`
3. When sending requests to the client, we need to generate an ID to go with it. I did this in the server because incrementing the ID has to happen under a mutex
4. I also moved to send messages after request responses. I'm not sure why it was inverted

### Automated Tests

Fixed an integration test, but the rest is just a refactor.