### PR TITLE
Don't support debugging on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To add a new expectations test runner for a new request handler:
 3. [`vscode-ruby-lsp`] Select `Run Extension` and click the green triangle (or press F5).
 4. [`vscode-ruby-lsp`] Now VS Code will:
     - Open another workspace as the `Extension Development Host`.
-    - Run `vscode-ruby-lsp` extension in debug mode, which will start a new `ruby-lsp` process with the `--debug` flag.
+    - Run `vscode-ruby-lsp` extension in debug mode, which will start a new `ruby-lsp` process with the `--debug` flag. Note that debugging is not available on Windows.
 5. Open `ruby-lsp` in VS Code.
 6. [`ruby-lsp`] Run `bin/rdbg -A` to connect to the running `ruby-lsp` process.
 7. [`ruby-lsp`] Use commands like `b <file>:<line>` or `b Class#method` to set breakpoints and type `c` to continue the process.

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -31,7 +31,7 @@ RubyLsp::Requests::Support::RailsDocumentClient.send(:search_index)
 RubyLsp::Requests::DocumentLink.gem_paths
 
 ITERATIONS = 1000
-CACHE_FILE_PATH = "#{Dir.tmpdir}/ruby_lsp_benchmark_results.json"
+CACHE_FILE_PATH = "/tmp/ruby_lsp_benchmark_results.json"
 
 def avg_bench(method, params)
   results = (0...ITERATIONS).map do

--- a/bin/rdbg
+++ b/bin/rdbg
@@ -2,11 +2,10 @@
 # frozen_string_literal: true
 
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
-require "tmpdir"
 
 # This is to match the directory vscode-ruby-lsp specifies for creating sockets.
 # It's required for attaching to a running LSP server process once it's activated in debug mode.
-ENV["RUBY_DEBUG_SOCK_DIR"] = "#{Dir.tmpdir}/ruby-lsp-debug-sockets"
+ENV["RUBY_DEBUG_SOCK_DIR"] = "/tmp/ruby-lsp-debug-sockets"
 
 bundle_binstub = File.expand_path("bundle", __dir__)
 

--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -21,7 +21,12 @@ end
 require_relative "../lib/ruby_lsp/internal"
 
 if ARGV.include?("--debug")
-  sockets_dir = "#{Dir.tmpdir}/ruby-lsp-debug-sockets"
+  if ["x64-mingw-ucrt", "x64-mingw32"].include?(RUBY_PLATFORM)
+    puts "Debugging is not supported on Windows"
+    exit 1
+  end
+
+  sockets_dir = "/tmp/ruby-lsp-debug-sockets"
   Dir.mkdir(sockets_dir) unless Dir.exist?(sockets_dir)
   # ruby-debug-ENV["USER"] is an implicit naming pattern in ruby/debug
   # if it's not present, rdbg will not find the socket

--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -6,7 +6,6 @@ require "syntax_tree"
 require "language_server-protocol"
 require "benchmark"
 require "bundler"
-require "tmpdir"
 
 require "ruby-lsp"
 require "ruby_lsp/utils"


### PR DESCRIPTION
### Motivation

The previous changes break on macos. Unix complains the socket path is too long using tmpdir and fails to start.

### Implementation

It doesn’t even make sense to create a socket path for Windows since can’t use unix sockets on Windows. So we will just disable debugging on Windows.

### Automated Tests

n/a

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
