### PR TITLE
Return code lens for debugging tests

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -110,24 +110,41 @@ module RubyLsp
 
       sig { params(node: SyntaxTree::Node, name: String, command: String).void }
       def add_code_lens(node, name:, command:)
+        range = range_from_syntax_tree_node(node)
+        arguments = [
+          @path,
+          name,
+          command,
+          {
+            start_line: node.location.start_line - 1,
+            start_column: node.location.start_column,
+            end_line: node.location.end_line - 1,
+            end_column: node.location.end_column,
+          },
+        ]
+
         @results << Interface::CodeLens.new(
-          range: range_from_syntax_tree_node(node),
+          range: range,
           command: Interface::Command.new(
             title: "Run",
             command: "rubyLsp.runTest",
-            arguments: [
-              @path,
-              name,
-              command,
-              {
-                start_line: node.location.start_line - 1,
-                start_column: node.location.start_column,
-                end_line: node.location.end_line - 1,
-                end_column: node.location.end_column,
-              },
-            ],
+            arguments: arguments,
           ),
-          data: { type: "test" },
+          data: {
+            type: "test",
+          },
+        )
+
+        @results << Interface::CodeLens.new(
+          range: range,
+          command: Interface::Command.new(
+            title: "Debug",
+            command: "rubyLsp.debugTest",
+            arguments: arguments,
+          ),
+          data: {
+            type: "debug",
+          },
         )
       end
     end

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -33,6 +33,36 @@
     {
       "range": {
         "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fake.rb",
+          "Test",
+          "bundle exec ruby -Itest /fake.rb",
+          {
+            "start_line": 0,
+            "start_column": 0,
+            "end_line": 18,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "debug"
+      }
+    },
+    {
+      "range": {
+        "start": {
           "line": 5,
           "character": 2
         },
@@ -58,6 +88,36 @@
       },
       "data": {
         "type": "test"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 2
+        },
+        "end": {
+          "line": 5,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fake.rb",
+          "test_public",
+          "bundle exec ruby -Itest /fake.rb --name test_public",
+          {
+            "start_line": 5,
+            "start_column": 2,
+            "end_line": 5,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "debug"
       }
     },
     {
@@ -93,6 +153,36 @@
     {
       "range": {
         "start": {
+          "line": 9,
+          "character": 9
+        },
+        "end": {
+          "line": 9,
+          "character": 37
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fake.rb",
+          "test_public_command",
+          "bundle exec ruby -Itest /fake.rb --name test_public_command",
+          {
+            "start_line": 9,
+            "start_column": 9,
+            "end_line": 9,
+            "end_column": 37
+          }
+        ]
+      },
+      "data": {
+        "type": "debug"
+      }
+    },
+    {
+      "range": {
+        "start": {
           "line": 11,
           "character": 9
         },
@@ -123,6 +213,36 @@
     {
       "range": {
         "start": {
+          "line": 11,
+          "character": 9
+        },
+        "end": {
+          "line": 11,
+          "character": 37
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fake.rb",
+          "test_another_public",
+          "bundle exec ruby -Itest /fake.rb --name test_another_public",
+          {
+            "start_line": 11,
+            "start_column": 9,
+            "end_line": 11,
+            "end_column": 37
+          }
+        ]
+      },
+      "data": {
+        "type": "debug"
+      }
+    },
+    {
+      "range": {
+        "start": {
           "line": 17,
           "character": 2
         },
@@ -148,6 +268,36 @@
       },
       "data": {
         "type": "test"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 2
+        },
+        "end": {
+          "line": 17,
+          "character": 28
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fake.rb",
+          "test_public_vcall",
+          "bundle exec ruby -Itest /fake.rb --name test_public_vcall",
+          {
+            "start_line": 17,
+            "start_column": 2,
+            "end_line": 17,
+            "end_column": 28
+          }
+        ]
+      },
+      "data": {
+        "type": "debug"
       }
     }
   ],


### PR DESCRIPTION
### Motivation

This will allow the extension to display `Debug` code lens for debugging tests.

### Implementation

Add another code lens for the `Debug` action.

### Automated Tests

The original test should already cover it.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
