### PR TITLE
Add instrocution for eglot client

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -7,3 +7,13 @@ Code, use the official [Ruby LSP extension](https://github.com/Shopify/vscode-ru
 new H2 header in this file containing the instructions. -->
 
 - [Emacs LSP Mode](https://emacs-lsp.github.io/lsp-mode/page/lsp-ruby-lsp/)
+- [Emacs Eglot](#Emacs Eglot)
+
+## Emacs Eglot
+
+[Eglot](https://github.com/joaotavora/eglot) runs solargraph server by default. To set it up with ruby-lsp you need to put that in your init file:
+```el
+(with-eval-after-load 'eglot
+ (add-to-list 'eglot-server-programs '((ruby-mode ruby-ts-mode) "ruby-lsp")))
+ ```
+ When you run `eglot` command it will run `ruby-lsp` process for you.


### PR DESCRIPTION
### Motivation

Editors.md file lacks instructions for Emacs [eglot](https://github.com/joaotavora/eglot)

### Implementation

Added the instructions.

### Automated Tests

No need.

### Manual Tests
Run a modern Emacs version with `-q` command. Evaluate expression:
```el
(with-eval-after-load 'eglot
 (add-to-list 'eglot-server-programs '((ruby-mode ruby-ts-mode) "ruby-lsp")))
```
Open a ruby file and run `eglot` command.