### PR TITLE
Fix behaviour of DocumentLink for when a gem has been removed

### DIFF
--- a/lib/ruby_lsp/requests/document_link.rb
+++ b/lib/ruby_lsp/requests/document_link.rb
@@ -94,7 +94,9 @@ module RubyLsp
         return unless match
 
         uri = T.cast(URI(T.must(match[0])), URI::Source)
-        gem_version = T.must(resolve_version(uri))
+        gem_version = resolve_version(uri)
+        return if gem_version.nil?
+
         file_path = self.class.gem_paths.dig(uri.gem_name, gem_version, uri.path)
         return if file_path.nil?
 


### PR DESCRIPTION
### Motivation

Issue #464

### Implementation

Early return in case of `resolve_version` returns `nil`

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
