### PR TITLE
Migrate code action resolve to YARP

### DIFF
--- a/lib/ruby_lsp/requests/base_request.rb
+++ b/lib/ruby_lsp/requests/base_request.rb
@@ -4,7 +4,7 @@
 module RubyLsp
   module Requests
     # :nodoc:
-    class BaseRequest < SyntaxTree::Visitor
+    class BaseRequest < YARP::Visitor
       extend T::Sig
       extend T::Helpers
       include Support::Common


### PR DESCRIPTION
Partially addresses https://github.com/Shopify/ruby-lsp/issues/449

This is a direct cherry-pick from @vinistock's branch. `bin/test test/requests/code_action_resolve_expectations_test.rb` is passing.