### PR TITLE
Expand heredoc test for selection range

### DIFF
--- a/test/expectations/selection_ranges/heredoc.exp.json
+++ b/test/expectations/selection_ranges/heredoc.exp.json
@@ -14,7 +14,7 @@
                 },
                 "end": {
                     "line": 1,
-                    "character": 12
+                    "character": 11
                 }
             },
             "parent": {

--- a/test/fixtures/heredoc.rb
+++ b/test/fixtures/heredoc.rb
@@ -1,3 +1,3 @@
 <<~HEREDOC
-  some text
+  some text#{1 + 1}other text
 HEREDOC


### PR DESCRIPTION
### Motivation

Document the current behaviour to assist with the migration to YARP.

### Implementation

In YARP, a heredoc is respresented as a `InterpolatedStringNode`. In the fixture here, `parts` corresponds to the 3 elements of the string.

### Automated Tests

Updated

### Manual Tests

n/a
