### PR TITLE
Use the absolute BUNDLE_PATH to run the server

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -156,11 +156,12 @@ module RubyLsp
       # `.ruby-lsp` folder, which is not the user's intention. For example, if the path is configured as `vendor`, we
       # want to install it in the top level `vendor` and not `.ruby-lsp/vendor`
       path = Bundler.settings["path"]
+      expanded_path = File.expand_path(path, Dir.pwd) if path
 
       # Use the absolute `BUNDLE_PATH` to prevent accidentally creating unwanted folders under `.ruby-lsp`
       env = {}
       env["BUNDLE_GEMFILE"] = bundle_gemfile.to_s
-      env["BUNDLE_PATH"] = File.expand_path(path, Dir.pwd) if path
+      env["BUNDLE_PATH"] = expanded_path if expanded_path
 
       # If both `ruby-lsp` and `debug` are already in the Gemfile, then we shouldn't try to upgrade them or else we'll
       # produce undesired source control changes. If the custom bundle was just created and either `ruby-lsp` or `debug`
@@ -187,7 +188,7 @@ module RubyLsp
       # Add bundle update
       warn("Ruby LSP> Running bundle install for the custom bundle. This may take a while...")
       system(env, command)
-      [bundle_gemfile.to_s, path]
+      [bundle_gemfile.to_s, expanded_path]
     end
   end
 end

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -124,7 +124,7 @@ class SetupBundlerTest < Minitest::Test
     Bundler.settings.set_global("path", "vendor/bundle")
     Object.any_instance.expects(:system).with(bundle_env(".ruby-lsp/Gemfile"), "bundle install 1>&2")
     Bundler::LockfileParser.any_instance.expects(:dependencies).returns({}).at_least_once
-    run_script
+    run_script(expected_path: File.expand_path("vendor/bundle", Dir.pwd))
   ensure
     # We need to revert the changes to the bundler config or else this actually changes ~/.bundle/config
     Bundler.settings.set_global("path", nil)
@@ -212,8 +212,10 @@ class SetupBundlerTest < Minitest::Test
 
   # This method runs the script and then immediately unloads it. This allows us to make assertions against the effects
   # of running the script multiple times
-  def run_script(path = "/fake/project/path")
-    RubyLsp::SetupBundler.new(path).setup!
+  def run_script(path = "/fake/project/path", expected_path: nil)
+    _bundle_gemfile, bundle_path = RubyLsp::SetupBundler.new(path).setup!
+
+    assert_equal(expected_path, bundle_path) if expected_path
   end
 
   def bundle_env(bundle_gemfile = "Gemfile")


### PR DESCRIPTION
### Motivation

Closes #738

We were expanding the path to set `ENV["BUNDLE_PATH"]`, but `setup!` was returning the non-expanded path. This meant that we ran `bundle install` correctly, but tried to boot the server using the non-expanded path, which fails.

### Implementation

We need to return the absolute path from the script, so that we can run the server with the correct bundle path.

### Automated Tests

Added an expectation to make sure we don't regress.

### Manual Tests

1. Pick a project and set the bundle path in the local config `bundle config --local path .bundle`
2. Run bundle install
3. Run `exe/ruby-lsp` inside that project's folder
4. Verify that it boots the LSP successfully
5. Cleanup the bundle configuration `rm -rf .bundle`