### PR TITLE
Fix small issues with end insertion

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -117,7 +117,7 @@ module RubyLsp
           move_cursor_to(@position[:line], @indentation + 2)
         elsif next_line.nil? || next_line.strip.empty?
           add_edit_with_text("#{indents}end", { line: @position[:line] + 1, character: @position[:character] })
-          move_cursor_to(@position[:line], @indentation + 3)
+          move_cursor_to(@position[:line] - 1, @indentation + @previous_line.size + 1)
         end
       end
 

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -116,7 +116,7 @@ module RubyLsp
           add_edit_with_text("#{indents}end")
           move_cursor_to(@position[:line], @indentation + 2)
         elsif next_line.nil? || next_line.strip.empty?
-          add_edit_with_text("#{indents}end", { line: @position[:line] + 1, character: @position[:character] })
+          add_edit_with_text("#{indents}end\n", { line: @position[:line] + 1, character: @position[:character] })
           move_cursor_to(@position[:line] - 1, @indentation + @previous_line.size + 1)
         end
       end

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -112,7 +112,8 @@ module RubyLsp
         next_line = @lines[@position[:line] + 1]
 
         if current_line.nil? || current_line.strip.empty?
-          add_edit_with_text(" \n#{indents}end")
+          add_edit_with_text("\n")
+          add_edit_with_text("#{indents}end")
           move_cursor_to(@position[:line], @indentation + 2)
         elsif next_line.nil? || next_line.strip.empty?
           add_edit_with_text("#{indents}end", { line: @position[:line] + 1, character: @position[:character] })

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -20,7 +20,11 @@ class OnTypeFormattingTest < Minitest::Test
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
-        newText: " \nend",
+        newText: "\n",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "end",
       },
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
@@ -302,7 +306,11 @@ class OnTypeFormattingTest < Minitest::Test
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
-        newText: " \nend",
+        newText: "\n",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "end",
       },
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -336,4 +336,31 @@ class OnTypeFormattingTest < Minitest::Test
     edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "\n").run
     assert_empty(edits)
   end
+
+  def test_breaking_line_immediately_after_keyword
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "  def\nfoo",
+      }],
+      version: 2,
+    )
+    document.parse
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
+    expected_edits = [
+      {
+        range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
+        newText: "  end",
+      },
+      {
+        range: { start: { line: 0, character: 6 }, end: { line: 0, character: 6 } },
+        newText: "$0",
+      },
+    ]
+
+    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
 end

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -353,7 +353,7 @@ class OnTypeFormattingTest < Minitest::Test
     expected_edits = [
       {
         range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
-        newText: "  end",
+        newText: "  end\n",
       },
       {
         range: { start: { line: 0, character: 6 }, end: { line: 0, character: 6 } },


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

This PR fixes a couple of small issues with inserting `end` as part of on-type formatting:

- Removes the trailing whitespace after the cursor
- Ensures the cursor is placed correctly when breaking after the keyword
- Ensures the `end` is inserted on a new line rather than replacing one, when breaking after the keyword

<details>
  <summary>Before and after videos</summary>

  https://github.com/Shopify/ruby-lsp/assets/770763/64cd0888-7cba-4ff0-ba40-5f4f536861b7

  https://github.com/Shopify/ruby-lsp/assets/770763/27906b36-a1d7-4d78-b5b1-6de675cd4745

</details>

Happy to split this up if some of these fixes are more contentious than others.


### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

> Removes the trailing white space after the cursor

For some reason, if we try to insert the newline character and the `end` keyword via a single edit without the extra space, [`applyEdit`](https://github.com/Shopify/vscode-ruby-lsp/blob/74e45e754aac281a22d5627c22a1a2a3e73d8b33/src/client.ts#L160) strips the indentation and the cursor ends up at the beginning of the middle line. Inserting the newline via a separate edit doesn't seem to have this problem.

> Ensures the cursor is placed correctly when breaking after the keyword

There was [some discussion](https://github.com/Shopify/ruby-lsp/pull/462#discussion_r1082642170) about whether the cursor should remain where it would normally be if the end insertion didn't happen, but it appears moving it back to where the break happened is the intended behavior. Personally, I would find it more natural to leave the cursor where it is as per the linked comment, but I think the intended behavior makes sense too.

> Ensures the `end` is inserted on a new line rather than replacing one

This just adds a newline character after the `end`.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

I updated the existing tests for the trailing whitespace issue and added a new test for the cursor placement and newline fixes.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

> Removes the trailing whitespace after the cursor

Start defining a method and hit return with the cursor immediately after the method name:

<img src="https://github.com/Shopify/ruby-lsp/assets/770763/a55ea65b-7e0f-485b-81bf-130b22944761" width="200">

The current behavior is that the cursor is in the correct position but there is a trailing whitespace character:

<img src="https://github.com/Shopify/ruby-lsp/assets/770763/c6b1e82d-0c37-455e-90e9-a2213126847f" width="200">

The expected behavior after this change is that the cursor will be at the end of the new line without trailing whitespace:

<img src="https://github.com/Shopify/ruby-lsp/assets/770763/fea3c035-65f0-45d8-88ec-56dbd8411053" width="200">

> Ensures the cursor is placed correctly when breaking after the keyword

Break the line here:

<img src="https://github.com/Shopify/ruby-lsp/assets/770763/2cbdbf6a-ffbd-4e6b-a1ad-dee4336161f3" width="200">

The current behavior is that the cursor incorrectly moves to a position part-way through the second line:

<img src="https://github.com/Shopify/ruby-lsp/assets/770763/8eb23f81-cd44-4e97-b40c-5761531c4ee3" width="200">

The intended behavior is that the cursor moves back to a position where the user can continue typing the condition:

<img src="https://github.com/Shopify/ruby-lsp/assets/770763/dc83ff3f-ecb9-4b77-8423-a0f53bcd863c" width="200">

> Ensures the `end` is inserted on a new line rather than replacing one

Break the line here:

<img src="https://github.com/Shopify/ruby-lsp/assets/770763/a30a2a7c-252b-4bed-b60f-44d0f1685759" width="200">

The current behavior is that the `end` replaces the blank line:

<img src="https://github.com/Shopify/ruby-lsp/assets/770763/9ebb1aeb-6980-4e14-8a13-b90a4cc35c1e" width="200">

I would expect it to have inserted a new line:

<img src="https://github.com/Shopify/ruby-lsp/assets/770763/72d5268e-0871-4d36-b6ed-24ae1b23eb5e" width="200">







