### PR TITLE
Auto detect formatter when client did not specify it

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -421,7 +421,7 @@ module RubyLsp
       end
 
       formatter = options.dig(:initializationOptions, :formatter)
-      @store.formatter = if formatter == "auto"
+      @store.formatter = if formatter == "auto" || formatter == '' || formatter.nil?
         detected_formatter
       else
         formatter


### PR DESCRIPTION
### Motivation

I was playing with ruby-lsp and Emacs client [eglot](https://github.com/joaotavora/eglot) and I noticed that formatting of the buffer is not working. It seems that the client is not passing the "auto" formatter in the `initializationOptions`. 

I'm very green to lsp so I don't quite understand everything. But when following this [thread](https://github.com/Microsoft/language-server-protocol/issues/567) I've read that the server should apply defaults by itself:
> a server should work with an empty literal as well and simply assume a set of defaults

### Implementation

Simply assume by default that the formatter should be auto detected if it's the option is missing.

### Automated Tests

No automated tests yet since I'm opening a draft pull request in order to find out if it's the right way to proceed.

### Manual Tests

* Install Emacs 26.3+
* create `~/.emacs.d/init.el` file with contents:
```el
  (require 'package)
  (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
  (add-to-list 'package-archives '("gnu-devel" . "https://elpa.gnu.org/devel/") t)
  (package-initialize))

  (package-install "eglot")
  (require 'eglot)
  (add-to-list 'eglot-server-programs '((ruby-mode ruby-ts-mode) "ruby-lsp"))
```
* open a ruby file in Emacs
* run `eglot` command in Emacs
* run `eglot-format-buffer` command in Emacs, you should see the error message "Unknown formatter: " in the minibuffer
* apply the patch to your `ruby-lsp` gem
* run `eglot-reconnect` command in Emacs
* run `eglot-format-buffer` command in Emacs, you should not see the error
