### PR TITLE
Allow extensions to register formatters

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -543,6 +543,8 @@ module RubyLsp
       return unless @store.formatter == "rubocop"
 
       unless defined?(RubyLsp::Requests::Support::RuboCopRunner)
+        @store.formatter = "none"
+
         @message_queue << Notification.new(
           message: "window/showMessage",
           params: Interface::ShowMessageParams.new(

--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -49,6 +49,7 @@ module RubyLsp
       autoload :RailsDocumentClient, "ruby_lsp/requests/support/rails_document_client"
       autoload :PrefixTree, "ruby_lsp/requests/support/prefix_tree"
       autoload :Common, "ruby_lsp/requests/support/common"
+      autoload :FormatterRunner, "ruby_lsp/requests/support/formatter_runner"
     end
   end
 end

--- a/lib/ruby_lsp/requests/support/formatter_runner.rb
+++ b/lib/ruby_lsp/requests/support/formatter_runner.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Requests
+    module Support
+      module FormatterRunner
+        extend T::Sig
+        extend T::Helpers
+
+        interface!
+
+        sig { abstract.params(uri: String, document: Document).returns(T.nilable(String)) }
+        def run(uri, document); end
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/requests/support/rubocop_formatting_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_formatting_runner.rb
@@ -13,6 +13,7 @@ module RubyLsp
       class RuboCopFormattingRunner
         extend T::Sig
         include Singleton
+        include Support::FormatterRunner
 
         sig { void }
         def initialize
@@ -20,7 +21,7 @@ module RubyLsp
           @runner = T.let(RuboCopRunner.new("-a"), RuboCopRunner)
         end
 
-        sig { params(uri: String, document: Document).returns(String) }
+        sig { override.params(uri: String, document: Document).returns(String) }
         def run(uri, document)
           filename = CGI.unescape(URI.parse(uri).path)
 

--- a/lib/ruby_lsp/requests/support/syntax_tree_formatting_runner.rb
+++ b/lib/ruby_lsp/requests/support/syntax_tree_formatting_runner.rb
@@ -11,6 +11,7 @@ module RubyLsp
       class SyntaxTreeFormattingRunner
         extend T::Sig
         include Singleton
+        include Support::FormatterRunner
 
         sig { void }
         def initialize
@@ -25,7 +26,7 @@ module RubyLsp
             )
         end
 
-        sig { params(uri: String, document: Document).returns(T.nilable(String)) }
+        sig { override.params(uri: String, document: Document).returns(T.nilable(String)) }
         def run(uri, document)
           relative_path = Pathname.new(URI(uri).path).relative_path_from(T.must(WORKSPACE_URI.path))
           return if @options.ignore_files.any? { |pattern| File.fnmatch(pattern, relative_path) }

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -181,7 +181,7 @@ class ExecutorTest < Minitest::Test
       executor.execute(method: "initialize", params: { initializationOptions: { formatter: "rubocop" } })
       executor.execute(method: "initialized")
 
-      assert_equal("rubocop", @store.formatter)
+      assert_equal("none", @store.formatter)
       refute_empty(@message_queue)
       notification = T.must(@message_queue.pop)
       assert_equal("window/showMessage", notification.message)


### PR DESCRIPTION
### Motivation

Closes #649 #409 #432

This PR is a proposal of how we can allow other gems to register formatters in the Ruby LSP.

### Implementation

I tried to make a generic formatter registration mechanism that would work for our bundled ones too.

1. Added a common interface that all formatter runners need to comply to. Basically, we want the formatters to receive the URI and the document and then return the formatted source
2. Added a way to register formatters in `Formatting` - which we are now using to register RuboCop and Syntax Tree
3. Started setting the formatter to `none` if we identify that RuboCop is not available. This is just so that we can avoid special handling for RuboCop

This is how the formatter gem would use this:
```ruby
class MyFormatterRubyLspExtension < RubyLsp::Extension
  def name
    "My Formatter"
  end

  def activate
    # The first argument here is what people will need to pass as the `rubyLsp.formatter`
    # configuration
    RubyLsp::Requests::Formatting.register_formatter("my_formatter", MyFormatterRunner.instance)
  end
end

class MyFormatterRunner
  include RubyLsp::Requests::Support::FormatterRunner

  def run(uri, document)
    source = document.source
    formatted_source = format_the_source_using_my_formatter(source)
    formatted_source
  end
end
```

### Automated Tests

Added a test with a dummy formatter.