### PR TITLE
Make indexing a stable feature

### DIFF
--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -109,14 +109,12 @@ class ExecutorTest < Minitest::Test
   end
 
   def test_initialized_populates_index
-    @store.experimental_features = true
     @executor.execute({ method: "initialized", params: {} })
     index = @executor.instance_variable_get(:@index)
     refute_empty(index.instance_variable_get(:@entries))
   end
 
   def test_initialized_recovers_from_indexing_failures
-    @store.experimental_features = true
     RubyIndexer::Index.any_instance.expects(:index_all).once.raises(StandardError, "boom!")
 
     @executor.execute({ method: "initialized", params: {} })
@@ -204,6 +202,12 @@ class ExecutorTest < Minitest::Test
 
       assert_equal("none", @store.formatter)
       refute_empty(@message_queue)
+
+      # Account for starting and ending the progress notifications during initialized
+      assert_equal("window/workDoneProgress/create", @message_queue.pop.message)
+      assert_equal("$/progress", @message_queue.pop.message)
+      assert_equal("$/progress", @message_queue.pop.message)
+
       notification = T.must(@message_queue.pop)
       assert_equal("window/showMessage", notification.message)
       assert_equal(

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -364,11 +364,9 @@ class IntegrationTest < Minitest::Test
   end
 
   def test_workspace_symbol
-    initialize_lsp(["workspaceSymbol"], experimental_features_enabled: true)
+    initialize_lsp(["workspaceSymbol"])
     open_file_with("class Foo\nend")
     # Read the response for the progress indicator notifications
-    read_response("window/workDoneProgress/create")
-    read_response("$/progress")
     read_response("textDocument/didOpen")
 
     # Populate the index
@@ -447,6 +445,8 @@ class IntegrationTest < Minitest::Test
 
     enabled_providers = enabled_features.map { |feature| FEATURE_TO_PROVIDER[feature] }
     assert_equal([:positionEncoding, :textDocumentSync, *enabled_providers], response[:capabilities].keys)
+    read_response("window/workDoneProgress/create")
+    read_response("$/progress")
   end
 
   def open_file_with(content)

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -12,7 +12,6 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     position = @__params&.first || { character: 0, line: 0 }
 
     store = RubyLsp::Store.new
-    store.experimental_features = true
     store.set(uri: URI("file:///folder/fake.rb"), source: source, version: 1)
     executor = RubyLsp::Executor.new(store, message_queue)
 
@@ -58,7 +57,6 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     uri = URI::Generic.from_path(path: path)
 
     store = RubyLsp::Store.new
-    store.experimental_features = true
     store.set(uri: URI("file:///folder/fake.rb"), source: <<~RUBY, version: 1)
       Pathname
     RUBY


### PR DESCRIPTION
### Motivation

We've had a few releases with indexing as experimental and fixed all issues encountered so far. Let's make indexing stable and get definition, workspace symbol and hover in the hands of devs.

### Implementation

Just removed the experimental checks.

### Automated Tests

Since we push progress notifications, some tests had to be adapted to account for those.