### PR TITLE
Catch LoadError exceptions from formatting calls

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -130,7 +130,7 @@ module RubyLsp
           )
 
           nil
-        rescue StandardError => error
+        rescue StandardError, LoadError => error
           @message_queue << Notification.new(
             message: "window/showMessage",
             params: Interface::ShowMessageParams.new(
@@ -156,7 +156,7 @@ module RubyLsp
       when "textDocument/diagnostic"
         begin
           diagnostic(uri)
-        rescue StandardError => error
+        rescue StandardError, LoadError => error
           @message_queue << Notification.new(
             message: "window/showMessage",
             params: Interface::ShowMessageParams.new(


### PR DESCRIPTION
### Motivation

Rubocop will raise a `LoadError` when it can't resolve requirements listed in `.rubocop.yml`.

Currently these exceptions are missed, and formatting silently fails.

### Implementation

We should catch `LoadError` in addition to `StandardError`

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

I can only reproduce this in one internal repo when using nvim & the ruby_ls plugin. I haven't managed to create a small test case for this yet.

I think it has something to do with in-repo gems. In my case the RuboCopRunner raises a LoadError somewhere in `find_target_files` when trying to load the in-repo gem listed in the  `require` section of `.rubocop.yml`