### PR TITLE
Index modules and classes starting with unicode characters

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
@@ -77,10 +77,7 @@ module RubyIndexer
     sig { params(node: T.any(YARP::ClassNode, YARP::ModuleNode), klass: T.class_of(Index::Entry)).void }
     def add_index_entry(node, klass)
       name = node.constant_path.location.slice
-
-      unless /^[A-Z:]/.match?(name)
-        return visit_child_nodes(node)
-      end
+      return visit_child_nodes(node) unless /^[[:upper:]:]/.match?(name)
 
       comments = collect_comments(node)
       @index << klass.new(fully_qualify_name(name), @file_path, node.location, comments)

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -216,5 +216,21 @@ module RubyIndexer
       second_foo_entry = @index["Bar"][0]
       assert_equal("This is a Bar comment", second_foo_entry.comments.join("\n"))
     end
+
+    def test_constants_using_unicode_names_are_properly_indexed
+      index(<<~RUBY)
+        class Árvore
+        end
+
+        module Ônibus
+        end
+
+        ÓCULOS = 1
+      RUBY
+
+      assert_entry("Árvore", Index::Entry::Class, "/fake/path/foo.rb:0-0:1-2")
+      assert_entry("Ônibus", Index::Entry::Module, "/fake/path/foo.rb:3-0:4-2")
+      assert_entry("ÓCULOS", Index::Entry::Constant, "/fake/path/foo.rb:6-0:6-9")
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Ruby allows using unicode characters in constant names, so we have to account for that when indexing.

Uncovered while addressing https://github.com/Shopify/ruby-lsp/pull/957#discussion_r1313489032.

NOTE: this PR identified a bug in YARP. It's currently ignoring the original string's encoding when doing `node.slice`.

### Implementation

Switched the regex to allow for any uppercase character, which will include unicode ones.

### Automated Tests

Added a test demonstrating some unicode character classes.