### PR TITLE
Migrate path completion to YARP

### DIFF
--- a/lib/ruby_lsp/event_emitter.rb
+++ b/lib/ruby_lsp/event_emitter.rb
@@ -42,7 +42,7 @@ module RubyLsp
       when YARP::ConstantPathNode
         @listeners[:on_constant_path_node]&.each { |l| T.unsafe(l).on_constant_path_node(node) }
       when YARP::StringNode
-        @listeners[:on_string_node]&.each { |l| T.unsafe(l).on_string_node(node) }
+        @listeners[:on_string]&.each { |l| T.unsafe(l).on_string(node) }
       end
     end
 

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -396,42 +396,29 @@ module RubyLsp
     end
     def completion(uri, position)
       document = @store.get(uri)
-      return unless document.parsed?
 
       char_position = document.create_scanner.find_char_position(position)
-      matched, parent = document.locate(
-        T.must(document.tree),
-        char_position,
-        node_types: [SyntaxTree::Command, SyntaxTree::CommandCall, SyntaxTree::CallNode],
-      )
-
+      matched, parent =
+        document.locate(document.tree, char_position, node_types: [YARP::CallNode])
       return unless matched && parent
 
-      target = case matched
-      when SyntaxTree::Command, SyntaxTree::CallNode, SyntaxTree::CommandCall
-        message = matched.message
-        return if message.is_a?(Symbol)
-        return unless message.value == "require"
+      message = matched.message
+      return unless message == "require"
 
-        args = matched.arguments
-        args = args.arguments if args.is_a?(SyntaxTree::ArgParen)
-        return if args.nil? || args.is_a?(SyntaxTree::ArgsForward)
+      args = matched.arguments
+      return unless args
 
-        argument = args.parts.first
-        return unless argument.is_a?(SyntaxTree::StringLiteral)
+      args = args.arguments
+      return if args.is_a?(YARP::ForwardingArgumentsNode)
 
-        path_node = argument.parts.first
-        return unless path_node.is_a?(SyntaxTree::TStringContent)
-        return unless (path_node.location.start_char..path_node.location.end_char).cover?(char_position)
+      argument = args.first
+      return unless argument.is_a?(YARP::StringNode)
 
-        path_node
-      end
-
-      return unless target
+      return unless (argument.location.start_offset..argument.location.end_offset).cover?(char_position)
 
       emitter = EventEmitter.new
       listener = Requests::PathCompletion.new(emitter, @message_queue)
-      emitter.emit_for_target(target)
+      emitter.emit_for_target(argument)
       listener.response
     end
 

--- a/lib/ruby_lsp/requests/path_completion.rb
+++ b/lib/ruby_lsp/requests/path_completion.rb
@@ -28,12 +28,12 @@ module RubyLsp
         @response = T.let([], ResponseType)
         @tree = T.let(Support::PrefixTree.new(collect_load_path_files), Support::PrefixTree)
 
-        emitter.register(self, :on_tstring_content)
+        emitter.register(self, :on_string)
       end
 
-      sig { params(node: SyntaxTree::TStringContent).void }
-      def on_tstring_content(node)
-        @tree.search(node.value).sort.each do |path|
+      sig { params(node: YARP::StringNode).void }
+      def on_string(node)
+        @tree.search(node.content).sort.each do |path|
           @response << build_completion(path, node)
         end
       end
@@ -49,12 +49,13 @@ module RubyLsp
         end
       end
 
-      sig { params(label: String, node: SyntaxTree::TStringContent).returns(Interface::CompletionItem) }
+      sig { params(label: String, node: YARP::StringNode).returns(Interface::CompletionItem) }
       def build_completion(label, node)
+        # debugger
         Interface::CompletionItem.new(
           label: label,
           text_edit: Interface::TextEdit.new(
-            range: range_from_syntax_tree_node(node),
+            range: range_from_location(node.content_loc),
             new_text: label,
           ),
           kind: Constant::CompletionItemKind::REFERENCE,

--- a/test/requests/path_completion_test.rb
+++ b/test/requests/path_completion_test.rb
@@ -27,7 +27,7 @@ class PathCompletionTest < Minitest::Test
     }
     end_position = {
       line: 0,
-      character: document.source.rindex('"'),
+      character: T.must(document.source.rindex('"')) - 1,
     }
 
     result = with_file_structure do
@@ -64,7 +64,7 @@ class PathCompletionTest < Minitest::Test
     }
     end_position = {
       line: 0,
-      character: document.source.rindex('"'),
+      character: T.must(document.source.rindex('"')) - 1,
     }
 
     result = with_file_structure do
@@ -100,7 +100,7 @@ class PathCompletionTest < Minitest::Test
     }
     end_position = {
       line: 0,
-      character: document.source.rindex('"'),
+      character: T.must(document.source.rindex('"')) - 1,
     }
 
     result = with_file_structure do
@@ -136,7 +136,7 @@ class PathCompletionTest < Minitest::Test
     }
     end_position = {
       line: 0,
-      character: document.source.rindex('"'),
+      character: T.must(document.source.rindex('"')) - 1,
     }
 
     result = with_file_structure do


### PR DESCRIPTION
Partially addresses https://github.com/Shopify/ruby-lsp/pull/873

Co-authored with @bitwise-aiden, cherry-picked from @vinistock's WIP version, then updated.

`bin/test test/requests/path_completion_test.rb` is passing