### PR TITLE
Unescape URIs using `DEFAULT_PARSER.unescape` instead of CGI

### DIFF
--- a/lib/core_ext/uri.rb
+++ b/lib/core_ext/uri.rb
@@ -26,7 +26,7 @@ module URI
       parsed_path = path
       return unless parsed_path
 
-      unescaped_path = CGI.unescape(parsed_path)
+      unescaped_path = DEFAULT_PARSER.unescape(parsed_path)
 
       # On Windows, when we're getting the file system path back from the URI, we need to remove the leading forward
       # slash

--- a/test/requests/support/uri_test.rb
+++ b/test/requests/support/uri_test.rb
@@ -39,5 +39,11 @@ module RubyLsp
       uri = URI("file:///c%3A/some/windows/path/to/file.rb")
       assert_equal("c:/some/windows/path/to/file.rb", uri.to_standardized_path)
     end
+
+    def test_plus_signs_are_properly_unescaped
+      path = "/opt/rubies/3.3.0/lib/ruby/3.3.0+0/pathname.rb"
+      uri = URI::Generic.from_path(path: path)
+      assert_equal(path, uri.to_standardized_path)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

I noticed this issue accidentally when working on #925.

Using `CGI.unescape` for a URI doesn't work in some cases and we should prefer `DEFAULT_PARSER.unescape` instead.

For example, if the path includes a `+`, `CGI.unescape` will turn it into a blank space when turning the URI back into a path, which is incorrect (it should just be the `+`).

### Implementation

Using `URI::DEFAULT_PARSER.unescape` fixes the problem and is probably what we should be using given that it's the opposite operation of what we do in `from_path`.

### Automated Tests

Added a test to ensure we don't regress.