### PR TITLE
Fix nesting when a target class is specified

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -154,16 +154,6 @@ module RubyLsp
         # already
         break if char_position < loc.start_char
 
-        # If there are node types to filter by, and the current node is not one of those types, then skip it
-        next if node_types.any? && node_types.none? { |type| candidate.class == type }
-
-        # If the current node is narrower than or equal to the previous closest node, then it is more precise
-        closest_loc = closest.location
-        if loc.end_char - loc.start_char <= closest_loc.end_char - closest_loc.start_char
-          parent = closest
-          closest = candidate
-        end
-
         # If the candidate starts after the end of the previous nesting level, then we've exited that nesting level and
         # need to pop the stack
         previous_level = nesting.last
@@ -173,6 +163,16 @@ module RubyLsp
         # target when it is a constant
         if candidate.is_a?(SyntaxTree::ClassDeclaration) || candidate.is_a?(SyntaxTree::ModuleDeclaration)
           nesting << candidate
+        end
+
+        # If there are node types to filter by, and the current node is not one of those types, then skip it
+        next if node_types.any? && node_types.none? { |type| candidate.class == type }
+
+        # If the current node is narrower than or equal to the previous closest node, then it is more precise
+        closest_loc = closest.location
+        if loc.end_char - loc.start_char <= closest_loc.end_char - closest_loc.start_char
+          parent = closest
+          closest = candidate
         end
       end
 

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -502,6 +502,22 @@ class DocumentTest < Minitest::Test
     assert_equal(["Foo", "Other"], nesting)
   end
 
+  def test_locate_returns_correct_nesting_when_specifying_target_classes
+    document = RubyLsp::Document.new(source: <<~RUBY, version: 1, uri: "file:///foo/bar.rb")
+      module Foo
+        class Bar
+          def baz
+            Qux
+          end
+        end
+      end
+    RUBY
+
+    found, _parent, nesting = document.locate_node({ line: 3, character: 6 }, node_types: [SyntaxTree::Const])
+    assert_equal("Qux", T.cast(found, SyntaxTree::Const).value)
+    assert_equal(["Foo", "Bar"], nesting)
+  end
+
   def test_reparsing_without_new_edits_does_nothing
     document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///foo/bar.rb")
     document.push_edits(


### PR DESCRIPTION
### Motivation

When a target class is specified, we skip to the next iteration of the loop early. We need the nesting operations to happen before we skip, otherwise we always ignore class and module declarations because they don't match the specified target class.

### Implementation

I just moved the code a little further up so that we keep track of the nesting before skipping.

### Automated Tests

Added an example that fails before the fix.