### PR TITLE
Remove exit code benchmark

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -299,7 +299,6 @@ if File.exist?(CACHE_FILE_PATH)
     # If this phrase is changed, we have to update .github/workflows/benchmark.yml since this is used to determine
     # whether to fail the build or not
     puts "\n\nAt least one benchmark is slower than the main branch."
-    exit(1)
   end
 end
 

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -296,8 +296,6 @@ if File.exist?(CACHE_FILE_PATH)
   end
 
   unless success
-    # If this phrase is changed, we have to update .github/workflows/benchmark.yml since this is used to determine
-    # whether to fail the build or not
     puts "\n\nAt least one benchmark is slower than the main branch."
   end
 end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -250,7 +250,7 @@ requests = {
   "textDocument/codeAction" => code_action_params,
   "textDocument/onTypeFormatting" => base_params.merge(position: { line: 1, character: 31 }, ch: "\n"),
   "codeAction/resolve" => base_params.merge(data: { range: range, uri: FILE_URI }),
-  "textDocument/completion" => base_params.merge(position: position),
+  "textDocument/completion" => base_params.merge(position: { line: 1, character: 50 }),
   "textDocument/codeLens" => base_params,
 }
 


### PR DESCRIPTION
### Motivation

- Since failing is not monitored anymore on CI (https://github.com/Shopify/ruby-lsp/pull/531), this exit should be removed too, to avoid dead code 👍 .

- Then I saw that PathCompletion wasn't loaded anymore, so the benchmark wasn't run on the request really. I fixed it but can be reverted.

### Implementation

- Simply remove the `exit(1)` which is not caught anymore. 
- Change the position param to be sure that `lib/ruby_lsp/executor.rb#completion` load the PathCompletion request.

### Automated Tests

Not relevant

### Manual Tests

Run the `bin/benchmark`, output is not a failing command if a request is slower.