### PR TITLE
WIP - extension support for diagnostics

### DIFF
--- a/SERVER_EXTENSIONS.md
+++ b/SERVER_EXTENSIONS.md
@@ -175,6 +175,44 @@ class MyFormatterRunner
 end
 ```
 
+### Registering diagnostics providers
+
+Gems may also provide a diagnostic provider to be used by the Ruby LSP. To do that, the extension must create a diagnostic runner
+and register it.
+
+```ruby
+class MyDiagnosticsRubyLspExtension < RubyLsp::Extension
+  def name
+    "My Diagnostics"
+  end
+
+  def activate
+    # The first argument is an identifier users can pick to enable these diagnostics. To use these diagnostics, users must
+    # have rubyLsp.diagnostics configured to include "my_diagnostics"
+    # The second argument is a singleton instance that implements the `DiagnosticsRunner` interface (see below)
+    RubyLsp::Requests::Diagnostics.register_diagnostics("my_diagnostics", MyDiagnosticsRunner.instance)
+  end
+end
+
+# Custom diagnostic runner
+class MyDiagnosticsRunner
+  # Make it a singleton class
+  include Singleton
+  # If using Sorbet to develop the extension, then include this interface to make sure the class is properly implemented
+  include RubyLsp::Requests::Support::DiagnosticsRunner
+
+  # Use the initialize method to perform any sort of ahead of time work. For example, reading configurations for your
+  # diagnostic provider since they are unlikely to change between requests
+  def initialize
+  end
+
+  # The main part of the interface is implementing the run method. It receives the URI and the document being analyzed.
+  # IMPORTANT: This method must return an array of Interface::Diagnostic items
+  def run(uri, document)
+  end
+end
+```
+
 ### Sending notifications to the client
 
 Sometimes, requests may want to send asynchronous information to the client. For example, a slow request may want to

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -351,7 +351,7 @@ module RubyLsp
         Requests::Diagnostics.new(document).run
       end
 
-      Interface::FullDocumentDiagnosticReport.new(kind: "full", items: response.map(&:to_lsp_diagnostic)) if response
+      Interface::FullDocumentDiagnosticReport.new(kind: "full", items: response) if response
     end
 
     sig { params(uri: String, range: Document::RangeShape).returns(Interface::SemanticTokens) }

--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -49,6 +49,7 @@ module RubyLsp
       autoload :RailsDocumentClient, "ruby_lsp/requests/support/rails_document_client"
       autoload :PrefixTree, "ruby_lsp/requests/support/prefix_tree"
       autoload :Common, "ruby_lsp/requests/support/common"
+      autoload :DiagnosticsRunner, "ruby_lsp/requests/support/diagnostics_runner"
       autoload :FormatterRunner, "ruby_lsp/requests/support/formatter_runner"
     end
   end

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -22,9 +22,7 @@ module RubyLsp
       extend T::Sig
 
       @diagnostics_runners = T.let(
-        {
-          "rubocop" => Support::RuboCopDiagnosticsRunner.instance,
-        },
+        {},
         T::Hash[String, Support::DiagnosticsRunner],
       )
 

--- a/lib/ruby_lsp/requests/support/diagnostics_runner.rb
+++ b/lib/ruby_lsp/requests/support/diagnostics_runner.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Requests
+    module Support
+      module DiagnosticsRunner
+        extend T::Sig
+        extend T::Helpers
+
+        interface!
+
+        sig { abstract.params(uri: String, document: Document).returns(T::Array[Interface::Diagnostic]) }
+        def run(uri, document); end
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/requests/support/rubocop_diagnostics_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostics_runner.rb
@@ -13,20 +13,21 @@ module RubyLsp
       class RuboCopDiagnosticsRunner
         extend T::Sig
         include Singleton
+        include Support::DiagnosticsRunner
 
         sig { void }
         def initialize
           @runner = T.let(RuboCopRunner.new, RuboCopRunner)
         end
 
-        sig { params(uri: String, document: Document).returns(T::Array[Support::RuboCopDiagnostic]) }
+        sig { override.params(uri: String, document: Document).returns(T::Array[Interface::Diagnostic]) }
         def run(uri, document)
           filename = CGI.unescape(URI.parse(uri).path)
           # Invoke RuboCop with just this file in `paths`
           @runner.run(filename, document.source)
 
           @runner.offenses.map do |offense|
-            Support::RuboCopDiagnostic.new(offense, uri)
+            Support::RuboCopDiagnostic.new(offense, uri).to_lsp_diagnostic
           end
         end
       end

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -25,7 +25,7 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
     end
 
     assert_empty(stdout)
-    T.must(result).map(&:to_lsp_diagnostic)
+    T.must(result)
   end
 
   def assert_expectations(source, expected)


### PR DESCRIPTION
### Motivation

I want to have complexity metrics as calculated by `flog` supported as a diagnostic by a ruby-lsp extension.

The server extension API doesn't yet support registering other diagnostics providers.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
