### PR TITLE
Fix event emitter example title

### DIFF
--- a/lib/ruby_lsp/event_emitter.rb
+++ b/lib/ruby_lsp/event_emitter.rb
@@ -9,7 +9,7 @@ module RubyLsp
   # - For nonpositional requests, use `visit` to go through the AST, which will fire events for each listener as nodes
   # are found
   #
-  # = Example
+  # # Example
   #
   # ```ruby
   # target_node = document.locate_node(position)


### PR DESCRIPTION
### Motivation

We use markdown for our YARD docs, so to create a title we need to use `#` and not `=`.