### PR TITLE
Always use complete URI for store key

### DIFF
--- a/lib/core_ext/uri.rb
+++ b/lib/core_ext/uri.rb
@@ -36,10 +36,5 @@ module URI
         unescaped_path
       end
     end
-
-    sig { returns(String) }
-    def storage_key
-      T.must(to_standardized_path || opaque)
-    end
   end
 end

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -22,25 +22,23 @@ module RubyLsp
 
     sig { params(uri: URI::Generic).returns(Document) }
     def get(uri)
-      path = uri.to_standardized_path
-      return T.must(@state[T.must(uri.opaque)]) unless path
-
-      document = @state[path]
+      document = @state[uri.to_s]
       return document unless document.nil?
 
-      set(uri: uri, source: File.binread(CGI.unescape(path)), version: 0)
-      T.must(@state[path])
+      path = T.must(uri.to_standardized_path)
+      set(uri: uri, source: File.binread(path), version: 0)
+      T.must(@state[uri.to_s])
     end
 
     sig { params(uri: URI::Generic, source: String, version: Integer).void }
     def set(uri:, source:, version:)
       document = Document.new(source: source, version: version, uri: uri, encoding: @encoding)
-      @state[uri.storage_key] = document
+      @state[uri.to_s] = document
     end
 
     sig { params(uri: URI::Generic, edits: T::Array[Document::EditShape], version: Integer).void }
     def push_edits(uri:, edits:, version:)
-      T.must(@state[uri.storage_key]).push_edits(edits, version: version)
+      T.must(@state[uri.to_s]).push_edits(edits, version: version)
     end
 
     sig { void }
@@ -55,7 +53,7 @@ module RubyLsp
 
     sig { params(uri: URI::Generic).void }
     def delete(uri)
-      @state.delete(uri.storage_key)
+      @state.delete(uri.to_s)
     end
 
     sig do


### PR DESCRIPTION
### Motivation

There are scenarios where we can receive the same file path with different schemes from VS Code. For example, when someone is looking at the diff editor, we receive the same path twice with two different schemes:

```
file:///foo/bar.rb
git:///foo/bar.rb
```

Because we were using the file path as the storage key, these two URIs would conflict and result in inconsistent internal state in the LSP. If you closed the git version, it would delete the file version too and that file would no longer exist (from the LSP's perspective).

### Implementation

The switch to use file paths and untitled names as the storage key was a mistake. We should always use the complete URI so that there are no conflicts and each scheme has a separate version of the document. VS Code sends duplicate requests for each scheme version, so we should respect that and treat them as separate documents.

### Automated tests

Added some examples that catch the issue.