### PR TITLE
Support selection in show syntax tree

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -170,8 +170,13 @@ module RubyLsp
       when "textDocument/definition"
         definition(uri, request.dig(:params, :position))
       when "rubyLsp/textDocument/showSyntaxTree"
-        { ast: Requests::ShowSyntaxTree.new(@store.get(uri)).run }
+        show_syntax_tree(uri, request.dig(:params, :range))
       end
+    end
+
+    sig { params(uri: String, range: T.nilable(Document::RangeShape)).returns({ ast: String }) }
+    def show_syntax_tree(uri, range)
+      { ast: Requests::ShowSyntaxTree.new(@store.get(uri), range).run }
     end
 
     sig { params(uri: String, position: Document::PositionShape).returns(T.nilable(Interface::Location)) }


### PR DESCRIPTION
### Motivation

Support handling ranges in show syntax tree. This allows developers to see the AST only for a specific portion of the code.

### Implementation

The only notable part is the decision to artificially remove the initial `program` and `statements` nodes when there's a range. It doesn't make much sense to include them, since the developer is selecting a specific part of the document and those two initial nodes are related to the top level of the file.

### Automated Tests

Added tests.

### Manual Tests

1. Using the branches of both the server and client parts, start the LSP
2. Make a valid selection
3. Execute Show syntax tree
4. Verify the AST only includes what you selected
5. Make an invalid selection
6. Execute Show syntax tree
7. Verify that a message is shown informing of the parse error