### PR TITLE
Don't generate test code lenses when the test library is not supported

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -29,6 +29,7 @@ module RubyLsp
 
       BASE_COMMAND = T.let((File.exist?("Gemfile.lock") ? "bundle exec ruby" : "ruby") + " -Itest ", String)
       ACCESS_MODIFIERS = T.let(["public", "private", "protected"], T::Array[String])
+      SUPPORTED_TEST_LIBRARIES = T.let(["minitest", "test-unit"], T::Array[String])
 
       sig { override.returns(ResponseType) }
       attr_reader :response
@@ -156,6 +157,9 @@ module RubyLsp
 
       sig { params(node: SyntaxTree::Node, name: String, command: String, kind: Symbol).void }
       def add_test_code_lens(node, name:, command:, kind:)
+        # don't add code lenses if the test library is not supported or unknown
+        return unless SUPPORTED_TEST_LIBRARIES.include?(@test_library)
+
         arguments = [
           @path,
           name,

--- a/lib/ruby_lsp/requests/support/dependency_detector.rb
+++ b/lib/ruby_lsp/requests/support/dependency_detector.rb
@@ -27,8 +27,7 @@ module RubyLsp
         elsif direct_dependency?(/^rspec/)
           "rspec"
         else
-          warn("WARNING: No test library detected. Assuming minitest.")
-          "minitest"
+          "unknown"
         end
       end
 

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -43,6 +43,42 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     )
   end
 
+  def test_no_code_lens_for_unknown_test_framework
+    source = <<~RUBY
+      class FooTest < Test::Unit::TestCase
+        def test_bar; end
+      end
+    RUBY
+    uri = "file:///fake.rb"
+
+    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
+
+    emitter = RubyLsp::EventEmitter.new
+    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "unknown")
+    emitter.visit(document.tree)
+    response = listener.response
+
+    assert_equal(0, response.size)
+  end
+
+  def test_no_code_lens_for_rspec
+    source = <<~RUBY
+      class FooTest < Test::Unit::TestCase
+        def test_bar; end
+      end
+    RUBY
+    uri = "file:///fake.rb"
+
+    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
+
+    emitter = RubyLsp::EventEmitter.new
+    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "rspec")
+    emitter.visit(document.tree)
+    response = listener.response
+
+    assert_equal(0, response.size)
+  end
+
   def test_after_request_hook
     message_queue = Thread::Queue.new
     create_code_lens_hook_class


### PR DESCRIPTION
### Motivation

Since we want extensions to provide code lenses for libraries like RSpec, we should not generate any code lens ourselves when the test library is not supported/unknown. Otherwise it could create wrong code lenses and mess with with what our extensions generate.

### Implementation

1. Instead of falling back test library to `minitest`, we simply return `unknown` if it's not a known one.
2. Before generating test code lenses, we check if the test library is supported. If not, we don't generate any code lenses.

### Automated Tests

Added 2 test cases to make sure code lenses will not be generated when the library is `rspec` or `unknown`.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
