### PR TITLE
Drop Ruby 2.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2"]
         exclude:
           - os: windows-latest
             ruby: "3.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ require:
 AllCops:
   NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
   - "vendor/**/*"
   - "features/**/*"

--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -11,12 +11,8 @@ module RubyLsp
 
       abstract!
 
-      # We must accept rest keyword arguments here, so that the argument count matches when
-      # SyntaxTree::WithScope#initialize invokes `super` for Sorbet. We don't actually use these parameters for
-      # anything. We can remove these arguments once we drop support for Ruby 2.7
-      # https://github.com/ruby-syntax-tree/syntax_tree/blob/4dac90b53df388f726dce50ce638a1ba71cc59f8/lib/syntax_tree/with_scope.rb#L122
-      sig { params(document: Document, _kwargs: T.untyped).void }
-      def initialize(document, **_kwargs)
+      sig { params(document: Document).void }
+      def initialize(document)
         @document = document
         super()
       end

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -6,7 +6,7 @@ module RubyLsp
   VOID = T.let(Object.new.freeze, Object)
 
   # This freeze is not redundant since the interpolated string is mutable
-  WORKSPACE_URI = T.let(URI("file://#{Dir.pwd}".freeze), URI::Generic) # rubocop:disable Style/RedundantFreeze
+  WORKSPACE_URI = T.let(URI("file://#{Dir.pwd}".freeze), URI::Generic)
 
   # A notification to be sent to the client
   class Message

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency("sorbet-runtime")
   s.add_dependency("syntax_tree", ">= 6.1.1", "< 7")
 
-  s.required_ruby_version = ">= 2.7.3"
+  s.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
### Motivation

Ruby 2.7 is EOL

### Implementation

n/a

### Automated Tests

n/a

### Manual Tests

n/a