### PR TITLE
Parse documents under mutex lock when pushing jobs in the queue

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -166,7 +166,6 @@ module RubyLsp
     end
     def hover(uri, position)
       document = @store.get(uri)
-      document.parse
       return if document.syntax_error?
 
       target, parent = document.locate_node(position)

--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -18,11 +18,6 @@ module RubyLsp
       sig { params(document: Document, _kwargs: T.untyped).void }
       def initialize(document, **_kwargs)
         @document = document
-
-        # Parsing the document here means we're taking a lazy approach by only doing it when the first feature request
-        # is received by the server. This happens because {Document#parse} remembers if there are new edits to be parsed
-        @document.parse
-
         super()
       end
 

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -14,6 +14,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
+    document.parse
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 8 }, "\n").run
     expected_edits = [
@@ -39,6 +40,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
+    document.parse
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 11 }, "{").run
     expected_edits = [
@@ -64,6 +66,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
+    document.parse
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 11 }, "|").run
     expected_edits = [
@@ -89,6 +92,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
+    document.parse
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 11 }, "|").run
     assert_empty(T.must(edits))
@@ -104,6 +108,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
+    document.parse
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").run
     expected_edits = [
@@ -129,6 +134,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
+    document.parse
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 5 }, "\n").run
     assert_empty(edits)
@@ -146,6 +152,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
+    document.parse
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").run
     expected_edits = [
@@ -174,6 +181,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
+    document.parse
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 7 }, "\n").run
     expected_edits = [
@@ -199,6 +207,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
+    document.parse
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
     expected_edits = [


### PR DESCRIPTION
### Motivation

In very large files, the server sometimes switches thread in the middle of parsing. When this happens, there's a chance that the document source will be changed by text edits in the middle of parsing.

Because Syntax Tree is not dupping the source string, this means we're changing the same reference that is being used to parse. This puts the parser in an invalid internal state since it computed line counts based on the initial source string, but it was changed in the middle.

### Implementation

Started parsing documents when pushing jobs into the queue. This is equivalent to parsing it in the `BaseRequest`, but now it is done under a mutex lock.

### Automated Tests

This is quite hard to write a test for, but it's reproducible manually.

### Manual Tests

1. Use the development version of `vscode-ruby-lsp` so start the Ruby LSP server in debug mode on this branch
2. Attach the debugger to the running LSP server
3. Open `~/.gem/ruby/3.2.1/gems/syntax_tree-6.1.1/lib/syntax_tree/parser.rb`
4. Put a breakpoint on line 2997 (`raise "Comment location..."`)
5. Edit this file really fast. Just type a bunch `puts` statements and change the strings really fast
6. On `main` (where the bug exists still) the debugger will hit the breakpoint, indicating the parser is in an inconsistent state
7. On this branch, it should never hit the breakpoint