### PR TITLE
Memoize magic comment regex

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -134,7 +134,7 @@ module RubyIndexer
 
     sig { returns(Regexp) }
     def magic_comment_regex
-      /^\s*#\s*#{@excluded_magic_comments.join("|")}/
+      @magic_comment_regex ||= T.let(/^\s*#\s*#{@excluded_magic_comments.join("|")}/, T.nilable(Regexp))
     end
 
     private


### PR DESCRIPTION
### Motivation

I was doing some profiling of the indexing process and discovered we were spending about 7-10 seconds inside the `magic_comment_regex` method.

I don't know why it's so expensive to instantiate that regex, but there's also no point in creating it every time since it's always the same one.

With memoization this is 40x faster than the previous implementation.

### Implementation

Just memoized the regex.