### PR TITLE
Use absolute BUNDLE_PATH when running the server

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -12,7 +12,16 @@ if ENV["BUNDLE_GEMFILE"].nil? && File.exist?("Gemfile.lock")
   # However, we still want to run the server with `bundle exec`. We need to make sure we're pointing to the right
   # `Gemfile`
   bundle_gemfile = File.exist?(".ruby-lsp/Gemfile") ? ".ruby-lsp/Gemfile" : "Gemfile"
-  exit exec("BUNDLE_GEMFILE=#{bundle_gemfile} bundle exec ruby-lsp #{ARGV.join(" ")}")
+
+  # In addition to BUNDLE_GEMFILE, we also need to make sure that BUNDLE_PATH is absolute and not relative. For example,
+  # if BUNDLE_PATH is `vendor/bundle`, we want the top level `vendor/bundle` and not `.ruby-lsp/vendor/bundle`.
+  # Expanding to get the absolute path ensures we're pointing to the correct folder, which is the same one we use in
+  # SetupBundler to install the gems
+  path = Bundler.settings["path"]
+
+  command = +"BUNDLE_GEMFILE=#{bundle_gemfile} bundle exec ruby-lsp #{ARGV.join(" ")}"
+  command.prepend("BUNDLE_PATH=#{File.expand_path(path, Dir.pwd)} ") if path
+  exit exec(command)
 end
 
 require "sorbet-runtime"


### PR DESCRIPTION
### Motivation

Closes #823

`BUNDLE_PATH` is always configured to be a relative path (e.g.: `vendor/bundle`). If we don't turn it into an absolute path, instead of pointing to the top level `vendor/bundle`, we end up pointing to `.ruby-lsp/vendor/bundle`, which is not what we want.

We already make `BUNDLE_PATH` absolute when installing the gems in `SetupBundler`, but we forgot to include it when executing it. If we don't include it, then we installed the gems at `top_level/vendor/bundle`, but when trying to `bundle exec` we're looking for them in `.ruby-lsp/vendor/bundle`.

### Implementation

Basically identical to what we do when installing gems. If there's a `BUNDLE_PATH` configured, then we want to get the absolute path in respect to the top level where the LSP is being executed and include that when running `bundle exec`.