### PR TITLE
Use pathnames and bundler methods in custom bundle logic

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -1,32 +1,21 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# We should make sure that, if we're running on a bundler project, that it has a Gemfile.lock
-if File.exist?("Gemfile") && !File.exist?("Gemfile.lock")
-  warn("Project contains a Gemfile, but no Gemfile.lock. Run `bundle install` to lock gems and restart the server")
-  exit(78)
-end
-
 # When we're running without bundler, then we need to make sure the custom bundle is fully configured and re-execute
 # using `BUNDLE_GEMFILE=.ruby-lsp/Gemfile bundle exec ruby-lsp` so that we have access to the gems that are a part of
 # the application's bundle
-if ENV["BUNDLE_GEMFILE"].nil? && File.exist?("Gemfile.lock")
+if ENV["BUNDLE_GEMFILE"].nil?
   require_relative "../lib/ruby_lsp/setup_bundler"
-  RubyLsp::SetupBundler.new(Dir.pwd).setup!
 
-  # In some cases, like when the `ruby-lsp` is already a part of the bundle, we don't generate `.ruby-lsp/Gemfile`.
-  # However, we still want to run the server with `bundle exec`. We need to make sure we're pointing to the right
-  # `Gemfile`
-  bundle_gemfile = File.exist?(".ruby-lsp/Gemfile") ? ".ruby-lsp/Gemfile" : "Gemfile"
-
-  # In addition to BUNDLE_GEMFILE, we also need to make sure that BUNDLE_PATH is absolute and not relative. For example,
-  # if BUNDLE_PATH is `vendor/bundle`, we want the top level `vendor/bundle` and not `.ruby-lsp/vendor/bundle`.
-  # Expanding to get the absolute path ensures we're pointing to the correct folder, which is the same one we use in
-  # SetupBundler to install the gems
-  path = Bundler.settings["path"]
+  begin
+    bundle_gemfile, bundle_path = RubyLsp::SetupBundler.new(Dir.pwd).setup!
+  rescue RubyLsp::SetupBundler::BundleNotLocked
+    warn("Project contains a Gemfile, but no Gemfile.lock. Run `bundle install` to lock gems and restart the server")
+    exit(78)
+  end
 
   env = { "BUNDLE_GEMFILE" => bundle_gemfile }
-  env["BUNDLE_PATH"] = File.expand_path(path, Dir.pwd) if path
+  env["BUNDLE_PATH"] = bundle_path if bundle_path
   exit exec(env, "bundle exec ruby-lsp #{ARGV.join(" ")}")
 end
 


### PR DESCRIPTION
### Motivation

I noticed an issue with the custom bundle logic and ended up improving 3 separate things:
1. If a project had no bundle (no Gemfile) the logic didn't work at all (original problem)
2. We were concatenating strings to build paths. This is not a good strategy since different operating systems may use different ways of building paths. We should always rely on `Pathname` to do the right thing for us
3. We were again using strings for referencing the main bundle, but we should rely on methods coming from bundler. For example, if a project uses `gems.rb` instead of `Gemfile`, we would fail to set up the custom bundle
4. Bundler actually allows gems to have multiple gemspecs. We were not accounting for that when loading them

### Implementation

1. Removed the special check for the `ruby-lsp` folder. This is actually not necessary, because the Ruby LSP always falls under the scenario of having both `ruby-lsp` and `debug` in the bundle, so we can simplify the logic there
2. Started using pathnames for everything
3. Started using `Bundler.default_gemfile` and `Bundler.default_lockfile` to find the correct bundle files
5. Started returning the correct bundler configuration from `setup!` so that we can use it on the executable and avoid duplicating logic
6. Moved the check for a bundle that hasn't been locked yet inside the setup script

### Automated Tests

Added some more tests.