### PR TITLE
Perform initial indexing and synchronization

### DIFF
--- a/.index.yml
+++ b/.index.yml
@@ -1,0 +1,2 @@
+excluded_patterns:
+  - "**/test/fixtures/**/*.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -7,21 +7,23 @@ gemspec
 # sorbet-static is not available on Windows. We also skip Tapioca since it depends on sorbet-static-and-runtime
 NON_WINDOWS_PLATFORMS = [:ruby] # C Ruby (MRI), Rubinius or TruffleRuby, but NOT Windows
 
-gem "bundler", "~> 2.4.2"
-gem "debug", "~> 1.8", require: false
-gem "minitest", "~> 5.19"
-gem "minitest-reporters", "~> 1.6"
-gem "mocha", "~> 2.1"
-gem "rake", "~> 13.0"
-gem "rubocop", "~> 1.56"
-gem "rubocop-shopify", "~> 2.14", require: false
-gem "rubocop-minitest", "~> 0.31.0", require: false
-gem "rubocop-rake", "~> 0.6.0", require: false
-gem "rubocop-sorbet", "~> 0.7", require: false
-gem "sorbet-static-and-runtime", platforms: NON_WINDOWS_PLATFORMS
-gem "tapioca", "~> 0.11", require: false, platforms: NON_WINDOWS_PLATFORMS
-gem "rdoc", require: false
-gem "psych", "~> 5.1", require: false
+group :development do
+  gem "bundler", "~> 2.4.2"
+  gem "debug", "~> 1.8", require: false
+  gem "minitest", "~> 5.19"
+  gem "minitest-reporters", "~> 1.6"
+  gem "mocha", "~> 2.1"
+  gem "rake", "~> 13.0"
+  gem "rubocop", "~> 1.56"
+  gem "rubocop-shopify", "~> 2.14", require: false
+  gem "rubocop-minitest", "~> 0.31.0", require: false
+  gem "rubocop-rake", "~> 0.6.0", require: false
+  gem "rubocop-sorbet", "~> 0.7", require: false
+  gem "sorbet-static-and-runtime", platforms: NON_WINDOWS_PLATFORMS
+  gem "tapioca", "~> 0.11", require: false, platforms: NON_WINDOWS_PLATFORMS
+  gem "rdoc", require: false
+  gem "psych", "~> 5.1", require: false
 
-# The Rails documentation link only activates when railties is detected.
-gem "railties", "~> 7.0", require: false
+  # The Rails documentation link only activates when railties is detected.
+  gem "railties", "~> 7.0", require: false
+end

--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -5,16 +5,55 @@ module RubyIndexer
   class Configuration
     extend T::Sig
 
-    sig { returns(T::Array[String]) }
-    attr_accessor :files_to_index
-
     sig { void }
     def initialize
-      files_to_index = $LOAD_PATH.flat_map { |p| Dir.glob("#{p}/**/*.rb", base: p) }
-      files_to_index.concat(Dir.glob("#{Dir.pwd}/**/*.rb"))
-      files_to_index.reject! { |path| path.end_with?("_test.rb") }
+      development_only_dependencies = Bundler.definition.dependencies.filter_map do |dependency|
+        dependency.name if dependency.groups == [:development]
+      end
 
-      @files_to_index = T.let(files_to_index, T::Array[String])
+      @excluded_gems = T.let(development_only_dependencies, T::Array[String])
+      @included_gems = T.let([], T::Array[String])
+      @excluded_patterns = T.let(["*_test.rb"], T::Array[String])
+      @included_patterns = T.let(["#{Dir.pwd}/**/*.rb"], T::Array[String])
+    end
+
+    sig { params(config: T::Hash[String, T.untyped]).void }
+    def apply_config(config)
+      excluded_gems = config.delete("excluded_gems")
+      @excluded_gems.concat(excluded_gems) if excluded_gems
+
+      included_gems = config.delete("included_gems")
+      @included_gems.concat(included_gems) if included_gems
+
+      excluded_patterns = config.delete("excluded_patterns")
+      @excluded_patterns.concat(excluded_patterns) if excluded_patterns
+
+      included_patterns = config.delete("included_patterns")
+      @included_patterns.concat(included_patterns) if included_patterns
+
+      raise ArgumentError, "Unknown configuration options: #{config.keys.join(", ")}" if config.any?
+    end
+
+    sig { returns(T::Array[String]) }
+    def files_to_index
+      files_to_index = $LOAD_PATH.flat_map { |p| Dir.glob("#{p}/**/*.rb", base: p) }
+
+      @included_patterns.each do |pattern|
+        files_to_index.concat(Dir.glob(pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB))
+      end
+
+      excluded_gem_paths = (@excluded_gems - @included_gems).filter_map do |gem_name|
+        Gem::Specification.find_by_name(gem_name).full_gem_path
+      rescue Gem::MissingSpecError
+        warn("Gem #{gem_name} is excluded in .index.yml, but that gem was not found in the bundle")
+      end
+
+      files_to_index.reject! do |path|
+        @excluded_patterns.any? { |pattern| File.fnmatch?(pattern, path, File::FNM_PATHNAME | File::FNM_EXTGLOB) } ||
+          excluded_gem_paths.any? { |gem_path| File.fnmatch?("#{gem_path}/**/*.rb", path) }
+      end
+      files_to_index.uniq!
+      files_to_index
     end
   end
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -5,9 +5,6 @@ module RubyIndexer
   class Index
     extend T::Sig
 
-    sig { returns(T::Hash[String, T::Array[Entry]]) }
-    attr_reader :entries
-
     sig { void }
     def initialize
       # Holds all entries in the index using the following format:
@@ -70,9 +67,16 @@ module RubyIndexer
       nil
     end
 
-    sig { void }
-    def clear
-      @entries.clear
+    sig { params(paths: T::Array[String]).void }
+    def index_all(paths: RubyIndexer.configuration.files_to_index)
+      paths.each { |path| index_single(path) }
+    end
+
+    sig { params(path: String, source: T.nilable(String)).void }
+    def index_single(path, source = nil)
+      content = source || File.read(path)
+      visitor = IndexVisitor.new(self, YARP.parse(content), path)
+      visitor.run
     end
 
     class Entry

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -11,14 +11,6 @@ module RubyIndexer
   class << self
     extend T::Sig
 
-    sig { void }
-    def load_configuration_file
-      return unless File.exist?(".index.yml")
-
-      config = YAML.parse_file(".index.yml")
-      configuration.apply_config(config.to_ruby) if config
-    end
-
     sig { returns(Configuration) }
     def configuration
       @configuration ||= T.let(Configuration.new, T.nilable(Configuration))

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "yaml"
+
 require "ruby_indexer/lib/ruby_indexer/visitor"
 require "ruby_indexer/lib/ruby_indexer/index"
 require "ruby_indexer/lib/ruby_indexer/configuration"
@@ -9,28 +11,17 @@ module RubyIndexer
   class << self
     extend T::Sig
 
-    sig { params(block: T.proc.params(configuration: Configuration).void).void }
-    def configure(&block)
-      block.call(configuration)
+    sig { void }
+    def load_configuration_file
+      return unless File.exist?(".index.yml")
+
+      config = YAML.parse_file(".index.yml")
+      configuration.apply_config(config.to_ruby) if config
     end
 
     sig { returns(Configuration) }
     def configuration
       @configuration ||= T.let(Configuration.new, T.nilable(Configuration))
-    end
-
-    sig { params(paths: T::Array[String]).returns(Index) }
-    def index(paths = configuration.files_to_index)
-      index = Index.new
-      paths.each { |path| index_single(index, path) }
-      index
-    end
-
-    sig { params(index: Index, path: String, source: T.nilable(String)).void }
-    def index_single(index, path, source = nil)
-      content = source || File.read(path)
-      visitor = IndexVisitor.new(index, YARP.parse(content), path)
-      visitor.run
     end
   end
 end

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -9,10 +9,6 @@ module RubyIndexer
       @index = Index.new
     end
 
-    def teardown
-      @index.clear
-    end
-
     def test_empty_statements_class
       index(<<~RUBY)
         class Foo
@@ -212,7 +208,7 @@ module RubyIndexer
     private
 
     def index(source)
-      RubyIndexer.index_single(@index, "/fake/path/foo.rb", source)
+      @index.index_single("/fake/path/foo.rb", source)
     end
 
     def assert_entry(expected_name, type, expected_location)

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -4,25 +4,31 @@
 require "test_helper"
 
 module RubyIndexer
-  class RubyIndexerTest < Minitest::Test
+  class ConfigurationTest < Minitest::Test
+    def setup
+      @config = Configuration.new
+    end
+
     def test_load_configuration_executes_configure_block
-      RubyIndexer.load_configuration_file
-      files_to_index = RubyIndexer.configuration.files_to_index
+      @config.load_config
+      files_to_index = @config.files_to_index
 
       assert(files_to_index.none? { |path| path.include?("test/fixtures") })
       assert(files_to_index.none? { |path| path.include?("minitest-reporters") })
     end
 
     def test_paths_are_unique
-      RubyIndexer.load_configuration_file
-      files_to_index = RubyIndexer.configuration.files_to_index
+      @config.load_config
+      files_to_index = @config.files_to_index
 
       assert_equal(files_to_index.uniq.length, files_to_index.length)
     end
 
     def test_configuration_raises_for_unknown_keys
+      Psych::Nodes::Document.any_instance.expects(:to_ruby).returns({ "unknown_config" => 123 })
+
       assert_raises(ArgumentError) do
-        RubyIndexer.configuration.apply_config({ "unknown" => 123 })
+        @config.load_config
       end
     end
   end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -9,16 +9,12 @@ module RubyIndexer
       @index = Index.new
     end
 
-    def teardown
-      @index.clear
-    end
-
     def test_deleting_one_entry_for_a_class
-      RubyIndexer.index_single(@index, "/fake/path/foo.rb", <<~RUBY)
+      @index.index_single("/fake/path/foo.rb", <<~RUBY)
         class Foo
         end
       RUBY
-      RubyIndexer.index_single(@index, "/fake/path/other_foo.rb", <<~RUBY)
+      @index.index_single("/fake/path/other_foo.rb", <<~RUBY)
         class Foo
         end
       RUBY
@@ -32,7 +28,7 @@ module RubyIndexer
     end
 
     def test_deleting_all_entries_for_a_class
-      RubyIndexer.index_single(@index, "/fake/path/foo.rb", <<~RUBY)
+      @index.index_single("/fake/path/foo.rb", <<~RUBY)
         class Foo
         end
       RUBY
@@ -46,7 +42,7 @@ module RubyIndexer
     end
 
     def test_index_resolve
-      RubyIndexer.index_single(@index, "/fake/path/foo.rb", <<~RUBY)
+      @index.index_single("/fake/path/foo.rb", <<~RUBY)
         class Bar; end
 
         module Foo
@@ -80,7 +76,7 @@ module RubyIndexer
     end
 
     def test_accessing_with_colon_colon_prefix
-      RubyIndexer.index_single(@index, "/fake/path/foo.rb", <<~RUBY)
+      @index.index_single("/fake/path/foo.rb", <<~RUBY)
         class Bar; end
 
         module Foo

--- a/lib/ruby_indexer/test/ruby_indexer_test.rb
+++ b/lib/ruby_indexer/test/ruby_indexer_test.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RubyIndexer
+  class RubyIndexerTest < Minitest::Test
+    def test_load_configuration_executes_configure_block
+      RubyIndexer.load_configuration_file
+      files_to_index = RubyIndexer.configuration.files_to_index
+
+      assert(files_to_index.none? { |path| path.include?("test/fixtures") })
+      assert(files_to_index.none? { |path| path.include?("minitest-reporters") })
+    end
+
+    def test_paths_are_unique
+      RubyIndexer.load_configuration_file
+      files_to_index = RubyIndexer.configuration.files_to_index
+
+      assert_equal(files_to_index.uniq.length, files_to_index.length)
+    end
+
+    def test_configuration_raises_for_unknown_keys
+      assert_raises(ArgumentError) do
+        RubyIndexer.configuration.apply_config({ "unknown" => 123 })
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -61,7 +61,7 @@ module RubyLsp
         if @store.experimental_features
           # The begin progress invocation happens during `initialize`, so that the notification is sent before we are
           # stuck indexing files
-          RubyIndexer.load_configuration_file
+          RubyIndexer.configuration.load_config
           @index.index_all
           end_progress("indexing-progress")
         end

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -13,11 +13,19 @@ module RubyLsp
     sig { returns(String) }
     attr_accessor :formatter
 
+    sig { returns(T::Boolean) }
+    attr_accessor :supports_progress
+
+    sig { returns(T::Boolean) }
+    attr_accessor :experimental_features
+
     sig { void }
     def initialize
       @state = T.let({}, T::Hash[String, Document])
       @encoding = T.let(Constant::PositionEncodingKind::UTF8, String)
       @formatter = T.let("auto", String)
+      @supports_progress = T.let(true, T::Boolean)
+      @experimental_features = T.let(false, T::Boolean)
     end
 
     sig { params(uri: URI::Generic).returns(Document) }

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -108,6 +108,13 @@ class ExecutorTest < Minitest::Test
     assert_includes("utf-16", hash.dig("capabilities", "positionEncoding"))
   end
 
+  def test_initialized_populates_index
+    @store.experimental_features = true
+    @executor.execute({ method: "initialized", params: {} })
+    index = @executor.instance_variable_get(:@index)
+    refute_empty(index.instance_variable_get(:@entries))
+  end
+
   def test_rubocop_errors_push_window_notification
     @executor.expects(:formatting).raises(StandardError, "boom").once
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -292,7 +292,7 @@ class IntegrationTest < Minitest::Test
   end
 
   def test_code_lens
-    initialize_lsp(["codeLens"], experimental_features_enabled: true)
+    initialize_lsp(["codeLens"])
     open_file_with("class Foo\n\nend")
 
     assert_telemetry("textDocument/didOpen")


### PR DESCRIPTION
### Motivation

This PR performs the initial indexing of files and maintains the index synchronized upon modifications.

### Implementation

There were a few issues in the code structure I had to address.
1. Because the Ruby LSP runs in a separate process from the application, we need some sort of DSL file to allow people to configure the index. Otherwise, there's nowhere to put the configuration. I created the concept of `.indexrc` for this, which is a Ruby DSL file that can be used to configure the index
2. The API for indexing at the `RubyIndexer` level was a bit weird, since we need to control the index from the outside. I moved `index_all` and `index_single` inside the `Index` class itself, which feels like a much nicer interface
3. Having people configure `files_to_index` is a bit too much. Instead, we can just provide folks with an array of excluded gems and excluded file patterns, which we will use to tune the files indexed. This makes the index easier to configure

Finally, after addressing those, I started:
1. Pushing a progress notification before starting indexing
2. Indexing all files on the `initialized` notification and then closing the progress report
3. Dynamically registering the editor to listen to Ruby file modifications
4. Handling the modifications to synchronize the index

Everything is marked as experimental for now, so that we can test it first.

### Automated Tests

Added a few tests.

### Manual Tests

For now, the only behaviour change is seeing the progress notification while indexing is happening.
1. Switch to this branch
2. Reload the VS Code window
3. Verify that a status shows up in the status bar saying that we're indexing files