### PR TITLE
Only handle gem statements if they have string literal arguments

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -199,10 +199,13 @@ module RubyLsp
 
       sig { params(node: SyntaxTree::Command).returns(T.nilable(String)) }
       def resolve_gem_remote(node)
-        gem_statement = node.arguments.parts.flat_map(&:child_nodes).first
-        return unless gem_statement
+        gem_statement = node.arguments.parts.first
+        return unless gem_statement.is_a?(SyntaxTree::StringLiteral)
 
-        spec = Gem::Specification.stubs.find { |gem| gem.name == gem_statement.value }&.to_spec
+        gem_name = gem_statement.parts.first
+        return unless gem_name.is_a?(SyntaxTree::TStringContent)
+
+        spec = Gem::Specification.stubs.find { |gem| gem.name == gem_name.value }&.to_spec
         return if spec.nil?
 
         [spec.homepage, spec.metadata["source_code_uri"]].compact.find do |page|

--- a/test/fixtures/Gemfile.rb
+++ b/test/fixtures/Gemfile.rb
@@ -8,3 +8,5 @@ end
 
 # Make sure we don't break as the user is typing
 gem ""
+
+gem something_that_isnt_a_string


### PR DESCRIPTION
### Motivation

We're still getting some errors while users are actively editing the `Gemfile`. I couldn't figure out exactly what triggers some of them, but I figured it would be worth to make the implementation more explicit that we only handle string literals.

### Implementation

Started returning early if the first argument is not a string literal. And then if inside that literal the first part is not a string content.

### Automated Tests

Added a new test.