### PR TITLE
Add instructions for Sublime Text LSP

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -82,7 +82,7 @@ require("lspconfig").ruby_ls.setup({
 
 ## Sublime Text LSP
 
-[LSP for Sublime Text](https://github.com/sublimelsp/LSP) has built-in support for [Solargraph](https://lsp.sublimetext.io/language_servers/#solargraph) and [Sorbet](https://lsp.sublimetext.io/language_servers/#sorbet)
+[LSP for Sublime Text](https://github.com/sublimelsp/LSP) includes setup instructions for [Solargraph](https://lsp.sublimetext.io/language_servers/#solargraph) and [Sorbet](https://lsp.sublimetext.io/language_servers/#sorbet)
 
 To add ruby-lsp support, add the following configuration to your LSP client configuration:
 
@@ -93,12 +93,15 @@ To add ruby-lsp support, add the following configuration to your LSP client conf
     "command": [
       "ruby-lsp"
     ],
-    "selector": "source.ruby | text.html.ruby | text.html.erb | text.html.rails",
+    "selector": "source.ruby",
     "initializationOptions": {
-      "diagnostics": false
+      "enabledFeatures": {
+        "diagnostics": false
+      },
+      "experimentalFeaturesEnabled": true
     }
   }
 }
 ```
 
-Restart LSP or Sublime Text and `ruby-lsp` will automatically activate when opening `.rb` or `.erb` files.
+Restart LSP or Sublime Text and `ruby-lsp` will automatically activate when opening ruby files.

--- a/EDITORS.md
+++ b/EDITORS.md
@@ -9,6 +9,7 @@ new H2 header in this file containing the instructions. -->
 - [Emacs LSP Mode](https://emacs-lsp.github.io/lsp-mode/page/lsp-ruby-lsp/)
 - [Emacs Eglot](#Emacs-Eglot)
 - [Neovim LSP](#Neovim-LSP)
+- [Sublime Text LSP](#sublime-text-lsp)
 
 ## Emacs Eglot
 
@@ -78,3 +79,26 @@ require("lspconfig").ruby_ls.setup({
   end,
 })
 ```
+
+## Sublime Text LSP
+
+[LSP for Sublime Text](https://github.com/sublimelsp/LSP) has built-in support for [Solargraph](https://lsp.sublimetext.io/language_servers/#solargraph) and [Sorbet](https://lsp.sublimetext.io/language_servers/#sorbet)
+
+To add ruby-lsp support, add the following configuration to your LSP client configuration:
+
+```json
+"clients": {
+  "ruby-lsp": {
+    "enabled": true,
+    "command": [
+      "ruby-lsp"
+    ],
+    "selector": "source.ruby | text.html.ruby | text.html.erb | text.html.rails",
+    "initializationOptions": {
+      "diagnostics": false
+    }
+  }
+}
+```
+
+Restart LSP or Sublime Text and `ruby-lsp` will automatically activate when opening `.rb` or `.erb` files.

--- a/EDITORS.md
+++ b/EDITORS.md
@@ -82,9 +82,7 @@ require("lspconfig").ruby_ls.setup({
 
 ## Sublime Text LSP
 
-[LSP for Sublime Text](https://github.com/sublimelsp/LSP) includes setup instructions for [Solargraph](https://lsp.sublimetext.io/language_servers/#solargraph) and [Sorbet](https://lsp.sublimetext.io/language_servers/#sorbet)
-
-To add ruby-lsp support, add the following configuration to your LSP client configuration:
+To configure the Ruby LSP using [LSP for Sublime Text](https://github.com/sublimelsp/LSP), add the following configuration to your LSP client configuration:
 
 ```json
 "clients": {


### PR DESCRIPTION
### Motivation

I think it would be great to expand the existing documentation to include `ruby-lsp` configuration for Sublime Text. This would make it easier for Sublime Text users to enjoy the benefits of `ruby-lsp`.

### Implementation

The documented Sublime Text LSP configiguration is based on the official documentation for configuring [solargraph](https://lsp.sublimetext.io/language_servers/#solargraph)

### Automated Tests

Not applicable because this is a change affecting documentation only.

### Manual Tests

(1) shows the LSP configuration
(2) shows that `ruby-lsp` is picked up correctly
(3) shows a rubocop offense

![CleanShot 2023-08-31 at 21 21 32@2x](https://github.com/Shopify/ruby-lsp/assets/106914804/88e87b8c-3875-4cd3-8e0f-ac46778331d1)