### PR TITLE
Allow specifying a branch to launch the LSP with

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -1,6 +1,46 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "optparse"
+
+options = {}
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: ruby-lsp [options]"
+
+  opts.on("--version", "Print ruby-lsp version") do
+    require "ruby-lsp"
+    puts RubyLsp::VERSION
+    exit(0)
+  end
+
+  opts.on("--debug", "Launch the Ruby LSP with a debugger attached") do
+    options[:debug] = true
+  end
+
+  opts.on(
+    "--branch [BRANCH]",
+    "Launch the Ruby LSP using the specified branch rather than the release version",
+  ) do |branch|
+    options[:branch] = branch
+  end
+
+  opts.on("-h", "--help", "Print this help") do
+    puts opts.help
+    puts
+    puts "See https://shopify.github.io/ruby-lsp/ for more information"
+    exit(0)
+  end
+end
+
+begin
+  parser.parse!
+rescue OptionParser::InvalidOption => e
+  warn(e)
+  warn("")
+  warn(parser.help)
+  exit(1)
+end
+
 # When we're running without bundler, then we need to make sure the custom bundle is fully configured and re-execute
 # using `BUNDLE_GEMFILE=.ruby-lsp/Gemfile bundle exec ruby-lsp` so that we have access to the gems that are a part of
 # the application's bundle
@@ -8,7 +48,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
   require_relative "../lib/ruby_lsp/setup_bundler"
 
   begin
-    bundle_gemfile, bundle_path = RubyLsp::SetupBundler.new(Dir.pwd).setup!
+    bundle_gemfile, bundle_path = RubyLsp::SetupBundler.new(Dir.pwd, branch: options[:branch]).setup!
   rescue RubyLsp::SetupBundler::BundleNotLocked
     warn("Project contains a Gemfile, but no Gemfile.lock. Run `bundle install` to lock gems and restart the server")
     exit(78)
@@ -37,38 +77,6 @@ rescue
 end
 
 require_relative "../lib/ruby_lsp/internal"
-
-require "optparse"
-
-options = {}
-parser = OptionParser.new do |opts|
-  opts.banner = "Usage: ruby-lsp [options]"
-
-  opts.on("--version", "Print ruby-lsp version") do
-    puts RubyLsp::VERSION
-    exit(0)
-  end
-
-  opts.on("--debug", "Launch the Ruby LSP with a debugger attached") do
-    options[:debug] = true
-  end
-
-  opts.on("-h", "--help", "Print this help") do
-    puts opts.help
-    puts
-    puts "See https://shopify.github.io/ruby-lsp/ for more information"
-    exit(0)
-  end
-end
-
-begin
-  parser.parse!
-rescue OptionParser::InvalidOption => e
-  warn(e)
-  warn("")
-  warn(parser.help)
-  exit(1)
-end
 
 if options[:debug]
   if ["x64-mingw-ucrt", "x64-mingw32"].include?(RUBY_PLATFORM)

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -17,9 +17,10 @@ module RubyLsp
 
     class BundleNotLocked < StandardError; end
 
-    sig { params(project_path: String).void }
-    def initialize(project_path)
+    sig { params(project_path: String, branch: T.nilable(String)).void }
+    def initialize(project_path, branch: nil)
       @project_path = project_path
+      @branch = branch
 
       # Custom bundle paths
       @custom_dir = T.let(Pathname.new(".ruby-lsp").expand_path(Dir.pwd), Pathname)
@@ -119,7 +120,9 @@ module RubyLsp
       end
 
       unless @dependencies["ruby-lsp"]
-        parts << 'gem "ruby-lsp", require: false, group: :development'
+        ruby_lsp_entry = +'gem "ruby-lsp", require: false, group: :development'
+        ruby_lsp_entry << ", github: \"Shopify/ruby-lsp\", branch: \"#{@branch}\"" if @branch
+        parts << ruby_lsp_entry
       end
 
       unless @dependencies["debug"]


### PR DESCRIPTION
### Motivation

We currently have no convenient way of testing huge changes to the LSP in other projects. It would be extremely beneficial for us to be able to test things out from a branch, so that we can spot issues early, before them being merged to main.

In particular for the YARP migration, it will be really useful to test the LSP on the branch extensively before merging it to main.

### Implementation

I propose we allow for this using the following mechanism:
- I moved the option parsing to be the first thing in our executable script
- It now accepts the option `branch`, where you can specify a branch from this repo to be used (e.g.: `exe/ruby-lsp --branch yarp_migration`)
- It then generates the custom Gemfile using that branch, which means the LSP will be running the code on the specified branch

With these changes in place, we can add a configuration on the extension side to allow us to test branches ahead of time on any project. Let me know what you think about the approach.

### Automated Tests

Added a test verifying the right `github` and `branch` are specified in the `Gemfile` when the `--branch` option is passed.