### PR TITLE
Fix test file exclusion glob pattern

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -24,7 +24,7 @@ module RubyIndexer
 
       @excluded_gems = T.let(development_only_dependencies, T::Array[String])
       @included_gems = T.let([], T::Array[String])
-      @excluded_patterns = T.let(["*_test.rb"], T::Array[String])
+      @excluded_patterns = T.let(["**/*_test.rb"], T::Array[String])
       @included_patterns = T.let(["#{Dir.pwd}/**/*.rb"], T::Array[String])
       @excluded_magic_comments = T.let(
         [

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -15,6 +15,7 @@ module RubyIndexer
 
       assert(files_to_index.none? { |path| path.include?("test/fixtures") })
       assert(files_to_index.none? { |path| path.include?("minitest-reporters") })
+      assert(files_to_index.none? { |path| path == __FILE__ })
     end
 
     def test_paths_are_unique


### PR DESCRIPTION
### Motivation

I noticed that we were actually getting results from test files. The reason is because the glob pattern was wrong. `*_test.rb` doesn't provide matching for the beginning of the path and always fails.

### Implementation

Fixed the glob pattern by using the correct matching with `**/*_test.rb`.

### Automated Tests

Added a test to make sure we do not regress.