### PR TITLE
Enable all Hover tests (YARP migration)

### DIFF
--- a/lib/ruby_lsp/event_emitter.rb
+++ b/lib/ruby_lsp/event_emitter.rb
@@ -49,6 +49,8 @@ module RubyLsp
         @listeners[:on_module]&.each { |l| T.unsafe(l).on_module(node) }
       when YARP::ConstantWriteNode
         @listeners[:on_constant_write]&.each { |l| T.unsafe(l).on_constant_write(node) }
+      when YARP::ConstantReadNode
+        @listeners[:on_constant_read]&.each { |l| T.unsafe(l).on_constant_read(node) }
       end
     end
 

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -284,7 +284,7 @@ module RubyLsp
 
       if (Requests::Hover::ALLOWED_TARGETS.include?(parent.class) &&
           !Requests::Hover::ALLOWED_TARGETS.include?(target.class)) ||
-          (parent.is_a?(SyntaxTree::ConstPathRef) && target.is_a?(SyntaxTree::Const))
+          (parent.is_a?(YARP::ConstantPathNode) && target.is_a?(YARP::ConstantReadNode))
         target = parent
       end
 

--- a/test/expectations/definition/class_reference.exp.json
+++ b/test/expectations/definition/class_reference.exp.json
@@ -8,7 +8,7 @@
                     "character": 2
                 },
                 "end": {
-                    "line": 185,
+                    "line": 187,
                     "character": 4
                 }
             }

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -53,9 +53,6 @@ class ExpectationsTestRunner < Minitest::Test
         # temporarily skip until we figure out comment handling
         next if handler_class == RubyLsp::Requests::DocumentLink && path == "test/fixtures/source_comment.rb"
 
-        # temporarily skip until we figure out nesting here
-        next if handler_class == RubyLsp::Requests::Hover && path == "test/fixtures/documented_namespaced_class.rb"
-
         test_name = File.basename(path, ".rb")
 
         expectations_dir = File.join(TEST_EXP_DIR, expectation_suffix)

--- a/test/expectations/hover/documented_namespaced_class.exp.json
+++ b/test/expectations/hover/documented_namespaced_class.exp.json
@@ -17,7 +17,7 @@
             },
             "end": {
                 "line": 1,
-                "character": 14
+                "character": 13
             }
         }
     }


### PR DESCRIPTION
### Motivation

When updating to stay in sync with main, I had temporarily disabled some tests that were tricky to get passing. They are re-enabled in this PR.

Paired on with @vinistock.
