### PR TITLE
Don't use Minitest for running tests in a Rails app

### DIFF
--- a/lib/ruby_lsp/requests/support/dependency_detector.rb
+++ b/lib/ruby_lsp/requests/support/dependency_detector.rb
@@ -20,8 +20,12 @@ module RubyLsp
 
       sig { returns(String) }
       def detected_test_library
+        # A Rails app may have a dependency on minitest, but we would instead want to use the Rails test runner provided
+        # by ruby-lsp-rails.
+        if direct_dependency?(/^rails$/)
+          "rails"
         # NOTE: Intentionally ends with $ to avoid mis-matching minitest-reporters, etc. in a Rails app.
-        if direct_dependency?(/^minitest$/)
+        elsif direct_dependency?(/^minitest$/)
           "minitest"
         elsif direct_dependency?(/^test-unit/)
           "test-unit"

--- a/test/requests/support/dependency_detector_test.rb
+++ b/test/requests/support/dependency_detector_test.rb
@@ -1,0 +1,43 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RubyLsp
+  class DependencyDetectorTest < Minitest::Test
+    def test_detects_no_test_library_when_there_are_no_dependencies
+      dependencies = {}
+      Bundler.locked_gems.stubs(dependencies: dependencies)
+
+      assert_equal("unknown", DependencyDetector.detected_test_library)
+    end
+
+    def test_detects_minitest
+      dependencies = { "minitest" => "1.2.3" }
+      Bundler.locked_gems.stubs(dependencies: dependencies)
+
+      assert_equal("minitest", DependencyDetector.detected_test_library)
+    end
+
+    def test_does_not_detect_minitest_related_gems_as_minitest
+      dependencies = { "minitest-reporters" => "1.2.3" }
+      Bundler.locked_gems.stubs(dependencies: dependencies)
+
+      assert_equal("unknown", DependencyDetector.detected_test_library)
+    end
+
+    def test_detects_test_unit
+      dependencies = { "test-unit" => "1.2.3" }
+      Bundler.locked_gems.stubs(dependencies: dependencies)
+
+      assert_equal("test-unit", DependencyDetector.detected_test_library)
+    end
+
+    def test_detects_rails_if_both_rails_and_minitest_are_present
+      dependencies = { "minitest" => "1.2.3", "rails" => "1.2.3" }
+      Bundler.locked_gems.stubs(dependencies: dependencies)
+
+      assert_equal("rails", DependencyDetector.detected_test_library)
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

The testing behaviour provided by Rails is built on top of minitest, but invoked differently. If a repo has a direct dependency on both `minitest` and `rails`, then we want the test running to be handled by `ruby-lsp-rails` instead.

### Implementation

Adjust the conditional.

### Automated Tests

Included

### Manual Tests

On Core, configure:

```
  gem "ruby-lsp", require: true, github: "Shopify/ruby-lsp", branch: "andyw8/dont-use-minitest-for-test-running-in-rails-app"
  gem "ruby-lsp-rails", require: true, github: "Shopify/ruby-lsp-rails", branch: "andyw8/add-code-lens-extension"
```
Open a test and verify that the `Run in Terminal` code lenses for the both the class and the test methods use `bin/rails test ...` and not `ruby -Itest ...`


