### PR TITLE
Remove unnecessary `let`

### DIFF
--- a/lib/ruby_lsp/requests/path_completion.rb
+++ b/lib/ruby_lsp/requests/path_completion.rb
@@ -29,7 +29,7 @@ module RubyLsp
         # We can't verify if we're inside a require when there are syntax errors
         return [] if @document.syntax_error?
 
-        target = T.let(find, T.nilable(SyntaxTree::TStringContent))
+        target = find
         # no target means the we are not inside a `require` call
         return [] unless target
 


### PR DESCRIPTION
Just as small thing I noticed while working on https://github.com/Shopify/ruby-lsp/pull/665. The type is already known from the return value of the method.