### PR TITLE
Skip test code lens on methods unless its inside a test class

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -80,11 +80,13 @@ module RubyLsp
 
       sig { params(node: SyntaxTree::DefNode).void }
       def on_def(node)
+        class_name = @class_stack.last
+        return unless class_name
+
         visibility, _ = @visibility_stack.last
         if visibility == "public"
           method_name = node.name.value
           if method_name.start_with?("test_")
-            class_name = T.must(@class_stack.last)
             add_test_code_lens(
               node,
               name: method_name,

--- a/test/fixtures/minitest_tests.rb
+++ b/test/fixtures/minitest_tests.rb
@@ -25,3 +25,7 @@ end
 class AnotherTest < Minitest::Test
   def test_public; end
 end
+
+class Foo
+  def test_public; end
+end


### PR DESCRIPTION
### Motivation

Some non-test methods could also have `test_` prefix in their names. And in that case we don't want to show code lens for them.

### Implementation

If there isn't a test class on the `@class_stack`, we don't try to generate the code lens.

### Automated Tests

Added a new test case for it.

### Manual Tests

1. Add a file that has this code

    ```rb
    class Foo
      def test_public; end
    end
    ```
1. When opening up file with `main`, Ruby LSP should log errors like:

    ```
    [Trace - 17:18:13] Received response 'textDocument/codeLens - (541)' in 5ms. Request failed: #<NoMethodError: undefined method `+' for nil:NilClass> (-32603).
    [Error - 17:18:13] Request textDocument/codeLens failed.
      Message: #<NoMethodError: undefined method `+' for nil:NilClass>
      Code: -32603 
    ```
1. It should not log any error with this branch.