### PR TITLE
Always append test class name to the test command

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -78,10 +78,11 @@ module RubyLsp
         if visibility == "public"
           method_name = node.name.value
           if method_name.start_with?("test_")
+            class_name = T.must(@class_stack.last)
             add_code_lens(
               node,
               name: method_name,
-              command: generate_test_command(method_name: method_name, class_name: @class_stack.last),
+              command: generate_test_command(method_name: method_name, class_name: class_name),
             )
           end
         end
@@ -188,12 +189,14 @@ module RubyLsp
         end
       end
 
-      sig { params(class_name: T.nilable(String), method_name: T.nilable(String)).returns(String) }
+      sig { params(class_name: String, method_name: T.nilable(String)).returns(String) }
       def generate_test_command(class_name:, method_name: nil)
         command = BASE_COMMAND + @path
 
-        if method_name
-          command += " --name " + "/#{Shellwords.escape(T.must(class_name) + "#" + method_name)}/"
+        command += if method_name
+          " --name " + "/#{Shellwords.escape(class_name + "#" + method_name)}/"
+        else
+          " --name " + "/#{Shellwords.escape(class_name)}/"
         end
 
         command

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -17,7 +17,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test/",
           {
             "start_line": 0,
             "start_column": 0,
@@ -48,7 +48,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test/",
           {
             "start_line": 0,
             "start_column": 0,
@@ -79,7 +79,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test/",
           {
             "start_line": 0,
             "start_column": 0,
@@ -575,7 +575,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "AnotherTest",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /AnotherTest/",
           {
             "start_line": 24,
             "start_column": 0,
@@ -606,7 +606,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "AnotherTest",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /AnotherTest/",
           {
             "start_line": 24,
             "start_column": 0,
@@ -637,7 +637,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "AnotherTest",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /AnotherTest/",
           {
             "start_line": 24,
             "start_column": 0,
@@ -745,5 +745,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/expectations/code_lens/nested_minitest_tests.exp.json
+++ b/test/expectations/code_lens/nested_minitest_tests.exp.json
@@ -17,7 +17,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "ParentTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /ParentTest/",
           {
             "start_line": 0,
             "start_column": 0,
@@ -48,7 +48,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "ParentTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /ParentTest/",
           {
             "start_line": 0,
             "start_column": 0,
@@ -79,7 +79,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "ParentTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /ParentTest/",
           {
             "start_line": 0,
             "start_column": 0,
@@ -203,7 +203,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "FirstChildTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /FirstChildTest/",
           {
             "start_line": 5,
             "start_column": 2,
@@ -234,7 +234,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "FirstChildTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /FirstChildTest/",
           {
             "start_line": 5,
             "start_column": 2,
@@ -265,7 +265,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "FirstChildTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /FirstChildTest/",
           {
             "start_line": 5,
             "start_column": 2,
@@ -389,7 +389,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "SecondChildTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /SecondChildTest/",
           {
             "start_line": 13,
             "start_column": 2,
@@ -420,7 +420,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "SecondChildTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /SecondChildTest/",
           {
             "start_line": 13,
             "start_column": 2,
@@ -451,7 +451,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "SecondChildTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb",
+          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /SecondChildTest/",
           {
             "start_line": 13,
             "start_column": 2,
@@ -652,5 +652,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }


### PR DESCRIPTION
This is a missed change of https://github.com/Shopify/ruby-lsp/pull/736

### Automated Tests

Updated

### Manual Tests

1. Add this to `test/requests/code_lens_expectations_test.rb`

```rb
class FooTest < Minitest::Test
  def test_bar; end
end
```

2. Click the `Run In Terminal` above `FooTest`
3. It should run only 1 test and pass. On main, it'll still run 133 tests.
