### PR TITLE
Determine formatter for 'auto' (no longer fallback to `syntax_tree`).

### DIFF
--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -141,4 +141,45 @@ class ExecutorTest < Minitest::Test
   ensure
     @store.delete("file:///foo.rb")
   end
+
+  def test_detects_rubocop_if_direct_dependency
+    stub_dependencies(rubocop: true, syntax_tree: false)
+    RubyLsp::Executor.new(@store, @message_queue)
+      .execute(method: "initialize", params: { initializationOptions: { formatter: "auto" } })
+    assert_equal("rubocop", @store.formatter)
+  end
+
+  def test_detects_syntax_tree_if_direct_dependency
+    stub_dependencies(rubocop: false, syntax_tree: true)
+    RubyLsp::Executor.new(@store, @message_queue)
+      .execute(method: "initialize", params: { initializationOptions: { formatter: "auto" } })
+    assert_equal("syntax_tree", @store.formatter)
+  end
+
+  def test_gives_rubocop_precedence_if_syntax_tree_also_present
+    stub_dependencies(rubocop: true, syntax_tree: true)
+    RubyLsp::Executor.new(@store, @message_queue).send(
+      :initialize_request,
+      { initializationOptions: { formatter: "auto" } },
+    )
+    assert_equal("rubocop", @store.formatter)
+  end
+
+  def test_sets_formatter_to_none_if_neither_rubocop_or_syntax_tree_are_present
+    stub_dependencies(rubocop: false, syntax_tree: false)
+    RubyLsp::Executor.new(@store, @message_queue).send(
+      :initialize_request,
+      { initializationOptions: { formatter: "auto" } },
+    )
+    assert_equal("none", @store.formatter)
+  end
+
+  private
+
+  def stub_dependencies(rubocop:, syntax_tree:)
+    dependencies = {}
+    dependencies["syntax_tree"] = "..." if syntax_tree
+    dependencies["rubocop"] = "..." if rubocop
+    Bundler.locked_gems.stubs(:dependencies).returns(dependencies)
+  end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -385,6 +385,7 @@ class IntegrationTest < Minitest::Test
         initializationOptions: {
           enabledFeatures: enabled_features,
           experimentalFeaturesEnabled: experimental_features_enabled,
+          formatter: "rubocop",
         },
       },
     )[:result]

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -9,7 +9,7 @@ class FormattingExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::Document.new(source: source, version: 1, uri: "file://#{__FILE__}")
-    RubyLsp::Requests::Formatting.new(document).run&.first&.new_text
+    RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run&.first&.new_text
   end
 
   def assert_expectations(source, expected)

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -13,8 +13,8 @@ class FormattingTest < Minitest::Test
     RUBY
   end
 
-  def test_formats_with_rubocop_when_present
-    assert_equal(<<~RUBY, formatted_document)
+  def test_formats_with_rubocop
+    assert_equal(<<~RUBY, formatted_document("rubocop"))
       # typed: true
       # frozen_string_literal: true
 
@@ -25,15 +25,18 @@ class FormattingTest < Minitest::Test
     RUBY
   end
 
-  def test_formats_with_syntax_tree_when_rubocop_is_not_present
-    with_uninstalled_rubocop do
-      assert_equal(<<~RUBY, formatted_document)
-        class Foo
-          def foo
-          end
+  def test_formats_with_syntax_tree
+    assert_equal(<<~RUBY, formatted_document("syntax_tree"))
+      class Foo
+        def foo
         end
-      RUBY
-    end
+      end
+    RUBY
+  end
+
+  def test_does_not_format_with_formatter_is_none
+    document = RubyLsp::Document.new(source: "def foo", version: 1, uri: "file://#{__FILE__}")
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "none").run)
   end
 
   def test_syntax_tree_formatting_uses_options_from_streerc
@@ -67,16 +70,14 @@ class FormattingTest < Minitest::Test
   end
 
   def test_syntax_tree_formatting_ignores_syntax_invalid_documents
-    with_uninstalled_rubocop do
-      require "ruby_lsp/requests"
-      document = RubyLsp::Document.new(source: "def foo", version: 1, uri: "file://#{__FILE__}")
-      assert_nil(RubyLsp::Requests::Formatting.new(document).run)
-    end
+    require "ruby_lsp/requests"
+    document = RubyLsp::Document.new(source: "def foo", version: 1, uri: "file://#{__FILE__}")
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "syntax_tree").run)
   end
 
   def test_rubocop_formatting_ignores_syntax_invalid_documents
     document = RubyLsp::Document.new(source: "def foo", version: 1, uri: "file://#{__FILE__}")
-    assert_nil(RubyLsp::Requests::Formatting.new(document).run)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run)
   end
 
   def test_returns_nil_if_document_is_already_formatted
@@ -89,7 +90,7 @@ class FormattingTest < Minitest::Test
         end
       end
     RUBY
-    assert_nil(RubyLsp::Requests::Formatting.new(document).run)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run)
   end
 
   def test_returns_nil_if_document_is_not_in_project_folder
@@ -122,31 +123,7 @@ class FormattingTest < Minitest::Test
 
   private
 
-  def with_uninstalled_rubocop(&block)
-    rubocop_paths = $LOAD_PATH.select { |path| path.include?("gems/rubocop") }
-    rubocop_paths.each { |path| $LOAD_PATH.delete(path) }
-    $LOADED_FEATURES.delete_if do |path|
-      path.include?("ruby_lsp/requests") || path.include?("gems/rubocop") || path.include?("rubocop/cop/ruby_lsp")
-    end
-    unload_constants
-
-    block.call
-  ensure
-    $LOAD_PATH.unshift(*rubocop_paths)
-    $LOADED_FEATURES.delete_if { |path| path.include?("ruby_lsp/requests") }
-    RubyLsp.send(:remove_const, :Requests)
-    require "ruby_lsp/requests"
-    require "rubocop/cop/ruby_lsp/use_language_server_aliases"
-  end
-
-  def unload_constants
-    RubyLsp.send(:remove_const, :Requests)
-    Object.send(:remove_const, :RuboCop)
-  rescue NameError
-    # Constants are already unloaded
-  end
-
-  def formatted_document(formatter = "auto")
+  def formatted_document(formatter)
     require "ruby_lsp/requests"
     RubyLsp::Requests::Formatting.new(@document, formatter: formatter).run&.first&.new_text
   end


### PR DESCRIPTION
### Motivation

Ruby LSP supports two formatters, RuboCop and syntax_tree. When formatting is set to `auto`, we check for RuboCop, and use that if available, otherwise we fallback to syntax tree.

This means for the repos which use neither, we were applying syntax tree formatting. This led to unexpected changes in formatting.

### Implementation

A better way is to check for the presence of RuboCop or syntax_tree in `Gemfile.lock`. But we want to avoid false positives through transitive dependencies, so we only check for **direct** dependencies.

We also want to support RuboCop-based gems such as `rubocop-shopify`, so we pattern match on gems beginning named `^rubocop`.

### Automated Tests

Included

### Manual Tests

With `rubyLsp.formatting` set to `auto`:

* Open a repo which doesn't use any formatter, e.g. `ruby/debug`. Add `ruby-lsp` to the Gemfile, pointing to this branch. Ensure that no formatting is applied when saving a file.
* Open a repo which uses RuboCop, e.g. `Shopify/tapioca`. Add `ruby-lsp` to the Gemfile, pointing to this branch. Ensure that RuboCop formatting is applied when saving a file.
* Open a repo which uses Syntax Tree, e.g. https://github.com/andyw8/syntax_tree_example. Add `ruby-lsp` to the Gemfile, pointing to this branch. Ensure that Syntax Tree formatting is applied when saving a file.

With `rubyLsp.formatting` set to `none`:

* Open a repo which uses RuboCop, e.g. Shopify/tapioca. Add ruby-lsp to the Gemfile, pointing to this branch. Ensure that formatting is **not** applied when saving a file.

With `rubyLsp.formatting` set to `rubocop`:

* Open a repo which doesn't use any formatter, e.g. `ruby/debug`. Add `ruby-lsp` to the Gemfile, pointing to this branch. Try format the file and verify you see an error "Formatter is set to 'rubocop' but RuboCop was not found".

With `rubyLsp.formatting` set to `syntax_tree`:

* Open a repo which uses RuboCop, e.g. Shopify/tapioca. Add ruby-lsp to the Gemfile, pointing to this branch. Ensure that **syntax_tree** formatting is applied when saving a file.

(syntax_tree is always available since it ships with Ruby LSP)

**Known Limitations**

On a repo which has syntax_tree but also has a gem named `rubocop-*`, e.g. https://github.com/discourse/discourse it will wrongly use RuboCop formatting.