### PR TITLE
Add neovim-lspconfig instructions

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -7,3 +7,22 @@ Code, use the official [Ruby LSP extension](https://github.com/Shopify/vscode-ru
 new H2 header in this file containing the instructions. -->
 
 - [Emacs LSP Mode](https://emacs-lsp.github.io/lsp-mode/page/lsp-ruby-lsp/)
+- [neovim](#neovim-via-nvim-lspconfig) (via [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig))
+
+## Neovim (via [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig))
+
+- Install [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) via your favourite plugin manager (eg: [Packer](https://github.com/wbthomason/packer.nvim)).
+- Enable nvim-lspconfig's ruby_ls configuration:
+  ```lua
+  require('lspconfig').ruby_ls.setup {
+    init_options = {
+      -- Add Ruby LSP configuration here, eg:
+      -- formatter = 'auto'
+    },
+    -- Add your lspconfig configurations/overrides here, eg:
+    on_attach = function(client, buffer)
+      -- ...
+    end,
+  }
+  ```
+- To make inline diagnostics (`textDocument/diagnostics`) work you need to [add a custom handler](https://github.com/neovim/nvim-lspconfig/pull/2498).


### PR DESCRIPTION
### Motivation

Adding configuration instructions for Neovim (via neovim-lspconfig) as per [this comment](https://github.com/Shopify/ruby-lsp/issues/188#issuecomment-1456941648).

### Implementation

Just adding documentation.
