### PR TITLE
Ensure CI runs on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: bundle exec srb tc
 
       - name: Lint Ruby files
-        run: bin/rubocop
+        run: bundle exec rubocop
 
       - name: Run tests
-        run: bin/test
+        run: bundle exec rake

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -74,12 +74,6 @@ class ExpectationsTestRunner < Minitest::Test
         elsif expectation_path && File.file?(expectation_path)
           class_eval(<<~RB, __FILE__, __LINE__ + 1)
             def test_#{expectation_suffix}__#{test_name}
-              if RUBY_PLATFORM.match?(/(mswin|mingw)/) && "#{expectation_suffix}" == "diagnostics"
-                if "#{test_name}" == "if_inside_else" || "#{test_name}" == "def_bad_formatting"
-                  skip "Skipping on Windows: https://github.com/Shopify/ruby-lsp/issues/751"
-                end
-              end
-
               @_path = "#{path}"
               source = File.read(@_path)
               expected = File.read("#{expectation_path}")

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -74,7 +74,7 @@ class ExpectationsTestRunner < Minitest::Test
         elsif expectation_path && File.file?(expectation_path)
           class_eval(<<~RB, __FILE__, __LINE__ + 1)
             def test_#{expectation_suffix}__#{test_name}
-              if "#{ENV["RUNNER_OS"]}" == "Windows" && "#{expectation_suffix}" == "diagnostics"
+              if RUBY_PLATFORM.match?(/(mswin|mingw)/) && "#{expectation_suffix}" == "diagnostics"
                 if "#{test_name}" == "if_inside_else" || "#{test_name}" == "def_bad_formatting"
                   skip "Skipping on Windows: https://github.com/Shopify/ruby-lsp/issues/751"
                 end

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -74,6 +74,12 @@ class ExpectationsTestRunner < Minitest::Test
         elsif expectation_path && File.file?(expectation_path)
           class_eval(<<~RB, __FILE__, __LINE__ + 1)
             def test_#{expectation_suffix}__#{test_name}
+              if "#{ENV["RUNNER_OS"]}" == "Windows" && "#{expectation_suffix}" == "diagnostics"
+                if "#{test_name}" == "if_inside_else" || "#{test_name}" == "def_bad_formatting"
+                  skip "Skipping on Windows: https://github.com/Shopify/ruby-lsp/issues/751"
+                end
+              end
+
               @_path = "#{path}"
               source = File.read(@_path)
               expected = File.read("#{expectation_path}")

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -29,6 +29,8 @@ class IntegrationTest < Minitest::Test
   }.freeze
 
   def setup
+    skip("Skipping for Windows: https://github.com/Shopify/ruby-lsp/issues/751") if ENV["RUNNER_OS"] == "Windows"
+
     # Start a new Ruby LSP server in a separate process and set the IOs to binary mode
     @stdin, @stdout, @stderr, @wait_thr = Open3.popen3("bundle exec ruby-lsp")
   end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -29,8 +29,9 @@ class IntegrationTest < Minitest::Test
   }.freeze
 
   def setup
-    skip("Skipping for Windows: https://github.com/Shopify/ruby-lsp/issues/751") if ENV["RUNNER_OS"] == "Windows"
-
+    if RUBY_PLATFORM.match?(/(mswin|mingw)/)
+      skip("Skipping for Windows: https://github.com/Shopify/ruby-lsp/issues/751")
+    end
     # Start a new Ruby LSP server in a separate process and set the IOs to binary mode
     @stdin, @stdout, @stderr, @wait_thr = Open3.popen3("bundle exec ruby-lsp")
   end

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -8,6 +8,11 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Diagnostics, "diagnostics"
 
   def run_expectations(source)
+    if RUBY_PLATFORM.match?(/(mswin|mingw)/) &&
+        (@_path == "test/fixtures/if_inside_else.rb" || @_path == "test/fixtures/def_bad_formatting.rb")
+      skip("Skipping on Windows: https://github.com/Shopify/ruby-lsp/issues/751")
+    end
+
     document = RubyLsp::Document.new(source: source, version: 1, uri: "file://#{__FILE__}")
     RubyLsp::Requests::Diagnostics.new(document).run
     result = T.let(nil, T.nilable(T::Array[RubyLsp::Requests::Support::RuboCopDiagnostic]))


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby-lsp/issues/738

Skips the tests that are not yet passing on Windows. The work to fix them is being tracked in https://github.com/Shopify/ruby-lsp/issues/751.

It makes sense that the exe path in the binstub would not be valid on Windows.

I don't yet know why it why it wasn't being marked as a failure though.