### PR TITLE
Add `Run In Terminal` code lens

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -119,6 +119,8 @@ module RubyLsp
       def add_code_lens(node, name:, command:)
         @response << create_code_lens(
           node,
+          title: "Run",
+          command_name: "rubyLsp.runTest",
           path: @path,
           name: name,
           test_command: command,
@@ -127,10 +129,22 @@ module RubyLsp
 
         @response << create_code_lens(
           node,
+          title: "Debug",
+          command_name: "rubyLsp.debugTest",
           path: @path,
           name: name,
           test_command: command,
           type: "debug",
+        )
+
+        @response << create_code_lens(
+          node,
+          title: "Run In Terminal",
+          command_name: "rubyLsp.runTestInTerminal",
+          path: @path,
+          name: name,
+          test_command: command,
+          type: "test_in_terminal",
         )
       end
     end

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -53,15 +53,15 @@ module RubyLsp
         sig do
           params(
             node: SyntaxTree::Node,
+            title: String,
+            command_name: String,
             path: String,
             name: String,
             test_command: String,
             type: String,
           ).returns(Interface::CodeLens)
         end
-        def create_code_lens(node, path:, name:, test_command:, type:)
-          title = type == "test" ? "Run" : "Debug"
-          command = type == "test" ? "rubyLsp.runTest" : "rubyLsp.debugTest"
+        def create_code_lens(node, title:, command_name:, path:, name:, test_command:, type:)
           range = range_from_syntax_tree_node(node)
           arguments = [
             path,
@@ -79,7 +79,7 @@ module RubyLsp
             range: range,
             command: Interface::Command.new(
               title: title,
-              command: command,
+              command: command_name,
               arguments: arguments,
             ),
             data: { type: type },

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -63,6 +63,36 @@
     {
       "range": {
         "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fake.rb",
+          "Test",
+          "bundle exec ruby -Itest /fake.rb",
+          {
+            "start_line": 0,
+            "start_column": 0,
+            "end_line": 18,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal"
+      }
+    },
+    {
+      "range": {
+        "start": {
           "line": 5,
           "character": 2
         },
@@ -118,6 +148,36 @@
       },
       "data": {
         "type": "debug"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 2
+        },
+        "end": {
+          "line": 5,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fake.rb",
+          "test_public",
+          "bundle exec ruby -Itest /fake.rb --name test_public",
+          {
+            "start_line": 5,
+            "start_column": 2,
+            "end_line": 5,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal"
       }
     },
     {
@@ -183,6 +243,36 @@
     {
       "range": {
         "start": {
+          "line": 9,
+          "character": 9
+        },
+        "end": {
+          "line": 9,
+          "character": 37
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fake.rb",
+          "test_public_command",
+          "bundle exec ruby -Itest /fake.rb --name test_public_command",
+          {
+            "start_line": 9,
+            "start_column": 9,
+            "end_line": 9,
+            "end_column": 37
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal"
+      }
+    },
+    {
+      "range": {
+        "start": {
           "line": 11,
           "character": 9
         },
@@ -243,6 +333,36 @@
     {
       "range": {
         "start": {
+          "line": 11,
+          "character": 9
+        },
+        "end": {
+          "line": 11,
+          "character": 37
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fake.rb",
+          "test_another_public",
+          "bundle exec ruby -Itest /fake.rb --name test_another_public",
+          {
+            "start_line": 11,
+            "start_column": 9,
+            "end_line": 11,
+            "end_column": 37
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal"
+      }
+    },
+    {
+      "range": {
+        "start": {
           "line": 17,
           "character": 2
         },
@@ -298,6 +418,36 @@
       },
       "data": {
         "type": "debug"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 2
+        },
+        "end": {
+          "line": 17,
+          "character": 28
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fake.rb",
+          "test_public_vcall",
+          "bundle exec ruby -Itest /fake.rb --name test_public_vcall",
+          {
+            "start_line": 17,
+            "start_column": 2,
+            "end_line": 17,
+            "end_column": 28
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal"
       }
     }
   ],

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -25,7 +25,8 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     }).response
 
     assert_match("Run", response.first.command.title)
-    assert_match("Run Test", response[2].command.title)
+    assert_match("Debug", response[1].command.title)
+    assert_match("Run In Terminal", response[2].command.title)
   ensure
     RubyLsp::Requests::Hover.listeners.clear
     T.must(message_queue).close


### PR DESCRIPTION
### Motivation

Because the test controller isn't able to handle dynamically generated tests, the `Run` code lens is not able to run them. This means those tests are not supported by any code lens anymore, while in prior versions they could be run in the terminal.

This commits adds a new code lens `Run In Terminal` that will run the tests in the terminal.

(This requires https://github.com/Shopify/vscode-ruby-lsp/pull/596)

### Implementation

1. Update the `create_code_lens` method so it handles more than 2 types of code lens.
2. Add a new type of code lens titled: `Run In Terminal`

Result: 

<img width="780" alt="Screenshot 2023-05-02 at 23 18 11" src="https://user-images.githubusercontent.com/5079556/235797885-e92dea98-2aef-4dc6-a7b7-e0ffcde4f583.png">

### Automated Tests

The existing tests have covered it.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
