### PR TITLE
Use untyped instead of T::Class

### DIFF
--- a/lib/ruby_lsp/check_docs.rb
+++ b/lib/ruby_lsp/check_docs.rb
@@ -52,7 +52,7 @@ module RubyLsp
       # Find all classes that inherit from BaseRequest or Listener, which are the ones we want to make sure are
       # documented
       features = ObjectSpace.each_object(Class).filter_map do |k|
-        klass = T.cast(k, T::Class[T.anything])
+        klass = T.unsafe(k)
         klass if klass < RubyLsp::Requests::BaseRequest || klass < RubyLsp::Listener
       end
 

--- a/lib/ruby_lsp/requests/support/source_uri.rb
+++ b/lib/ruby_lsp/requests/support/source_uri.rb
@@ -78,7 +78,7 @@ module URI
     if URI.respond_to?(:register_scheme)
       URI.register_scheme("SOURCE", self)
     else
-      @@schemes = T.let(@@schemes, T::Hash[String, T::Class[T.anything]]) # rubocop:disable Style/ClassVars
+      @@schemes = T.let(@@schemes, T::Hash[String, T.untyped]) # rubocop:disable Style/ClassVars
       @@schemes["SOURCE"] = self
     end
   end


### PR DESCRIPTION
### Motivation

The new `T::Class` generic only exists in new versions of Sorbet. If we use it in our code, it will create an implicit dependency on newer versions and throw `undefined T::Class` errors for any application using an older `sorbet-runtime`.

Since we're not using `T::Class` extensively yet, I think it's better to use untyped and avoid restricting the Sorbet version too much.

### Implementation

Switch the two usages to untyped.