### PR TITLE
Migrate inlay hint to listener

### DIFF
--- a/lib/ruby_lsp/event_emitter.rb
+++ b/lib/ruby_lsp/event_emitter.rb
@@ -116,5 +116,11 @@ module RubyLsp
       @listeners[:on_comment]&.each { |l| T.unsafe(l).on_comment(node) }
       super
     end
+
+    sig { override.params(node: SyntaxTree::Rescue).void }
+    def visit_rescue(node)
+      @listeners[:on_rescue]&.each { |l| T.unsafe(l).on_rescue(node) }
+      super
+    end
   end
 end

--- a/test/requests/inlay_hints_expectations_test.rb
+++ b/test/requests/inlay_hints_expectations_test.rb
@@ -7,6 +7,20 @@ require "expectations/expectations_test_runner"
 class InlayHintsExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::InlayHints, "inlay_hints"
 
+  def run_expectations(source)
+    message_queue = Thread::Queue.new
+    params = @__params&.any? ? @__params : default_args
+    uri = "file://#{@_path}"
+    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
+
+    emitter = RubyLsp::EventEmitter.new
+    listener = RubyLsp::Requests::InlayHints.new(params.first, emitter, message_queue)
+    emitter.visit(document.tree)
+    listener.response
+  ensure
+    T.must(message_queue).close
+  end
+
   def default_args
     [0..20]
   end


### PR DESCRIPTION
### Motivation

Closes #702

Migrate inlay hint to use the new listener pattern. This PR serves as a good example of how to migrate semantic highlighting, which may be executed with or without a range.

### Implementation

- Added `on_rescue` to emitter
- Migrated InlayHints
- Adapted Executor to use the new pattern

### Automated Tests

Fixed existing tests.