### PR TITLE
Fix code lens disappear after non-test class issue

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -62,8 +62,9 @@ module RubyLsp
       def on_class(node)
         @visibility_stack.push(["public", "public"])
         class_name = node.constant.constant.value
+        @class_stack.push(class_name)
+
         if class_name.end_with?("Test")
-          @class_stack.push(class_name)
           add_test_code_lens(
             node,
             name: class_name,
@@ -82,7 +83,7 @@ module RubyLsp
       sig { params(node: SyntaxTree::DefNode).void }
       def on_def(node)
         class_name = @class_stack.last
-        return unless class_name
+        return unless class_name&.end_with?("Test")
 
         visibility, _ = @visibility_stack.last
         if visibility == "public"

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -565,7 +565,7 @@
           "character": 0
         },
         "end": {
-          "line": 26,
+          "line": 32,
           "character": 3
         }
       },
@@ -579,7 +579,7 @@
           {
             "start_line": 24,
             "start_column": 0,
-            "end_line": 26,
+            "end_line": 32,
             "end_column": 3
           }
         ]
@@ -596,7 +596,7 @@
           "character": 0
         },
         "end": {
-          "line": 26,
+          "line": 32,
           "character": 3
         }
       },
@@ -610,7 +610,7 @@
           {
             "start_line": 24,
             "start_column": 0,
-            "end_line": 26,
+            "end_line": 32,
             "end_column": 3
           }
         ]
@@ -627,7 +627,7 @@
           "character": 0
         },
         "end": {
-          "line": 26,
+          "line": 32,
           "character": 3
         }
       },
@@ -641,7 +641,7 @@
           {
             "start_line": 24,
             "start_column": 0,
-            "end_line": 26,
+            "end_line": 32,
             "end_column": 3
           }
         ]
@@ -736,6 +736,99 @@
             "start_column": 2,
             "end_line": 25,
             "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 31,
+          "character": 2
+        },
+        "end": {
+          "line": 31,
+          "character": 24
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public_2",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /AnotherTest\\#test_public_2/",
+          {
+            "start_line": 31,
+            "start_column": 2,
+            "end_line": 31,
+            "end_column": 24
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 31,
+          "character": 2
+        },
+        "end": {
+          "line": 31,
+          "character": 24
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public_2",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /AnotherTest\\#test_public_2/",
+          {
+            "start_line": 31,
+            "start_column": 2,
+            "end_line": 31,
+            "end_column": 24
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 31,
+          "character": 2
+        },
+        "end": {
+          "line": 31,
+          "character": 24
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public_2",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /AnotherTest\\#test_public_2/",
+          {
+            "start_line": 31,
+            "start_column": 2,
+            "end_line": 31,
+            "end_column": 24
           }
         ]
       },

--- a/test/fixtures/minitest_tests.rb
+++ b/test/fixtures/minitest_tests.rb
@@ -24,6 +24,12 @@ end
 
 class AnotherTest < Minitest::Test
   def test_public; end
+
+  # shouldn't block code lenses below
+  class Bar
+  end
+
+  def test_public_2; end
 end
 
 class Foo


### PR DESCRIPTION
### Motivation

Currently we always pop a class from the stack when we run `after_class`, but only push a test class when we run `on_class`. This means that if we encounter a non-test class in the middle of a test class, we will mistakenly pop the test class from the stack.

### Implementation

This commit fixes this by pushing a non-test class to the stack too. But while doing so, we also need to check if `on_def` is in a test class or not.

### Automated Tests

Added a new case for it.

### Manual Tests

Currently, the `test_after_request_hook` in `HoverExpectationsTest` doesn't have code lens due to the issue I described. It should appear when switched to this branch.
