### PR TITLE
Migrate document symbol to YARP

### DIFF
--- a/lib/ruby_lsp/event_emitter.rb
+++ b/lib/ruby_lsp/event_emitter.rb
@@ -54,60 +54,53 @@ module RubyLsp
       super
     end
 
-    sig { override.params(node: SyntaxTree::ClassDeclaration).void }
-    def visit_class(node)
+    sig { override.params(node: YARP::ClassNode).void }
+    def visit_class_node(node)
       @listeners[:on_class]&.each { |l| T.unsafe(l).on_class(node) }
       super
       @listeners[:after_class]&.each { |l| T.unsafe(l).after_class(node) }
     end
 
-    sig { override.params(node: SyntaxTree::ModuleDeclaration).void }
-    def visit_module(node)
+    sig { override.params(node: YARP::ModuleNode).void }
+    def visit_module_node(node)
       @listeners[:on_module]&.each { |l| T.unsafe(l).on_module(node) }
       super
       @listeners[:after_module]&.each { |l| T.unsafe(l).after_module(node) }
     end
 
-    sig { override.params(node: SyntaxTree::Command).void }
-    def visit_command(node)
-      @listeners[:on_command]&.each { |l| T.unsafe(l).on_command(node) }
-      super
-      @listeners[:after_command]&.each { |l| T.unsafe(l).after_command(node) }
-    end
-
-    sig { override.params(node: SyntaxTree::CommandCall).void }
-    def visit_command_call(node)
-      @listeners[:on_command_call]&.each { |l| T.unsafe(l).on_command_call(node) }
-      super
-    end
-
-    sig { override.params(node: SyntaxTree::CallNode).void }
-    def visit_call(node)
+    sig { override.params(node: YARP::CallNode).void }
+    def visit_call_node(node)
       @listeners[:on_call]&.each { |l| T.unsafe(l).on_call(node) }
       super
       @listeners[:after_call]&.each { |l| T.unsafe(l).after_call(node) }
     end
 
-    sig { override.params(node: SyntaxTree::VCall).void }
-    def visit_vcall(node)
-      @listeners[:on_vcall]&.each { |l| T.unsafe(l).on_vcall(node) }
+    sig { override.params(node: YARP::ConstantPathWriteNode).void }
+    def visit_constant_path_write_node(node)
+      @listeners[:on_constant_path_write_node]&.each { |l| T.unsafe(l).on_constant_path_write_node(node) }
       super
     end
 
-    sig { override.params(node: SyntaxTree::ConstPathField).void }
-    def visit_const_path_field(node)
-      @listeners[:on_const_path_field]&.each { |l| T.unsafe(l).on_const_path_field(node) }
+    sig { override.params(node: YARP::ConstantWriteNode).void }
+    def visit_constant_write_node(node)
+      @listeners[:on_constant_write_node]&.each { |l| T.unsafe(l).on_constant_write_node(node) }
       super
     end
 
-    sig { override.params(node: SyntaxTree::TopConstField).void }
-    def visit_top_const_field(node)
-      @listeners[:on_top_const_field]&.each { |l| T.unsafe(l).on_top_const_field(node) }
+    sig { override.params(node: YARP::InstanceVariableWriteNode).void }
+    def visit_instance_variable_write_node(node)
+      @listeners[:on_instance_variable_write]&.each { |l| T.unsafe(l).on_instance_variable_write(node) }
       super
     end
 
-    sig { override.params(node: SyntaxTree::DefNode).void }
-    def visit_def(node)
+    sig { override.params(node: YARP::ClassVariableWriteNode).void }
+    def visit_class_variable_write_node(node)
+      @listeners[:on_class_variable_write]&.each { |l| T.unsafe(l).on_class_variable_write(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::DefNode).void }
+    def visit_def_node(node)
       @listeners[:on_def]&.each { |l| T.unsafe(l).on_def(node) }
       super
       @listeners[:after_def]&.each { |l| T.unsafe(l).after_def(node) }

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -99,7 +99,7 @@ module RubyLsp
         code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, @test_library)
 
         semantic_highlighting = Requests::SemanticHighlighting.new(emitter, @message_queue)
-        emitter.visit(document.tree) if document.parsed?
+        emitter.visit(document.tree)
 
         code_lens.merge_external_listeners_responses!
 

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -9,7 +9,7 @@ module RubyLsp
         # or extensions by created by developers outside of Shopify, so be cautious of changing anything.
         extend T::Sig
 
-        sig { params(node: SyntaxTree::Node).returns(Interface::Range) }
+        sig { params(node: YARP::Node).returns(Interface::Range) }
         def range_from_syntax_tree_node(node)
           loc = node.location
 
@@ -22,25 +22,15 @@ module RubyLsp
           )
         end
 
-        sig do
-          params(node: T.any(SyntaxTree::ConstPathRef, SyntaxTree::ConstRef, SyntaxTree::TopConstRef)).returns(String)
-        end
-        def full_constant_name(node)
-          name = node.constant.value.dup
-          constant = T.let(node, SyntaxTree::Node)
-
-          while constant.is_a?(SyntaxTree::ConstPathRef)
-            constant = constant.parent
-
-            case constant
-            when SyntaxTree::ConstPathRef
-              name.prepend("#{constant.constant.value}::")
-            when SyntaxTree::VarRef
-              name.prepend("#{constant.value.value}::")
-            end
-          end
-
-          name
+        sig { params(location: YARP::Location).returns(Interface::Range) }
+        def range_from_location(location)
+          Interface::Range.new(
+            start: Interface::Position.new(
+              line: location.start_line - 1,
+              character: location.start_column,
+            ),
+            end: Interface::Position.new(line: location.end_line - 1, character: location.end_column),
+          )
         end
 
         sig { params(node: T.nilable(YARP::Node), range: T.nilable(T::Range[Integer])).returns(T::Boolean) }
@@ -54,7 +44,7 @@ module RubyLsp
 
         sig do
           params(
-            node: SyntaxTree::Node,
+            node: YARP::Node,
             title: String,
             command_name: String,
             arguments: T.nilable(T::Array[T.untyped]),

--- a/test/expectations/document_symbol/attr_accessor.exp.json
+++ b/test/expectations/document_symbol/attr_accessor.exp.json
@@ -10,17 +10,17 @@
         },
         "end": {
           "line": 0,
-          "character": 14
+          "character": 13
         }
       },
       "selectionRange": {
         "start": {
           "line": 0,
-          "character": 13
+          "character": 12
         },
         "end": {
           "line": 0,
-          "character": 14
+          "character": 13
         }
       },
       "children": []
@@ -35,17 +35,17 @@
         },
         "end": {
           "line": 1,
-          "character": 14
+          "character": 13
         }
       },
       "selectionRange": {
         "start": {
           "line": 1,
-          "character": 13
+          "character": 12
         },
         "end": {
           "line": 1,
-          "character": 14
+          "character": 13
         }
       },
       "children": []
@@ -60,17 +60,17 @@
         },
         "end": {
           "line": 1,
-          "character": 18
+          "character": 17
         }
       },
       "selectionRange": {
         "start": {
           "line": 1,
-          "character": 17
+          "character": 16
         },
         "end": {
           "line": 1,
-          "character": 18
+          "character": 17
         }
       },
       "children": []
@@ -85,17 +85,17 @@
         },
         "end": {
           "line": 2,
-          "character": 16
+          "character": 15
         }
       },
       "selectionRange": {
         "start": {
           "line": 2,
-          "character": 15
+          "character": 14
         },
         "end": {
           "line": 2,
-          "character": 16
+          "character": 15
         }
       },
       "children": []

--- a/test/expectations/document_symbol/class_declaration_nested.exp.json
+++ b/test/expectations/document_symbol/class_declaration_nested.exp.json
@@ -10,7 +10,7 @@
         },
         "end": {
           "line": 2,
-          "character": 3
+          "character": 2
         }
       },
       "selectionRange": {
@@ -20,7 +20,7 @@
         },
         "end": {
           "line": 0,
-          "character": 9
+          "character": 8
         }
       },
       "children": [
@@ -34,7 +34,7 @@
             },
             "end": {
               "line": 1,
-              "character": 16
+              "character": 15
             }
           },
           "selectionRange": {
@@ -44,7 +44,7 @@
             },
             "end": {
               "line": 1,
-              "character": 11
+              "character": 10
             }
           },
           "children": []

--- a/test/expectations/document_symbol/const.exp.json
+++ b/test/expectations/document_symbol/const.exp.json
@@ -10,7 +10,7 @@
         },
         "end": {
           "line": 0,
-          "character": 2
+          "character": 6
         }
       },
       "selectionRange": {
@@ -20,13 +20,13 @@
         },
         "end": {
           "line": 0,
-          "character": 2
+          "character": 1
         }
       },
       "children": []
     },
     {
-      "name": "C2",
+      "name": "::C2",
       "kind": 14,
       "range": {
         "start": {
@@ -35,23 +35,23 @@
         },
         "end": {
           "line": 1,
-          "character": 4
+          "character": 8
         }
       },
       "selectionRange": {
         "start": {
           "line": 1,
-          "character": 2
+          "character": 0
         },
         "end": {
           "line": 1,
-          "character": 4
+          "character": 3
         }
       },
       "children": []
     },
     {
-      "name": "C3",
+      "name": "Foo::C3",
       "kind": 14,
       "range": {
         "start": {
@@ -60,23 +60,23 @@
         },
         "end": {
           "line": 2,
-          "character": 7
+          "character": 11
         }
       },
       "selectionRange": {
         "start": {
           "line": 2,
-          "character": 5
+          "character": 0
         },
         "end": {
           "line": 2,
-          "character": 7
+          "character": 6
         }
       },
       "children": []
     },
     {
-      "name": "C4",
+      "name": "::Foo::C4",
       "kind": 14,
       "range": {
         "start": {
@@ -85,17 +85,17 @@
         },
         "end": {
           "line": 3,
-          "character": 9
+          "character": 13
         }
       },
       "selectionRange": {
         "start": {
           "line": 3,
-          "character": 7
+          "character": 0
         },
         "end": {
           "line": 3,
-          "character": 9
+          "character": 8
         }
       },
       "children": []

--- a/test/expectations/document_symbol/def.exp.json
+++ b/test/expectations/document_symbol/def.exp.json
@@ -10,7 +10,7 @@
         },
         "end": {
           "line": 3,
-          "character": 3
+          "character": 2
         }
       },
       "selectionRange": {
@@ -20,7 +20,7 @@
         },
         "end": {
           "line": 0,
-          "character": 7
+          "character": 6
         }
       },
       "children": []

--- a/test/expectations/document_symbol/def_endless.exp.json
+++ b/test/expectations/document_symbol/def_endless.exp.json
@@ -10,7 +10,7 @@
         },
         "end": {
           "line": 2,
-          "character": 12
+          "character": 11
         }
       },
       "selectionRange": {
@@ -20,7 +20,7 @@
         },
         "end": {
           "line": 2,
-          "character": 7
+          "character": 6
         }
       },
       "children": []

--- a/test/expectations/document_symbol/def_with_decorators.exp.json
+++ b/test/expectations/document_symbol/def_with_decorators.exp.json
@@ -10,7 +10,7 @@
         },
         "end": {
           "line": 2,
-          "character": 3
+          "character": 2
         }
       },
       "selectionRange": {
@@ -20,12 +20,10 @@
         },
         "end": {
           "line": 0,
-          "character": 15
+          "character": 14
         }
       },
-      "children": [
-
-      ]
+      "children": []
     },
     {
       "name": "bar",
@@ -37,7 +35,7 @@
         },
         "end": {
           "line": 6,
-          "character": 3
+          "character": 2
         }
       },
       "selectionRange": {
@@ -47,12 +45,10 @@
         },
         "end": {
           "line": 4,
-          "character": 18
+          "character": 17
         }
       },
-      "children": [
-
-      ]
+      "children": []
     },
     {
       "name": "baz",
@@ -64,7 +60,7 @@
         },
         "end": {
           "line": 10,
-          "character": 3
+          "character": 2
         }
       },
       "selectionRange": {
@@ -74,15 +70,11 @@
         },
         "end": {
           "line": 8,
-          "character": 33
+          "character": 32
         }
       },
-      "children": [
-
-      ]
+      "children": []
     }
   ],
-  "params": [
-
-  ]
+  "params": []
 }

--- a/test/expectations/document_symbol/defs.exp.json
+++ b/test/expectations/document_symbol/defs.exp.json
@@ -10,7 +10,7 @@
         },
         "end": {
           "line": 3,
-          "character": 3
+          "character": 2
         }
       },
       "selectionRange": {
@@ -20,7 +20,7 @@
         },
         "end": {
           "line": 0,
-          "character": 12
+          "character": 11
         }
       },
       "children": []

--- a/test/expectations/document_symbol/ivar.exp.json
+++ b/test/expectations/document_symbol/ivar.exp.json
@@ -10,7 +10,7 @@
         },
         "end": {
           "line": 0,
-          "character": 2
+          "character": 6
         }
       },
       "selectionRange": {
@@ -20,7 +20,7 @@
         },
         "end": {
           "line": 0,
-          "character": 2
+          "character": 1
         }
       },
       "children": []
@@ -35,7 +35,7 @@
         },
         "end": {
           "line": 1,
-          "character": 3
+          "character": 7
         }
       },
       "selectionRange": {
@@ -45,7 +45,7 @@
         },
         "end": {
           "line": 1,
-          "character": 3
+          "character": 2
         }
       },
       "children": []
@@ -60,7 +60,7 @@
         },
         "end": {
           "line": 11,
-          "character": 3
+          "character": 2
         }
       },
       "selectionRange": {
@@ -70,7 +70,7 @@
         },
         "end": {
           "line": 3,
-          "character": 9
+          "character": 8
         }
       },
       "children": [
@@ -84,7 +84,7 @@
             },
             "end": {
               "line": 4,
-              "character": 4
+              "character": 8
             }
           },
           "selectionRange": {
@@ -94,7 +94,7 @@
             },
             "end": {
               "line": 4,
-              "character": 4
+              "character": 3
             }
           },
           "children": []
@@ -109,7 +109,7 @@
             },
             "end": {
               "line": 5,
-              "character": 5
+              "character": 9
             }
           },
           "selectionRange": {
@@ -119,7 +119,7 @@
             },
             "end": {
               "line": 5,
-              "character": 5
+              "character": 4
             }
           },
           "children": []
@@ -134,7 +134,7 @@
             },
             "end": {
               "line": 10,
-              "character": 5
+              "character": 4
             }
           },
           "selectionRange": {
@@ -144,7 +144,7 @@
             },
             "end": {
               "line": 7,
-              "character": 16
+              "character": 15
             }
           },
           "children": [
@@ -158,7 +158,7 @@
                 },
                 "end": {
                   "line": 8,
-                  "character": 6
+                  "character": 10
                 }
               },
               "selectionRange": {
@@ -168,7 +168,7 @@
                 },
                 "end": {
                   "line": 8,
-                  "character": 6
+                  "character": 5
                 }
               },
               "children": []
@@ -183,7 +183,7 @@
                 },
                 "end": {
                   "line": 9,
-                  "character": 7
+                  "character": 11
                 }
               },
               "selectionRange": {
@@ -193,7 +193,7 @@
                 },
                 "end": {
                   "line": 9,
-                  "character": 7
+                  "character": 6
                 }
               },
               "children": []

--- a/test/expectations/document_symbol/module_declaration.exp.json
+++ b/test/expectations/document_symbol/module_declaration.exp.json
@@ -10,7 +10,7 @@
         },
         "end": {
           "line": 6,
-          "character": 3
+          "character": 2
         }
       },
       "selectionRange": {
@@ -20,7 +20,7 @@
         },
         "end": {
           "line": 0,
-          "character": 10
+          "character": 9
         }
       },
       "children": [
@@ -34,7 +34,7 @@
             },
             "end": {
               "line": 2,
-              "character": 5
+              "character": 4
             }
           },
           "selectionRange": {
@@ -44,7 +44,7 @@
             },
             "end": {
               "line": 1,
-              "character": 11
+              "character": 10
             }
           },
           "children": []
@@ -59,7 +59,7 @@
             },
             "end": {
               "line": 5,
-              "character": 5
+              "character": 4
             }
           },
           "selectionRange": {
@@ -69,7 +69,7 @@
             },
             "end": {
               "line": 4,
-              "character": 12
+              "character": 11
             }
           },
           "children": []

--- a/test/expectations/document_symbol/one_line_nesting.exp.json
+++ b/test/expectations/document_symbol/one_line_nesting.exp.json
@@ -10,7 +10,7 @@
                 },
                 "end": {
                     "line": 1,
-                    "character": 3
+                    "character": 2
                 }
             },
             "selectionRange": {
@@ -20,7 +20,7 @@
                 },
                 "end": {
                     "line": 0,
-                    "character": 10
+                    "character": 9
                 }
             },
             "children": []
@@ -35,7 +35,7 @@
                 },
                 "end": {
                     "line": 4,
-                    "character": 3
+                    "character": 2
                 }
             },
             "selectionRange": {
@@ -45,7 +45,7 @@
                 },
                 "end": {
                     "line": 3,
-                    "character": 15
+                    "character": 14
                 }
             },
             "children": []
@@ -60,7 +60,7 @@
                 },
                 "end": {
                     "line": 7,
-                    "character": 3
+                    "character": 2
                 }
             },
             "selectionRange": {
@@ -70,7 +70,7 @@
                 },
                 "end": {
                     "line": 6,
-                    "character": 19
+                    "character": 18
                 }
             },
             "children": []
@@ -85,7 +85,7 @@
                 },
                 "end": {
                     "line": 12,
-                    "character": 3
+                    "character": 2
                 }
             },
             "selectionRange": {
@@ -95,7 +95,7 @@
                 },
                 "end": {
                     "line": 9,
-                    "character": 10
+                    "character": 9
                 }
             },
             "children": [
@@ -109,7 +109,7 @@
                         },
                         "end": {
                             "line": 11,
-                            "character": 5
+                            "character": 4
                         }
                     },
                     "selectionRange": {
@@ -119,7 +119,7 @@
                         },
                         "end": {
                             "line": 10,
-                            "character": 17
+                            "character": 16
                         }
                     },
                     "children": []


### PR DESCRIPTION
Partially addresses https://github.com/Shopify/ruby-lsp/issues/449

Based on @vinistock's commit in 82e975e7e7033c85e72b2e753d8167790e7f59a2, but I had trouble cherry-picking it so this was a partially manual effort.

`bin/test test/requests/document_symbol_expectations_test.rb` passes