### PR TITLE
Make requests easier to extend

### DIFF
--- a/SERVER_EXTENSIONS.md
+++ b/SERVER_EXTENSIONS.md
@@ -134,7 +134,7 @@ module RubyLsp
       ResponseType = type_member { { fixed: T.nilable(::RubyLsp::Interface::Hover) } }
 
       sig { override.returns(ResponseType) }
-      attr_reader :response
+      attr_reader :_response
 
       # Listeners are initialized with the EventEmitter. This object is used by the Ruby LSP to emit the events when it
       # finds nodes during AST analysis. Listeners must register which nodes they want to handle with the emitter (see
@@ -145,7 +145,7 @@ module RubyLsp
       def initialize(config, emitter, message_queue)
         super
 
-        @response = T.let(nil, ResponseType)
+        @_response = T.let(nil, ResponseType)
         @config = config
 
         # Register that this listener will handle `on_const` events (i.e.: whenever a constant is found in the code)
@@ -159,7 +159,7 @@ module RubyLsp
         # Certain helpers are made available to listeners to build LSP responses. The classes under `RubyLsp::Interface`
         # are generally used to build responses and they match exactly what the specification requests.
         contents = RubyLsp::Interface::MarkupContent.new(kind: "markdown", value: "Hello!")
-        @response = RubyLsp::Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
+        @_response = RubyLsp::Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
       end
     end
   end

--- a/lib/ruby_lsp/check_docs.rb
+++ b/lib/ruby_lsp/check_docs.rb
@@ -53,7 +53,8 @@ module RubyLsp
       # documented
       features = ObjectSpace.each_object(Class).filter_map do |k|
         klass = T.unsafe(k)
-        klass if klass < RubyLsp::Requests::BaseRequest || klass < RubyLsp::Listener
+        klass if klass < RubyLsp::Requests::BaseRequest ||
+          (klass < RubyLsp::Listener && klass != RubyLsp::ExtensibleListener)
       end
 
       missing_docs = T.let(Hash.new { |h, k| h[k] = [] }, T::Hash[String, T::Array[String]])

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -105,9 +105,9 @@ module RubyLsp
 
         # Store all responses retrieve in this round of visits in the cache and then return the response for the request
         # we actually received
-        document.cache_set("textDocument/documentSymbol", document_symbol.merged_response)
+        document.cache_set("textDocument/documentSymbol", document_symbol.response)
         document.cache_set("textDocument/documentLink", document_link.response)
-        document.cache_set("textDocument/codeLens", code_lens.merged_response)
+        document.cache_set("textDocument/codeLens", code_lens.response)
         document.cache_set(
           "textDocument/semanticTokens/full",
           Requests::Support::SemanticTokenEncoder.new.encode(semantic_highlighting.response),
@@ -296,7 +296,7 @@ module RubyLsp
       # Emit events for all listeners
       emitter.emit_for_target(target)
 
-      hover.merged_response
+      hover.response
     end
 
     sig do

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -103,14 +103,11 @@ module RubyLsp
         semantic_highlighting = Requests::SemanticHighlighting.new(emitter, @message_queue)
         emitter.visit(document.tree) if document.parsed?
 
-        code_lens.merge_external_listeners_responses!
-        document_symbol.merge_external_listeners_responses!
-
         # Store all responses retrieve in this round of visits in the cache and then return the response for the request
         # we actually received
-        document.cache_set("textDocument/documentSymbol", document_symbol.response)
+        document.cache_set("textDocument/documentSymbol", document_symbol.merged_response)
         document.cache_set("textDocument/documentLink", document_link.response)
-        document.cache_set("textDocument/codeLens", code_lens.response)
+        document.cache_set("textDocument/codeLens", code_lens.merged_response)
         document.cache_set(
           "textDocument/semanticTokens/full",
           Requests::Support::SemanticTokenEncoder.new.encode(semantic_highlighting.response),
@@ -299,8 +296,7 @@ module RubyLsp
       # Emit events for all listeners
       emitter.emit_for_target(target)
 
-      hover.merge_external_listeners_responses!
-      hover.response
+      hover.merged_response
     end
 
     sig do

--- a/lib/ruby_lsp/listener.rb
+++ b/lib/ruby_lsp/listener.rb
@@ -20,10 +20,15 @@ module RubyLsp
       @message_queue = message_queue
     end
 
+    sig { returns(ResponseType) }
+    def response
+      _response
+    end
+
     # Override this method with an attr_reader that returns the response of your listener. The listener should
     # accumulate results in a @response variable and then provide the reader so that it is accessible
     sig { abstract.returns(ResponseType) }
-    def response; end
+    def _response; end
   end
 
   # ExtensibleListener is an abstract class to be used by requests that accept extensions.
@@ -58,9 +63,9 @@ module RubyLsp
     end
 
     sig { returns(ResponseType) }
-    def merged_response
+    def response
       merge_external_listeners_responses! unless @response_merged
-      response
+      super
     end
 
     sig do

--- a/lib/ruby_lsp/listener.rb
+++ b/lib/ruby_lsp/listener.rb
@@ -18,7 +18,6 @@ module RubyLsp
     def initialize(emitter, message_queue)
       @emitter = emitter
       @message_queue = message_queue
-      @external_listeners = T.let([], T::Array[RubyLsp::Listener[ResponseType]])
     end
 
     # Override this method with an attr_reader that returns the response of your listener. The listener should
@@ -26,18 +25,44 @@ module RubyLsp
     sig { abstract.returns(ResponseType) }
     def response; end
 
-    # Merge responses from all external listeners into the base listener's response. We do this to return a single
-    # response to the editor including the results of all extensions
-    sig { void }
-    def merge_external_listeners_responses!
-      @external_listeners.each { |l| merge_response!(l) }
-    end
+    module Extensible
+      extend T::Sig
+      extend T::Generic
 
-    # Does nothing by default. Requests that accept extensions should override this method to define how to merge
-    # responses coming from external listeners
-    sig { overridable.params(other: Listener[T.untyped]).returns(T.self_type) }
-    def merge_response!(other)
-      self
+      ResponseType = type_member
+
+      abstract!
+
+      requires_ancestor { Listener }
+
+      sig { params(emitter: EventEmitter, message_queue: Thread::Queue).void }
+      def initialize(emitter, message_queue)
+        super
+        @external_listeners = T.let(
+          Extension.extensions.filter_map do |ext|
+            initialize_external_listener(ext)
+          end,
+          T::Array[RubyLsp::Listener[ResponseType]],
+        )
+      end
+
+      # Merge responses from all external listeners into the base listener's response. We do this to return a single
+      # response to the editor including the results of all extensions
+      sig { void }
+      def merge_external_listeners_responses!
+        @external_listeners.each { |l| merge_response!(l) }
+      end
+
+      sig do
+        abstract.params(extension: RubyLsp::Extension).returns(T.nilable(RubyLsp::Listener[ResponseType]))
+      end
+      def initialize_external_listener(extension); end
+
+      # Does nothing by default. Requests that accept extensions should override this method to define how to merge
+      # responses coming from external listeners
+      sig { abstract.params(other: Listener[T.untyped]).returns(T.self_type) }
+      def merge_response!(other)
+      end
     end
   end
 end

--- a/lib/ruby_lsp/listener.rb
+++ b/lib/ruby_lsp/listener.rb
@@ -24,45 +24,54 @@ module RubyLsp
     # accumulate results in a @response variable and then provide the reader so that it is accessible
     sig { abstract.returns(ResponseType) }
     def response; end
+  end
 
-    module Extensible
-      extend T::Sig
-      extend T::Generic
+  # ExtensibleListener is an abstract class to be used by requests that accept extensions.
+  class ExtensibleListener < Listener
+    extend T::Sig
+    extend T::Generic
 
-      ResponseType = type_member
+    ResponseType = type_member
 
-      abstract!
+    abstract!
 
-      requires_ancestor { Listener }
+    # When inheriting from ExtensibleListener, the `super` of constructor must be called **after** the subclass's own
+    # ivars have been initialized. This is because the constructor of ExtensibleListener calls
+    # `initialize_external_listener` which may depend on the subclass's ivars.
+    sig { params(emitter: EventEmitter, message_queue: Thread::Queue).void }
+    def initialize(emitter, message_queue)
+      super
+      @response_merged = T.let(false, T::Boolean)
+      @external_listeners = T.let(
+        Extension.extensions.filter_map do |ext|
+          initialize_external_listener(ext)
+        end,
+        T::Array[RubyLsp::Listener[ResponseType]],
+      )
+    end
 
-      sig { params(emitter: EventEmitter, message_queue: Thread::Queue).void }
-      def initialize(emitter, message_queue)
-        super
-        @external_listeners = T.let(
-          Extension.extensions.filter_map do |ext|
-            initialize_external_listener(ext)
-          end,
-          T::Array[RubyLsp::Listener[ResponseType]],
-        )
-      end
+    # Merge responses from all external listeners into the base listener's response. We do this to return a single
+    # response to the editor including the results of all extensions
+    sig { void }
+    def merge_external_listeners_responses!
+      @external_listeners.each { |l| merge_response!(l) }
+    end
 
-      # Merge responses from all external listeners into the base listener's response. We do this to return a single
-      # response to the editor including the results of all extensions
-      sig { void }
-      def merge_external_listeners_responses!
-        @external_listeners.each { |l| merge_response!(l) }
-      end
+    sig { returns(ResponseType) }
+    def merged_response
+      merge_external_listeners_responses! unless @response_merged
+      response
+    end
 
-      sig do
-        abstract.params(extension: RubyLsp::Extension).returns(T.nilable(RubyLsp::Listener[ResponseType]))
-      end
-      def initialize_external_listener(extension); end
+    sig do
+      abstract.params(extension: RubyLsp::Extension).returns(T.nilable(RubyLsp::Listener[ResponseType]))
+    end
+    def initialize_external_listener(extension); end
 
-      # Does nothing by default. Requests that accept extensions should override this method to define how to merge
-      # responses coming from external listeners
-      sig { abstract.params(other: Listener[T.untyped]).returns(T.self_type) }
-      def merge_response!(other)
-      end
+    # Does nothing by default. Requests that accept extensions should override this method to define how to merge
+    # responses coming from external listeners
+    sig { abstract.params(other: Listener[T.untyped]).returns(T.self_type) }
+    def merge_response!(other)
     end
   end
 end

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -29,13 +29,13 @@ module RubyLsp
       SUPPORTED_TEST_LIBRARIES = T.let(["minitest", "test-unit"], T::Array[String])
 
       sig { override.returns(ResponseType) }
-      attr_reader :response
+      attr_reader :_response
 
       sig { params(uri: URI::Generic, emitter: EventEmitter, message_queue: Thread::Queue, test_library: String).void }
       def initialize(uri, emitter, message_queue, test_library)
         @uri = T.let(uri, URI::Generic)
         @test_library = T.let(test_library, String)
-        @response = T.let([], ResponseType)
+        @_response = T.let([], ResponseType)
         @path = T.let(uri.to_standardized_path, T.nilable(String))
         # visibility_stack is a stack of [current_visibility, previous_visibility]
         @visibility_stack = T.let([["public", "public"]], T::Array[T::Array[T.nilable(String)]])
@@ -153,7 +153,7 @@ module RubyLsp
 
       sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }
       def merge_response!(other)
-        @response.concat(other.response)
+        @_response.concat(other.response)
         self
       end
 
@@ -176,7 +176,7 @@ module RubyLsp
           },
         ]
 
-        @response << create_code_lens(
+        @_response << create_code_lens(
           node,
           title: "Run",
           command_name: "rubyLsp.runTest",
@@ -184,7 +184,7 @@ module RubyLsp
           data: { type: "test", kind: kind },
         )
 
-        @response << create_code_lens(
+        @_response << create_code_lens(
           node,
           title: "Run In Terminal",
           command_name: "rubyLsp.runTestInTerminal",
@@ -192,7 +192,7 @@ module RubyLsp
           data: { type: "test_in_terminal", kind: kind },
         )
 
-        @response << create_code_lens(
+        @_response << create_code_lens(
           node,
           title: "Debug",
           command_name: "rubyLsp.debugTest",
@@ -241,7 +241,7 @@ module RubyLsp
 
       sig { params(node: SyntaxTree::Command, remote: String).void }
       def add_open_gem_remote_code_lens(node, remote)
-        @response << create_code_lens(
+        @_response << create_code_lens(
           node,
           title: "Open remote",
           command_name: "rubyLsp.openLink",

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -18,11 +18,9 @@ module RubyLsp
     # class Test < Minitest::Test
     # end
     # ```
-    class CodeLens < Listener
+    class CodeLens < ExtensibleListener
       extend T::Sig
       extend T::Generic
-
-      include Extensible
 
       ResponseType = type_member { { fixed: T::Array[Interface::CodeLens] } }
 

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -24,7 +24,7 @@ module RubyLsp
       ResponseType = type_member { { fixed: T.nilable(T.any(T::Array[Interface::Location], Interface::Location)) } }
 
       sig { override.returns(ResponseType) }
-      attr_reader :response
+      attr_reader :_response
 
       sig do
         params(
@@ -41,7 +41,7 @@ module RubyLsp
         @uri = uri
         @nesting = nesting
         @index = index
-        @response = T.let(nil, ResponseType)
+        @_response = T.let(nil, ResponseType)
         emitter.register(self, :on_command, :on_const, :on_const_path_ref)
       end
 
@@ -76,7 +76,7 @@ module RubyLsp
           if entry
             candidate = entry.full_path
 
-            @response = Interface::Location.new(
+            @_response = Interface::Location.new(
               uri: URI::Generic.from_path(path: candidate).to_s,
               range: Interface::Range.new(
                 start: Interface::Position.new(line: 0, character: 0),
@@ -90,7 +90,7 @@ module RubyLsp
           current_folder = path ? Pathname.new(CGI.unescape(path)).dirname : Dir.pwd
           candidate = File.expand_path(File.join(current_folder, required_file))
 
-          @response = Interface::Location.new(
+          @_response = Interface::Location.new(
             uri: URI::Generic.from_path(path: candidate).to_s,
             range: Interface::Range.new(
               start: Interface::Position.new(line: 0, character: 0),
@@ -113,7 +113,7 @@ module RubyLsp
           nil
         end
 
-        @response = entries.filter_map do |entry|
+        @_response = entries.filter_map do |entry|
           location = entry.location
           # If the project has Sorbet, then we only want to handle go to definition for constants defined in gems, as an
           # additional behavior on top of jumping to RBIs. Sorbet can already handle go to definition for all constants

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -28,7 +28,7 @@ module RubyLsp
       ResponseType = type_member { { fixed: T::Array[Interface::DocumentHighlight] } }
 
       sig { override.returns(ResponseType) }
-      attr_reader :response
+      attr_reader :_response
 
       sig do
         params(
@@ -41,7 +41,7 @@ module RubyLsp
       def initialize(target, parent, emitter, message_queue)
         super(emitter, message_queue)
 
-        @response = T.let([], T::Array[Interface::DocumentHighlight])
+        @_response = T.let([], T::Array[Interface::DocumentHighlight])
 
         return unless target && parent
 
@@ -83,7 +83,7 @@ module RubyLsp
       sig { params(match: Support::HighlightTarget::HighlightMatch).void }
       def add_highlight(match)
         range = range_from_syntax_tree_node(match.node)
-        @response << Interface::DocumentHighlight.new(range: range, kind: match.type)
+        @_response << Interface::DocumentHighlight.new(range: range, kind: match.type)
       end
     end
   end

--- a/lib/ruby_lsp/requests/document_link.rb
+++ b/lib/ruby_lsp/requests/document_link.rb
@@ -73,7 +73,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      attr_reader :response
+      attr_reader :_response
 
       sig { params(uri: URI::Generic, emitter: EventEmitter, message_queue: Thread::Queue).void }
       def initialize(uri, emitter, message_queue)
@@ -84,7 +84,7 @@ module RubyLsp
         path = uri.to_standardized_path
         version_match = path ? /(?<=%40)[\d.]+(?=\.rbi$)/.match(path) : nil
         @gem_version = T.let(version_match && version_match[0], T.nilable(String))
-        @response = T.let([], T::Array[Interface::DocumentLink])
+        @_response = T.let([], T::Array[Interface::DocumentLink])
 
         emitter.register(self, :on_comment)
       end
@@ -99,7 +99,7 @@ module RubyLsp
         file_path = self.class.gem_paths.dig(uri.gem_name, gem_version, CGI.unescape(uri.path))
         return if file_path.nil?
 
-        @response << Interface::DocumentLink.new(
+        @_response << Interface::DocumentLink.new(
           range: range_from_syntax_tree_node(node),
           target: "file://#{file_path}##{uri.line_number}",
           tooltip: "Jump to #{file_path}##{uri.line_number}",

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -26,11 +26,9 @@ module RubyLsp
     #   end
     # end
     # ```
-    class DocumentSymbol < Listener
+    class DocumentSymbol < ExtensibleListener
       extend T::Sig
       extend T::Generic
-
-      include Extensible
 
       ResponseType = type_member { { fixed: T::Array[Interface::DocumentSymbol] } }
 

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -47,12 +47,12 @@ module RubyLsp
       end
 
       sig { override.returns(T::Array[Interface::DocumentSymbol]) }
-      attr_reader :response
+      attr_reader :_response
 
       sig { params(emitter: EventEmitter, message_queue: Thread::Queue).void }
       def initialize(emitter, message_queue)
         @root = T.let(SymbolHierarchyRoot.new, SymbolHierarchyRoot)
-        @response = T.let(@root.children, T::Array[Interface::DocumentSymbol])
+        @_response = T.let(@root.children, T::Array[Interface::DocumentSymbol])
         @stack = T.let(
           [@root],
           T::Array[T.any(SymbolHierarchyRoot, Interface::DocumentSymbol)],
@@ -83,7 +83,7 @@ module RubyLsp
       # Merges responses from other listeners
       sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }
       def merge_response!(other)
-        @response.concat(other.response)
+        @_response.concat(other.response)
         self
       end
 

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -13,11 +13,9 @@ module RubyLsp
     # ```ruby
     # String # -> Hovering over the class reference will show all declaration locations and the documentation
     # ```
-    class Hover < Listener
+    class Hover < ExtensibleListener
       extend T::Sig
       extend T::Generic
-
-      include Extensible
 
       ResponseType = type_member { { fixed: T.nilable(Interface::Hover) } }
 

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -30,7 +30,7 @@ module RubyLsp
       )
 
       sig { override.returns(ResponseType) }
-      attr_reader :response
+      attr_reader :_response
 
       sig do
         params(
@@ -43,7 +43,7 @@ module RubyLsp
       def initialize(index, nesting, emitter, message_queue)
         @nesting = nesting
         @index = index
-        @response = T.let(nil, ResponseType)
+        @_response = T.let(nil, ResponseType)
 
         super(emitter, message_queue)
         emitter.register(self, :on_const_path_ref, :on_const)
@@ -60,10 +60,10 @@ module RubyLsp
         other_response = other.response
         return self unless other_response
 
-        if @response.nil?
-          @response = other.response
+        if @_response.nil?
+          @_response = other.response
         else
-          @response.contents.value << "\n\n" << other_response.contents.value
+          @_response.contents.value << "\n\n" << other_response.contents.value
         end
 
         self
@@ -113,7 +113,7 @@ module RubyLsp
           kind: "markdown",
           value: "#{title}\n\n**Definitions**: #{definitions.join(" | ")}\n\n#{content}",
         )
-        @response = Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
+        @_response = Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
       end
     end
   end

--- a/lib/ruby_lsp/requests/inlay_hints.rb
+++ b/lib/ruby_lsp/requests/inlay_hints.rb
@@ -27,13 +27,13 @@ module RubyLsp
       RESCUE_STRING_LENGTH = T.let("rescue".length, Integer)
 
       sig { override.returns(ResponseType) }
-      attr_reader :response
+      attr_reader :_response
 
       sig { params(range: T::Range[Integer], emitter: EventEmitter, message_queue: Thread::Queue).void }
       def initialize(range, emitter, message_queue)
         super(emitter, message_queue)
 
-        @response = T.let([], ResponseType)
+        @_response = T.let([], ResponseType)
         @range = range
 
         emitter.register(self, :on_rescue)
@@ -47,7 +47,7 @@ module RubyLsp
         loc = node.location
         return unless visible?(node, @range)
 
-        @response << Interface::InlayHint.new(
+        @_response << Interface::InlayHint.new(
           position: { line: loc.start_line - 1, character: loc.start_column + RESCUE_STRING_LENGTH },
           label: "StandardError",
           padding_left: true,

--- a/lib/ruby_lsp/requests/path_completion.rb
+++ b/lib/ruby_lsp/requests/path_completion.rb
@@ -20,12 +20,12 @@ module RubyLsp
       ResponseType = type_member { { fixed: T::Array[Interface::CompletionItem] } }
 
       sig { override.returns(ResponseType) }
-      attr_reader :response
+      attr_reader :_response
 
       sig { params(index: RubyIndexer::Index, emitter: EventEmitter, message_queue: Thread::Queue).void }
       def initialize(index, emitter, message_queue)
         super(emitter, message_queue)
-        @response = T.let([], ResponseType)
+        @_response = T.let([], ResponseType)
         @index = index
 
         emitter.register(self, :on_tstring_content)
@@ -34,7 +34,7 @@ module RubyLsp
       sig { params(node: SyntaxTree::TStringContent).void }
       def on_tstring_content(node)
         @index.search_require_paths(node.value).map!(&:require_path).sort!.each do |path|
-          @response << build_completion(T.must(path), node)
+          @_response << build_completion(T.must(path), node)
         end
       end
 

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -105,7 +105,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      attr_reader :response
+      attr_reader :_response
 
       sig do
         params(
@@ -117,7 +117,7 @@ module RubyLsp
       def initialize(emitter, message_queue, range: nil)
         super(emitter, message_queue)
 
-        @response = T.let([], ResponseType)
+        @_response = T.let([], ResponseType)
         @range = range
         @special_methods = T.let(nil, T.nilable(T::Array[String]))
 
@@ -174,7 +174,7 @@ module RubyLsp
         # When finding a module or class definition, we will have already pushed a token related to this constant. We
         # need to look at the previous two tokens and if they match this locatione exactly, avoid pushing another token
         # on top of the previous one
-        return if @response.last(2).any? { |token| token.location == node.location }
+        return if @_response.last(2).any? { |token| token.location == node.location }
 
         add_token(node.location, :namespace)
       end
@@ -327,7 +327,7 @@ module RubyLsp
       def add_token(location, type, modifiers = [])
         length = location.end_char - location.start_char
         modifiers_indices = modifiers.filter_map { |modifier| TOKEN_MODIFIERS[modifier] }
-        @response.push(
+        @_response.push(
           SemanticToken.new(
             location: location,
             length: length,

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -130,7 +130,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
         raise "uri can't be nil" unless uri
 
         klass = Class.new(RubyLsp::Listener) do
-          attr_reader :response
+          attr_reader :_response
 
           def initialize(uri, emitter, message_queue)
             super(emitter, message_queue)
@@ -140,7 +140,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
           def on_class(node)
             T.bind(self, RubyLsp::Listener[T.untyped])
 
-            @response = [RubyLsp::Interface::CodeLens.new(
+            @_response = [RubyLsp::Interface::CodeLens.new(
               range: range_from_syntax_tree_node(node),
               command: RubyLsp::Interface::Command.new(
                 title: "Run #{node.constant.constant.value}",

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -127,6 +127,8 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
       end
 
       def create_code_lens_listener(uri, emitter, message_queue)
+        raise "uri can't be nil" unless uri
+
         klass = Class.new(RubyLsp::Listener) do
           attr_reader :response
 

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -36,7 +36,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
 
       def create_document_symbol_listener(emitter, message_queue)
         klass = Class.new(RubyLsp::Listener) do
-          attr_reader :response
+          attr_reader :_response
 
           def initialize(emitter, message_queue)
             super
@@ -51,7 +51,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
             first_argument = node.arguments.parts.first
             test_name = first_argument.parts.map(&:value).join
 
-            @response = [RubyLsp::Interface::DocumentSymbol.new(
+            @_response = [RubyLsp::Interface::DocumentSymbol.new(
               name: test_name,
               kind: LanguageServer::Protocol::Constant::SymbolKind::METHOD,
               selection_range: range_from_syntax_tree_node(node),

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -63,7 +63,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
       def create_hover_listener(emitter, message_queue)
         klass = Class.new(RubyLsp::Listener) do
-          attr_reader :response
+          attr_reader :_response
 
           def initialize(emitter, message_queue)
             super
@@ -76,7 +76,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
               kind: "markdown",
               value: "Hello from middleware: #{node.value}",
             )
-            @response = RubyLsp::Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
+            @_response = RubyLsp::Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
           end
         end
 


### PR DESCRIPTION
### Motivation

This is part of https://github.com/Shopify/ruby-lsp/issues/808

Currently, to make a listener-based request extensible, we need to:

- Update its constructor to initialise an array of external listeners
- Implement a few interfaces like `merge_response!` and `merge_external_listeners_responses!`
- Remember to call `merge_external_listeners_responses!` in the `executor.rb` before accessing the response

It's not easy to remember all of them at the same time. And when it's not implemented correctly, we'd rely on runtime information to figure out what's missing.

So with this change, I want to utilise Sorbet as much as possible, while reducing the APIs that need to be implemented.

### Implementation

- When extending a listener class, we change its parent class from `Listener` to the new `ExtensibleListener` class. Sorbet would then require a few more interfaces on its child class than `Listener`'s.
- To make `ExtensibleListener#response` merge external responses automatically, I changed `Listener`'s response interface to `_response`. This will prevent individual listener classes from overriding the `response` method when declaring its `ResponseType`.
- I also changed a few utility scripts (e.g. doc check) as `ExtensibleListener` is `Listener`'s child class but is abstract.

One shortfall of this approach is that if `initialize_external_listener` uses ivars to initialise external listeners, `super` needs to be called **after** the ivars are initialised. And this could not be type-checked. (Ideally we should prepend a module for such order-dependant requirement, but it's not supported by Sorbet)

### Automated Tests

All existing tests should pass

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
