### PR TITLE
Use parse! for OptionParser

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -3,6 +3,7 @@
 
 require "optparse"
 
+original_args = ARGV.dup
 options = {}
 parser = OptionParser.new do |opts|
   opts.banner = "Usage: ruby-lsp [options]"
@@ -33,7 +34,7 @@ parser = OptionParser.new do |opts|
 end
 
 begin
-  parser.parse
+  parser.parse!
 rescue OptionParser::InvalidOption => e
   warn(e)
   warn("")
@@ -56,7 +57,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
 
   env = { "BUNDLE_GEMFILE" => bundle_gemfile }
   env["BUNDLE_PATH"] = bundle_path if bundle_path
-  exit exec(env, "bundle exec ruby-lsp #{ARGV.join(" ")}")
+  exit exec(env, "bundle exec ruby-lsp #{original_args.join(" ")}")
 end
 
 require "sorbet-runtime"


### PR DESCRIPTION
### Motivation

In #905, we ended up deciding to go with `parse` instead of `parse!` because it didn't mutate `ARGV`. However, it also doesn't invoke the `on` blocks and so `ruby-lsp --version` or `ruby-lsp --branch` don't work.

### Implementation

Changed the implementation to dup the `ARGV` first and then just used `parse!`.

### Automated Tests

I think we need to extract a `CLI` class to encapsulate all of these and make it easier to test. However, I don't think it's worth the investment immediately, let's just fix this for now and think about the `CLI` later.