### PR TITLE
Pass environment as a hash to system or exec calls

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -25,9 +25,9 @@ if ENV["BUNDLE_GEMFILE"].nil? && File.exist?("Gemfile.lock")
   # SetupBundler to install the gems
   path = Bundler.settings["path"]
 
-  command = +"BUNDLE_GEMFILE=#{bundle_gemfile} bundle exec ruby-lsp #{ARGV.join(" ")}"
-  command.prepend("BUNDLE_PATH=#{File.expand_path(path, Dir.pwd)} ") if path
-  exit exec(command)
+  env = { "BUNDLE_GEMFILE" => bundle_gemfile }
+  env["BUNDLE_PATH"] = File.expand_path(path, Dir.pwd) if path
+  exit exec(env, "bundle exec ruby-lsp #{ARGV.join(" ")}")
 end
 
 require "sorbet-runtime"

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -120,16 +120,18 @@ module RubyLsp
       # want to install it in the top level `vendor` and not `.ruby-lsp/vendor`
       path = Bundler.settings["path"]
 
-      command = +""
       # Use the absolute `BUNDLE_PATH` to prevent accidentally creating unwanted folders under `.ruby-lsp`
-      command << "BUNDLE_PATH=#{File.expand_path(path, Dir.pwd)} " if path
-      command << "BUNDLE_GEMFILE=#{bundle_gemfile} " if bundle_gemfile
+      env = {}
+      env["BUNDLE_GEMFILE"] = bundle_gemfile if bundle_gemfile
+      env["BUNDLE_PATH"] = File.expand_path(path, Dir.pwd) if path
 
       # If both `ruby-lsp` and `debug` are already in the Gemfile, then we shouldn't try to upgrade them or else we'll
       # produce undesired source control changes. If the custom bundle was just created and either `ruby-lsp` or `debug`
       # weren't a part of the Gemfile, then we need to run `bundle install` for the first time to generate the
       # Gemfile.lock with them included or else Bundler will complain that they're missing. We can only update if the
       # custom `.ruby-lsp/Gemfile.lock` already exists and includes both gems
+      command = +""
+
       if (@dependencies["ruby-lsp"] && @dependencies["debug"]) ||
           @custom_bundle_dependencies["ruby-lsp"].nil? || @custom_bundle_dependencies["debug"].nil?
         # Install gems using the custom bundle
@@ -147,7 +149,7 @@ module RubyLsp
 
       # Add bundle update
       warn("Ruby LSP> Running bundle install for the custom bundle. This may take a while...")
-      system(command)
+      system(env, command)
     end
   end
 end


### PR DESCRIPTION
### Motivation

Closes #840

Passing the environment variables in front of the command does not work on every operating system, such as Windows. We should rely on Ruby to do the correct thing for each OS.

I believe that this PR with https://github.com/Shopify/vscode-ruby-lsp/pull/712 will finally make the Ruby LSP work on Windows.

### Implementation

The entire `exec` family accepts extra environment variables as a hash for the first argument. Just started using that instead of concatenating the variables as a string.

### Automated Tests

Changed the tests to reflect the new approach.