### PR TITLE
Use URI objects instead of strings

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -62,8 +62,8 @@ def avg_bench(method, params)
   [average, standard_deviation]
 end
 
-FILE_URI = "file://#{File.expand_path(__FILE__)}"
-base_params = { textDocument: { uri: FILE_URI } }
+FILE_URI = URI("file://#{File.expand_path(__FILE__)}")
+base_params = { textDocument: { uri: FILE_URI.to_s } }
 range = {
   start: { line: 50, character: 0 },
   end: { line: 75, character: 0 },
@@ -89,7 +89,7 @@ code_action_params = base_params.merge(
             edit: {
               documentChanges: [
                 {
-                  textDocument: { uri: FILE_URI, version: nil },
+                  textDocument: { uri: FILE_URI.to_s, version: nil },
                   edits: [
                     {
                       range: {
@@ -249,7 +249,7 @@ requests = {
   "textDocument/hover" => base_params.merge(position: position),
   "textDocument/codeAction" => code_action_params,
   "textDocument/onTypeFormatting" => base_params.merge(position: { line: 1, character: 31 }, ch: "\n"),
-  "codeAction/resolve" => base_params.merge(data: { range: range, uri: FILE_URI }),
+  "codeAction/resolve" => base_params.merge(data: { range: range, uri: FILE_URI.to_s }),
   "textDocument/completion" => base_params.merge(position: { line: 5, character: 24 }),
   "textDocument/codeLens" => base_params,
   "textDocument/definition" => base_params.merge(position: { line: 4, character: 20 }),

--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -30,13 +30,13 @@ message_queue = Thread::Queue.new
 executor = RubyLsp::Executor.new(store, message_queue)
 
 files.each_with_index do |file, index|
-  uri = "file://#{file}"
+  uri = URI("file://#{file}")
   store.set(uri: uri, source: File.read(file), version: 1)
 
   # Executing any of the automatic requests will execute all of them, so here we just pick one
   result = executor.execute({
     method: "textDocument/documentSymbol",
-    params: { textDocument: { uri: uri } },
+    params: { textDocument: { uri: uri.to_s } },
   })
 
   error = result.error

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -18,16 +18,16 @@ module RubyLsp
     sig { returns(Integer) }
     attr_reader :version
 
-    sig { returns(String) }
+    sig { returns(URI::Generic) }
     attr_reader :uri
 
-    sig { params(source: String, version: Integer, uri: String, encoding: String).void }
+    sig { params(source: String, version: Integer, uri: URI::Generic, encoding: String).void }
     def initialize(source:, version:, uri:, encoding: Constant::PositionEncodingKind::UTF8)
       @cache = T.let({}, T::Hash[String, T.untyped])
       @encoding = T.let(encoding, String)
       @source = T.let(source, String)
       @version = T.let(version, Integer)
-      @uri = T.let(uri, String)
+      @uri = T.let(uri, URI::Generic)
       @unparsed_edits = T.let([], T::Array[EditShape])
       @syntax_error = T.let(false, T::Boolean)
       @tree = T.let(SyntaxTree.parse(@source), T.nilable(SyntaxTree::Node))

--- a/lib/ruby_lsp/extension.rb
+++ b/lib/ruby_lsp/extension.rb
@@ -109,7 +109,7 @@ module RubyLsp
     # Creates a new CodeLens listener. This method is invoked on every CodeLens request
     sig do
       overridable.params(
-        uri: String,
+        uri: URI::Generic,
         emitter: EventEmitter,
         message_queue: Thread::Queue,
       ).returns(T.nilable(Listener[T::Array[Interface::CodeLens]]))

--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -7,6 +7,7 @@ require "language_server-protocol"
 require "benchmark"
 require "bundler"
 require "uri"
+require "cgi"
 
 require "ruby-lsp"
 require "ruby_lsp/utils"

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -29,7 +29,7 @@ module RubyLsp
       def initialize(document, range, context)
         super(document)
 
-        @uri = T.let(document.uri, String)
+        @uri = T.let(document.uri, URI::Generic)
         @range = range
         @context = context
       end
@@ -63,14 +63,14 @@ module RubyLsp
           )
       end
 
-      sig { params(range: Document::RangeShape, uri: String).returns(Interface::CodeAction) }
+      sig { params(range: Document::RangeShape, uri: URI::Generic).returns(Interface::CodeAction) }
       def refactor_code_action(range, uri)
         Interface::CodeAction.new(
           title: "Refactor: Extract Variable",
           kind: Constant::CodeActionKind::REFACTOR_EXTRACT,
           data: {
             range: range,
-            uri: uri,
+            uri: uri.to_s,
           },
         )
       end

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -31,17 +31,17 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :response
 
-      sig { params(uri: String, emitter: EventEmitter, message_queue: Thread::Queue, test_library: String).void }
+      sig { params(uri: URI::Generic, emitter: EventEmitter, message_queue: Thread::Queue, test_library: String).void }
       def initialize(uri, emitter, message_queue, test_library)
         super(emitter, message_queue)
 
-        @uri = T.let(uri, String)
+        @uri = T.let(uri, URI::Generic)
         @external_listeners.concat(
           Extension.extensions.filter_map { |ext| ext.create_code_lens_listener(uri, emitter, message_queue) },
         )
         @test_library = T.let(test_library, String)
         @response = T.let([], ResponseType)
-        @path = T.let(T.must(URI(uri).path), String)
+        @path = T.let(uri.path, T.nilable(String))
         # visibility_stack is a stack of [current_visibility, previous_visibility]
         @visibility_stack = T.let([["public", "public"]], T::Array[T::Array[T.nilable(String)]])
         @class_stack = T.let([], T::Array[String])
@@ -106,7 +106,7 @@ module RubyLsp
         if ACCESS_MODIFIERS.include?(node_message) && node.arguments.parts.any?
           visibility, _ = @visibility_stack.pop
           @visibility_stack.push([node_message, visibility])
-        elsif @path.include?("Gemfile") && node_message.include?("gem") && node.arguments.parts.any?
+        elsif @path&.include?("Gemfile") && node_message.include?("gem") && node.arguments.parts.any?
           remote = resolve_gem_remote(node)
           return unless remote
 
@@ -160,7 +160,7 @@ module RubyLsp
       sig { params(node: SyntaxTree::Node, name: String, command: String, kind: Symbol).void }
       def add_test_code_lens(node, name:, command:, kind:)
         # don't add code lenses if the test library is not supported or unknown
-        return unless SUPPORTED_TEST_LIBRARIES.include?(@test_library)
+        return unless SUPPORTED_TEST_LIBRARIES.include?(@test_library) && @path
 
         arguments = [
           @path,
@@ -217,7 +217,7 @@ module RubyLsp
 
       sig { params(class_name: String, method_name: T.nilable(String)).returns(String) }
       def generate_test_command(class_name:, method_name: nil)
-        command = BASE_COMMAND + @path
+        command = BASE_COMMAND + T.must(@path)
 
         case @test_library
         when "minitest"

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -25,7 +25,7 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :response
 
-      sig { params(uri: String, emitter: EventEmitter, message_queue: Thread::Queue).void }
+      sig { params(uri: URI::Generic, emitter: EventEmitter, message_queue: Thread::Queue).void }
       def initialize(uri, emitter, message_queue)
         super(emitter, message_queue)
 
@@ -61,8 +61,8 @@ module RubyLsp
             )
           end
         when "require_relative"
-          current_file = T.must(URI.parse(@uri).path)
-          current_folder = Pathname.new(current_file).dirname
+          path = @uri.path
+          current_folder = path ? Pathname.new(CGI.unescape(path)).dirname : Dir.pwd
           candidate = File.expand_path(File.join(current_folder, required_file))
 
           if candidate

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -25,7 +25,7 @@ module RubyLsp
       def initialize(document)
         super(document)
 
-        @uri = T.let(document.uri, String)
+        @uri = T.let(document.uri, URI::Generic)
       end
 
       sig { override.returns(T.nilable(T.all(T::Array[Support::RuboCopDiagnostic], Object))) }
@@ -36,7 +36,8 @@ module RubyLsp
         return unless defined?(Support::RuboCopDiagnosticsRunner)
 
         # Don't try to run RuboCop diagnostics for files outside the current working directory
-        return unless URI(@uri).path&.start_with?(T.must(WORKSPACE_URI.path))
+        path = @uri.path
+        return unless path.nil? || path.start_with?(T.must(WORKSPACE_URI.path))
 
         Support::RuboCopDiagnosticsRunner.instance.run(@uri, @document)
       end

--- a/lib/ruby_lsp/requests/document_link.rb
+++ b/lib/ruby_lsp/requests/document_link.rb
@@ -75,13 +75,13 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :response
 
-      sig { params(uri: String, emitter: EventEmitter, message_queue: Thread::Queue).void }
+      sig { params(uri: URI::Generic, emitter: EventEmitter, message_queue: Thread::Queue).void }
       def initialize(uri, emitter, message_queue)
         super(emitter, message_queue)
 
         # Match the version based on the version in the RBI file name. Notice that the `@` symbol is sanitized to `%40`
         # in the URI
-        version_match = /(?<=%40)[\d.]+(?=\.rbi$)/.match(uri)
+        version_match = uri.path ? /(?<=%40)[\d.]+(?=\.rbi$)/.match(CGI.unescape(uri.path)) : nil
         @gem_version = T.let(version_match && version_match[0], T.nilable(String))
         @response = T.let([], T::Array[Interface::DocumentLink])
 
@@ -95,7 +95,7 @@ module RubyLsp
 
         uri = T.cast(URI(T.must(match[0])), URI::Source)
         gem_version = T.must(resolve_version(uri))
-        file_path = self.class.gem_paths.dig(uri.gem_name, gem_version, uri.path)
+        file_path = self.class.gem_paths.dig(uri.gem_name, gem_version, CGI.unescape(uri.path))
         return if file_path.nil?
 
         @response << Interface::DocumentLink.new(

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -58,7 +58,7 @@ module RubyLsp
       def initialize(document, formatter: "auto")
         super(document)
 
-        @uri = T.let(document.uri, String)
+        @uri = T.let(document.uri, URI::Generic)
         @formatter = formatter
       end
 
@@ -67,7 +67,8 @@ module RubyLsp
         return if @formatter == "none"
 
         # Don't try to format files outside the current working directory
-        return unless @uri.sub("file://", "").start_with?(Dir.pwd)
+        path = @uri.path
+        return unless path.nil? || path.start_with?(T.must(WORKSPACE_URI.path))
 
         return if @document.syntax_error?
 

--- a/lib/ruby_lsp/requests/support/formatter_runner.rb
+++ b/lib/ruby_lsp/requests/support/formatter_runner.rb
@@ -10,7 +10,7 @@ module RubyLsp
 
         interface!
 
-        sig { abstract.params(uri: String, document: Document).returns(T.nilable(String)) }
+        sig { abstract.params(uri: URI::Generic, document: Document).returns(T.nilable(String)) }
         def run(uri, document); end
       end
     end

--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -19,7 +19,7 @@ module RubyLsp
           T::Hash[Symbol, Integer],
         )
 
-        sig { params(offense: RuboCop::Cop::Offense, uri: String).void }
+        sig { params(offense: RuboCop::Cop::Offense, uri: URI::Generic).void }
         def initialize(offense, uri)
           @offense = offense
           @uri = uri
@@ -34,7 +34,7 @@ module RubyLsp
               document_changes: [
                 Interface::TextDocumentEdit.new(
                   text_document: Interface::OptionalVersionedTextDocumentIdentifier.new(
-                    uri: @uri,
+                    uri: @uri.to_s,
                     version: nil,
                   ),
                   edits: @offense.correctable? ? offense_replacements : [],

--- a/lib/ruby_lsp/requests/support/rubocop_diagnostics_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostics_runner.rb
@@ -3,7 +3,6 @@
 
 return unless defined?(RubyLsp::Requests::Support::RuboCopRunner)
 
-require "cgi"
 require "singleton"
 
 module RubyLsp
@@ -19,9 +18,9 @@ module RubyLsp
           @runner = T.let(RuboCopRunner.new, RuboCopRunner)
         end
 
-        sig { params(uri: String, document: Document).returns(T::Array[Support::RuboCopDiagnostic]) }
+        sig { params(uri: URI::Generic, document: Document).returns(T::Array[Support::RuboCopDiagnostic]) }
         def run(uri, document)
-          filename = CGI.unescape(URI.parse(uri).path)
+          filename = CGI.unescape(uri.path || uri.opaque)
           # Invoke RuboCop with just this file in `paths`
           @runner.run(filename, document.source)
 

--- a/lib/ruby_lsp/requests/support/rubocop_formatting_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_formatting_runner.rb
@@ -3,7 +3,6 @@
 
 return unless defined?(RubyLsp::Requests::Support::RuboCopRunner)
 
-require "cgi"
 require "singleton"
 
 module RubyLsp
@@ -21,9 +20,9 @@ module RubyLsp
           @runner = T.let(RuboCopRunner.new("-a"), RuboCopRunner)
         end
 
-        sig { override.params(uri: String, document: Document).returns(String) }
+        sig { override.params(uri: URI::Generic, document: Document).returns(String) }
         def run(uri, document)
-          filename = CGI.unescape(URI.parse(uri).path)
+          filename = CGI.unescape(uri.path || uri.opaque)
 
           # Invoke RuboCop with just this file in `paths`
           @runner.run(filename, document.source)

--- a/lib/ruby_lsp/requests/support/syntax_tree_formatting_runner.rb
+++ b/lib/ruby_lsp/requests/support/syntax_tree_formatting_runner.rb
@@ -26,9 +26,10 @@ module RubyLsp
             )
         end
 
-        sig { override.params(uri: String, document: Document).returns(T.nilable(String)) }
+        sig { override.params(uri: URI::Generic, document: Document).returns(T.nilable(String)) }
         def run(uri, document)
-          relative_path = Pathname.new(URI(uri).path).relative_path_from(T.must(WORKSPACE_URI.path))
+          relative_path = Pathname.new(CGI.unescape(uri.path || uri.opaque))
+            .relative_path_from(T.must(WORKSPACE_URI.path))
           return if @options.ignore_files.any? { |pattern| File.fnmatch(pattern, relative_path) }
 
           SyntaxTree.format(

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -106,7 +106,7 @@ module RubyLsp
             # source. Altering the source reference during parsing will put the parser in an invalid internal state,
             # since it started parsing with one source but then it changed in the middle
             uri = request.dig(:params, :textDocument, :uri)
-            @store.get(uri).parse if uri
+            @store.get(URI(uri)).parse if uri
           end
 
           @job_queue << job

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "cgi"
-require "uri"
 require "ruby_lsp/document"
 
 module RubyLsp
@@ -22,24 +20,25 @@ module RubyLsp
       @formatter = T.let("auto", String)
     end
 
-    sig { params(uri: String).returns(Document) }
+    sig { params(uri: URI::Generic).returns(Document) }
     def get(uri)
-      document = @state[uri]
+      path = unescaped_uri_path(uri)
+      document = @state[path]
       return document unless document.nil?
 
-      set(uri: uri, source: File.binread(CGI.unescape(URI.parse(uri).path)), version: 0)
-      T.must(@state[uri])
+      set(uri: uri, source: File.binread(CGI.unescape(path)), version: 0)
+      T.must(@state[path])
     end
 
-    sig { params(uri: String, source: String, version: Integer).void }
+    sig { params(uri: URI::Generic, source: String, version: Integer).void }
     def set(uri:, source:, version:)
       document = Document.new(source: source, version: version, uri: uri, encoding: @encoding)
-      @state[uri] = document
+      @state[unescaped_uri_path(uri)] = document
     end
 
-    sig { params(uri: String, edits: T::Array[Document::EditShape], version: Integer).void }
+    sig { params(uri: URI::Generic, edits: T::Array[Document::EditShape], version: Integer).void }
     def push_edits(uri:, edits:, version:)
-      T.must(@state[uri]).push_edits(edits, version: version)
+      T.must(@state[unescaped_uri_path(uri)]).push_edits(edits, version: version)
     end
 
     sig { void }
@@ -52,21 +51,33 @@ module RubyLsp
       @state.empty?
     end
 
-    sig { params(uri: String).void }
+    sig { params(uri: URI::Generic).void }
     def delete(uri)
-      @state.delete(uri)
+      @state.delete(unescaped_uri_path(uri))
     end
 
     sig do
       type_parameters(:T)
         .params(
-          uri: String,
+          uri: URI::Generic,
           request_name: String,
           block: T.proc.params(document: Document).returns(T.type_parameter(:T)),
         ).returns(T.type_parameter(:T))
     end
     def cache_fetch(uri, request_name, &block)
       get(uri).cache_fetch(request_name, &block)
+    end
+
+    private
+
+    sig { params(uri: URI::Generic).returns(String) }
+    def unescaped_uri_path(uri)
+      # When a file was written to disk, we get a file URI. If it's a temporary file, then the URI is
+      # `untitled:Untitled-1`, where the scheme is `untitled` and the opaque is the name of the temporary file (e.g.
+      # `Untitled-1`).
+      path = uri.path
+      path ||= uri.opaque
+      CGI.unescape(path)
     end
   end
 end

--- a/test/document_test.rb
+++ b/test/document_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 class DocumentTest < Minitest::Test
   def test_valid_incremental_edits
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       def foo
       end
     RUBY
@@ -55,7 +55,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_deletion_full_node
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       def foo
         puts 'a' # comment
       end
@@ -75,7 +75,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_deletion_single_character
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       def foo
         puts 'a'
       end
@@ -95,7 +95,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_add_delete_single_character
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///foo.rb"))
 
     # Add a
     document.push_edits(
@@ -115,7 +115,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_replace
-    document = RubyLsp::Document.new(source: +"puts 'a'", version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +"puts 'a'", version: 1, uri: URI("file:///foo.rb"))
 
     # Replace for puts 'b'
     document.push_edits(
@@ -130,7 +130,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_new_line_and_char_addition
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       # frozen_string_literal: true
 
       class Foo
@@ -169,7 +169,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_multi_cursor_edit
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       # frozen_string_literal: true
 
 
@@ -271,7 +271,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_pushing_edits_to_document_with_unicode
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       chars = ["億"]
     RUBY
 
@@ -320,7 +320,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_parsed_returns_true_when_parsed_successfully
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       # frozen_string_literal: true
       puts 'hello'
     RUBY
@@ -329,7 +329,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_parsed_returns_false_when_parsing_fails
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       class Foo
     RUBY
 
@@ -337,7 +337,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_document_handle_4_byte_unicode_characters
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb", encoding: "utf-16")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"), encoding: "utf-16")
       class Foo
         a = "👋"
       end
@@ -408,7 +408,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_failing_to_parse_indicates_syntax_error
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       def foo
       end
     RUBY
@@ -428,7 +428,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_files_opened_with_syntax_errors_are_properly_marked
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///foo.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"))
       def foo
     RUBY
 
@@ -436,7 +436,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_locate
-    document = RubyLsp::Document.new(source: <<~RUBY, version: 1, uri: "file:///foo/bar.rb")
+    document = RubyLsp::Document.new(source: <<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
       class Post < ActiveRecord::Base
         scope :published do
           # find posts that are published
@@ -477,7 +477,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_locate_returns_nesting
-    document = RubyLsp::Document.new(source: <<~RUBY, version: 1, uri: "file:///foo/bar.rb")
+    document = RubyLsp::Document.new(source: <<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
       module Foo
         class Other
           def do_it
@@ -503,7 +503,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_locate_returns_correct_nesting_when_specifying_target_classes
-    document = RubyLsp::Document.new(source: <<~RUBY, version: 1, uri: "file:///foo/bar.rb")
+    document = RubyLsp::Document.new(source: <<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
       module Foo
         class Bar
           def baz
@@ -519,7 +519,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_reparsing_without_new_edits_does_nothing
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///foo/bar.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///foo/bar.rb"))
     document.push_edits(
       [{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }, text: "def foo" }],
       version: 2,
@@ -531,7 +531,7 @@ class DocumentTest < Minitest::Test
   end
 
   def test_cache_set_and_get
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///foo/bar.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///foo/bar.rb"))
     value = [1, 2, 3]
 
     assert_equal(value, document.cache_set("textDocument/semanticHighlighting", value))

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -127,11 +127,12 @@ class ExecutorTest < Minitest::Test
   end
 
   def test_did_close_clears_diagnostics
-    @store.set(uri: "file:///foo.rb", source: "", version: 1)
+    uri = URI("file:///foo.rb")
+    @store.set(uri: uri, source: "", version: 1)
     @executor.execute({
       method: "textDocument/didClose",
       params: {
-        textDocument: { uri: "file:///foo.rb" },
+        textDocument: { uri: uri.to_s },
       },
     })
 
@@ -139,7 +140,7 @@ class ExecutorTest < Minitest::Test
     assert_equal("textDocument/publishDiagnostics", notification.message)
     assert_empty(T.cast(notification.params, RubyLsp::Interface::PublishDiagnosticsParams).diagnostics)
   ensure
-    @store.delete("file:///foo.rb")
+    @store.delete(uri)
   end
 
   def test_detects_rubocop_if_direct_dependency

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -31,7 +31,7 @@ class ExpectationsTestRunner < Minitest::Test
 
           def run_expectations(source)
             params = @__params&.any? ? @__params : default_args
-            document = RubyLsp::Document.new(source: source, version: 1, uri: "file:///fake.rb")
+            document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
             #{execute_request}
           end
 

--- a/test/requests/code_action_resolve_expectations_test.rb
+++ b/test/requests/code_action_resolve_expectations_test.rb
@@ -9,7 +9,7 @@ class CodeActionResolveExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     params = @__params&.any? ? @__params : default_args
-    document = RubyLsp::Document.new(source: source, version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
 
     RubyLsp::Requests::CodeActionResolve.new(document, params).run
   end

--- a/test/requests/code_actions_expectations_test.rb
+++ b/test/requests/code_actions_expectations_test.rb
@@ -9,7 +9,7 @@ class CodeActionsExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     params = @__params&.any? ? @__params : default_args
-    document = RubyLsp::Document.new(source: source, version: 1, uri: "file:///fake")
+    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake"))
     result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::CodeAction]))
 
     stdout, _ = capture_io do

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -8,7 +8,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeLens, "code_lens"
 
   def run_expectations(source)
-    uri = "file://#{@_path}"
+    uri = URI("file://#{@_path}")
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new
@@ -23,7 +23,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
         def test_bar; end
       end
     RUBY
-    uri = "file:///fake.rb"
+    uri = URI("file:///fake.rb")
 
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
@@ -49,7 +49,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
         def test_bar; end
       end
     RUBY
-    uri = "file:///fake.rb"
+    uri = URI("file:///fake.rb")
 
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
@@ -67,7 +67,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
         def test_bar; end
       end
     RUBY
-    uri = "file:///fake.rb"
+    uri = URI("file:///fake.rb")
 
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
@@ -84,7 +84,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     create_code_lens_extension
 
     store = RubyLsp::Store.new
-    store.set(uri: "file:///fake.rb", source: <<~RUBY, version: 1)
+    store.set(uri: URI("file:///fake.rb"), source: <<~RUBY, version: 1)
       class Test < Minitest::Test; end
     RUBY
 

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -12,7 +12,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     position = @__params&.first || { character: 0, line: 0 }
 
     store = RubyLsp::Store.new
-    store.set(uri: "file:///folder/fake.rb", source: source, version: 1)
+    store.set(uri: URI("file:///folder/fake.rb"), source: source, version: 1)
 
     response = RubyLsp::Executor.new(store, message_queue).execute({
       method: "textDocument/definition",

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -13,7 +13,7 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
       skip("Skipping on Windows: https://github.com/Shopify/ruby-lsp/issues/751")
     end
 
-    document = RubyLsp::Document.new(source: source, version: 1, uri: "file://#{__FILE__}")
+    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file://#{__FILE__}"))
     RubyLsp::Requests::Diagnostics.new(document).run
     result = T.let(nil, T.nilable(T::Array[RubyLsp::Requests::Support::RuboCopDiagnostic]))
 

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -6,14 +6,14 @@ require "test_helper"
 class DiagnosticsTest < Minitest::Test
   def test_empty_diagnostics_for_ignored_file
     fixture_path = File.expand_path("../fixtures/def_multiline_params.rb", __dir__)
-    document = RubyLsp::Document.new(source: File.read(fixture_path), version: 1, uri: "file://#{fixture_path}")
+    document = RubyLsp::Document.new(source: File.read(fixture_path), version: 1, uri: URI("file://#{fixture_path}"))
 
     result = RubyLsp::Requests::Diagnostics.new(document).run
     assert_empty(result)
   end
 
   def test_returns_nil_if_document_is_not_in_project_folder
-    document = RubyLsp::Document.new(source: <<~RUBY, version: 1, uri: "file:///some/other/folder/file.rb")
+    document = RubyLsp::Document.new(source: <<~RUBY, version: 1, uri: URI("file:///some/other/folder/file.rb"))
       def foo
       wrong_indent
       end

--- a/test/requests/document_highlight_expectations_test.rb
+++ b/test/requests/document_highlight_expectations_test.rb
@@ -8,7 +8,7 @@ class DocumentHighlightExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::DocumentHighlight, "document_highlight"
 
   def run_expectations(source)
-    uri = "file://#{@_path}"
+    uri = URI("file://#{@_path}")
     params = @__params&.any? ? @__params : default_args
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
     target, parent = document.locate_node(params.first)

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -22,7 +22,7 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     message_queue = Thread::Queue.new
-    uri = "file://#{@_path}"
+    uri = URI("file://#{@_path}")
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -8,7 +8,7 @@ class FormattingExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Formatting, "formatting"
 
   def run_expectations(source)
-    document = RubyLsp::Document.new(source: source, version: 1, uri: "file://#{__FILE__}")
+    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file://#{__FILE__}"))
     RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run&.first&.new_text
   end
 

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 class FormattingTest < Minitest::Test
   def setup
-    @document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file://#{__FILE__}")
+    @document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file://#{__FILE__}"))
       class Foo
       def foo
       end
@@ -35,7 +35,7 @@ class FormattingTest < Minitest::Test
   end
 
   def test_does_not_format_with_formatter_is_none
-    document = RubyLsp::Document.new(source: "def foo", version: 1, uri: "file://#{__FILE__}")
+    document = RubyLsp::Document.new(source: "def foo", version: 1, uri: URI("file://#{__FILE__}"))
     assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "none").run)
   end
 
@@ -46,7 +46,7 @@ class FormattingTest < Minitest::Test
     TXT
 
     with_syntax_tree_config_file(config_contents) do
-      @document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file://#{__FILE__}")
+      @document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file://#{__FILE__}"))
         class Foo
         def foo
         {one: "#{"a" * 50}", two: "#{"b" * 50}"}
@@ -71,7 +71,7 @@ class FormattingTest < Minitest::Test
 
   def test_syntax_tree_formatting_ignores_syntax_invalid_documents
     require "ruby_lsp/requests"
-    document = RubyLsp::Document.new(source: "def foo", version: 1, uri: "file://#{__FILE__}")
+    document = RubyLsp::Document.new(source: "def foo", version: 1, uri: URI("file://#{__FILE__}"))
     assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "syntax_tree").run)
   end
 
@@ -81,7 +81,7 @@ class FormattingTest < Minitest::Test
     TXT
 
     with_syntax_tree_config_file(config_contents) do
-      @document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file://#{__FILE__}")
+      @document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file://#{__FILE__}"))
         class Foo
         def foo
         end
@@ -92,12 +92,12 @@ class FormattingTest < Minitest::Test
   end
 
   def test_rubocop_formatting_ignores_syntax_invalid_documents
-    document = RubyLsp::Document.new(source: "def foo", version: 1, uri: "file://#{__FILE__}")
+    document = RubyLsp::Document.new(source: "def foo", version: 1, uri: URI("file://#{__FILE__}"))
     assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run)
   end
 
   def test_returns_nil_if_document_is_already_formatted
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file://#{__FILE__}")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file://#{__FILE__}"))
       # typed: strict
       # frozen_string_literal: true
 
@@ -110,7 +110,7 @@ class FormattingTest < Minitest::Test
   end
 
   def test_returns_nil_if_document_is_not_in_project_folder
-    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +<<~RUBY, version: 1, uri: URI("file:///fake.rb"))
       class Foo
       def foo
       end

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -18,7 +18,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
   def test_search_index_being_nil
     message_queue = Thread::Queue.new
     store = RubyLsp::Store.new
-    store.set(uri: "file:///fake.rb", source: "belongs_to :foo", version: 1)
+    store.set(uri: URI("file:///fake.rb"), source: "belongs_to :foo", version: 1)
 
     RubyLsp::Requests::Support::RailsDocumentClient.stubs(search_index: nil)
     RubyLsp::Executor.new(store, message_queue).execute({
@@ -47,7 +47,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
     Net::HTTP.stubs(get_response: fake_response)
     store = RubyLsp::Store.new
-    store.set(uri: "file:///fake.rb", source: source, version: 1)
+    store.set(uri: URI("file:///fake.rb"), source: source, version: 1)
 
     RubyLsp::Executor.new(store, message_queue).execute({
       method: "textDocument/hover",
@@ -65,7 +65,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
     Net::HTTP.stubs(get_response: fake_response)
 
     store = RubyLsp::Store.new
-    store.set(uri: "file:///fake.rb", source: <<~RUBY, version: 1)
+    store.set(uri: URI("file:///fake.rb"), source: <<~RUBY, version: 1)
       class Post
         belongs_to :user
       end

--- a/test/requests/inlay_hints_expectations_test.rb
+++ b/test/requests/inlay_hints_expectations_test.rb
@@ -10,7 +10,7 @@ class InlayHintsExpectationsTest < ExpectationsTestRunner
   def run_expectations(source)
     message_queue = Thread::Queue.new
     params = @__params&.any? ? @__params : default_args
-    uri = "file://#{@_path}"
+    uri = URI("file://#{@_path}")
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 
 class OnTypeFormattingTest < Minitest::Test
   def test_adding_missing_ends
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     document.push_edits(
       [{
@@ -31,7 +31,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_adding_missing_curly_brace_in_string_interpolation
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     document.push_edits(
       [{
@@ -57,7 +57,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_adding_missing_pipe
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     document.push_edits(
       [{
@@ -83,7 +83,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_pipe_is_not_added_in_regular_or_pipe
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     document.push_edits(
       [{
@@ -99,7 +99,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_pipe_is_removed_if_user_adds_manually_after_completion
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     document.push_edits(
       [{
@@ -155,7 +155,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_comment_continuation
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     document.push_edits(
       [{
@@ -181,7 +181,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_keyword_handling
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     document.push_edits(
       [{
@@ -197,7 +197,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_comment_continuation_with_other_line_break_matches
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     # If the current comment line has another word we match for, such as `while`, we still only want to complete the new
     # comment, but avoid adding an incorrect end to the comment's `while` word
@@ -225,7 +225,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_comment_continuation_when_inserting_new_line_in_the_middle
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     # When inserting a new line between while and blah, the document will have a syntax error momentarily before we auto
     # insert the comment continuation. We must avoid accidentally trying to add an `end` token to `while` while the
@@ -254,7 +254,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_breaking_line_between_keyword_and_more_content
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     document.push_edits(
       [{
@@ -281,7 +281,7 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_breaking_line_between_keyword_when_there_is_content_on_the_next_line
-    document = RubyLsp::Document.new(source: +"", version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
 
     document.push_edits(
       [{

--- a/test/requests/path_completion_test.rb
+++ b/test/requests/path_completion_test.rb
@@ -6,7 +6,7 @@ require "test_helper"
 class PathCompletionTest < Minitest::Test
   def setup
     @message_queue = Thread::Queue.new
-    @uri = "file:///fake.rb"
+    @uri = URI("file:///fake.rb")
     @store = RubyLsp::Store.new
   end
 
@@ -35,7 +35,7 @@ class PathCompletionTest < Minitest::Test
       @store.set(uri: @uri, source: document.source, version: 1)
       RubyLsp::Executor.new(@store, @message_queue).execute({
         method: "textDocument/completion",
-        params: { textDocument: { uri: @uri }, position: end_position },
+        params: { textDocument: { uri: @uri.to_s }, position: end_position },
       }).response
     end
 
@@ -71,7 +71,7 @@ class PathCompletionTest < Minitest::Test
       @store.set(uri: @uri, source: document.source, version: 1)
       RubyLsp::Executor.new(@store, @message_queue).execute({
         method: "textDocument/completion",
-        params: { textDocument: { uri: @uri }, position: end_position },
+        params: { textDocument: { uri: @uri.to_s }, position: end_position },
       }).response
     end
 
@@ -107,7 +107,7 @@ class PathCompletionTest < Minitest::Test
       @store.set(uri: @uri, source: document.source, version: 1)
       RubyLsp::Executor.new(@store, @message_queue).execute({
         method: "textDocument/completion",
-        params: { textDocument: { uri: @uri }, position: end_position },
+        params: { textDocument: { uri: @uri.to_s }, position: end_position },
       }).response
     end
 
@@ -143,7 +143,7 @@ class PathCompletionTest < Minitest::Test
       @store.set(uri: @uri, source: document.source, version: 1)
       RubyLsp::Executor.new(@store, @message_queue).execute({
         method: "textDocument/completion",
-        params: { textDocument: { uri: @uri }, position: end_position },
+        params: { textDocument: { uri: @uri.to_s }, position: end_position },
       }).response
     end
 
@@ -171,7 +171,7 @@ class PathCompletionTest < Minitest::Test
     @store.set(uri: @uri, source: document.source, version: 1)
     RubyLsp::Executor.new(@store, @message_queue).execute({
       method: "textDocument/completion",
-      params: { textDocument: { uri: @uri }, position: end_position },
+      params: { textDocument: { uri: @uri.to_s }, position: end_position },
     }).response
   end
 
@@ -188,7 +188,7 @@ class PathCompletionTest < Minitest::Test
     @store.set(uri: @uri, source: document.source, version: 1)
     response = RubyLsp::Executor.new(@store, @message_queue).execute({
       method: "textDocument/completion",
-      params: { textDocument: { uri: @uri }, position: end_position },
+      params: { textDocument: { uri: @uri.to_s }, position: end_position },
     }).response
     assert_nil(response)
   end

--- a/test/requests/selection_ranges_expectations_test.rb
+++ b/test/requests/selection_ranges_expectations_test.rb
@@ -8,7 +8,7 @@ class SelectionRangesExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::SelectionRanges, "selection_ranges"
 
   def run_expectations(source)
-    document = RubyLsp::Document.new(source: source, version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
     actual = RubyLsp::Requests::SelectionRanges.new(document).run
     params = @__params&.any? ? @__params : default_args
 

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -9,7 +9,7 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     message_queue = Thread::Queue.new
-    document = RubyLsp::Document.new(source: source, version: 1, uri: "file:///fake.rb")
+    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
     range = @__params&.any? ? @__params.first : nil
 
     if range

--- a/test/requests/show_syntax_tree_test.rb
+++ b/test/requests/show_syntax_tree_test.rb
@@ -14,7 +14,7 @@ class ShowSyntaxTreeTest < Minitest::Test
 
   def test_returns_nil_if_document_has_syntax_error
     store = RubyLsp::Store.new
-    store.set(uri: "file:///fake.rb", source: "foo do", version: 1)
+    store.set(uri: URI("file:///fake.rb"), source: "foo do", version: 1)
     response = RubyLsp::Executor.new(store, @message_queue).execute({
       method: "rubyLsp/textDocument/showSyntaxTree",
       params: { textDocument: { uri: "file:///fake.rb" } },
@@ -25,8 +25,8 @@ class ShowSyntaxTreeTest < Minitest::Test
 
   def test_returns_ast_if_document_is_parsed
     store = RubyLsp::Store.new
-    store.set(uri: "file:///fake.rb", source: "foo = 123", version: 1)
-    document = store.get("file:///fake.rb")
+    store.set(uri: URI("file:///fake.rb"), source: "foo = 123", version: 1)
+    document = store.get(URI("file:///fake.rb"))
     document.parse
 
     response = RubyLsp::Executor.new(store, @message_queue).execute({
@@ -40,13 +40,14 @@ class ShowSyntaxTreeTest < Minitest::Test
   end
 
   def test_returns_ast_for_a_selection
+    uri = URI("file:///fake.rb")
     store = RubyLsp::Store.new
-    store.set(uri: "file:///fake.rb", source: <<~RUBY, version: 1)
+    store.set(uri: uri, source: <<~RUBY, version: 1)
       foo = 123
       bar = 456
       hello = 123
     RUBY
-    document = store.get("file:///fake.rb")
+    document = store.get(uri)
     document.parse
 
     response = RubyLsp::Executor.new(store, @message_queue).execute({


### PR DESCRIPTION
### Motivation

Closes #709
Closes #781

Representing URIs with strings is incorrect. We should always rely on `URI` to get the correct file paths and further we delay this change, the more entangled it might become.

There are already two issues related to this: not handling spaces properly and being unable to support unsaved files (#633).

### Implementation

The most important changes are in `Store` and `Executor`. Everything else is pretty much just adapting the types from `String` to `URI::Generic`.

One thing to note is that for unsaved files the URI is `untitled:Untitled-1`, which has path as `nil` an `opaque` as the filename (`Untitled-1`).

This is a breaking change because extensions will no longer receive a URI string, but a URI object instead.

### Automated Tests

Adapted all tests to use URI objects.