### PR TITLE
Prevent dependency detector from failing outside of a bundle

### DIFF
--- a/lib/ruby_lsp/requests/support/dependency_detector.rb
+++ b/lib/ruby_lsp/requests/support/dependency_detector.rb
@@ -38,7 +38,10 @@ module RubyLsp
 
       sig { params(gem_pattern: Regexp).returns(T::Boolean) }
       def direct_dependency?(gem_pattern)
-        Bundler.locked_gems.dependencies.keys.grep(gem_pattern).any?
+        Bundler.with_original_env { Bundler.default_gemfile } &&
+          Bundler.locked_gems.dependencies.keys.grep(gem_pattern).any?
+      rescue Bundler::GemfileNotFound
+        false
       end
     end
   end

--- a/test/requests/support/dependency_detector_test.rb
+++ b/test/requests/support/dependency_detector_test.rb
@@ -39,5 +39,10 @@ module RubyLsp
 
       assert_equal("rails", DependencyDetector.detected_test_library)
     end
+
+    def test_direct_dependency_returns_false_outside_of_bundle
+      File.expects(:file?).at_least_once.returns(false)
+      refute(DependencyDetector.direct_dependency?(/^ruby-lsp/))
+    end
   end
 end


### PR DESCRIPTION
### Motivation

The issue #824 was on to something.

We want devs to be able to use the Ruby LSP on scripts and projects that don't have a `Gemfile`, but this code assumes that `locked_gems` will always exist. If there is a `Gemfile`, then I think it's fine to assume that people need to have locked their gems. But we also want to allow people to use the Ruby LSP without a `Gemfile` at all.

### Implementation

Checked if there is a top level `Gemfile` before trying to read locked gems.

### Automated Tests

Added an example. It's a bit of a weak test since it basically mocks the expected response, but it at least serves as documentation.