### PR TITLE
Make on type formatting `end` completions more robust

### DIFF
--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -10,20 +10,20 @@ class OnTypeFormattingTest < Minitest::Test
     document.push_edits(
       [{
         range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-        text: "class Foo\n",
+        text: "class Foo",
       }],
       version: 2,
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 8 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
     expected_edits = [
       {
-        range: { start: { line: 0, character: 8 }, end: { line: 0, character: 8 } },
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
         newText: " \nend",
       },
       {
-        range: { start: { line: 0, character: 2 }, end: { line: 0, character: 2 } },
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
         newText: "$0",
       },
     ]
@@ -222,5 +222,21 @@ class OnTypeFormattingTest < Minitest::Test
     ]
 
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
+
+  def test_breaking_line_between_keyword_when_there_is_content_on_the_next_line
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "if something\n  other_thing",
+      }],
+      version: 2,
+    )
+    document.parse
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "\n").run
+    assert_empty(edits)
   end
 end


### PR DESCRIPTION
### Motivation

Closes #500

This bug was bothering me too much. Instead of trying to use the document scanner, I switched the implementation of the on type formatting `end` completions to just deal with document lines. This simplifies the implementation and makes it easier to address the bug, so I think it's a win-win.

### Implementation

The way the lines work are as follows
```ruby
if something
#  ^ break here

# previous_line = "if "
# current_line = "  something"
# next_line = nil
```

So, the final logic is:
- If the current line is empty, then we broke the line at the end and so we can just put the `end` token normally
- If the current line is not empty and the next line is not empty either, then it's a bit hard to know what the intent of the user was. We just return early (this is the bug fix)
- Otherwise, we add the `end` token in a way that allows `something` to be in between

### Automated Tests

Added a scenario and fixed another one that was weird.

### Manual Tests

Basically fire up the LSP on this branch and play around breaking `if` statements. See if the `end` token ends up weird in any combination.