### PR TITLE
Migrate show syntax tree to YARP

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -32,7 +32,7 @@ module RubyLsp
       @parse_result = T.let(YARP.parse(@source), YARP::ParseResult)
     end
 
-    sig { returns(YARP::Node) }
+    sig { returns(YARP::ProgramNode) }
     def tree
       @parse_result.value
     end

--- a/lib/ruby_lsp/requests/show_syntax_tree.rb
+++ b/lib/ruby_lsp/requests/show_syntax_tree.rb
@@ -29,7 +29,6 @@ module RubyLsp
 
       sig { override.returns(String) }
       def run
-        return "Document contains syntax error" if @document.syntax_error?
         return ast_for_range if @range
 
         output_string = +""
@@ -47,7 +46,7 @@ module RubyLsp
         start_char = scanner.find_char_position(range[:start])
         end_char = scanner.find_char_position(range[:end])
 
-        queue = T.cast(@document.tree, SyntaxTree::Program).statements.body.dup
+        queue = @document.tree.statements.body.dup
         found_nodes = []
 
         until queue.empty?
@@ -58,7 +57,7 @@ module RubyLsp
 
           # If the node is fully covered by the selection, then we found one of the nodes to be displayed and don't want
           # to continue descending into its children
-          if (start_char..end_char).cover?(loc.start_char..loc.end_char)
+          if (start_char..end_char).cover?(loc.start_offset..loc.end_offset)
             found_nodes << node
           else
             queue.unshift(*node.child_nodes)

--- a/sorbet/rbi/shims/yarp.rbi
+++ b/sorbet/rbi/shims/yarp.rbi
@@ -7,7 +7,7 @@ module YARP
   end
 
   class ParseResult
-    sig { returns(YARP::Node) }
+    sig { returns(YARP::ProgramNode) }
     def value; end
 
     sig { returns(T::Boolean) }

--- a/test/requests/show_syntax_tree_test.rb
+++ b/test/requests/show_syntax_tree_test.rb
@@ -12,7 +12,7 @@ class ShowSyntaxTreeTest < Minitest::Test
     @message_queue.close
   end
 
-  def test_returns_nil_if_document_has_syntax_error
+  def test_returns_partial_tree_if_document_has_syntax_error
     store = RubyLsp::Store.new
     store.set(uri: URI("file:///fake.rb"), source: "foo do", version: 1)
     response = RubyLsp::Executor.new(store, @message_queue).execute({
@@ -20,7 +20,30 @@ class ShowSyntaxTreeTest < Minitest::Test
       params: { textDocument: { uri: "file:///fake.rb" } },
     }).response
 
-    assert_equal("Document contains syntax error", response[:ast])
+    assert_equal(<<~AST, response[:ast])
+      ProgramNode(0...6)(
+        [],
+        StatementsNode(0...6)(
+          [CallNode(0...6)(
+             nil,
+             nil,
+             (0...3),
+             nil,
+             nil,
+             nil,
+             BlockNode(4...6)(
+               [],
+               nil,
+               StatementsNode(4...6)([MissingNode(4...6)()]),
+               (4...6),
+               (6...6)
+             ),
+             0,
+             \"foo\"
+           )]
+        )
+      )
+    AST
   end
 
   def test_returns_ast_if_document_is_parsed
@@ -35,7 +58,18 @@ class ShowSyntaxTreeTest < Minitest::Test
     }).response
 
     assert_equal(<<~AST, response[:ast])
-      (program (statements ((assign (var_field (ident "foo")) (int "123")))))
+      ProgramNode(0...9)(
+        [:foo],
+        StatementsNode(0...9)(
+          [LocalVariableWriteNode(0...9)(
+             :foo,
+             0,
+             IntegerNode(6...9)(),
+             (0...3),
+             (4...5)
+           )]
+        )
+      )
     AST
   end
 
@@ -59,10 +93,18 @@ class ShowSyntaxTreeTest < Minitest::Test
     }).response
 
     assert_equal(<<~AST, response[:ast])
-      (assign (var_field (ident "foo")) (int "123"))
+      LocalVariableWriteNode(0...9)(:foo, 0, IntegerNode(6...9)(), (0...3), (4...5))
 
-      (assign (var_field (ident "bar")) (int "456"))
+      LocalVariableWriteNode(10...19)(
+        :bar,
+        0,
+        IntegerNode(16...19)(),
+        (10...13),
+        (14...15)
+      )
     AST
+
+    # We execute twice just to make sure we do not mutate by mistake.
 
     response = RubyLsp::Executor.new(store, @message_queue).execute({
       method: "rubyLsp/textDocument/showSyntaxTree",


### PR DESCRIPTION
Cherry-picked from @vinistock's PR then updated.

`bin/test test/requests/show_syntax_tree_test.rb ` is passing.

Partially addresses https://github.com/Shopify/ruby-lsp/issues/449