### PR TITLE
Account for lowercase drive letter on Windows

### DIFF
--- a/lib/core_ext/uri.rb
+++ b/lib/core_ext/uri.rb
@@ -9,7 +9,7 @@ module URI
       sig { params(path: String, scheme: String).returns(URI::Generic) }
       def from_path(path:, scheme: "file")
         # On Windows, if the path begins with the disk name, we need to add a leading slash to make it a valid URI
-        escaped_path = if /^[A-Z]:/.match?(path)
+        escaped_path = if /^[A-Z]:/i.match?(path)
           DEFAULT_PARSER.escape("/#{path}")
         else
           DEFAULT_PARSER.escape(path)
@@ -26,15 +26,15 @@ module URI
       parsed_path = path
       return unless parsed_path
 
+      unescaped_path = CGI.unescape(parsed_path)
+
       # On Windows, when we're getting the file system path back from the URI, we need to remove the leading forward
       # slash
-      actual_path = if %r{^/[A-Z]:}.match?(parsed_path)
-        parsed_path.delete_prefix("/")
+      if %r{^/[A-Z]:}i.match?(unescaped_path)
+        unescaped_path.delete_prefix("/")
       else
-        parsed_path
+        unescaped_path
       end
-
-      CGI.unescape(actual_path)
     end
 
     sig { returns(String) }

--- a/test/requests/support/uri_test.rb
+++ b/test/requests/support/uri_test.rb
@@ -15,14 +15,29 @@ module RubyLsp
       assert_equal("/C:/some/windows/path/to/file.rb", uri.path)
     end
 
-    def test_to_path_on_unix
+    def test_from_path_on_windows_with_lowercase_drive
+      uri = URI::Generic.from_path(path: "c:/some/windows/path/to/file.rb")
+      assert_equal("/c:/some/windows/path/to/file.rb", uri.path)
+    end
+
+    def test_to_standardized_path_on_unix
       uri = URI::Generic.from_path(path: "/some/unix/path/to/file.rb")
       assert_equal(uri.path, uri.to_standardized_path)
     end
 
-    def test_to_path_on_windows
+    def test_to_standardized_path_on_windows
       uri = URI::Generic.from_path(path: "C:/some/windows/path/to/file.rb")
       assert_equal("C:/some/windows/path/to/file.rb", uri.to_standardized_path)
+    end
+
+    def test_to_standardized_path_on_windows_with_lowercase_drive
+      uri = URI::Generic.from_path(path: "c:/some/windows/path/to/file.rb")
+      assert_equal("c:/some/windows/path/to/file.rb", uri.to_standardized_path)
+    end
+
+    def test_to_standardized_path_on_windows_with_received_uri
+      uri = URI("file:///c%3A/some/windows/path/to/file.rb")
+      assert_equal("c:/some/windows/path/to/file.rb", uri.to_standardized_path)
     end
   end
 end


### PR DESCRIPTION
### Motivation

The recent release of https://github.com/Shopify/vscode-ruby-lsp/commit/53fb04ac3c7048ab24dd52b94b4ec6bd50a8b74a made the extension work on Windows. On Windows, VS Code can spawn the terminal used by extensions with a lowecase drive letter, which causes the following error and prevents the extension from starting:
`URI::InvalidComponentError: bad component(expected absolute path component): c:/some/windows/path/to/file.rb`

### Implementation

The drive pattern introduced in #850 was switched to case-insensitive.

### Automated Tests

The tests also introduced in #850 were expanded to cover lowercase drive letters.
