### PR TITLE
Add gem actions in the Gemfile

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -156,6 +156,7 @@ module RubyLsp
         )
       end
 
+      sig { params(node: SyntaxTree::Command, homepage: String).void }
       def add_open_gem_code_lens(node, homepage:)
         range = range_from_syntax_tree_node(node)
 

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -69,14 +69,15 @@ module RubyLsp
 
       sig { params(node: SyntaxTree::Command).void }
       def on_command(node)
-        if ACCESS_MODIFIERS.include?(node.message.value) && node.arguments.parts.any?
+        node_message = node.message.value
+        if ACCESS_MODIFIERS.include?(node_message) && node.arguments.parts.any?
           @prev_visibility = @visibility
-          @visibility = node.message.value
-        elsif @path.include?("Gemfile") && node.message.value.include?("gem") && node.arguments.parts.any?
-          homepage = resolve_gem_homepage(node)
-          return unless homepage
+          @visibility = node_message
+        elsif @path.include?("Gemfile") && node_message.include?("gem") && node.arguments.parts.any?
+          remote = resolve_gem_remote(node)
+          return unless remote
 
-          add_open_gem_homepage_code_lens(node, homepage: homepage)
+          add_open_gem_remote_code_lens(node, remote)
         end
       end
 
@@ -155,26 +156,28 @@ module RubyLsp
       end
 
       sig { params(node: SyntaxTree::Command).returns(T.nilable(String)) }
-      def resolve_gem_homepage(node)
+      def resolve_gem_remote(node)
         gem_name = node.arguments.parts.flat_map(&:child_nodes).first.value
         spec = Gem::Specification.stubs.find { |gem| gem.name == gem_name }&.to_spec
         return if spec.nil?
 
-        spec.homepage || spec.metadata.fetch("homepage_uri", nil)
+        [spec.homepage, spec.metadata["source_code_uri"]].compact.find do |page|
+          page.start_with?("https://github.com", "https://gitlab.com")
+        end
       end
 
-      sig { params(node: SyntaxTree::Command, homepage: String).void }
-      def add_open_gem_homepage_code_lens(node, homepage:)
+      sig { params(node: SyntaxTree::Command, remote: String).void }
+      def add_open_gem_remote_code_lens(node, remote)
         range = range_from_syntax_tree_node(node)
 
         @response << Interface::CodeLens.new(
           range: range,
           command: Interface::Command.new(
-            title: "Open Homepage",
-            command: "rubyLsp.openGemHomepage",
-            arguments: [homepage],
+            title: "Open remote",
+            command: "rubyLsp.openLink",
+            arguments: [remote],
           ),
-          data: { type: "browser" },
+          data: { type: "link" },
         )
       end
     end

--- a/test/expectations/code_lens/Gemfile.exp.json
+++ b/test/expectations/code_lens/Gemfile.exp.json
@@ -1,0 +1,29 @@
+{
+  "params": [],
+  "result": [
+    {
+      "range": {
+        "start": { "line": 0, "character": 0 },
+        "end": { "line": 0, "character": 37 }
+      },
+      "command": {
+        "title": "Open",
+        "command": "rubyLsp.openGem",
+        "arguments": ["https://github.com/ruby/debug"]
+      },
+      "data": { "type": "browser" }
+    },
+    {
+      "range": {
+        "start": { "line": 1, "character": 0 },
+        "end": { "line": 1, "character": 21 }
+      },
+      "command": {
+        "title": "Open",
+        "command": "rubyLsp.openGem",
+        "arguments": ["https://github.com/ruby/rake"]
+      },
+      "data": { "type": "browser" }
+    }
+  ]
+}

--- a/test/expectations/code_lens/Gemfile.exp.json
+++ b/test/expectations/code_lens/Gemfile.exp.json
@@ -7,8 +7,8 @@
         "end": { "line": 0, "character": 37 }
       },
       "command": {
-        "title": "Open",
-        "command": "rubyLsp.openGem",
+        "title": "Open Homepage",
+        "command": "rubyLsp.openGemHomepage",
         "arguments": ["https://github.com/ruby/debug"]
       },
       "data": { "type": "browser" }
@@ -19,9 +19,21 @@
         "end": { "line": 1, "character": 21 }
       },
       "command": {
-        "title": "Open",
-        "command": "rubyLsp.openGem",
+        "title": "Open Homepage",
+        "command": "rubyLsp.openGemHomepage",
         "arguments": ["https://github.com/ruby/rake"]
+      },
+      "data": { "type": "browser" }
+    },
+    {
+      "range": {
+        "start": { "line": 2, "character": 0 },
+        "end": { "line": 2, "character": 51 }
+      },
+      "command": {
+        "title": "Open Homepage",
+        "command": "rubyLsp.openGemHomepage",
+        "arguments": ["https://docs.rubocop.org/rubocop-minitest/"]
       },
       "data": { "type": "browser" }
     }

--- a/test/expectations/code_lens/Gemfile.exp.json
+++ b/test/expectations/code_lens/Gemfile.exp.json
@@ -1,41 +1,65 @@
 {
-  "params": [],
   "result": [
     {
       "range": {
-        "start": { "line": 0, "character": 0 },
-        "end": { "line": 0, "character": 37 }
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 0,
+          "character": 21
+        }
       },
       "command": {
-        "title": "Open Homepage",
-        "command": "rubyLsp.openGemHomepage",
-        "arguments": ["https://github.com/ruby/debug"]
-      },
-      "data": { "type": "browser" }
-    },
-    {
-      "range": {
-        "start": { "line": 1, "character": 0 },
-        "end": { "line": 1, "character": 21 }
-      },
-      "command": {
-        "title": "Open Homepage",
-        "command": "rubyLsp.openGemHomepage",
+        "title": "Open remote",
+        "command": "rubyLsp.openLink",
         "arguments": ["https://github.com/ruby/rake"]
       },
-      "data": { "type": "browser" }
+      "data": {
+        "type": "link"
+      }
     },
     {
       "range": {
-        "start": { "line": 2, "character": 0 },
-        "end": { "line": 2, "character": 51 }
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 1,
+          "character": 51
+        }
       },
       "command": {
-        "title": "Open Homepage",
-        "command": "rubyLsp.openGemHomepage",
-        "arguments": ["https://docs.rubocop.org/rubocop-minitest/"]
+        "title": "Open remote",
+        "command": "rubyLsp.openLink",
+        "arguments": ["https://github.com/rubocop/rubocop-minitest"]
       },
-      "data": { "type": "browser" }
+      "data": {
+        "type": "link"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 2
+        },
+        "end": {
+          "line": 5,
+          "character": 39
+        }
+      },
+      "command": {
+        "title": "Open remote",
+        "command": "rubyLsp.openLink",
+        "arguments": ["https://github.com/ruby/debug"]
+      },
+      "data": {
+        "type": "link"
+      }
     }
-  ]
+  ],
+  "params": []
 }

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -480,9 +480,9 @@
         "title": "Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_with_q?",
-          "bundle exec ruby -Itest /fake.rb --name test_with_q\\?",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_with_q\\?",
           {
             "start_line": 19,
             "start_column": 2,
@@ -511,9 +511,9 @@
         "title": "Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_with_q?",
-          "bundle exec ruby -Itest /fake.rb --name test_with_q\\?",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_with_q\\?",
           {
             "start_line": 19,
             "start_column": 2,
@@ -542,9 +542,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_with_q?",
-          "bundle exec ruby -Itest /fake.rb --name test_with_q\\?",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_with_q\\?",
           {
             "start_line": 19,
             "start_column": 2,

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -15,9 +15,9 @@
         "title": "Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby -Itest /fake.rb",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
           {
             "start_line": 0,
             "start_column": 0,
@@ -46,9 +46,9 @@
         "title": "Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby -Itest /fake.rb",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
           {
             "start_line": 0,
             "start_column": 0,
@@ -77,9 +77,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby -Itest /fake.rb",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
           {
             "start_line": 0,
             "start_column": 0,
@@ -108,9 +108,9 @@
         "title": "Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_public",
-          "bundle exec ruby -Itest /fake.rb --name test_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public",
           {
             "start_line": 5,
             "start_column": 2,
@@ -139,9 +139,9 @@
         "title": "Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_public",
-          "bundle exec ruby -Itest /fake.rb --name test_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public",
           {
             "start_line": 5,
             "start_column": 2,
@@ -170,9 +170,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_public",
-          "bundle exec ruby -Itest /fake.rb --name test_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public",
           {
             "start_line": 5,
             "start_column": 2,
@@ -201,9 +201,9 @@
         "title": "Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_public_command",
-          "bundle exec ruby -Itest /fake.rb --name test_public_command",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public_command",
           {
             "start_line": 9,
             "start_column": 9,
@@ -232,9 +232,9 @@
         "title": "Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_public_command",
-          "bundle exec ruby -Itest /fake.rb --name test_public_command",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public_command",
           {
             "start_line": 9,
             "start_column": 9,
@@ -263,9 +263,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_public_command",
-          "bundle exec ruby -Itest /fake.rb --name test_public_command",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public_command",
           {
             "start_line": 9,
             "start_column": 9,
@@ -294,9 +294,9 @@
         "title": "Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_another_public",
-          "bundle exec ruby -Itest /fake.rb --name test_another_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_another_public",
           {
             "start_line": 11,
             "start_column": 9,
@@ -325,9 +325,9 @@
         "title": "Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_another_public",
-          "bundle exec ruby -Itest /fake.rb --name test_another_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_another_public",
           {
             "start_line": 11,
             "start_column": 9,
@@ -356,9 +356,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_another_public",
-          "bundle exec ruby -Itest /fake.rb --name test_another_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_another_public",
           {
             "start_line": 11,
             "start_column": 9,
@@ -387,9 +387,9 @@
         "title": "Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_public_vcall",
-          "bundle exec ruby -Itest /fake.rb --name test_public_vcall",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public_vcall",
           {
             "start_line": 17,
             "start_column": 2,
@@ -418,9 +418,9 @@
         "title": "Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_public_vcall",
-          "bundle exec ruby -Itest /fake.rb --name test_public_vcall",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public_vcall",
           {
             "start_line": 17,
             "start_column": 2,
@@ -449,9 +449,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fake.rb",
+          "/fixtures/minitest_tests.rb",
           "test_public_vcall",
-          "bundle exec ruby -Itest /fake.rb --name test_public_vcall",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public_vcall",
           {
             "start_line": 17,
             "start_column": 2,

--- a/test/fixtures/Gemfile
+++ b/test/fixtures/Gemfile
@@ -1,0 +1,4 @@
+gem "debug", "~> 1.7", require: false
+gem "rake", "~> 13.0"
+gem "rubocop-minitest", "~> 0.30.0", require: false
+

--- a/test/fixtures/Gemfile.rb
+++ b/test/fixtures/Gemfile.rb
@@ -1,5 +1,7 @@
-gem "debug", "~> 1.7", require: false
 gem "rake", "~> 13.0"
 gem "rubocop-minitest", "~> 0.30.0", require: false
 gem "foogem"
 
+group :development do
+  gem "debug", "~> 1.7", require: false
+end

--- a/test/fixtures/Gemfile.rb
+++ b/test/fixtures/Gemfile.rb
@@ -1,4 +1,5 @@
 gem "debug", "~> 1.7", require: false
 gem "rake", "~> 13.0"
 gem "rubocop-minitest", "~> 0.30.0", require: false
+gem "foogem"
 

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -3,14 +3,12 @@
 
 require "test_helper"
 require "expectations/expectations_test_runner"
-
 class CodeLensExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeLens, "code_lens"
 
   def run_expectations(source)
-    uri = "file:///fake.rb"
+    uri = "file://#{@_path}"
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
-
     emitter = RubyLsp::EventEmitter.new
     listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue)
     emitter.visit(document.tree)

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -3,12 +3,14 @@
 
 require "test_helper"
 require "expectations/expectations_test_runner"
+
 class CodeLensExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeLens, "code_lens"
 
   def run_expectations(source)
     uri = "file://#{@_path}"
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
+
     emitter = RubyLsp::EventEmitter.new
     listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue)
     emitter.visit(document.tree)


### PR DESCRIPTION
### Motivation

Closes: #585
Requires: https://github.com/Shopify/vscode-ruby-lsp/pull/605

### Implementation

Following indications in the issue: 

- on the `on_command` event check if the file is `Gemfile`, the command message includes `gem` 
- extract the gem name from the node 
- find the specification for this name
- extract its homepage property
- return a Codelens with this form:

```json
{
      "range": {
        "start": { "line": 1, "character": 0 },
        "end": { "line": 1, "character": 21 }
      },
      "command": {
        "title": "Open",
        "command": "rubyLsp.openGem",
        "arguments": ["https://github.com/ruby/rake"]
      },
      "data": { "type": "browser" }
    }
```

### Automated Tests

I added a fixture and expectation file for this specific Codelens. To make it work I had to:

- not faking URI in the document variable (I check it through the `@path` in the Codelens request)
- fix expectation (as it's not faked anymore) for the `minitest_test.exp.json`

To be honest, it's not a "hermetic" test. For example, I explicitly added `gem "rubocop-minitest"` in the fixture, because there is no homepage for this gem, so I test it by not providing it in `Gemfile.exp.json` but, if it's added, CI will fail. Not sure how to handle this differently. 

I'm also not sure that adding a Gemfile (even in `test/fixtures`) is without consequences.

### Manual Tests

- Check out this branch
- Checkout vscode-ruby-lsp branch
- Open a Gemfile
- Something like that is expected:

<details><summary>Record</summary>

![Screen-Recording-2023-05-09-at-22 37 45](https://github.com/Shopify/vscode-ruby-lsp/assets/38727166/71898ac7-e6f3-42f4-91ff-56f016dab175)
</details> 
