### PR TITLE
Fix missing require for `URI`

### DIFF
--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -6,6 +6,7 @@ require "syntax_tree"
 require "language_server-protocol"
 require "benchmark"
 require "bundler"
+require "uri"
 
 require "ruby-lsp"
 require "ruby_lsp/utils"


### PR DESCRIPTION
### Motivation

It will cause cursor.so loading `ruby-lsp` failed.

```log
bundler: failed to load command: ruby-lsp (/opt/homebrew/lib/ruby/gems/3.2.0/bin/ruby-lsp)
/opt/homebrew/lib/ruby/gems/3.2.0/gems/ruby-lsp-0.5.0/lib/ruby_lsp/utils.rb:9:in `<module:RubyLsp>': undefined method `URI' for RubyLsp:Module (NoMethodError)

  WORKSPACE_URI = T.let(URI("file://#{Dir.pwd}".freeze), URI::Generic) # rubocop:disable Style/RedundantFreeze
                        ^^^
	from /opt/homebrew/lib/ruby/gems/3.2.0/gems/ruby-lsp-0.5.0/lib/ruby_lsp/utils.rb:4:in `<top (required)>'
```

<img width="1705" alt="iShot_2023-05-04_23 44 43" src="https://user-images.githubusercontent.com/1131536/236259678-325f4f51-7a03-4cfc-82c2-de3c0d57763a.png">


### Implementation

Required 'uri' is not loading.

### Automated Tests

NO need.

### Manual Tests

After edit /opt/homebrew/lib/ruby/gems/3.2.0/gems/ruby-lsp-0.5.0/lib/ruby_lsp/utils.rb, add like in this PR, it resolved.
