### PR TITLE
Make CodeLens a Listener

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -23,7 +23,7 @@ module RubyLsp
 
     sig { params(source: String, version: Integer, uri: String, encoding: String).void }
     def initialize(source:, version:, uri:, encoding: Constant::PositionEncodingKind::UTF8)
-      @cache = T.let({}, T::Hash[Symbol, T.untyped])
+      @cache = T.let({}, T::Hash[String, T.untyped])
       @encoding = T.let(encoding, String)
       @source = T.let(source, String)
       @version = T.let(version, Integer)
@@ -40,10 +40,11 @@ module RubyLsp
       @source == other.source
     end
 
+    # TODO: remove this method once all nonpositional requests have been migrated to the listener pattern
     sig do
       type_parameters(:T)
         .params(
-          request_name: Symbol,
+          request_name: String,
           block: T.proc.params(document: Document).returns(T.type_parameter(:T)),
         ).returns(T.type_parameter(:T))
     end
@@ -54,6 +55,16 @@ module RubyLsp
       result = block.call(self)
       @cache[request_name] = result
       result
+    end
+
+    sig { type_parameters(:T).params(request_name: String, value: T.type_parameter(:T)).returns(T.type_parameter(:T)) }
+    def cache_set(request_name, value)
+      @cache[request_name] = value
+    end
+
+    sig { params(request_name: String).returns(T.untyped) }
+    def cache_get(request_name)
+      @cache[request_name]
     end
 
     sig { params(edits: T::Array[EditShape], version: Integer).void }

--- a/lib/ruby_lsp/event_emitter.rb
+++ b/lib/ruby_lsp/event_emitter.rb
@@ -62,6 +62,20 @@ module RubyLsp
     def visit_command(node)
       @listeners.each { |l| T.unsafe(l).on_command(node) if l.registered_for_event?(:on_command) }
       super
+      @listeners.each { |l| T.unsafe(l).after_command(node) if l.registered_for_event?(:after_command) }
+    end
+
+    sig { override.params(node: SyntaxTree::CallNode).void }
+    def visit_call(node)
+      @listeners.each { |l| T.unsafe(l).on_call(node) if l.registered_for_event?(:on_call) }
+      super
+      @listeners.each { |l| T.unsafe(l).after_call(node) if l.registered_for_event?(:after_call) }
+    end
+
+    sig { override.params(node: SyntaxTree::VCall).void }
+    def visit_vcall(node)
+      @listeners.each { |l| T.unsafe(l).on_vcall(node) if l.registered_for_event?(:on_vcall) }
+      super
     end
 
     sig { override.params(node: SyntaxTree::ConstPathField).void }

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -169,9 +169,17 @@ module RubyLsp
     def code_lens(uri)
       @store.cache_fetch(uri, "textDocument/codeLens") do |document|
         document.parse
-        listener = Requests::CodeLens.new(document.uri, @message_queue)
-        EventEmitter.new(listener).visit(document.tree) if document.parsed?
-        listener.response
+
+        # Instantiate all listeners
+        base_listener = Requests::CodeLens.new(document.uri, @message_queue)
+        listeners = Requests::CodeLens.listeners.map { |l| l.new(document.uri, @message_queue) }
+
+        # Emit events for all listeners
+        T.unsafe(EventEmitter).new(base_listener, *listeners).visit(document.tree) if document.parsed?
+
+        # Merge all responses into a single hover
+        listeners.each { |ext| base_listener.merge_response!(ext) }
+        base_listener.response
       end
     end
 

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -94,8 +94,8 @@ module RubyLsp
         listener = Requests::DocumentSymbol.new(@message_queue)
         EventEmitter.new(listener).visit(document.tree) if document.parsed?
 
-        # Store all responses retrieve in this round of visits in the cache. The last one we save must always be the one
-        # related to the request we're receiving since that's the response we want to return to the editor
+        # Store all responses retrieved in this round of visits in the cache. The last one we save must always be the
+        # one related to the request we're receiving since that's the response we want to return to the editor
         document.cache_set(request[:method], listener.response)
       when "textDocument/semanticTokens/full"
         semantic_tokens_full(uri)

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -168,7 +168,10 @@ module RubyLsp
     sig { params(uri: String).returns(T::Array[Interface::CodeLens]) }
     def code_lens(uri)
       @store.cache_fetch(uri, "textDocument/codeLens") do |document|
-        Requests::CodeLens.new(document).run
+        document.parse
+        listener = Requests::CodeLens.new(document.uri, @message_queue)
+        EventEmitter.new(listener).visit(document.tree) if document.parsed?
+        listener.response
       end
     end
 
@@ -190,8 +193,8 @@ module RubyLsp
       end
 
       # Instantiate all listeners
-      base_listener = Requests::Hover.new(@message_queue)
-      listeners = Requests::Hover.listeners.map { |l| l.new(@message_queue) }
+      base_listener = Requests::Hover.new(document.uri, @message_queue)
+      listeners = Requests::Hover.listeners.map { |l| l.new(document.uri, @message_queue) }
 
       # Emit events for all listeners
       T.unsafe(EventEmitter).new(base_listener, *listeners).emit_for_target(target)

--- a/lib/ruby_lsp/listener.rb
+++ b/lib/ruby_lsp/listener.rb
@@ -14,9 +14,10 @@ module RubyLsp
 
     abstract!
 
-    sig { params(message_queue: Thread::Queue).void }
-    def initialize(message_queue)
+    sig { params(uri: String, message_queue: Thread::Queue).void }
+    def initialize(uri, message_queue)
       @message_queue = message_queue
+      @uri = uri
     end
 
     @event_to_listener_map = T.let(Hash.new { |h, k| h[k] = [] }, T::Hash[Symbol, T::Array[T.class_of(Listener)]])

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -20,93 +20,94 @@ module RubyLsp
     # end
     # ```
 
-    class CodeLens < BaseRequest
+    class CodeLens < Listener
+      extend T::Sig
+      extend T::Generic
+
+      ResponseType = type_member { { fixed: T::Array[Interface::CodeLens] } }
+
       BASE_COMMAND = T.let((File.exist?("Gemfile.lock") ? "bundle exec ruby" : "ruby") + " -Itest ", String)
       ACCESS_MODIFIERS = T.let(["public", "private", "protected"], T::Array[String])
 
-      sig do
-        params(
-          document: Document,
-        ).void
-      end
-      def initialize(document)
-        super(document)
-        @results = T.let([], T::Array[Interface::CodeLens])
-        @path = T.let(document.uri.delete_prefix("file://"), String)
-        @modifier = T.let("public", String)
+      sig { override.returns(ResponseType) }
+      attr_reader :response
+
+      sig { params(uri: String, message_queue: Thread::Queue).void }
+      def initialize(uri, message_queue)
+        super
+
+        @response = T.let([], ResponseType)
+        @path = T.let(uri.delete_prefix("file://"), String)
+        @visibility = T.let("public", String)
+        @prev_visibility = T.let("public", String)
       end
 
-      sig { override.returns(T.all(T::Array[Interface::CodeLens], Object)) }
-      def run
-        visit(@document.tree) if @document.parsed?
-        @results
-      end
-
-      sig { override.params(node: SyntaxTree::ClassDeclaration).void }
-      def visit_class(node)
-        class_name = node.constant.constant.value
-        if class_name.end_with?("Test")
-          add_code_lens(node, name: class_name, command: BASE_COMMAND + @path)
-        end
-        visit(node.bodystmt)
-      end
-
-      sig { override.params(node: SyntaxTree::DefNode).void }
-      def visit_def(node)
-        if @modifier == "public"
-          method_name = node.name.value
-          if method_name.start_with?("test_")
-            add_code_lens(
-              node,
-              name: method_name,
-              command: BASE_COMMAND + @path + " --name " + method_name,
-            )
+      listener_events do
+        sig { params(node: SyntaxTree::ClassDeclaration).void }
+        def on_class(node)
+          class_name = node.constant.constant.value
+          if class_name.end_with?("Test")
+            add_code_lens(node, name: class_name, command: BASE_COMMAND + @path)
           end
         end
-      end
 
-      sig { override.params(node: SyntaxTree::Command).void }
-      def visit_command(node)
-        if node.message.value == "public"
-          with_visiblity("public", node)
-        end
-      end
-
-      sig { override.params(node: SyntaxTree::CallNode).void }
-      def visit_call(node)
-        ident = node.message if node.message.is_a?(SyntaxTree::Ident)
-
-        if ident
-          if T.cast(ident, SyntaxTree::Ident).value == "public"
-            with_visiblity("public", node)
+        sig { params(node: SyntaxTree::DefNode).void }
+        def on_def(node)
+          if @visibility == "public"
+            method_name = node.name.value
+            if method_name.start_with?("test_")
+              add_code_lens(
+                node,
+                name: method_name,
+                command: BASE_COMMAND + @path + " --name " + method_name,
+              )
+            end
           end
         end
-      end
 
-      sig { override.params(node: SyntaxTree::VCall).void }
-      def visit_vcall(node)
-        vcall_value = node.value.value
+        sig { params(node: SyntaxTree::Command).void }
+        def on_command(node)
+          if ACCESS_MODIFIERS.include?(node.message.value) && node.arguments.parts.any?
+            @prev_visibility = @visibility
+            @visibility = node.message.value
+          end
+        end
 
-        if ACCESS_MODIFIERS.include?(vcall_value)
-          @modifier = vcall_value
+        sig { params(node: SyntaxTree::Command).void }
+        def after_command(node)
+          @visibility = @prev_visibility
+        end
+
+        sig { params(node: SyntaxTree::CallNode).void }
+        def on_call(node)
+          ident = node.message if node.message.is_a?(SyntaxTree::Ident)
+
+          if ident
+            ident_value = T.cast(ident, SyntaxTree::Ident).value
+            if ACCESS_MODIFIERS.include?(ident_value)
+              @prev_visibility = @visibility
+              @visibility = ident_value
+            end
+          end
+        end
+
+        sig { params(node: SyntaxTree::CallNode).void }
+        def after_call(node)
+          @visibility = @prev_visibility
+        end
+
+        sig { params(node: SyntaxTree::VCall).void }
+        def on_vcall(node)
+          vcall_value = node.value.value
+
+          if ACCESS_MODIFIERS.include?(vcall_value)
+            @prev_visibility = vcall_value
+            @visibility = vcall_value
+          end
         end
       end
 
       private
-
-      sig do
-        params(
-          visibility: String,
-          node: T.any(SyntaxTree::CallNode, SyntaxTree::Command),
-        ).void
-      end
-      def with_visiblity(visibility, node)
-        current_visibility = @modifier
-        @modifier = visibility
-        visit(node.arguments)
-      ensure
-        @modifier = T.must(current_visibility)
-      end
 
       sig { params(node: SyntaxTree::Node, name: String, command: String).void }
       def add_code_lens(node, name:, command:)
@@ -123,8 +124,8 @@ module RubyLsp
           },
         ]
 
-        @results << Interface::CodeLens.new(
-          range: range,
+        @response << Interface::CodeLens.new(
+          range: range_from_syntax_tree_node(node),
           command: Interface::Command.new(
             title: "Run",
             command: "rubyLsp.runTest",

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -107,6 +107,12 @@ module RubyLsp
         end
       end
 
+      sig { params(other: Listener[ResponseType]).returns(T.self_type) }
+      def merge_response!(other)
+        @response.concat(other.response)
+        self
+      end
+
       private
 
       sig { params(node: SyntaxTree::Node, name: String, command: String).void }

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -81,8 +81,8 @@ module RubyLsp
       sig { override.returns(T::Array[Interface::DocumentSymbol]) }
       attr_reader :response
 
-      sig { params(message_queue: Thread::Queue).void }
-      def initialize(message_queue)
+      sig { params(uri: String, message_queue: Thread::Queue).void }
+      def initialize(uri, message_queue)
         super
 
         @root = T.let(SymbolHierarchyRoot.new, SymbolHierarchyRoot)

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -35,8 +35,8 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :response
 
-      sig { params(message_queue: Thread::Queue).void }
-      def initialize(message_queue)
+      sig { params(uri: String, message_queue: Thread::Queue).void }
+      def initialize(uri, message_queue)
         @response = T.let(nil, ResponseType)
 
         super

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -61,7 +61,7 @@ module RubyLsp
       type_parameters(:T)
         .params(
           uri: String,
-          request_name: Symbol,
+          request_name: String,
           block: T.proc.params(document: Document).returns(T.type_parameter(:T)),
         ).returns(T.type_parameter(:T))
     end

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+
+class QueryTest
+  test "parse empty query" do
+  end
+end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -485,6 +485,14 @@ class DocumentTest < Minitest::Test
     assert_empty(document.instance_variable_get(:@unparsed_edits))
   end
 
+  def test_cache_set_and_get
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///foo/bar.rb")
+    value = [1, 2, 3]
+
+    assert_equal(value, document.cache_set("textDocument/semanticHighlighting", value))
+    assert_equal(value, document.cache_get("textDocument/semanticHighlighting"))
+  end
+
   private
 
   def assert_error_edit(actual, error_range)

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -10,7 +10,7 @@ class ExpectationsTestRunner < Minitest::Test
     def expectations_tests(handler_class, expectation_suffix)
       execute_request = if handler_class < RubyLsp::Listener
         <<~RUBY
-          listener = #{handler_class}.new(@message_queue)
+          listener = #{handler_class}.new(document.uri, @message_queue)
           RubyLsp::EventEmitter.new(listener).visit(document.tree)
           listener.response
         RUBY

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"
@@ -6,4 +6,52 @@ require "expectations/expectations_test_runner"
 
 class CodeLensExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeLens, "code_lens"
+
+  def test_after_request_hook
+    message_queue = Thread::Queue.new
+    create_code_lens_hook_class
+
+    store = RubyLsp::Store.new
+    store.set(uri: "file:///fake.rb", source: <<~RUBY, version: 1)
+      class Test < Minitest::Test; end
+    RUBY
+
+    response = RubyLsp::Executor.new(
+      store,
+      message_queue,
+    ).execute({
+      method: "textDocument/codeLens",
+      params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 1, character: 2 } },
+    }).response
+
+    assert_match("Run", response.first.command.title)
+    assert_match("Run Test", response[1].command.title)
+  ensure
+    RubyLsp::Requests::Hover.listeners.clear
+    T.must(message_queue).close
+  end
+
+  private
+
+  def create_code_lens_hook_class
+    Class.new(RubyLsp::Listener) do
+      attr_reader :response
+
+      RubyLsp::Requests::CodeLens.add_listener(self)
+
+      listener_events do
+        def on_class(node)
+          T.bind(self, RubyLsp::Listener[T.untyped])
+
+          @response = [RubyLsp::Interface::CodeLens.new(
+            range: range_from_syntax_tree_node(node),
+            command: RubyLsp::Interface::Command.new(
+              title: "Run #{node.constant.constant.value}",
+              command: "rubyLsp.runTest",
+            ),
+          )]
+        end
+      end
+    end
+  end
 end

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -25,7 +25,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     }).response
 
     assert_match("Run", response.first.command.title)
-    assert_match("Run Test", response[1].command.title)
+    assert_match("Run Test", response[2].command.title)
   ensure
     RubyLsp::Requests::Hover.listeners.clear
     T.must(message_queue).close

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -78,7 +78,7 @@ class StoreTest < Minitest::Test
     counter = 0
 
     5.times do
-      @store.cache_fetch("/foo/bar.rb", :folding_ranges) do
+      @store.cache_fetch("/foo/bar.rb", "textDocument/foldingRange") do
         counter += 1
       end
     end
@@ -88,7 +88,7 @@ class StoreTest < Minitest::Test
     # After the entry in the storage is updated, the cache is invalidated
     @store.set(uri: "/foo/bar.rb", source: "def bar; end", version: 1)
     5.times do
-      @store.cache_fetch("/foo/bar.rb", :folding_ranges) do
+      @store.cache_fetch("/foo/bar.rb", "textDocument/foldingRange") do
         counter += 1
       end
     end


### PR DESCRIPTION
### Motivation

Closes #655 

This PR can be merged after #647 

### Implementation

1. Migrated `CodeLens` to use the listener strategy
    - Removed `with_visbility` helper method as this approach no longer worked with the listener strategy. Introduced a new instance variable `prev_visibility` to replace this functionality
3. Refactored `add_code_lens` to extract `create_code_lens` into a method that can be used in `ruby-lsp-rails` ([here](https://github.com/Shopify/ruby-lsp-rails/pull/59))

### Automated Tests

Added a test to ensure `CodeLens` responses were merged together.
