### PR TITLE
Avoid dependency on T::Class and newer Sorbet versions

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -12,7 +12,7 @@ module RubyIndexer
         "excluded_patterns" => Array,
         "included_patterns" => Array,
       }.freeze,
-      T::Hash[String, T::Class[Object]],
+      T::Hash[String, T.untyped],
     )
 
     sig { void }


### PR DESCRIPTION
### Motivation

Closes #900

We can't use `T::Class` because it only exists on newer versions of `sorbet-runtime`. We'll be able to lock our dependency version to something higher in the future, but I think it's worth waiting a little longer until it spreads across projects.

For now, we're stuck with `T.untyped`.