### PR TITLE
Refactor listener registration

### DIFF
--- a/lib/ruby_lsp/extension.rb
+++ b/lib/ruby_lsp/extension.rb
@@ -97,8 +97,32 @@ module RubyLsp
     sig { abstract.void }
     def activate; end
 
+    # Each extension should implement `MyExtension#deactivate` and use to perform any clean up, like shutting down a
+    # child process
+    sig { abstract.void }
+    def deactivate; end
+
     # Extensions should override the `name` method to return the extension name
     sig { abstract.returns(String) }
     def name; end
+
+    # Creates a new CodeLens listener. This method is invoked on every CodeLens request
+    sig do
+      overridable.params(
+        uri: String,
+        emitter: EventEmitter,
+        message_queue: Thread::Queue,
+      ).returns(T.nilable(Listener[T::Array[Interface::CodeLens]]))
+    end
+    def create_code_lens_listener(uri, emitter, message_queue); end
+
+    # Creates a new Hover listener. This method is invoked on every Hover request
+    sig do
+      overridable.params(
+        emitter: EventEmitter,
+        message_queue: Thread::Queue,
+      ).returns(T.nilable(Listener[T.nilable(Interface::Hover)]))
+    end
+    def create_hover_listener(emitter, message_queue); end
   end
 end

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -39,29 +39,15 @@ module RubyLsp
       def initialize(emitter, message_queue)
         super
 
-        @external_listeners = T.let([], T::Array[RubyLsp::Listener[ResponseType]])
+        @external_listeners.concat(
+          Extension.extensions.filter_map { |ext| ext.create_hover_listener(emitter, message_queue) },
+        )
         @response = T.let(nil, ResponseType)
         emitter.register(self, :on_command, :on_const_path_ref, :on_call)
-
-        register_external_listeners!
-      end
-
-      sig { void }
-      def register_external_listeners!
-        self.class.listeners.each do |l|
-          @external_listeners << T.unsafe(l).new(@emitter, @message_queue)
-        end
-      end
-
-      sig { void }
-      def merge_external_listeners_responses!
-        @external_listeners.each do |l|
-          merge_response!(l)
-        end
       end
 
       # Merges responses from other hover listeners
-      sig { params(other: Listener[ResponseType]).returns(T.self_type) }
+      sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }
       def merge_response!(other)
         other_response = other.response
         return self unless other_response

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -86,6 +86,7 @@ module RubyLsp
           @message_dispatcher.join
           @store.clear
 
+          Extension.extensions.each(&:deactivate)
           finalize_request(Result.new(response: nil), request)
         when "exit"
           # We return zero if shutdown has already been received or one otherwise as per the recommendation in the spec

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -57,9 +57,9 @@ class HoverExpectationsTest < ExpectationsTestRunner
     T.must(message_queue).close
   end
 
-  def test_after_request_hook
+  def test_hover_extensions
     message_queue = Thread::Queue.new
-    create_hover_hook_class
+    create_hover_extension
     js_content = File.read(File.join(TEST_FIXTURES_DIR, "rails_search_index.js"))
     fake_response = FakeHTTPResponse.new("200", js_content)
     Net::HTTP.stubs(get_response: fake_response)
@@ -79,31 +79,40 @@ class HoverExpectationsTest < ExpectationsTestRunner
     assert_match("Method from middleware: belongs_to", response.contents.value)
     assert_match("[Rails Document: `ActiveRecord::Associations::ClassMethods#belongs_to`]", response.contents.value)
   ensure
-    RubyLsp::Requests::Hover.listeners.clear
+    RubyLsp::Extension.extensions.clear
     T.must(message_queue).close
   end
 
   private
 
-  def create_hover_hook_class
-    Class.new(RubyLsp::Listener) do
-      attr_reader :response
+  def create_hover_extension
+    Class.new(RubyLsp::Extension) do
+      def activate; end
 
-      RubyLsp::Requests::Hover.add_listener(self)
-
-      def initialize(emitter, message_queue)
-        super
-
-        emitter.register(self, :on_command)
+      def name
+        "HoverExtension"
       end
 
-      def on_command(node)
-        T.bind(self, RubyLsp::Listener[T.untyped])
-        contents = RubyLsp::Interface::MarkupContent.new(
-          kind: "markdown",
-          value: "Method from middleware: #{node.message.value}",
-        )
-        @response = RubyLsp::Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
+      def create_hover_listener(emitter, message_queue)
+        klass = Class.new(RubyLsp::Listener) do
+          attr_reader :response
+
+          def initialize(emitter, message_queue)
+            super
+            emitter.register(self, :on_command)
+          end
+
+          def on_command(node)
+            T.bind(self, RubyLsp::Listener[T.untyped])
+            contents = RubyLsp::Interface::MarkupContent.new(
+              kind: "markdown",
+              value: "Method from middleware: #{node.message.value}",
+            )
+            @response = RubyLsp::Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
+          end
+        end
+
+        klass.new(emitter, message_queue)
       end
     end
   end


### PR DESCRIPTION
### Motivation

Allowing extensions to perform listener registration using class methods does not give the LSP enough control to deactivate extensions properly. It also doesn't allow extensions to perform store ahead of time configuration in the `Extension` instance and pass that to their listeners.

This PR proposes a refactor in how listener registration happens. Instead of registering listener classes that we instantiate from the LSP, we invert the responsibility and require the extensions to implement factory methods that will create the listener instances based on parameters. This allows extensions to use information stored in the `Extension` instance in their listeners and also allows us to easily disable extensions, since the factory methods are invoked on every request.

Example
```ruby
class MyExtension < RubyLsp::Extension
  def activate
    @important_info = 123
  end

  # This is invoked on every request. Disabling the extension would then mean just removing
  # it from the list which automatically makes us not invoke these factory methods
  def create_code_lens_listener(uri, emitter, queue)
    MyCodeLensListener.new(@important_info, uri, emitter, queue)
  end
end
```

### Implementation

There are tradeoffs with each approach, so I'd love to hear opinions on this. The idea is that we'd need to provide empty factory methods from the base `Extension` class that are overridden to do the right thing if your extension needs it. I don't love invoking a bunch of empty methods, but I couldn't come up with an alternative.

There's also the question of formatters. Those are still registered at a class level since a factory method doesn't make much sense for them. We just need to know an identifier and an instance of the formatter.

### Automated Tests

Adapted tests.