### PR TITLE
Test against Ruby head and use 3.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["3.0", "3.1", "3.2"]
-        exclude:
-          - os: windows-latest
-            ruby: "3.3"
+        ruby: ["3.0", "3.1", "3.2", "head"]
+        include:
+          - ruby: "head"
+            experimental: true
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ !!matrix.experimental }}
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: ruby-lsp
 type: ruby
 
 up:
-  - ruby: '3.3.0-preview1'
+  - ruby: '3.2.2'
   - bundler:
       gemfile: Gemfile
 


### PR DESCRIPTION
### Motivation

We'll be able to catch more errors/changes if we continuously test against Ruby head than by continuously developing against the same preview version. Also, the preview version is sometimes causing compilation issues for certain gems.