### PR TITLE
Add .irbrc to customise IRB for the project

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require_relative "lib/ruby_lsp/internal"
+
+IRB.conf[:IRB_NAME] = IRB::Color.colorize("ruby-lsp", [:BLUE, :BOLD])
+IRB.conf[:HISTORY_FILE] = "~/.irb_history"

--- a/bin/console
+++ b/bin/console
@@ -1,9 +1,0 @@
-#!/usr/bin/env ruby
-# typed: strict
-# frozen_string_literal: true
-
-require "bundler/setup"
-require_relative "../lib/ruby_lsp/internal"
-require "irb"
-
-IRB.start(__FILE__)


### PR DESCRIPTION
### Motivation

@vinistock mentioned that he often forgot to use `bin/console` and used `irb` directly, and then needed to require RubyLsp manually. I also share the same experience, so I'd like to customise IRB for the project with `.irbrc`.

### Implementation

- Add `.irbrc` to the project that
    - Require `ruby_lsp/internal` so `RubyLsp` is right away accessible
    - Change IRB's prompt so it's clearer that it's started with `RubyLsp` loaded.

**Result**

![Screenshot 2023-08-08 at 16 32 51](https://github.com/Shopify/ruby-lsp/assets/5079556/9bb83586-ac52-434c-9372-abf7e1579715)

There are some gotchas though, which I'd like to improve on the IRB side:

- If the user has `~/.irbrc`, IRB doesn't read `PROJECT/.irbrc`. I think this doesn't provide a good experience so I'd like to propose a change on it.
    - For this reason, I'd like to keep `bin/console` until IRB updates it
- When the project has local IRB config, IRB also stores IRB history locally with `PROJECT/.irb_history`. So we need to add it to gitignore.

### Manual Tests

Pull the branch and run `$ irb` in the terminal.
