### PR TITLE
Add extension management

### DIFF
--- a/SERVER_EXTENSIONS.md
+++ b/SERVER_EXTENSIONS.md
@@ -62,9 +62,13 @@ module RubyLsp
     class Extension < ::RubyLsp::Extension
       extend T::Sig
 
-      # Performs any activation that needs to happen once when the language server is booted
+      # Performs any activation that needs to happen once when the language server is booted in addition to registering
+      # listeners and request enhancements
       sig { override.void }
       def activate
+        # Register the MyGem::Hover listener to enhance hover functionality
+        # IMPORTANT: listener and request enhancement registration must be done inside `activate`
+        ::RubyLsp::Requests::Hover.add_listener(MyGem::Hover)
       end
 
       # Returns the name of the extension
@@ -97,9 +101,6 @@ module RubyLsp
       extend T::Generic
 
       ResponseType = type_member { { fixed: T.nilable(::RubyLsp::Interface::Hover) } }
-
-      # Register this listener class in the hover request
-      ::RubyLsp::Requests::Hover.add_listener(self)
 
       sig { override.returns(ResponseType) }
       attr_reader :response

--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -16,7 +16,7 @@ end
 
 require_relative "../lib/ruby_lsp/internal"
 
-RubyLsp::Extension.load_extensions
+RubyLsp::Extension.load_extensions({})
 
 T::Utils.run_all_sig_blocks
 

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -41,7 +41,7 @@ module RubyLsp
       when "initialize"
         initialize_request(request.dig(:params))
       when "initialized"
-        Extension.load_extensions
+        Extension.load_extensions(@store.server_extensions)
 
         errored_extensions = Extension.extensions.select(&:error?)
 
@@ -449,6 +449,9 @@ module RubyLsp
       else
         formatter
       end
+
+      server_extensions = options.dig(:initializationOptions, :serverExtensions)
+      @store.server_extensions = server_extensions if server_extensions
 
       configured_features = options.dig(:initializationOptions, :enabledFeatures)
 

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -171,6 +171,8 @@ module RubyLsp
         definition(uri, request.dig(:params, :position))
       when "rubyLsp/textDocument/showSyntaxTree"
         { ast: Requests::ShowSyntaxTree.new(@store.get(uri)).run }
+      when "rubyLsp/workspace/registeredExtensions"
+        Extension.extensions.map(&:to_hash)
       end
     end
 

--- a/lib/ruby_lsp/extension.rb
+++ b/lib/ruby_lsp/extension.rb
@@ -100,5 +100,13 @@ module RubyLsp
     # Extensions should override the `name` method to return the extension name
     sig { abstract.returns(String) }
     def name; end
+
+    sig { returns(T::Hash[Symbol, T.untyped]) }
+    def to_hash
+      {
+        name: name,
+        errors: @errors.map(&:message),
+      }
+    end
   end
 end

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -9,17 +9,23 @@ module RubyLsp
   class Store
     extend T::Sig
 
+    ExtensionStore = T.type_alias { T::Hash[String, { activated: T::Boolean }] }
+
     sig { returns(String) }
     attr_accessor :encoding
 
     sig { returns(String) }
     attr_accessor :formatter
 
+    sig { returns(ExtensionStore) }
+    attr_accessor :server_extensions
+
     sig { void }
     def initialize
       @state = T.let({}, T::Hash[String, Document])
       @encoding = T.let(Constant::PositionEncodingKind::UTF8, String)
       @formatter = T.let("auto", String)
+      @server_extensions = T.let({}, ExtensionStore)
     end
 
     sig { params(uri: String).returns(Document) }

--- a/test/extension_test.rb
+++ b/test/extension_test.rb
@@ -51,7 +51,7 @@ module RubyLsp
         end
       end
 
-      Extension.load_extensions
+      Extension.load_extensions({})
       error_extension = T.must(Extension.extensions.find(&:error?))
 
       assert_predicate(error_extension, :error?)
@@ -59,6 +59,21 @@ module RubyLsp
         My extension:
           Failed to activate
       MESSAGE
+    end
+
+    def test_load_extensions_does_not_activated_disabled_extensions
+      Class.new(Extension) do
+        def activate
+          RubyLsp::Requests::Hover.add_listener(Class.new(RubyLsp::Listener))
+        end
+
+        def name
+          "My extension"
+        end
+      end
+
+      Extension.load_extensions({ "My extension" => { activated: false } })
+      assert_empty(RubyLsp::Requests::Hover.listeners)
     end
   end
 end


### PR DESCRIPTION
### Motivation

Closes #590

It will be good to allow clients to both display which Ruby LSP extensions are being used and also deactivate them if desired. Maybe an extension is failing and we want to disable it temporarily.

This PR adds a custom request that clients can use to discover which extensions have been registered and also starts accepting an initialization option with extension configuration, which clients can use to disable specific extensions.

### Implementation

I split the implementation by commits.
1. Add a custom request that returns the discovered extensions
2. Starts accepting initialization options with extension configuration, so that we can skip activating disabled ones
3. Made an adjustment to our documentation mentioning that extensions should register their functionality all inside of `activate`. We'll need to update `ruby-lsp-rails` to match this, but I couldn't think of another way to de-register a listener that wouldn't involve messing up with the `$LOAD_PATH` and `$LOADED_FEATURES`

I'd appreciate feedback on the approach.

### Automated Tests

Added some tests.