### PR TITLE
Reuse same PR comment for benchmark results

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,12 +48,35 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
-            await github.rest.issues.createComment({
+            const GITHUB_ACTIONS_USER_ID = 41898282
+            const BODY_COMMENT = '```#${{ steps.benchmark.outputs.REPORT }}#```'.split("#").join("\n")
+
+            const { data: issueComments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '```#${{ steps.benchmark.outputs.REPORT }}#```'.split("#").join("\n"),
             });
+
+            commentToUpdate = issueComments.find(comment => {
+              const { body, user: { id } } = comment
+              return id === GITHUB_ACTIONS_USER_ID && body.includes("Benchmark results")
+            })
+
+            if (commentToUpdate) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentToUpdate.id,
+                body: BODY_COMMENT,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: BODY_COMMENT,
+              });
+            }
 
       # Fail the job based on the benchmark output
       - name: Finalize job

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
-            const GITHUB_ACTIONS_USER_ID = 41898282
             const BODY_COMMENT = '```#${{ steps.benchmark.outputs.REPORT }}#```'.split("#").join("\n")
 
             const { data: issueComments } = await github.rest.issues.listComments({
@@ -57,10 +56,9 @@ jobs:
               issue_number: context.issue.number,
             });
 
-            commentToUpdate = issueComments.find(comment => {
-              const { body, user: { id } } = comment
-              return id === GITHUB_ACTIONS_USER_ID && body.includes("Benchmark results")
-            })
+            commentToUpdate = issueComments.find((comment) =>
+              comment.body.includes("Benchmark results in seconds (slowest at top)")
+            );
 
             if (commentToUpdate) {
               await github.rest.issues.updateComment({


### PR DESCRIPTION
### Motivation

Closes: #637

Avoid comments flooding from benchmark results.

### Implementation

This step use [actions/github-script](https://github.com/actions/github-script) which under the hood uses https://octokit.github.io/rest.js/v19.

* fetch all comments on issues: https://octokit.github.io/rest.js/v19#issues-list-comments
* find the comment from the `github-actions` user && body including Benchmark results

Then based on the presence or not

* update the comment https://octokit.github.io/rest.js/v19#issues-update-comment
* create (as this is already the case) https://octokit.github.io/rest.js/v19#issues-create-comment

### Automated Tests

Workflow isn’t tested.

### Manual Tests

Push to this PR multiple times (with blank or useless commits) to ensure that the comment is well-updated.

As I need validation from maintainers to run CI I did a test before on my fork and its works: https://github.com/snutij/ruby-lsp/pull/1#issuecomment-1509620116