### PR TITLE
Add entries prefix tree

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb
@@ -64,6 +64,10 @@ module RubyIndexer
         node = node.children[char] ||= Node.new(char, value, node)
       end
 
+      # This line is to allow a value to be overridden. When we are indexing files, we want to be able to update entries
+      # for a given fully qualified name if we find more occurrences of it. Without being able to override, that would
+      # not be possible
+      node.value = value
       node.leaf = true
     end
 
@@ -116,7 +120,7 @@ module RubyIndexer
       attr_reader :key
 
       sig { returns(Value) }
-      attr_reader :value
+      attr_accessor :value
 
       sig { returns(T::Boolean) }
       attr_accessor :leaf

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -138,5 +138,25 @@ module RubyIndexer
 
       assert_equal(["path/foo", "path/other_foo"], @index.search_require_paths("path"))
     end
+
+    def test_searching_for_entries_based_on_prefix
+      @index.index_single(IndexablePath.new("/fake", "/fake/path/foo.rb"), <<~RUBY)
+        class Foo::Bar
+        end
+      RUBY
+      @index.index_single(IndexablePath.new("/fake", "/fake/path/other_foo.rb"), <<~RUBY)
+        class Foo::Bar
+        end
+
+        class Foo::Baz
+        end
+      RUBY
+
+      results = @index.prefix_search("Foo", []).map { |entries| entries.map(&:name) }
+      assert_equal([["Foo::Bar", "Foo::Bar"], ["Foo::Baz"]], results)
+
+      results = @index.prefix_search("Ba", ["Foo"]).map { |entries| entries.map(&:name) }
+      assert_equal([["Foo::Bar", "Foo::Bar"], ["Foo::Baz"]], results)
+    end
   end
 end

--- a/lib/ruby_indexer/test/prefix_tree_test.rb
+++ b/lib/ruby_indexer/test/prefix_tree_test.rb
@@ -136,5 +136,15 @@ module RubyIndexer
       assert_empty(tree.search("abcdef"))
       assert_equal(["value1"], tree.search("abc"))
     end
+
+    def test_overriding_values
+      tree = PrefixTree[Integer].new
+
+      tree.insert("foo/bar", 123)
+      assert_equal([123], tree.search("foo/bar"))
+
+      tree.insert("foo/bar", 456)
+      assert_equal([456], tree.search("foo/bar"))
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Closes #939

Maintain a `PrefixTree` for index entries so that we can search them based on a prefix and provide autocompletion.

### Implementation

By commit:
1. Started allowing us to override values in the `PrefixTree`. This is necessary because we may find multiple re-openings for classes or modules, so need some way of updating an existing entry in the tree
2. Added a `PrefixTree` for entries and started managing it in additions and deletions

### Automated Tests

Added tests.