### PR TITLE
Improve CodeLens tests

### DIFF
--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -58,7 +58,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     emitter.visit(document.tree)
     response = listener.response
 
-    assert_equal(0, response.size)
+    assert_empty(response)
   end
 
   def test_no_code_lens_for_rspec
@@ -76,7 +76,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     emitter.visit(document.tree)
     response = listener.response
 
-    assert_equal(0, response.size)
+    assert_empty(response)
   end
 
   def test_after_request_hook

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -99,7 +99,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     assert_match("Debug", response[2].command.title)
     assert_match("Run Test", response[3].command.title)
   ensure
-    RubyLsp::Requests::Hover.listeners.clear
+    RubyLsp::Requests::CodeLens.listeners.clear
     T.must(message_queue).close
   end
 


### PR DESCRIPTION
1. Fix `CodeLens`'s listener test cleanup logic. It was incorrectly cleaning up `Hover`'s listeners.
2. Improve empty responses' assertion logic.