### PR TITLE
Use empty? instead of blank? on strings

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -88,10 +88,10 @@ module RubyLsp
         current_line = @lines[@position[:line]]
         next_line = @lines[@position[:line] + 1]
 
-        if current_line.nil? || current_line.blank?
+        if current_line.nil? || current_line.strip.empty?
           add_edit_with_text(" \n#{indents}end")
           move_cursor_to(@position[:line], @indentation + 2)
-        elsif next_line.nil? || next_line.blank?
+        elsif next_line.nil? || next_line.strip.empty?
           add_edit_with_text("#{indents}end", { line: @position[:line] + 1, character: @position[:character] })
           move_cursor_to(@position[:line], @indentation + 3)
         end


### PR DESCRIPTION
### Motivation

The usage of `blank?` was breaking in our metrics. Apparently, RuboCop patches `String` to add it, which is why it never failed while developing it. However, applications that don't use RuboCop break.

The solution is to use the correct method, which is `empty?`. I also added `strip` because that matches we do not care about blank spaces or line breaks in this case.