### PR TITLE
Use a stable bundler version in the lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,4 +191,4 @@ DEPENDENCIES
   tapioca (~> 0.11)
 
 BUNDLED WITH
-   2.5.0.dev
+   2.4.10


### PR DESCRIPTION
### Motivation

Because we're using a preview version of Ruby, bundler `2.5.0.dev` is not published to rubygems and just comes bundled with Ruby itself.

This is not normally an issue, but it doesn't play well with `dev`. Let's use a stable bundler version for convenience.
