### PR TITLE
Use bundle check and only update every 4 hours

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -6,6 +6,7 @@ require "bundler"
 require "fileutils"
 require "pathname"
 require "digest"
+require "time"
 
 # This file is a script that will configure a custom bundle for the Ruby LSP. The custom bundle allows developers to use
 # the Ruby LSP without including the gem in their application's Gemfile while at the same time giving us access to the
@@ -17,6 +18,8 @@ module RubyLsp
 
     class BundleNotLocked < StandardError; end
 
+    FOUR_HOURS = T.let(4 * 60 * 60, Integer)
+
     sig { params(project_path: String, branch: T.nilable(String)).void }
     def initialize(project_path, branch: nil)
       @project_path = project_path
@@ -27,6 +30,7 @@ module RubyLsp
       @custom_gemfile = T.let(@custom_dir + "Gemfile", Pathname)
       @custom_lockfile = T.let(@custom_dir + "Gemfile.lock", Pathname)
       @lockfile_hash_path = T.let(@custom_dir + "main_lockfile_hash", Pathname)
+      @last_updated_path = T.let(@custom_dir + "last_updated", Pathname)
 
       # Regular bundle paths
       @gemfile = T.let(
@@ -173,15 +177,16 @@ module RubyLsp
       # custom `.ruby-lsp/Gemfile.lock` already exists and includes both gems
       command = +""
 
-      if (@dependencies["ruby-lsp"] && @dependencies["debug"]) ||
-          custom_bundle_dependencies["ruby-lsp"].nil? || custom_bundle_dependencies["debug"].nil?
+      if should_bundle_install?
         # Install gems using the custom bundle
-        command << "bundle install "
+        command << "bundle check || bundle install "
       else
         # If ruby-lsp or debug are not in the Gemfile, try to update them to the latest version
         command << "bundle update "
         command << "ruby-lsp " unless @dependencies["ruby-lsp"]
         command << "debug " unless @dependencies["debug"]
+
+        @last_updated_path.write(Time.now.iso8601)
       end
 
       # Redirect stdout to stderr to prevent going into an infinite loop. The extension might confuse stdout output with
@@ -192,6 +197,13 @@ module RubyLsp
       warn("Ruby LSP> Running bundle install for the custom bundle. This may take a while...")
       system(env, command)
       [bundle_gemfile.to_s, expanded_path]
+    end
+
+    sig { returns(T::Boolean) }
+    def should_bundle_install?
+      (!@dependencies["ruby-lsp"].nil? && !@dependencies["debug"].nil?) ||
+        custom_bundle_dependencies["ruby-lsp"].nil? || custom_bundle_dependencies["debug"].nil? ||
+        (@last_updated_path.exist? && Time.parse(@last_updated_path.read) > (Time.now - FOUR_HOURS))
     end
   end
 end

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -6,14 +6,14 @@ require "ruby_lsp/setup_bundler"
 
 class SetupBundlerTest < Minitest::Test
   def test_does_nothing_if_both_ruby_lsp_and_debug_are_in_the_bundle
-    Object.any_instance.expects(:system).with(bundle_env, "bundle install 1>&2")
+    Object.any_instance.expects(:system).with(bundle_env, "bundle check || bundle install 1>&2")
     Bundler::LockfileParser.any_instance.expects(:dependencies).returns({ "ruby-lsp" => true, "debug" => true })
     run_script
     refute_path_exists(".ruby-lsp")
   end
 
   def test_removes_ruby_lsp_folder_if_both_gems_were_added_to_the_bundle
-    Object.any_instance.expects(:system).with(bundle_env, "bundle install 1>&2")
+    Object.any_instance.expects(:system).with(bundle_env, "bundle check || bundle install 1>&2")
     Bundler::LockfileParser.any_instance.expects(:dependencies).returns({ "ruby-lsp" => true, "debug" => true })
     FileUtils.mkdir(".ruby-lsp")
     run_script
@@ -23,7 +23,7 @@ class SetupBundlerTest < Minitest::Test
   end
 
   def test_creates_custom_bundle
-    Object.any_instance.expects(:system).with(bundle_env(".ruby-lsp/Gemfile"), "bundle install 1>&2")
+    Object.any_instance.expects(:system).with(bundle_env(".ruby-lsp/Gemfile"), "bundle check || bundle install 1>&2")
     Bundler::LockfileParser.any_instance.expects(:dependencies).returns({}).at_least_once
     run_script
 
@@ -75,7 +75,10 @@ class SetupBundlerTest < Minitest::Test
         # ruby-lsp is a part of the custom lockfile and would try to run `bundle update ruby-lsp`, which would fail. If
         # we evaluate lazily, then we only find dependencies after the lockfile was copied, and then run bundle install
         # instead, which re-locks and adds the ruby-lsp
-        Object.any_instance.expects(:system).with(bundle_env(".ruby-lsp/Gemfile"), "bundle install 1>&2")
+        Object.any_instance.expects(:system).with(
+          bundle_env(".ruby-lsp/Gemfile"),
+          "bundle check || bundle install 1>&2",
+        )
         Bundler.with_unbundled_env do
           run_script
         end
@@ -120,9 +123,44 @@ class SetupBundlerTest < Minitest::Test
     end
   end
 
+  def test_does_only_updates_every_4_hours
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+          source "https://rubygems.org"
+          gem "rdoc"
+        GEMFILE
+
+        capture_subprocess_io do
+          Bundler.with_unbundled_env do
+            # Run bundle install to generate the lockfile
+            system("bundle install")
+
+            # Run the script once to generate a custom bundle
+            run_script
+          end
+        end
+
+        File.write(File.join(dir, ".ruby-lsp", "last_updated"), (Time.now - 30 * 60).iso8601)
+
+        capture_subprocess_io do
+          Object.any_instance.expects(:system).with(
+            bundle_env(".ruby-lsp/Gemfile"),
+            "bundle check || bundle install 1>&2",
+          )
+
+          Bundler.with_unbundled_env do
+            # Run the script again without having the lockfile modified
+            run_script
+          end
+        end
+      end
+    end
+  end
+
   def test_uses_absolute_bundle_path_for_bundle_install
     Bundler.settings.set_global("path", "vendor/bundle")
-    Object.any_instance.expects(:system).with(bundle_env(".ruby-lsp/Gemfile"), "bundle install 1>&2")
+    Object.any_instance.expects(:system).with(bundle_env(".ruby-lsp/Gemfile"), "bundle check || bundle install 1>&2")
     Bundler::LockfileParser.any_instance.expects(:dependencies).returns({}).at_least_once
     run_script(expected_path: File.expand_path("vendor/bundle", Dir.pwd))
   ensure
@@ -136,7 +174,10 @@ class SetupBundlerTest < Minitest::Test
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         bundle_gemfile = Pathname.new(".ruby-lsp").expand_path(Dir.pwd) + "Gemfile"
-        Object.any_instance.expects(:system).with(bundle_env(bundle_gemfile.to_s), "bundle install 1>&2")
+        Object.any_instance.expects(:system).with(
+          bundle_env(bundle_gemfile.to_s),
+          "bundle check || bundle install 1>&2",
+        )
 
         Bundler.with_unbundled_env do
           run_script
@@ -198,7 +239,7 @@ class SetupBundlerTest < Minitest::Test
         FileUtils.touch(File.join(dir, "Gemfile.lock"))
 
         Bundler.with_unbundled_env do
-          Object.any_instance.expects(:system).with(bundle_env, "bundle install 1>&2")
+          Object.any_instance.expects(:system).with(bundle_env, "bundle check || bundle install 1>&2")
           Bundler::LockfileParser.any_instance.expects(:dependencies).returns({})
           run_script
         end
@@ -212,7 +253,10 @@ class SetupBundlerTest < Minitest::Test
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         bundle_gemfile = Pathname.new(".ruby-lsp").expand_path(Dir.pwd) + "Gemfile"
-        Object.any_instance.expects(:system).with(bundle_env(bundle_gemfile.to_s), "bundle install 1>&2")
+        Object.any_instance.expects(:system).with(
+          bundle_env(bundle_gemfile.to_s),
+          "bundle check || bundle install 1>&2",
+        )
 
         Bundler.with_unbundled_env do
           run_script(branch: "test-branch")


### PR DESCRIPTION
### Motivation

Running bundle install or update in very large projects can be quite slow. Using bundle check to verify if dependencies are satisfied is significantly faster than running either of the other commands by a lot. For some projects, it's 14x faster to run bundle check.

Additionally, we don't need to check for updates every single time we start the server. We can add another file under the .ruby-lsp folder to remember when we last tried updating and then space updates a little bit, so that we can avoid running bundle update.

Speeding up the initial custom bundle setup is especially relevant now that indexing will also slow down the booting process of the server.

### Implementation

Started creating a last_updated file with the timestamp when we last ran bundle update. If we tried updating in the last 4 hours, then we just run bundle check || bundle install, which will only try to install if the dependencies are not satisfied, which is much faster.

### Automated Tests

Adapted test expectations and added an example to verify we don't try to update more than once within 4 hours.