### PR TITLE
Distinguish test-unit and minitest in code lens

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -93,7 +93,8 @@ module RubyLsp
         emitter = EventEmitter.new
         document_symbol = Requests::DocumentSymbol.new(emitter, @message_queue)
         document_link = Requests::DocumentLink.new(uri, emitter, @message_queue)
-        code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, "minitest")
+        test_library = detected_test_library
+        code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, test_library)
         code_lens_extensions_listeners = Requests::CodeLens.listeners.map do |l|
           T.unsafe(l).new(document.uri, emitter, @message_queue)
         end
@@ -542,6 +543,20 @@ module RubyLsp
         "syntax_tree"
       else
         "none"
+      end
+    end
+
+    sig { returns(String) }
+    def detected_test_library
+      if direct_dependency?(/^minitest/)
+        "minitest"
+      elsif direct_dependency?(/^test-unit/)
+        "test-unit"
+      elsif direct_dependency?(/^rspec/)
+        "rspec"
+      else
+        warn("WARNING: No test library detected. Assuming minitest.")
+        "minitest"
       end
     end
 

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -13,6 +13,7 @@ module RubyLsp
       # Requests that mutate the store must be run sequentially! Parallel requests only receive a temporary copy of the
       # store
       @store = store
+      @test_library = T.let(DependencyDetector.detected_test_library, String)
       @message_queue = message_queue
     end
 
@@ -95,8 +96,7 @@ module RubyLsp
         emitter = EventEmitter.new
         document_symbol = Requests::DocumentSymbol.new(emitter, @message_queue)
         document_link = Requests::DocumentLink.new(uri, emitter, @message_queue)
-        test_library = DependencyDetector.detected_test_library
-        code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, test_library)
+        code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, @test_library)
         code_lens_extensions_listeners = Requests::CodeLens.listeners.map do |l|
           T.unsafe(l).new(document.uri, emitter, @message_queue)
         end

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -93,7 +93,7 @@ module RubyLsp
         emitter = EventEmitter.new
         document_symbol = Requests::DocumentSymbol.new(emitter, @message_queue)
         document_link = Requests::DocumentLink.new(uri, emitter, @message_queue)
-        code_lens = Requests::CodeLens.new(uri, emitter, @message_queue)
+        code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, "minitest")
         code_lens_extensions_listeners = Requests::CodeLens.listeners.map do |l|
           T.unsafe(l).new(document.uri, emitter, @message_queue)
         end

--- a/lib/ruby_lsp/requests/support/dependency_detector.rb
+++ b/lib/ruby_lsp/requests/support/dependency_detector.rb
@@ -1,0 +1,41 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module DependencyDetector
+    class << self
+      extend T::Sig
+
+      sig { returns(String) }
+      def detected_formatter
+        # NOTE: Intentionally no $ at end, since we want to match rubocop-shopify, etc.
+        if direct_dependency?(/^rubocop/)
+          "rubocop"
+        elsif direct_dependency?(/^syntax_tree$/)
+          "syntax_tree"
+        else
+          "none"
+        end
+      end
+
+      sig { returns(String) }
+      def detected_test_library
+        if direct_dependency?(/^minitest/)
+          "minitest"
+        elsif direct_dependency?(/^test-unit/)
+          "test-unit"
+        elsif direct_dependency?(/^rspec/)
+          "rspec"
+        else
+          warn("WARNING: No test library detected. Assuming minitest.")
+          "minitest"
+        end
+      end
+
+      sig { params(gem_pattern: Regexp).returns(T::Boolean) }
+      def direct_dependency?(gem_pattern)
+        Bundler.locked_gems.dependencies.keys.grep(gem_pattern).any?
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

Because `minitest` and `test-unit` uses different command line flags to specify the test class, we need to start distinguishing the 2. Otherwise, the code lens feature will not work properly in projects that use `test-unit`, like most of the Ruby core projects.

### Implementation

1. Make code lens test-framework aware and could generate different commands for `minitest` and `test-unit` projects.
2. Use the project's direct dependency to detect its test framework. Some notes:
    - Currently both frameworks are bundled gems. That is, they'll be installed with Ruby by default
    - If the project doesn't use bundler, users can require either one and we can't detect that easily. Currently I make it guess `minitest`


### Automated Tests

All CodeLens tests still assume the framework to be `minitest`, but I added one to make sure it generates correct commands when the test framework is `test-unit`.

### Manual Tests

1. Open a project that uses `test-unit`
2. Add `gem "ruby-lsp", branch: "support-test-unit"` in Gemfile
3. Restart its Ruby LSP
4. Click the `Run In Terminal` code lens in any of the test file. See if the test class is specified through the `--testcase` flag
5. In the Ruby LSP project itself, perform 4) but expect the command to be `--name /TestClass#test_method/` instead
