### PR TITLE
Prevent breaking on empty gem statements

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -193,8 +193,10 @@ module RubyLsp
 
       sig { params(node: SyntaxTree::Command).returns(T.nilable(String)) }
       def resolve_gem_remote(node)
-        gem_name = node.arguments.parts.flat_map(&:child_nodes).first.value
-        spec = Gem::Specification.stubs.find { |gem| gem.name == gem_name }&.to_spec
+        gem_statement = node.arguments.parts.flat_map(&:child_nodes).first
+        return unless gem_statement
+
+        spec = Gem::Specification.stubs.find { |gem| gem.name == gem_statement.value }&.to_spec
         return if spec.nil?
 
         [spec.homepage, spec.metadata["source_code_uri"]].compact.find do |page|

--- a/test/fixtures/Gemfile.rb
+++ b/test/fixtures/Gemfile.rb
@@ -5,3 +5,6 @@ gem "foogem"
 group :development do
   gem "debug", "~> 1.7", require: false
 end
+
+# Make sure we don't break as the user is typing
+gem ""


### PR DESCRIPTION
### Motivation

If code lens runs while the user is typing, we may sometimes catch a `gem` statement that is incomplete. We should not break if that's the case.

### Implementation

Returned early if the string node parts are empty (which would cause `child_nodes.first` to be `nil`).

### Automated Tests

Added a test that reproduces the issue.