### PR TITLE
Use consistent ordering in expectation files

### DIFF
--- a/test/expectations/code_lens/Gemfile.exp.json
+++ b/test/expectations/code_lens/Gemfile.exp.json
@@ -1,4 +1,5 @@
 {
+  "params": [],
   "result": [
     {
       "range": {
@@ -14,7 +15,9 @@
       "command": {
         "title": "Open remote",
         "command": "rubyLsp.openLink",
-        "arguments": ["https://github.com/ruby/rake"]
+        "arguments": [
+          "https://github.com/ruby/rake"
+        ]
       },
       "data": {
         "type": "link"
@@ -34,7 +37,9 @@
       "command": {
         "title": "Open remote",
         "command": "rubyLsp.openLink",
-        "arguments": ["https://github.com/rubocop/rubocop-minitest"]
+        "arguments": [
+          "https://github.com/rubocop/rubocop-minitest"
+        ]
       },
       "data": {
         "type": "link"
@@ -54,12 +59,13 @@
       "command": {
         "title": "Open remote",
         "command": "rubyLsp.openLink",
-        "arguments": ["https://github.com/ruby/debug"]
+        "arguments": [
+          "https://github.com/ruby/debug"
+        ]
       },
       "data": {
         "type": "link"
       }
     }
-  ],
-  "params": []
+  ]
 }

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -1,4 +1,5 @@
 {
+  "params": [],
   "result": [
     {
       "range": {
@@ -837,6 +838,5 @@
         "kind": "example"
       }
     }
-  ],
-  "params": []
+  ]
 }

--- a/test/expectations/code_lens/nested_minitest_tests.exp.json
+++ b/test/expectations/code_lens/nested_minitest_tests.exp.json
@@ -1,4 +1,5 @@
 {
+  "params": [],
   "result": [
     {
       "range": {
@@ -651,6 +652,5 @@
         "kind": "example"
       }
     }
-  ],
-  "params": []
+  ]
 }

--- a/test/expectations/definition/class_reference.exp.json
+++ b/test/expectations/definition/class_reference.exp.json
@@ -1,4 +1,10 @@
 {
+    "params": [
+        {
+            "line": 0,
+            "character": 19
+        }
+    ],
     "result": [
         {
             "uri": "file:///ruby_lsp/event_emitter.rb",
@@ -12,12 +18,6 @@
                     "character": 4
                 }
             }
-        }
-    ],
-    "params": [
-        {
-            "line": 0,
-            "character": 19
         }
     ]
 }

--- a/test/expectations/definition/require_relative.exp.json
+++ b/test/expectations/definition/require_relative.exp.json
@@ -1,4 +1,10 @@
 {
+    "params": [
+        {
+            "line": 0,
+            "character": 20
+        }
+    ],
     "result": {
         "uri": "file:///ruby_lsp/utils.rb",
         "range": {
@@ -11,11 +17,5 @@
                 "character": 0
             }
         }
-    },
-    "params": [
-        {
-            "line": 0,
-            "character": 20
-        }
-    ]
+    }
 }

--- a/test/expectations/definition/requires.exp.json
+++ b/test/expectations/definition/requires.exp.json
@@ -1,4 +1,10 @@
 {
+    "params": [
+        {
+            "line": 0,
+            "character": 20
+        }
+    ],
     "result": {
         "uri": "file:///ruby_lsp/utils.rb",
         "range": {
@@ -11,11 +17,5 @@
                 "character": 0
             }
         }
-    },
-    "params": [
-        {
-            "line": 0,
-            "character": 20
-        }
-    ]
+    }
 }

--- a/test/expectations/document_symbol/def_with_decorators.exp.json
+++ b/test/expectations/document_symbol/def_with_decorators.exp.json
@@ -1,4 +1,5 @@
 {
+  "params": [],
   "result": [
     {
       "name": "foo",
@@ -23,9 +24,7 @@
           "character": 15
         }
       },
-      "children": [
-
-      ]
+      "children": []
     },
     {
       "name": "bar",
@@ -50,9 +49,7 @@
           "character": 18
         }
       },
-      "children": [
-
-      ]
+      "children": []
     },
     {
       "name": "baz",
@@ -77,12 +74,7 @@
           "character": 33
         }
       },
-      "children": [
-
-      ]
+      "children": []
     }
-  ],
-  "params": [
-
   ]
 }

--- a/test/expectations/folding_ranges/block_with_class.exp.json
+++ b/test/expectations/folding_ranges/block_with_class.exp.json
@@ -1,4 +1,5 @@
 {
+    "params": [],
     "result": [
         {
             "startLine": 0,
@@ -10,6 +11,5 @@
             "endLine": 2,
             "kind": "region"
         }
-    ],
-    "params": []
+    ]
 }

--- a/test/expectations/folding_ranges/block_with_class_no_parens.exp.json
+++ b/test/expectations/folding_ranges/block_with_class_no_parens.exp.json
@@ -1,4 +1,5 @@
 {
+    "params": [],
     "result": [
         {
             "startLine": 0,
@@ -10,6 +11,5 @@
             "endLine": 2,
             "kind": "region"
         }
-    ],
-    "params": []
+    ]
 }

--- a/test/expectations/folding_ranges/chained_command_call.exp.json
+++ b/test/expectations/folding_ranges/chained_command_call.exp.json
@@ -1,4 +1,5 @@
 {
+    "params": [],
     "result": [
         {
             "startLine": 0,
@@ -10,6 +11,5 @@
             "endLine": 3,
             "kind": "region"
         }
-    ],
-    "params": []
+    ]
 }

--- a/test/expectations/folding_ranges/command_multiline_args.exp.json
+++ b/test/expectations/folding_ranges/command_multiline_args.exp.json
@@ -1,4 +1,5 @@
 {
+  "params": [],
   "result": [
     {
       "startLine": 0,
@@ -15,6 +16,5 @@
       "endLine": 9,
       "kind": "region"
     }
-  ],
-  "params": []
+  ]
 }

--- a/test/expectations/hover/controller.exp.json
+++ b/test/expectations/hover/controller.exp.json
@@ -1,4 +1,10 @@
 {
+  "params": [
+    {
+      "line": 1,
+      "character": 3
+    }
+  ],
   "result": {
     "contents": {
       "kind": "markdown",
@@ -14,11 +20,5 @@
         "character": 15
       }
     }
-  },
-  "params": [
-    {
-      "line": 1,
-      "character": 3
-    }
-  ]
+  }
 }

--- a/test/expectations/hover/job.exp.json
+++ b/test/expectations/hover/job.exp.json
@@ -1,4 +1,10 @@
 {
+  "params": [
+    {
+      "line": 1,
+      "character": 3
+    }
+  ],
   "result": {
     "contents": {
       "kind": "markdown",
@@ -14,11 +20,5 @@
         "character": 10
       }
     }
-  },
-  "params": [
-    {
-      "line": 1,
-      "character": 3
-    }
-  ]
+  }
 }

--- a/test/expectations/hover/model.exp.json
+++ b/test/expectations/hover/model.exp.json
@@ -1,4 +1,10 @@
 {
+  "params": [
+    {
+      "line": 1,
+      "character": 3
+    }
+  ],
   "result": {
     "contents": {
       "kind": "markdown",
@@ -14,11 +20,5 @@
         "character": 10
       }
     }
-  },
-  "params": [
-    {
-      "line": 1,
-      "character": 3
-    }
-  ]
+  }
 }

--- a/test/expectations/hover/model_action_text.exp.json
+++ b/test/expectations/hover/model_action_text.exp.json
@@ -1,4 +1,10 @@
 {
+  "params": [
+    {
+      "line": 1,
+      "character": 3
+    }
+  ],
   "result": {
     "contents": {
       "kind": "markdown",
@@ -14,11 +20,5 @@
         "character": 15
       }
     }
-  },
-  "params": [
-    {
-      "line": 1,
-      "character": 3
-    }
-  ]
+  }
 }

--- a/test/expectations/hover/model_active_record_constant.exp.json
+++ b/test/expectations/hover/model_active_record_constant.exp.json
@@ -1,4 +1,10 @@
 {
+  "params": [
+    {
+      "line": 0,
+      "character": 27
+    }
+  ],
   "result": {
     "contents": {
       "kind": "markdown",
@@ -14,11 +20,5 @@
         "character": 31
       }
     }
-  },
-  "params": [
-    {
-      "line": 0,
-      "character": 27
-    }
-  ]
+  }
 }

--- a/test/expectations/hover/model_active_storage.exp.json
+++ b/test/expectations/hover/model_active_storage.exp.json
@@ -1,4 +1,10 @@
 {
+  "params": [
+    {
+      "line": 1,
+      "character": 3
+    }
+  ],
   "result": {
     "contents": {
       "kind": "markdown",
@@ -14,11 +20,5 @@
         "character": 18
       }
     }
-  },
-  "params": [
-    {
-      "line": 1,
-      "character": 3
-    }
-  ]
+  }
 }

--- a/test/expectations/hover/routes.exp.json
+++ b/test/expectations/hover/routes.exp.json
@@ -1,4 +1,10 @@
 {
+  "params": [
+    {
+      "line": 1,
+      "character": 3
+    }
+  ],
   "result": {
     "contents": {
       "kind": "markdown",
@@ -14,11 +20,5 @@
         "character": 6
       }
     }
-  },
-  "params": [
-    {
-      "line": 1,
-      "character": 3
-    }
-  ]
+  }
 }

--- a/verify_expectations_format.rb
+++ b/verify_expectations_format.rb
@@ -1,0 +1,10 @@
+require 'json'
+
+Dir["test/expectations/**/*.json"].each do |file|
+  json = JSON.parse(File.read(file))
+  params_index = json.keys.index("params")
+  result_index = json.keys.index("result")
+  if params_index && params_index > result_index
+    exit("Params should be before result in #{file}")
+  end
+end

--- a/verify_expectations_format.rb
+++ b/verify_expectations_format.rb
@@ -1,10 +1,14 @@
-require 'json'
+# typed: strict
+# frozen_string_literal: true
+
+require "json"
 
 Dir["test/expectations/**/*.json"].each do |file|
   json = JSON.parse(File.read(file))
   params_index = json.keys.index("params")
   result_index = json.keys.index("result")
   if params_index && params_index > result_index
-    exit("Params should be before result in #{file}")
+    puts "params should be before result in #{file}"
+    exit(1)
   end
 end


### PR DESCRIPTION
### Motivation

For consistency and readability, let's ensure the `params` are always listed before the `results`.

I've also included a script to verify this automatically for future, but I'm trying to decide where this should live, as a separate Rake task to run in CI?
