### PR TITLE
Upgrade Psych to v5.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "rubocop-sorbet", "~> 0.7", require: false
 gem "sorbet-static-and-runtime", platforms: NON_WINDOWS_PLATFORMS
 gem "tapioca", "~> 0.11", require: false, platforms: NON_WINDOWS_PLATFORMS
 gem "rdoc", require: false
+gem "psych", "~> 5.1", require: false
 
 # The Rails documentation link only activates when railties is detected.
 gem "railties", "~> 7.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
     parser (3.2.2.1)
       ast (~> 2.4.1)
     prettier_print (1.2.1)
-    psych (5.0.1)
+    psych (5.1.0)
       stringio
     racc (1.6.2)
     rack (2.2.7)
@@ -139,7 +139,7 @@ GEM
       sorbet (>= 0.5.10187)
       sorbet-runtime (>= 0.5.9204)
       thor (>= 0.19.2)
-    stringio (3.0.4)
+    stringio (3.0.6)
     syntax_tree (6.1.1)
       prettier_print (>= 1.2.0)
     tapioca (0.11.6)
@@ -177,6 +177,7 @@ DEPENDENCIES
   minitest (~> 5.18)
   minitest-reporters (~> 1.6)
   mocha (~> 2.0)
+  psych (~> 5.1)
   railties (~> 7.0)
   rake (~> 13.0)
   rdoc


### PR DESCRIPTION
### Motivation

Upgrading to the latest Psych fixes the issue we've been seeing in our CI when trying to build nokogiri.