### PR TITLE
Allow definition and workspace symbol to return default gem symbols

### DIFF
--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -117,10 +117,15 @@ module RubyLsp
           # If the project has Sorbet, then we only want to handle go to definition for constants defined in gems, as an
           # additional behavior on top of jumping to RBIs. Sorbet can already handle go to definition for all constants
           # in the project, even if the files are typed false
-          next if DependencyDetector::HAS_TYPECHECKER && bundle_path && !entry.file_path.start_with?(bundle_path)
+          file_path = entry.file_path
+          if DependencyDetector::HAS_TYPECHECKER && bundle_path && !file_path.start_with?(bundle_path) &&
+              !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])
+
+            next
+          end
 
           Interface::Location.new(
-            uri: URI::Generic.from_path(path: entry.file_path).to_s,
+            uri: URI::Generic.from_path(path: file_path).to_s,
             range: Interface::Range.new(
               start: Interface::Position.new(line: location.start_line - 1, character: location.start_column),
               end: Interface::Position.new(line: location.end_line - 1, character: location.end_column),

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -49,4 +49,30 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
   ensure
     T.must(message_queue).close
   end
+
+  def test_jumping_to_default_gems
+    message_queue = Thread::Queue.new
+    position = { character: 0, line: 0 }
+
+    path = "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb"
+    uri = URI::Generic.from_path(path: path)
+
+    store = RubyLsp::Store.new
+    store.experimental_features = true
+    store.set(uri: URI("file:///folder/fake.rb"), source: <<~RUBY, version: 1)
+      Pathname
+    RUBY
+
+    executor = RubyLsp::Executor.new(store, message_queue)
+    executor.instance_variable_get(:@index).index_single(T.must(uri.to_standardized_path))
+
+    response = executor.execute({
+      method: "textDocument/definition",
+      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: position },
+    }).response
+
+    refute_empty(response)
+  ensure
+    T.must(message_queue).close
+  end
 end

--- a/test/requests/workspace_symbol_test.rb
+++ b/test/requests/workspace_symbol_test.rb
@@ -84,4 +84,11 @@ class WorkspaceSymbolTest < Minitest::Test
     assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
     assert_equal("Foo", T.must(result).container_name)
   end
+
+  def test_finds_default_gem_symbols
+    @index.index_single("#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb")
+
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Pathname", @index).run
+    refute_empty(result)
+  end
 end


### PR DESCRIPTION
### Motivation

If Sorbet is present in the application, we only want to include results for definition and workspace symbols related to gems, so that people can jump to the gem source.

We were performing out check against `Bundle.bundle_path` only, but that won't cover default gems, which are installed in `RbConfig::CONFIG["rubylibdir"]`.

### Implementation

Enhanced the check to test against `RbConfig::CONFIG["rubylibdir"]` as well.

### Automated Tests

Added tests so that we do not regress.