### PR TITLE
Avoid mutating document tree in show syntax tree

### DIFF
--- a/lib/ruby_lsp/requests/show_syntax_tree.rb
+++ b/lib/ruby_lsp/requests/show_syntax_tree.rb
@@ -47,7 +47,7 @@ module RubyLsp
         start_char = scanner.find_char_position(range[:start])
         end_char = scanner.find_char_position(range[:end])
 
-        queue = T.cast(@document.tree, SyntaxTree::Program).statements.body
+        queue = T.cast(@document.tree, SyntaxTree::Program).statements.body.dup
         found_nodes = []
 
         until queue.empty?

--- a/test/requests/show_syntax_tree_test.rb
+++ b/test/requests/show_syntax_tree_test.rb
@@ -62,5 +62,14 @@ class ShowSyntaxTreeTest < Minitest::Test
 
       (assign (var_field (ident "bar")) (int "456"))
     AST
+
+    response = RubyLsp::Executor.new(store, @message_queue).execute({
+      method: "rubyLsp/textDocument/showSyntaxTree",
+      params: {
+        textDocument: { uri: "file:///fake.rb" },
+        range: { start: { line: 1, character: 0 }, end: { line: 1, character: 9 } },
+      },
+    }).response
+    refute_empty(response[:ast])
   end
 end


### PR DESCRIPTION
### Motivation

We set the `queue` variable to the statements body array without duplicating it. This means that when we `shift` immediately below, it's actually mutating the structure of the document tree accidentally.

### Implementation

Just invoked `dup` on the tree to guarantee we have our own copy.

### Automated Tests

Enhanced an existing test to make sure that executing show syntax tree more than once still returns expected results.