### PR TITLE
Add ruby-lsp-check executable

### DIFF
--- a/.github/workflows/lsp_check.yml
+++ b/.github/workflows/lsp_check.yml
@@ -1,0 +1,19 @@
+name: lsp_check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: LSP check
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+
+      - name: Run ruby-lsp-check
+        run: bundle exec ruby-lsp-check

--- a/dev.yml
+++ b/dev.yml
@@ -23,7 +23,8 @@ commands:
       bundle exec rake check_visit_overrides &&
       bundle exec srb tc &&
       bin/rubocop &&
-      bin/test"
+      bin/test &&
+      bundle exec exe/ruby-lsp-check"
   test:
     syntax:
       argument: file

--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This executable checks if all automatic LSP requests run successfully on every Ruby file under the current directory
+
+require "sorbet-runtime"
+
+begin
+  T::Configuration.default_checked_level = :never
+  T::Configuration.call_validation_error_handler = ->(*) {}
+  T::Configuration.inline_type_error_handler = ->(*) {}
+  T::Configuration.sig_validation_error_handler = ->(*) {}
+rescue
+  nil
+end
+
+require_relative "../lib/ruby_lsp/internal"
+
+RubyLsp::Extension.load_extensions
+
+T::Utils.run_all_sig_blocks
+
+files = Dir.glob("#{Dir.pwd}/**/*.rb")
+
+puts "Verifying that all automatic LSP requests execute successfully. This may take a while..."
+
+errors = {}
+store = RubyLsp::Store.new
+message_queue = Thread::Queue.new
+executor = RubyLsp::Executor.new(store, message_queue)
+
+files.each_with_index do |file, index|
+  uri = "file://#{file}"
+  store.set(uri: uri, source: File.read(file), version: 1)
+
+  # Executing any of the automatic requests will execute all of them, so here we just pick one
+  result = executor.execute({
+    method: "textDocument/documentSymbol",
+    params: { textDocument: { uri: uri } },
+  })
+
+  error = result.error
+  errors[file] = error if error
+ensure
+  store.delete(uri)
+  print("\033[M\033[0KCompleted #{index + 1}/#{files.length}") unless ENV["CI"]
+end
+
+puts "\n"
+message_queue.close
+
+if errors.empty?
+  puts "All automatic LSP requests executed successfully"
+  exit
+end
+
+puts <<~ERRORS
+  Errors while executing requests:
+
+  #{errors.map { |file, error| "#{file}: #{error.message}" }.join("\n")}
+ERRORS
+exit!

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("lib/**/*.rb") + ["README.md", "VERSION", "LICENSE.txt"]
   s.bindir = "exe"
-  s.executables = ["ruby-lsp"]
+  s.executables = ["ruby-lsp", "ruby-lsp-check"]
   s.require_paths = ["lib"]
 
   s.add_dependency("language_server-protocol", "~> 3.17.0")


### PR DESCRIPTION
### Motivation

The easiest way for us to verify that a release didn't break anything critical is to run our requests against large codebases with numerous examples of syntax.

Having an executable that we can easily invoke to check if everything is fine before releasing should assist us in finding bugs ahead of time.

### Implementation

The executable lists every file in the project and then executes one of our automatic requests. In the new listener pattern, it means all automatic requests are executed with it and so any issues with these critical requests will be surfaced.


### Manual Tests

1. Switch to this branch
2. Go to any project you'd like to use the executable on
3. Run `/path/to/ruby-lsp-check` in the project
4. Verify that it runs fine