### PR TITLE
Avoid mutating nodes in full_constant_name

### DIFF
--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -26,7 +26,7 @@ module RubyLsp
           params(node: T.any(SyntaxTree::ConstPathRef, SyntaxTree::ConstRef, SyntaxTree::TopConstRef)).returns(String)
         end
         def full_constant_name(node)
-          name = +node.constant.value
+          name = node.constant.value.dup
           constant = T.let(node, SyntaxTree::Node)
 
           while constant.is_a?(SyntaxTree::ConstPathRef)


### PR DESCRIPTION
### Motivation

Similarly to https://github.com/Shopify/ruby-lsp/pull/835, we were unintentionally mutating the AST in this method. Every time this method got invoked, the node's name got stuff prepended to it, making it grow until an edit was made to the file.

### Implementation

I dupped the string for now. This method will no longer be necessary after YARP because there's a more convenient way to get the full name of `ConstPathRef` nodes, so I think it's fine for now.

### Automated Tests

Didn't add a test since this method will be removed as soon as we migrate to YARP.