### PR TITLE
Return `VOID` by default for unhandled requests

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -178,6 +178,8 @@ module RubyLsp
         workspace_symbol(request.dig(:params, :query))
       when "rubyLsp/textDocument/showSyntaxTree"
         show_syntax_tree(uri, request.dig(:params, :range))
+      else
+        VOID
       end
     end
 

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -217,6 +217,15 @@ class ExecutorTest < Minitest::Test
     end
   end
 
+  def test_returns_void_for_unhandled_request
+    executor = RubyLsp::Executor.new(@store, @message_queue)
+
+    result = executor.execute(method: "anything/not/existing", params: {})
+    assert_same(RubyLsp::VOID, result.response)
+  end
+
+  private
+
   def with_uninstalled_rubocop(&block)
     rubocop_paths = $LOAD_PATH.select { |path| path.include?("gems/rubocop") }
     rubocop_paths.each { |path| $LOAD_PATH.delete(path) }
@@ -236,8 +245,6 @@ class ExecutorTest < Minitest::Test
   rescue NameError
     # Depending on which tests have run prior to this one, `RuboCopRunner` may or may not be defined
   end
-
-  private
 
   def stub_dependencies(rubocop:, syntax_tree:)
     dependencies = {}


### PR DESCRIPTION
### Motivation

Closes #882

Currently, if we receive a request we don't handle, we are returning `nil` back to the editor. Based on the issue reported, not every editor handles this and some completely stop the execution of the LSP.

This is probably happening when the server makes a [request to the client to initiate progress](https://github.com/Shopify/ruby-lsp/blob/d3610077a097adaaf04d75d92e0f857ac8151876/lib/ruby_lsp/executor.rb#L514). Because this is not a notification, but a request to the client, it actually sends back a response. When we receive that response back, we should not return `nil` back to the editor, since it does not expect anything back.

Generally, I don't think the LSP should ever return anything back to the editor for requests we don't handle explicitly.

### Implementation

Added an `else` branch to our case statement to always return `VOID` for unhandled requests.

### Automated Tests

Added a test verifying the new behaviour. Also moved the `private` since there were some helper methods defined outside of that section.