### PR TITLE
Add `SyntaxTree::RescueEx` test case for Selection Range request

### DIFF
--- a/test/expectations/selection_ranges/rescue_multiple.exp.json
+++ b/test/expectations/selection_ranges/rescue_multiple.exp.json
@@ -1,0 +1,58 @@
+{
+    "params": [
+        {
+            "line": 1,
+            "character": 10
+        }
+    ],
+    "result": [
+        {
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 7
+                },
+                "end": {
+                    "line": 1,
+                    "character": 16
+                }
+            },
+            "parent": {
+                "range": {
+                    "start": {
+                        "line": 1,
+                        "character": 7
+                    },
+                    "end": {
+                        "line": 1,
+                        "character": 36
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 1,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 3
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/test/fixtures/rescue_multiple.rb
+++ b/test/fixtures/rescue_multiple.rb
@@ -1,0 +1,3 @@
+begin
+rescue Exception, StandardError => e
+end


### PR DESCRIPTION
### Motivation

To help with the migration to YARP.

https://ruby-syntax-tree.github.io/syntax_tree/SyntaxTree/RescueEx.html

### Implementation

No changes, only tests.

### Automated Tests

Included.

### Manual Tests

n/a
