### PR TITLE
Ignore magic comments and prejoin comments

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -11,6 +11,7 @@ module RubyIndexer
         "included_gems" => Array,
         "excluded_patterns" => Array,
         "included_patterns" => Array,
+        "excluded_magic_comments" => Array,
       }.freeze,
       T::Hash[String, T.untyped],
     )
@@ -25,6 +26,22 @@ module RubyIndexer
       @included_gems = T.let([], T::Array[String])
       @excluded_patterns = T.let(["*_test.rb"], T::Array[String])
       @included_patterns = T.let(["#{Dir.pwd}/**/*.rb"], T::Array[String])
+      @excluded_magic_comments = T.let(
+        [
+          "frozen_string_literal:",
+          "typed:",
+          "compiled:",
+          "encoding:",
+          "shareable_constant_value:",
+          "warn_indent:",
+          "rubocop:",
+          "nodoc:",
+          "doc:",
+          "coding:",
+          "warn_past_scope:",
+        ],
+        T::Array[String],
+      )
     end
 
     sig { void }
@@ -63,6 +80,11 @@ module RubyIndexer
       files_to_index
     end
 
+    sig { returns(Regexp) }
+    def magic_comment_regex
+      /^\s*#\s*#{@excluded_magic_comments.join("|")}/
+    end
+
     private
 
     sig { params(config: T::Hash[String, T.untyped]).void }
@@ -86,6 +108,7 @@ module RubyIndexer
       @included_gems.concat(config["included_gems"]) if config["included_gems"]
       @excluded_patterns.concat(config["excluded_patterns"]) if config["excluded_patterns"]
       @included_patterns.concat(config["included_patterns"]) if config["included_patterns"]
+      @excluded_magic_comments.concat(config["excluded_magic_comments"]) if config["excluded_magic_comments"]
     end
   end
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
@@ -105,7 +105,12 @@ module RubyIndexer
         comment = @comments_by_line[line]
         break unless comment
 
-        comments.unshift(comment.location.slice)
+        comment_content = comment.location.slice.chomp
+        next if comment_content.match?(RubyIndexer.configuration.magic_comment_regex)
+
+        comment_content.delete_prefix!("#")
+        comment_content.delete_prefix!(" ")
+        comments.unshift(comment_content)
       end
 
       comments

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -162,10 +162,10 @@ module RubyIndexer
       RUBY
 
       foo_entry = @index["Foo"].first
-      assert_equal("# This is a Foo comment\n# This is another Foo comment\n", foo_entry.comments.join)
+      assert_equal("This is a Foo comment\nThis is another Foo comment", foo_entry.comments.join("\n"))
 
       bar_entry = @index["Bar"].first
-      assert_equal("# This Bar comment has 1 line padding\n", bar_entry.comments.join)
+      assert_equal("This Bar comment has 1 line padding", bar_entry.comments.join("\n"))
     end
 
     def test_comments_can_be_attached_to_a_namespaced_class
@@ -179,10 +179,10 @@ module RubyIndexer
       RUBY
 
       foo_entry = @index["Foo"].first
-      assert_equal("# This is a Foo comment\n# This is another Foo comment\n", foo_entry.comments.join)
+      assert_equal("This is a Foo comment\nThis is another Foo comment", foo_entry.comments.join("\n"))
 
       bar_entry = @index["Foo::Bar"].first
-      assert_equal("# This is a Bar comment\n", bar_entry.comments.join)
+      assert_equal("This is a Bar comment", bar_entry.comments.join("\n"))
     end
 
     def test_comments_can_be_attached_to_a_reopened_class
@@ -195,10 +195,26 @@ module RubyIndexer
       RUBY
 
       first_foo_entry = @index["Foo"][0]
-      assert_equal("# This is a Foo comment\n", first_foo_entry.comments.join)
+      assert_equal("This is a Foo comment", first_foo_entry.comments.join("\n"))
 
       second_foo_entry = @index["Foo"][1]
-      assert_equal("# This is another Foo comment\n", second_foo_entry.comments.join)
+      assert_equal("This is another Foo comment", second_foo_entry.comments.join("\n"))
+    end
+
+    def test_comments_removes_the_leading_pound_and_space
+      index(<<~RUBY)
+        # This is a Foo comment
+        class Foo; end
+
+        #This is a Bar comment
+        class Bar; end
+      RUBY
+
+      first_foo_entry = @index["Foo"][0]
+      assert_equal("This is a Foo comment", first_foo_entry.comments.join("\n"))
+
+      second_foo_entry = @index["Bar"][0]
+      assert_equal("This is a Bar comment", second_foo_entry.comments.join("\n"))
     end
   end
 end

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -31,5 +31,25 @@ module RubyIndexer
         @config.load_config
       end
     end
+
+    def test_magic_comments_regex
+      regex = RubyIndexer.configuration.magic_comment_regex
+
+      [
+        "# frozen_string_literal:",
+        "# typed:",
+        "# compiled:",
+        "# encoding:",
+        "# shareable_constant_value:",
+        "# warn_indent:",
+        "# rubocop:",
+        "# nodoc:",
+        "# doc:",
+        "# coding:",
+        "# warn_past_scope:",
+      ].each do |comment|
+        assert_match(regex, comment)
+      end
+    end
   end
 end

--- a/lib/ruby_indexer/test/constant_test.rb
+++ b/lib/ruby_indexer/test/constant_test.rb
@@ -84,16 +84,16 @@ module RubyIndexer
       RUBY
 
       foo_comment = @index["FOO"].first.comments.join("\n")
-      assert_equal("# FOO comment\n", foo_comment)
+      assert_equal("FOO comment", foo_comment)
 
       a_foo_comment = @index["A::FOO"].first.comments.join("\n")
-      assert_equal("# A::FOO comment\n", a_foo_comment)
+      assert_equal("A::FOO comment", a_foo_comment)
 
       bar_comment = @index["BAR"].first.comments.join("\n")
-      assert_equal("# ::BAR comment\n", bar_comment)
+      assert_equal("::BAR comment", bar_comment)
 
       a_baz_comment = @index["A::BAZ"].first.comments.join("\n")
-      assert_equal("# A::BAZ comment\n", a_baz_comment)
+      assert_equal("A::BAZ comment", a_baz_comment)
     end
 
     def test_variable_path_constants_are_ignored


### PR DESCRIPTION
### Motivation

In preparation for #201, I identified a couple of things that can be improved in how we index comments.
1. We should skip magic comments like `frozen_string_literal` or `typed` since those aren't actual documentation
2. I can't think of a reason why we'd want the array of comments rather than having the concatenated string already, so we might as well treat them as a full string of documentation

### Implementation

Changed `Entry#comments` to be a string and be collected as such. Also started ignoring the most common magic comments from being indexed.

### Automated Tests

Added a new example and adapted others.