### PR TITLE
Introduce indexables

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/indexable_path.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/indexable_path.rb
@@ -1,0 +1,29 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyIndexer
+  class IndexablePath
+    extend T::Sig
+
+    sig { returns(T.nilable(String)) }
+    attr_reader :require_path
+
+    sig { returns(String) }
+    attr_reader :full_path
+
+    # An IndexablePath is instantiated with a load_path_entry and a full_path. The load_path_entry is where the file can
+    # be found in the $LOAD_PATH, which we use to determine the require_path. The load_path_entry may be `nil` if the
+    # indexer is configured to go through files that do not belong in the $LOAD_PATH. For example,
+    # `sorbet/tapioca/require.rb` ends up being a part of the paths to be indexed because it's a Ruby file inside the
+    # project, but the `sorbet` folder is not a part of the $LOAD_PATH. That means that both its load_path_entry and
+    # require_path will be `nil`, since it cannot be required by the project
+    sig { params(load_path_entry: T.nilable(String), full_path: String).void }
+    def initialize(load_path_entry, full_path)
+      @full_path = full_path
+      @require_path = T.let(
+        load_path_entry ? Pathname.new(full_path).relative_path_from(load_path_entry).to_s.delete_suffix(".rb") : nil,
+        T.nilable(String),
+      )
+    end
+  end
+end

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -4,6 +4,7 @@
 require "yaml"
 require "did_you_mean"
 
+require "ruby_indexer/lib/ruby_indexer/indexable_path"
 require "ruby_indexer/lib/ruby_indexer/visitor"
 require "ruby_indexer/lib/ruby_indexer/index"
 require "ruby_indexer/lib/ruby_indexer/configuration"

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -139,7 +139,7 @@ module RubyIndexer
 
       assert_entry("Foo", Index::Entry::Class, "/fake/path/foo.rb:0-0:1-2")
 
-      @index.delete("/fake/path/foo.rb")
+      @index.delete(IndexablePath.new(nil, "/fake/path/foo.rb"))
       refute_entry("Foo")
       assert_empty(@index.instance_variable_get(:@files_to_entries))
     end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -6,11 +6,11 @@ require_relative "test_case"
 module RubyIndexer
   class IndexTest < TestCase
     def test_deleting_one_entry_for_a_class
-      @index.index_single("/fake/path/foo.rb", <<~RUBY)
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
         class Foo
         end
       RUBY
-      @index.index_single("/fake/path/other_foo.rb", <<~RUBY)
+      @index.index_single(IndexablePath.new(nil, "/fake/path/other_foo.rb"), <<~RUBY)
         class Foo
         end
       RUBY
@@ -18,13 +18,13 @@ module RubyIndexer
       entries = @index["Foo"]
       assert_equal(2, entries.length)
 
-      @index.delete("/fake/path/other_foo.rb")
+      @index.delete(IndexablePath.new(nil, "/fake/path/other_foo.rb"))
       entries = @index["Foo"]
       assert_equal(1, entries.length)
     end
 
     def test_deleting_all_entries_for_a_class
-      @index.index_single("/fake/path/foo.rb", <<~RUBY)
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
         class Foo
         end
       RUBY
@@ -32,13 +32,13 @@ module RubyIndexer
       entries = @index["Foo"]
       assert_equal(1, entries.length)
 
-      @index.delete("/fake/path/foo.rb")
+      @index.delete(IndexablePath.new(nil, "/fake/path/foo.rb"))
       entries = @index["Foo"]
       assert_nil(entries)
     end
 
     def test_index_resolve
-      @index.index_single("/fake/path/foo.rb", <<~RUBY)
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
         class Bar; end
 
         module Foo
@@ -72,7 +72,7 @@ module RubyIndexer
     end
 
     def test_accessing_with_colon_colon_prefix
-      @index.index_single("/fake/path/foo.rb", <<~RUBY)
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
         class Bar; end
 
         module Foo
@@ -92,7 +92,7 @@ module RubyIndexer
     end
 
     def test_fuzzy_search
-      @index.index_single("/fake/path/foo.rb", <<~RUBY)
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
         class Bar; end
 
         module Foo
@@ -121,7 +121,7 @@ module RubyIndexer
 
     def test_index_single_ignores_directories
       FileUtils.mkdir("lib/this_is_a_dir.rb")
-      @index.index_single("lib/this_is_a_dir.rb")
+      @index.index_single(IndexablePath.new(nil, "lib/this_is_a_dir.rb"))
     ensure
       FileUtils.rm_r("lib/this_is_a_dir.rb")
     end

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -12,7 +12,7 @@ module RubyIndexer
     private
 
     def index(source)
-      @index.index_single("/fake/path/foo.rb", source)
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), source)
     end
 
     def assert_entry(expected_name, type, expected_location)

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -105,7 +105,7 @@ class ExpectationsTestRunner < Minitest::Test
 
   private
 
-  def test_extension(extension_creation_method, source:, &block)
+  def test_extension(extension_creation_method, source:)
     RubyLsp::DependencyDetector.const_set(:HAS_TYPECHECKER, false)
     message_queue = Thread::Queue.new
 
@@ -116,7 +116,10 @@ class ExpectationsTestRunner < Minitest::Test
     store.set(uri: uri, source: source, version: 1)
 
     executor = RubyLsp::Executor.new(store, message_queue)
-    executor.instance_variable_get(:@index).index_single(uri.to_standardized_path, source)
+    executor.instance_variable_get(:@index).index_single(
+      RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)),
+      source,
+    )
 
     yield(executor)
   ensure

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -15,10 +15,15 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     store.set(uri: URI("file:///folder/fake.rb"), source: source, version: 1)
     executor = RubyLsp::Executor.new(store, message_queue)
 
-    executor.instance_variable_get(:@index).index_single(File.expand_path(
-      "../../lib/ruby_lsp/event_emitter.rb",
-      __dir__,
-    ))
+    executor.instance_variable_get(:@index).index_single(
+      RubyIndexer::IndexablePath.new(
+        nil,
+        File.expand_path(
+          "../../lib/ruby_lsp/event_emitter.rb",
+          __dir__,
+        ),
+      ),
+    )
 
     begin
       # We need to pretend that Sorbet is not a dependency or else we can't properly test
@@ -62,7 +67,12 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     RUBY
 
     executor = RubyLsp::Executor.new(store, message_queue)
-    executor.instance_variable_get(:@index).index_single(T.must(uri.to_standardized_path))
+    executor.instance_variable_get(:@index).index_single(
+      RubyIndexer::IndexablePath.new(
+        nil,
+        T.must(uri.to_standardized_path),
+      ),
+    )
 
     response = executor.execute({
       method: "textDocument/definition",

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -17,7 +17,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
     executor = RubyLsp::Executor.new(store, message_queue)
     index = executor.instance_variable_get(:@index)
-    index.index_single(uri.to_standardized_path, source)
+    index.index_single(RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source)
 
     begin
       # We need to pretend that Sorbet is not a dependency or else we can't properly test


### PR DESCRIPTION
### Motivation

First step for #938

In order to provide require path completion through our index, we need to first remember what are the require paths for each entry. We currently only use the full path.

I think it'll be useful to have a concept of an `Indexable` as the unit of items to be indexed. In the future, if we need to include the gem name where we found an entry, we will also be able to do that.

### Implementation

I recommend reviewing by commit:
- Add `Indexable`
- Started returning indexables instead of strings from the configuration
- Started using indexables in `Index`
- Started using indexables for synchronizing document modifications
- Fixed tests

### Automated Tests

Adapted existing tests.