### PR TITLE
Do not try to generate test command for temporary files

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -65,7 +65,7 @@ module RubyLsp
         class_name = node.constant.constant.value
         @class_stack.push(class_name)
 
-        if class_name.end_with?("Test")
+        if @path && class_name.end_with?("Test")
           add_test_code_lens(
             node,
             name: class_name,
@@ -89,7 +89,7 @@ module RubyLsp
         visibility, _ = @visibility_stack.last
         if visibility == "public"
           method_name = node.name.value
-          if method_name.start_with?("test_")
+          if @path && method_name.start_with?("test_")
             add_test_code_lens(
               node,
               name: method_name,

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -79,6 +79,24 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     assert_empty(response)
   end
 
+  def test_no_code_lens_for_unsaved_files
+    source = <<~RUBY
+      class FooTest < Test::Unit::TestCase
+        def test_bar; end
+      end
+    RUBY
+    uri = URI::Generic.build(scheme: "untitled", opaque: "Untitled-1")
+
+    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
+
+    emitter = RubyLsp::EventEmitter.new
+    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "minitest")
+    emitter.visit(document.tree)
+    response = listener.response
+
+    assert_empty(response)
+  end
+
   def test_code_lens_extensions
     message_queue = Thread::Queue.new
     create_code_lens_extension


### PR DESCRIPTION
### Motivation

For unsaved files, the URI has no path and therefore there's no way to run tests defined in them. Currently, we're breaking when generating the test command.

### Implementation

We need to check if there's a path before trying to generate test commands or code lens.

### Automated Tests

Added an example that reproduces the problem.