### PR TITLE
Increase timeout on CI

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -358,7 +358,9 @@ class IntegrationTest < Minitest::Test
   end
 
   def read_response(request)
-    Timeout.timeout(5) do
+    timeout_amount = ENV["CI"] ? 20 : 5
+
+    Timeout.timeout(timeout_amount) do
       # Read headers until line breaks
       headers = @stdout.gets("\r\n\r\n")
       # Read the response content based on the length received in the headers


### PR DESCRIPTION
### Motivation

The low timeout is useful locally to figure out if an integration test is not working. However, we need to be more relaxed on CI or else it fails from time to time.