### PR TITLE
Remove comment about experimental Code Lens

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -7,9 +7,6 @@ module RubyLsp
   module Requests
     # ![Code lens demo](../../code_lens.gif)
     #
-    # This feature is currently experimental. Clients will need to pass `experimentalFeaturesEnabled`
-    # in the initialization options to enable it.
-    #
     # The
     # [code lens](https://microsoft.github.io/language-server-protocol/specification#textDocument_codeLens)
     # request informs the editor of runnable commands such as tests


### PR DESCRIPTION
This was made stable in [v0.7.0](https://github.com/Shopify/ruby-lsp/releases/tag/v0.7.0).