### PR TITLE
Prevent exception on shutdown (Ignore `$/setTrace` requests)

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -70,6 +70,8 @@ module RubyLsp
         when "$/cancelRequest"
           # Cancel the job if it's still in the queue
           @mutex.synchronize { @jobs[request[:params][:id]]&.cancel }
+        when "$/setTrace"
+          VOID
         when "shutdown"
           warn("Shutting down Ruby LSP...")
 


### PR DESCRIPTION
### Motivation

When shutting down, a `$/setTrace` call was being received from the extension, i.e.:

```
*** REQUEST: shutdown
Shutting down Ruby LSP...
*** REQUEST: $/setTrace
[Trace - 2:01:49 PM] Received response 'shutdown - (10)' in 6ms.
[Trace - 2:01:49 PM] Sending notification 'exit'.
>> Running `bundle install`...
*** REQUEST: exit
```

The `else` branch of the `case` was trying to enqueue this, but at that point the queue was already closed, resulting in a `ClosedQueueError` exception.

This wasn't actually breaking the extension, since it restarts successfully afterwards, but we want to avoid this happening.

### Implementation

Ignore requests for `$/setTrace`.

(`$/setTrace` is [used to set verbosity](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/) but we don't make use of that LSP feature currently).

Approach was agreed with by @vinistock 

### Automated Tests

n/a

### Manual Tests

Enable or disable an LSP feature through the UI and verify no exception shows in the output log.
