### PR TITLE
Only start server in bundler projects if lockfile is present

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -1,6 +1,12 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# We should make sure that, if we're running on a bundler project, that it has a Gemfile.lock
+if File.exist?("Gemfile") && !File.exist?("Gemfile.lock")
+  warn("You are missing your Gemfile.lock. Run `bundle install` and restart the server")
+  exit(1)
+end
+
 # When we're running without bundler, then we need to make sure the custom bundle is fully configured and re-execute
 # using `BUNDLE_GEMFILE=.ruby-lsp/Gemfile bundle exec ruby-lsp` so that we have access to the gems that are a part of
 # the application's bundle


### PR DESCRIPTION
### Motivation

Currently, if we are using `ruby-lsp` in an editor other than VS Code, if we happen to open a bundler project that has a Gemfile but that we haven't run `bundle install` yet, the language server crashes due to the lack of the locked dependencies of the app. The main issue is that the user just gets the exception in the output and no explanation of what needs to be done.

Fixes #824 

### Implementation

As per @vinistock's suggestion, I simply added a check that prints a warning message if the project has a Gemfile but _doesn't_ have a Gemfile.lock and exits the server program.

My only point of uncertainty is concerning the message itself, but, otherwise, manually testing on Sublime, this worked fine. Which is to say, sublime just complains the server crashes, but attempting to start the process manually show the error message as expected. For the editor, I believe that, like the VS Code extension, the problem needs to be dealt with the Sublime package running the server.

### Automated Tests

I haven't added automated tests because I couldn't find the file where the executable is tested, or at least the files that I expected to have the executable tests seemed to test other things. But if there is a place to add an automated test for this, I'd be happy to know and add that to the PR.

### Manual Tests

This issue doesn't affect VS Code. It seems that the editor's extension runs bundle install in case there is no lockfile.

In other editors or simply running the server in the terminal all you need to do is:

1. Create a new gem, cd into the folder and try to run the server manually or through whatever LSP plugin the editor uses before running `bundle install`

or

2. Open whatever project that uses bundler, make sure it has no lockfile and attempt to start the server as described before.

The error message, however, is only visible if you try to start it manually or if you open up your editor's LSP plugin's logs. For example, in Sublime, you can do Cmd + Shift + P (or Ctrl + Shift + P on Windows and Linux, I believe) and run `LSP: Toggle Log Panel`. You should see output similar to this:

```
:: [21:23:27.710] --> ruby-lsp initialize (1): {'rootPath': '/Users/mateus/Projects/ruby/jekyll-cdn-url-migrator', 'rootUri': 'file:///Users/mateus/Projects/ruby/jekyll-cdn-url-migrator', 'workspaceFolders': [{'name': 'jekyll-cdn-url-migrator', 'uri': 'file:///Users/mateus/Projects/ruby/jekyll-cdn-url-migrator'}], 'processId': 46644, 'initializationOptions': {'enabledFeatures': ['completion', 'hover', 'documentHighlights', 'documentSymbols', 'codeActions', 'documentLink', 'formatting', 'onTypeFormatting', 'foldingRanges', 'selectionRanges', 'semanticHighlighting', 'inlayHint', 'diagnostics', 'definition'], 'telemetryEnabled': True}, 'clientInfo': {'name': 'Sublime Text LSP', 'version': '1.24.0'}, 'capabilities': {'window': {'workDoneProgress': True, 'showDocument': {'support': True}, 'showMessage': {'messageActionItem': {'additionalPropertiesSupport': True}}}, 'textDocument': {'implementation': {'dynamicRegistration': True, 'linkSupport': True}, 'rename': {'dynamicRegistration': True, 'prepareSupportDefaultBehavior': 1, 'prepareSupport': True}, 'typeDefinition': {'dynamicRegistration': True, 'linkSupport': True}, 'publishDiagnostics': {'relatedInformation': True, 'codeDescriptionSupport': True, 'versionSupport': True, 'tagSupport': {'valueSet': [2, 1]}, 'dataSupport': True}, 'colorProvider': {'dynamicRegistration': True}, 'codeLens': {'dynamicRegistration': True}, 'inlayHint': {'dynamicRegistration': True, 'resolveSupport': {'properties': ['textEdits', 'label.command']}}, 'callHierarchy': {'dynamicRegistration': True}, 'documentSymbol': {'symbolKind': {'valueSet': [7, 20, 24, 2, 11, 4, 8, 10, 18, 9, 5, 1, 12, 16, 15, 14, 6, 13, 17, 3, 21, 22, 25, 26, 23, 19]}, 'dynamicRegistration': True, 'hierarchicalDocumentSymbolSupport': True, 'tagSupport': {'valueSet': [1]}}, 'codeAction': {'dynamicRegistration': True, 'isPreferredSupport': True, 'resolveSupport': {'properties': ['edit']}, 'codeActionLiteralSupport': {'codeActionKind': {'valueSet': ['quickfix', 'refactor', 'refactor.extract', 'refactor.inline', 'refactor.rewrite', 'source.fixAll', 'source.organizeImports']}}, 'dataSupport': True}, 'selectionRange': {'dynamicRegistration': True}, 'hover': {'dynamicRegistration': True, 'contentFormat': ['markdown', 'plaintext']}, 'rangeFormatting': {'dynamicRegistration': True}, 'documentHighlight': {'dynamicRegistration': True}, 'documentLink': {'dynamicRegistration': True, 'tooltipSupport': True}, 'definition': {'dynamicRegistration': True, 'linkSupport': True}, 'diagnostic': {'relatedDocumentSupport': True, 'dynamicRegistration': True}, 'typeHierarchy': {'dynamicRegistration': True}, 'signatureHelp': {'contextSupport': True, 'dynamicRegistration': True, 'signatureInformation': {'documentationFormat': ['markdown', 'plaintext'], 'activeParameterSupport': True, 'parameterInformation': {'labelOffsetSupport': True}}}, 'completion': {'insertTextMode': 2, 'dynamicRegistration': True, 'completionItem': {'resolveSupport': {'properties': ['detail', 'documentation', 'additionalTextEdits']}, 'insertReplaceSupport': True, 'deprecatedSupport': True, 'labelDetailsSupport': True, 'documentationFormat': ['markdown', 'plaintext'], 'snippetSupport': True, 'insertTextModeSupport': {'valueSet': [2]}, 'tagSupport': {'valueSet': [1]}}, 'completionItemKind': {'valueSet': [10, 12, 16, 23, 9, 4, 17, 5, 13, 14, 2, 3, 18, 7, 8, 15, 6, 11, 1, 20, 21, 24, 25, 22, 19]}, 'completionList': {'itemDefaults': ['editRange', 'insertTextFormat', 'data']}}, 'references': {'dynamicRegistration': True}, 'declaration': {'dynamicRegistration': True, 'linkSupport': True}, 'synchronization': {'dynamicRegistration': True, 'willSaveWaitUntil': True, 'willSave': True, 'didSave': True}, 'semanticTokens': {'tokenTypes': ['property', 'type', 'event', 'interface', 'typeParameter', 'enum', 'keyword', 'method', 'regexp', 'function', 'class', 'number', 'comment', 'string', 'parameter', 'variable', 'macro', 'decorator', 'enumMember', 'operator', 'modifier', 'struct', 'namespace'], 'formats': ['relative'], 'requests': {'full': {'delta': True}, 'range': True}, 'tokenModifiers': ['async', 'abstract', 'definition', 'static', 'documentation', 'modification', 'deprecated', 'declaration', 'readonly', 'defaultLibrary'], 'augmentsSyntaxTokens': True, 'overlappingTokenSupport': False, 'dynamicRegistration': True, 'multilineTokenSupport': True}, 'formatting': {'dynamicRegistration': True}}, 'general': {'regularExpressions': {'engine': 'ECMAScript'}, 'markdown': {'version': '3.2.2', 'parser': 'Python-Markdown'}}, 'workspace': {'didChangeConfiguration': {'dynamicRegistration': True}, 'codeLens': {'refreshSupport': True}, 'executeCommand': {}, 'workspaceFolders': True, 'diagnostics': {'refreshSupport': True}, 'configuration': True, 'symbol': {'symbolKind': {'valueSet': [7, 20, 24, 2, 11, 4, 8, 10, 18, 9, 5, 1, 12, 16, 15, 14, 6, 13, 17, 3, 21, 22, 25, 26, 23, 19]}, 'dynamicRegistration': True, 'tagSupport': {'valueSet': [1]}}, 'applyEdit': True, 'semanticTokens': {'refreshSupport': True}, 'inlayHint': {'refreshSupport': True}, 'workspaceEdit': {'documentChanges': True, 'failureHandling': 'abort'}}}}
ruby-lsp: You are missing your Gemfile.lock. Run `bundle install` and restart the server
```
