### PR TITLE
Stop failing CI on benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,13 +75,3 @@ jobs:
                 body: BODY_COMMENT,
               });
             }
-
-      # Fail the job based on the benchmark output
-      - name: Finalize job
-        run: |
-          report="${{ steps.benchmark.outputs.REPORT }}"
-          if [[ "$report" == *"At least one benchmark is slower than the main branch"* ]] || [[ "$report" == *"Missing benchmarks"* ]]; then
-            exit 1
-          else
-            exit 0
-          fi

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -316,7 +316,6 @@ if missing_benchmarks.any?
   puts "=" * 80
   puts "Missing benchmarks:\n\n"
   puts missing_benchmarks.map(&:to_s)
-  exit(1)
 end
 
 File.write(CACHE_FILE_PATH, results.to_json)


### PR DESCRIPTION
### Motivation

We knew that running benchmarks on GitHub actions was bound to not be so accurate since the infrastructure is not really dedicated for running performance comparisons.

After a while running this, it really seems that we benefit more from just having the information printed on PRs and not so much from failing CI - given that most of the time the failures are not real and just reflect fluctuations in the infrastructure.

### Implementation

Stopped failing the benchmark step. We now just print the results in comments.