### PR TITLE
Make sending client messages async

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -34,6 +34,7 @@ ITERATIONS = 1000
 CACHE_FILE_PATH = "/tmp/ruby_lsp_benchmark_results.json"
 
 def avg_bench(method, params)
+  message_queue = Thread::Queue.new
   results = (0...ITERATIONS).map do
     # Create a new store every time to prevent caching
     store = RubyLsp::Store.new
@@ -43,12 +44,13 @@ def avg_bench(method, params)
 
     GC.disable
     result = Benchmark.measure do
-      RubyLsp::Executor.new(store).execute({
+      RubyLsp::Executor.new(store, message_queue).execute({
         method: method,
         params: params,
       })
     end.utime
     GC.enable
+    message_queue.close
     result
   end
 

--- a/lib/ruby_lsp/listener.rb
+++ b/lib/ruby_lsp/listener.rb
@@ -14,6 +14,11 @@ module RubyLsp
 
     abstract!
 
+    sig { params(message_queue: Thread::Queue).void }
+    def initialize(message_queue)
+      @message_queue = message_queue
+    end
+
     class << self
       extend T::Sig
 

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -35,10 +35,11 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :response
 
-      sig { void }
-      def initialize
+      sig { params(message_queue: Thread::Queue).void }
+      def initialize(message_queue)
         @response = T.let(nil, ResponseType)
-        super()
+
+        super
       end
 
       # Merges responses from other hover listeners

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -38,9 +38,6 @@ module RubyLsp
     sig { returns(T.untyped) }
     attr_reader :response
 
-    sig { returns(T::Array[Message]) }
-    attr_reader :messages
-
     sig { returns(T.nilable(Exception)) }
     attr_reader :error
 
@@ -50,14 +47,12 @@ module RubyLsp
     sig do
       params(
         response: T.untyped,
-        messages: T::Array[Message],
         error: T.nilable(Exception),
         request_time: T.nilable(Float),
       ).void
     end
-    def initialize(response:, messages:, error: nil, request_time: nil)
+    def initialize(response:, error: nil, request_time: nil)
       @response = response
-      @messages = messages
       @error = error
       @request_time = request_time
     end

--- a/test/extension_test.rb
+++ b/test/extension_test.rb
@@ -24,10 +24,13 @@ module RubyLsp
     end
 
     def test_registering_an_extension_invokes_activate_on_initialized
-      Executor.new(RubyLsp::Store.new).execute({ method: "initialized" })
+      message_queue = Thread::Queue.new
+      Executor.new(RubyLsp::Store.new, message_queue).execute({ method: "initialized" })
 
       extension_instance = T.must(Extension.extensions.find { |ext| ext.is_a?(@extension) })
       assert_predicate(extension_instance, :activated)
+    ensure
+      T.must(message_queue).close
     end
 
     def test_extensions_are_automatically_tracked


### PR DESCRIPTION
### Motivation

Currently, we can only send messages to the client in association with a request. We basically push items to the `@messages` array either in the beginning or end of a request.

This is super limiting and kind of defeats the whole asynchronous approach of language servers, where messages can be sent at any time to the client.

For example, in the current design, it is impossible for the server to send notifications to the client to display progress for long running tasks, such as indexing, loading extensions or even just a slow request.

I believe it's safe to assume we won't be investing in actual parallelism for a while (maybe never?) given that
- We have been able to improve performance by a lot so far
- #611 will further improve performance
- Adopting YARP will greatly improve parsing performance

Based on this, I believe it is safe to assume that we can allow requests to push messages into a queue as they please to provide more flexibility in our implementations and provide a nicer experience.

### Implementation

The whole idea here is to have a `Thread::Queue` where we can push messages that have to be sent to the client. A Thread will watch that queue and write the messages back to the client. I believe the best place to put this is in our `Store` - since it is our global state object.

- The first commit makes Store a singleton. There's no reason why we'd have more than one global state and this makes it easier to use it without having to pass the store around
- The second commit adds the new `Thread::Queue` and `message_dispatcher` thread

### Automated Tests

This approach also makes it easier to test certain things, like the RuboCop failure window messages or that we clear diagnostics when closing files. I moved those tests to `executor_test.rb`, which is faster and less brittle.

### Manual Tests

This is a refactor, there shouldn't be any differences in behaviour.