### PR TITLE
Add Index#fuzzy_search to search for entries based on Jaro-Winkler

### DIFF
--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "yaml"
+require "did_you_mean"
 
 require "ruby_indexer/lib/ruby_indexer/visitor"
 require "ruby_indexer/lib/ruby_indexer/index"

--- a/sorbet/rbi/shims/did_you_mean.rbi
+++ b/sorbet/rbi/shims/did_you_mean.rbi
@@ -1,0 +1,6 @@
+# typed: true
+
+module DidYouMean::JaroWinkler
+  sig { params(str1: String, str2: String).returns(Float) }
+  def self.distance(str1, str2); end
+end


### PR DESCRIPTION
### Motivation

First step for #204

If we use a string similarity algorithm to filter and sort results when searching the index, we can show more relevant results on top.

VS Code will actually apply another layer of filtering on top of it, so it might not behave exactly as one would expected (e.g.: it filters out matches with incorrect characters in the middle).

However, I think it may still be beneficial to have this available in the index. It can not only power workspace symbols, but also enable other tooling to search the index with a potentially incorrect query.

**Note**

When we add autocomplete, we will need to explore turning the entries into a Prefix Tree for faster access. However, it would still be nice to offer a slower fuzzy search that doesn't require exact matches. Or maybe there's a way to support that in a Prefix Tree?

### Implementation

The implementation uses the `DidYouMean::JaroWinkler` implementation. Notice that the method is called `distance`, but it's actually computing the similarity. The distance would be `1 - similarity`.

We calculate the similarity for entries based on `query` and their `name`, filter out anything with a similarity lower than 0.7 and sort it based on that similarity score.

### Automated Tests

Added a test showing how to fuzzy search the index.