### PR TITLE
Push hover separator before extension results

### DIFF
--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -61,7 +61,7 @@ module RubyLsp
         if @response.nil?
           @response = other.response
         else
-          @response.contents.value << other_response.contents.value << "\n\n"
+          @response.contents.value << "\n\n" << other_response.contents.value
         end
 
         self


### PR DESCRIPTION
### Motivation

This PR inverts the order in which we push the double line break separator for hover. Now that we have a default hover response, we need the separator to be pushed in between so that hover responses coming from extensions are properly separated.

This is what the Ruby LSP Rails hover looks like with our default response (using the changes in this PR). Without this change, the Rails document link is squished into the end of the documentation line, which looks odd.

<img width="762" alt="Screenshot 2023-08-24 at 10 16 42 AM" src="https://github.com/Shopify/ruby-lsp/assets/18742907/ae2b1b3b-075f-4723-acbd-e7a749057609">


### Implementation

Just inverted the order and pushed the line breaks before the extension's response.

### Automated Tests

Improved our tests to make sure that we consider the base response and the separation between extension responses.