### PR TITLE
Run Tapoica gem verify prior to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,15 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
+
+      - name: Check if gem RBIs are update to date
+        run: bundle exec tapioca gem --verify
+
       - name: Create release
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
### Motivation

As discussed with @Morriar.

Outdated RBIs could mean that typechecking failures are missed. But updating the RBIs every time a gem is updated is tedious. As a middle-ground, let's verify just prior to release.

### Implementation

Add a step to the release script. 

### Automated Tests

n/a

### Manual Tests

This is a bit awkward to verify without actually making a release - I suggest that we observe it next time we do a release, since it is low risk.