### PR TITLE
Remove unnecessary `uri.to_s` in integration tests

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -64,7 +64,7 @@ class IntegrationTest < Minitest::Test
 
     assert_telemetry("textDocument/didOpen")
 
-    response = make_request("textDocument/documentSymbol", { textDocument: { uri: @uri.to_s } })
+    response = make_request("textDocument/documentSymbol", { textDocument: { uri: @uri } })
     symbol = response[:result].first
     assert_equal("Foo", symbol[:name])
     assert_equal(RubyLsp::Requests::DocumentSymbol::SYMBOL_KIND[:class], symbol[:kind])
@@ -78,7 +78,7 @@ class IntegrationTest < Minitest::Test
 
     response = make_request(
       "textDocument/documentHighlight",
-      { textDocument: { uri: @uri.to_s }, position: { line: 0, character: 1 } },
+      { textDocument: { uri: @uri }, position: { line: 0, character: 1 } },
     )
 
     range = response[:result].first
@@ -93,7 +93,7 @@ class IntegrationTest < Minitest::Test
 
     response = make_request(
       "textDocument/hover",
-      { textDocument: { uri: @uri.to_s }, position: { line: 0, character: 1 } },
+      { textDocument: { uri: @uri }, position: { line: 0, character: 1 } },
     )
 
     assert_nil(response[:result])
@@ -108,7 +108,7 @@ class IntegrationTest < Minitest::Test
 
     response = make_request(
       "textDocument/definition",
-      { textDocument: { uri: @uri.to_s }, position: { line: 0, character: 20 } },
+      { textDocument: { uri: @uri }, position: { line: 0, character: 20 } },
     )
 
     assert_nil(response[:error])
@@ -121,7 +121,7 @@ class IntegrationTest < Minitest::Test
 
     response = make_request(
       "textDocument/documentHighlight",
-      { textDocument: { uri: @uri.to_s }, position: { line: 0, character: 1 } },
+      { textDocument: { uri: @uri }, position: { line: 0, character: 1 } },
     )
 
     assert_nil(response[:result])
@@ -134,7 +134,7 @@ class IntegrationTest < Minitest::Test
 
     assert_telemetry("textDocument/didOpen")
 
-    response = make_request("textDocument/semanticTokens/full", { textDocument: { uri: @uri.to_s } })
+    response = make_request("textDocument/semanticTokens/full", { textDocument: { uri: @uri } })
     assert_equal([0, 6, 3, 2, 1], response[:result][:data])
   end
 
@@ -148,7 +148,7 @@ class IntegrationTest < Minitest::Test
 
     assert_telemetry("textDocument/didOpen")
 
-    response = make_request("textDocument/documentLink", { textDocument: { uri: @uri.to_s } })
+    response = make_request("textDocument/documentLink", { textDocument: { uri: @uri } })
     assert_match(/syntax_tree/, response.dig(:result, 0, :target))
   end
 
@@ -158,7 +158,7 @@ class IntegrationTest < Minitest::Test
 
     assert_telemetry("textDocument/didOpen")
 
-    response = make_request("textDocument/formatting", { textDocument: { uri: @uri.to_s } })
+    response = make_request("textDocument/formatting", { textDocument: { uri: @uri } })
     assert_equal(<<~FORMATTED, response[:result].first[:newText])
       # typed: true
       # frozen_string_literal: true
@@ -176,7 +176,7 @@ class IntegrationTest < Minitest::Test
 
     response = make_request(
       "textDocument/onTypeFormatting",
-      { textDocument: { uri: @uri.to_s, position: { line: 0, character: 0 }, character: "\n" } },
+      { textDocument: { uri: @uri, position: { line: 0, character: 0 }, character: "\n" } },
     )
     assert_nil(response[:result])
   end
@@ -190,7 +190,7 @@ class IntegrationTest < Minitest::Test
     response = make_request(
       "textDocument/codeAction",
       {
-        textDocument: { uri: @uri.to_s },
+        textDocument: { uri: @uri },
         range: { start: { line: 2 }, end: { line: 4 } },
         context: {
           diagnostics: [
@@ -209,7 +209,7 @@ class IntegrationTest < Minitest::Test
                   edit: {
                     documentChanges: [
                       {
-                        textDocument: { uri: @uri.to_s, version: nil },
+                        textDocument: { uri: @uri, version: nil },
                         edits: [
                           {
                             range: {
@@ -249,7 +249,7 @@ class IntegrationTest < Minitest::Test
         kind: "refactor.extract",
         data: {
           range: { start: { line: 1, character: 1 }, end: { line: 1, character: 3 } },
-          uri: @uri.to_s,
+          uri: @uri,
         },
       },
     )
@@ -262,7 +262,7 @@ class IntegrationTest < Minitest::Test
 
     assert_telemetry("textDocument/didOpen")
 
-    assert(send_request("textDocument/didClose", { textDocument: { uri: @uri.to_s } }))
+    assert(send_request("textDocument/didClose", { textDocument: { uri: @uri } }))
   end
 
   def test_document_did_change
@@ -272,7 +272,7 @@ class IntegrationTest < Minitest::Test
     assert(send_request(
       "textDocument/didChange",
       {
-        textDocument: { uri: @uri.to_s },
+        textDocument: { uri: @uri },
         contentChanges: [{
           text: "class Foo\ndef bar\nend\nend",
           range: { start: { line: 0, character: 0 }, end: { line: 1, character: 3 } },
@@ -287,7 +287,7 @@ class IntegrationTest < Minitest::Test
 
     assert_telemetry("textDocument/didOpen")
 
-    response = make_request("textDocument/foldingRange", { textDocument: { uri: @uri.to_s } })
+    response = make_request("textDocument/foldingRange", { textDocument: { uri: @uri } })
     assert_equal({ startLine: 0, endLine: 1, kind: "region" }, response[:result].first)
   end
 
@@ -297,7 +297,7 @@ class IntegrationTest < Minitest::Test
 
     assert_telemetry("textDocument/didOpen")
 
-    response = make_request("textDocument/codeLens", { textDocument: { uri: @uri.to_s } })
+    response = make_request("textDocument/codeLens", { textDocument: { uri: @uri } })
     assert_empty(response[:result])
   end
 
@@ -305,7 +305,7 @@ class IntegrationTest < Minitest::Test
     initialize_lsp(["foldingRanges"])
     open_file_with("class Foo\n\nend")
 
-    send_request("textDocument/foldingRange", { textDocument: { uri: @uri.to_s } })
+    send_request("textDocument/foldingRange", { textDocument: { uri: @uri } })
 
     assert_telemetry("textDocument/didOpen")
 
@@ -323,7 +323,7 @@ class IntegrationTest < Minitest::Test
     response = make_request(
       "textDocument/selectionRange",
       {
-        textDocument: { uri: @uri.to_s },
+        textDocument: { uri: @uri },
         positions: [{ line: 0, character: 0 }],
       },
     )
@@ -341,7 +341,7 @@ class IntegrationTest < Minitest::Test
     response = make_request(
       "textDocument/selectionRange",
       {
-        textDocument: { uri: @uri.to_s },
+        textDocument: { uri: @uri },
         positions: [{ line: 0, character: 0 }],
       },
     )
@@ -356,7 +356,7 @@ class IntegrationTest < Minitest::Test
 
     assert_telemetry("textDocument/didOpen")
 
-    response = make_request("textDocument/diagnostic", { textDocument: { uri: @uri.to_s } })
+    response = make_request("textDocument/diagnostic", { textDocument: { uri: @uri } })
 
     assert_equal("full", response.dig(:result, :kind))
     refute_empty(response.dig(:result, :items))
@@ -432,6 +432,6 @@ class IntegrationTest < Minitest::Test
   end
 
   def open_file_with(content)
-    make_request("textDocument/didOpen", { textDocument: { uri: @uri.to_s, text: content } })
+    make_request("textDocument/didOpen", { textDocument: { uri: @uri, text: content } })
   end
 end


### PR DESCRIPTION
### Motivation

In integration tests, the arguments are turned into JSON, so there's no need to invoke `to_s`.