### PR TITLE
Migrate document link to listener

### DIFF
--- a/lib/ruby_lsp/event_emitter.rb
+++ b/lib/ruby_lsp/event_emitter.rb
@@ -88,5 +88,11 @@ module RubyLsp
       @listeners.each { |l| T.unsafe(l).on_var_field(node) if l.registered_for_event?(:on_var_field) }
       super
     end
+
+    sig { override.params(node: SyntaxTree::Comment).void }
+    def visit_comment(node)
+      @listeners.each { |l| T.unsafe(l).on_comment(node) if l.registered_for_event?(:on_comment) }
+      super
+    end
   end
 end

--- a/lib/ruby_lsp/listener.rb
+++ b/lib/ruby_lsp/listener.rb
@@ -14,9 +14,10 @@ module RubyLsp
 
     abstract!
 
-    sig { params(message_queue: Thread::Queue).void }
-    def initialize(message_queue)
+    sig { params(uri: String, message_queue: Thread::Queue).void }
+    def initialize(uri, message_queue)
       @message_queue = message_queue
+      @uri = uri
     end
 
     @event_to_listener_map = T.let(Hash.new { |h, k| h[k] = [] }, T::Hash[Symbol, T::Array[T.class_of(Listener)]])

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -81,8 +81,8 @@ module RubyLsp
       sig { override.returns(T::Array[Interface::DocumentSymbol]) }
       attr_reader :response
 
-      sig { params(message_queue: Thread::Queue).void }
-      def initialize(message_queue)
+      sig { params(uri: String, message_queue: Thread::Queue).void }
+      def initialize(uri, message_queue)
         super
 
         @root = T.let(SymbolHierarchyRoot.new, SymbolHierarchyRoot)

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -35,8 +35,8 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :response
 
-      sig { params(message_queue: Thread::Queue).void }
-      def initialize(message_queue)
+      sig { params(uri: String, message_queue: Thread::Queue).void }
+      def initialize(uri, message_queue)
         @response = T.let(nil, ResponseType)
 
         super

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -10,7 +10,7 @@ class ExpectationsTestRunner < Minitest::Test
     def expectations_tests(handler_class, expectation_suffix)
       execute_request = if handler_class < RubyLsp::Listener
         <<~RUBY
-          listener = #{handler_class}.new(@message_queue)
+          listener = #{handler_class}.new(document.uri, @message_queue)
           RubyLsp::EventEmitter.new(listener).visit(document.tree)
           listener.response
         RUBY

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -21,8 +21,15 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
   end
 
   def run_expectations(source)
-    document = RubyLsp::Document.new(source: source, version: 1, uri: "file://#{@_path}")
-    RubyLsp::Requests::DocumentLink.new(document).run
+    message_queue = Thread::Queue.new
+    uri = "file://#{@_path}"
+    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
+
+    listener = RubyLsp::Requests::DocumentLink.new(uri, message_queue)
+    RubyLsp::EventEmitter.new(listener).visit(document.tree)
+    listener.response
+  ensure
+    T.must(message_queue).close
   end
 
   private


### PR DESCRIPTION
### Motivation

Closes #659

Migrate our document link request to use the listener pattern. This PR also demonstrates how we would cache multiple responses and then just return the cached values on subsequent requests.

### Implementation

1. Migrated document link to use `Listener`
2. Started executing document link together with document symbol
3. We cache both responses and return only the response relevant to the current request. This way we can retrieve information about multiple requests in a single AST visit

### Automated Tests

Adjusted some tests, but this is mostly a refactor and current tests should cover the functionality.

### Manual Tests

If you wish to see the caching idea in practice, you can try this out:
1. In `.vscode/settings.json`, change the trace server configuration to `off` to make it easier to see output
2. Add `warn "Returning cached response for #{request[:method]} (#{request[:id]})"` when returning a cached response
3. Add `warn "Running request #{request[:method]} (#{request[:id]})"` when running the event emitter
4. In the output tab, verify that we never execute both document link and document symbol. One of them should be executed, but then the next should always returned a cached response