### PR TITLE
Only index gem require paths

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -111,17 +111,17 @@ module RubyIndexer
       end
 
       # Add the locked gems to the list of files to be indexed
-      locked_gems&.each do |spec|
-        next if excluded_gems.include?(spec.name)
+      locked_gems&.each do |lazy_spec|
+        next if excluded_gems.include?(lazy_spec.name)
 
-        full_gem_path = Gem::Specification.find_by_name(spec.name).full_gem_path
+        spec = Gem::Specification.find_by_name(lazy_spec.name)
 
         # When working on a gem, it will be included in the locked_gems list. Since these are the project's own files,
         # we have already included and handled exclude patterns for it and should not re-include or it'll lead to
         # duplicates or accidentally ignoring exclude patterns
-        next if full_gem_path == Dir.pwd
+        next if spec.full_gem_path == Dir.pwd
 
-        files_to_index.concat(Dir.glob("#{full_gem_path}/**/*.rb"))
+        files_to_index.concat(Dir.glob("#{spec.full_gem_path}/{#{spec.require_paths.join(",")}}/**/*.rb"))
       rescue Gem::MissingSpecError
         # If a gem is scoped only to some specific platform, then its dependencies may not be installed either, but they
         # are still listed in locked_gems. We can't index them because they are not installed for the platform, so we

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -95,6 +95,8 @@ module RubyIndexer
       content = source || File.read(path)
       visitor = IndexVisitor.new(self, YARP.parse(content), path)
       visitor.run
+    rescue Errno::EISDIR
+      # If `path` is a directory, just ignore it and continue indexing
     end
 
     class Entry

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -118,5 +118,12 @@ module RubyIndexer
       assert_equal(4, result.length)
       assert_equal(["Foo::Baz", "Foo::Bar", "Foo", "Foo::Baz::Something"], result.map(&:name))
     end
+
+    def test_index_single_ignores_directories
+      FileUtils.mkdir("lib/this_is_a_dir.rb")
+      @index.index_single("lib/this_is_a_dir.rb")
+    ensure
+      FileUtils.rm_r("lib/this_is_a_dir.rb")
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Some gems ship their test folders in the release and that can sometimes cause problems. I noticed this because of a gem that tests for bad folder names and actually names a folder as something.rb, which we identify as a file and try to index and then it blows up.

We only care about files that are intended to be required, so we should only index require_paths and not the entire gem structure. This will make indexing faster for gems that ship with their test files and will prevent failures from weird setups.

### Implementation

Instead of indexing full_gem_path/**/.rb, we're now indexing full_gem_path/{lib,app,other_require_paths}/**/*.rb.

### Automated Tests

Added a test to verify we don't try to index any gem's test folders.