### PR TITLE
Reset visibilities after code lens detection has moved out of a class

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -42,7 +42,17 @@ module RubyLsp
         @visibility = T.let("public", String)
         @prev_visibility = T.let("public", String)
 
-        emitter.register(self, :on_class, :on_def, :on_command, :after_command, :on_call, :after_call, :on_vcall)
+        emitter.register(
+          self,
+          :on_class,
+          :after_class,
+          :on_def,
+          :on_command,
+          :after_command,
+          :on_call,
+          :after_call,
+          :on_vcall,
+        )
       end
 
       sig { params(node: SyntaxTree::ClassDeclaration).void }
@@ -51,6 +61,12 @@ module RubyLsp
         if class_name.end_with?("Test")
           add_code_lens(node, name: class_name, command: BASE_COMMAND + @path)
         end
+      end
+
+      sig { params(node: SyntaxTree::ClassDeclaration).void }
+      def after_class(node)
+        @prev_visibility = "public"
+        @visibility = "public"
       end
 
       sig { params(node: SyntaxTree::DefNode).void }

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -7,7 +7,7 @@
           "character": 0
         },
         "end": {
-          "line": 20,
+          "line": 22,
           "character": 3
         }
       },
@@ -21,7 +21,7 @@
           {
             "start_line": 0,
             "start_column": 0,
-            "end_line": 20,
+            "end_line": 22,
             "end_column": 3
           }
         ]
@@ -38,7 +38,7 @@
           "character": 0
         },
         "end": {
-          "line": 20,
+          "line": 22,
           "character": 3
         }
       },
@@ -52,7 +52,7 @@
           {
             "start_line": 0,
             "start_column": 0,
-            "end_line": 20,
+            "end_line": 22,
             "end_column": 3
           }
         ]
@@ -69,7 +69,7 @@
           "character": 0
         },
         "end": {
-          "line": 20,
+          "line": 22,
           "character": 3
         }
       },
@@ -83,7 +83,7 @@
           {
             "start_line": 0,
             "start_column": 0,
-            "end_line": 20,
+            "end_line": 22,
             "end_column": 3
           }
         ]
@@ -550,6 +550,192 @@
             "start_column": 2,
             "end_line": 19,
             "end_column": 23
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "test_library": "minitest"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 24,
+          "character": 0
+        },
+        "end": {
+          "line": 26,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "AnotherTest",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
+          {
+            "start_line": 24,
+            "start_column": 0,
+            "end_line": 26,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "test_library": "minitest"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 24,
+          "character": 0
+        },
+        "end": {
+          "line": 26,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "AnotherTest",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
+          {
+            "start_line": 24,
+            "start_column": 0,
+            "end_line": 26,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "test_library": "minitest"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 24,
+          "character": 0
+        },
+        "end": {
+          "line": 26,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "AnotherTest",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
+          {
+            "start_line": 24,
+            "start_column": 0,
+            "end_line": 26,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "test_library": "minitest"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 25,
+          "character": 2
+        },
+        "end": {
+          "line": 25,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public",
+          {
+            "start_line": 25,
+            "start_column": 2,
+            "end_line": 25,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "test_library": "minitest"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 25,
+          "character": 2
+        },
+        "end": {
+          "line": 25,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public",
+          {
+            "start_line": 25,
+            "start_column": 2,
+            "end_line": 25,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "test_library": "minitest"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 25,
+          "character": 2
+        },
+        "end": {
+          "line": 25,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name test_public",
+          {
+            "start_line": 25,
+            "start_column": 2,
+            "end_line": 25,
+            "end_column": 22
           }
         ]
       },

--- a/test/fixtures/minitest_tests.rb
+++ b/test/fixtures/minitest_tests.rb
@@ -18,4 +18,10 @@ class Test < Minitest::Test
   def test_public_vcall; end
 
   def test_with_q?; end
+
+  private
+end
+
+class AnotherTest < Minitest::Test
+  def test_public; end
 end


### PR DESCRIPTION
### Motivation

Currently, the previous test class' last visibility "leaks" to the next class. This causes problem like:

```rb
class FirstTest # has code lens
  def test_something # has code lens
  end

  private
end

class SecondTest # has code lens
  # doesn't have code lens because ruby-lsp thinks it's private
  def test_something
  end
end
```

### Implementation

This commit fixes the problem by resetting the visibilities after moving out of a class definition.

### Automated Tests

I've updated the `minitest_tests` case.

### Manual Tests

Viewing the above snippet with `main` should reveal the issue. And after switching back to this branch, the issue should disappear.
