### PR TITLE
Escape test name in the commandline to run it in the terminal

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "shellwords"
+
 module RubyLsp
   module Requests
     # ![Code lens demo](../../code_lens.gif)

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -59,7 +59,7 @@ module RubyLsp
             add_code_lens(
               node,
               name: method_name,
-              command: BASE_COMMAND + @path + " --name " + method_name,
+              command: BASE_COMMAND + @path + " --name " + Shellwords.escape(method_name),
             )
           end
         end

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -7,7 +7,7 @@
           "character": 0
         },
         "end": {
-          "line": 18,
+          "line": 20,
           "character": 3
         }
       },
@@ -21,7 +21,7 @@
           {
             "start_line": 0,
             "start_column": 0,
-            "end_line": 18,
+            "end_line": 20,
             "end_column": 3
           }
         ]
@@ -38,7 +38,7 @@
           "character": 0
         },
         "end": {
-          "line": 18,
+          "line": 20,
           "character": 3
         }
       },
@@ -52,7 +52,7 @@
           {
             "start_line": 0,
             "start_column": 0,
-            "end_line": 18,
+            "end_line": 20,
             "end_column": 3
           }
         ]
@@ -69,7 +69,7 @@
           "character": 0
         },
         "end": {
-          "line": 18,
+          "line": 20,
           "character": 3
         }
       },
@@ -83,7 +83,7 @@
           {
             "start_line": 0,
             "start_column": 0,
-            "end_line": 18,
+            "end_line": 20,
             "end_column": 3
           }
         ]
@@ -457,6 +457,99 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 28
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "test_library": "minitest"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 19,
+          "character": 2
+        },
+        "end": {
+          "line": 19,
+          "character": 23
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fake.rb",
+          "test_with_q?",
+          "bundle exec ruby -Itest /fake.rb --name test_with_q\\?",
+          {
+            "start_line": 19,
+            "start_column": 2,
+            "end_line": 19,
+            "end_column": 23
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "test_library": "minitest"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 19,
+          "character": 2
+        },
+        "end": {
+          "line": 19,
+          "character": 23
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fake.rb",
+          "test_with_q?",
+          "bundle exec ruby -Itest /fake.rb --name test_with_q\\?",
+          {
+            "start_line": 19,
+            "start_column": 2,
+            "end_line": 19,
+            "end_column": 23
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "test_library": "minitest"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 19,
+          "character": 2
+        },
+        "end": {
+          "line": 19,
+          "character": 23
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fake.rb",
+          "test_with_q?",
+          "bundle exec ruby -Itest /fake.rb --name test_with_q\\?",
+          {
+            "start_line": 19,
+            "start_column": 2,
+            "end_line": 19,
+            "end_column": 23
           }
         ]
       },

--- a/test/fixtures/minitest_tests.rb
+++ b/test/fixtures/minitest_tests.rb
@@ -16,4 +16,6 @@ class Test < Minitest::Test
   public
 
   def test_public_vcall; end
+
+  def test_with_q?; end
 end


### PR DESCRIPTION
### Motivation

The test name may end with `?` or `!`, and passing it without escape results in a failure like `zsh: no matches found: test_has?`.

### Implementation

Escaping the file name with `Shellwords.escape`.

Not sure if the same problem exists for rspec or other supported frameworks...