### PR TITLE
Indicate that using `bundle exec` is no longer recommended as of v0.7.0

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -11,15 +11,11 @@ new H2 header in this file containing the instructions. -->
 
 ## Emacs Eglot
 
-[Eglot](https://github.com/joaotavora/eglot) runs solargraph server by default. To set it up with ruby-lsp you need to put that in your init file:
+[Eglot](https://github.com/joaotavora/eglot) runs solargraph server by default. To set it up with ruby-lsp you need to
+put that in your init file:
 ```el
 (with-eval-after-load 'eglot
  (add-to-list 'eglot-server-programs '((ruby-mode ruby-ts-mode) "ruby-lsp")))
  ```
-Or if you want to run it with bundler:
-```el
-(with-eval-after-load 'eglot
- (add-to-list 'eglot-server-programs '((ruby-mode ruby-ts-mode) "bundle" "exec" "ruby-lsp")))
-```
- 
+
 When you run `eglot` command it will run `ruby-lsp` process for you.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ The gem can be installed by doing
 gem install ruby-lsp
 ```
 
-If you decide to add the gem to the bundle, it is not necessary to require it.
+**NOTE**: starting with v0.7.0, it is no longer recommended to add the `ruby-lsp` to the bundle. The gem will generate a
+custom bundle in `.ruby-lsp/Gemfile` which is used to identify the versions of dependencies that should be used for the
+application (e.g.: the correct RuboCop version).
+
+For older versions, if you decide to add the gem to the bundle, it is not necessary to require it.
 ```ruby
 group :development do
   gem "ruby-lsp", require: false


### PR DESCRIPTION
### Motivation

Starting with v0.7.0, we'll ship with the custom bundle functionality from the server and there's no more need to use `bundle exec` or include the gem in the `Gemfile`.
