### PR TITLE
Correct create_document_symbol_listener's signature

### DIFF
--- a/lib/ruby_lsp/extension.rb
+++ b/lib/ruby_lsp/extension.rb
@@ -130,7 +130,7 @@ module RubyLsp
       overridable.params(
         emitter: EventEmitter,
         message_queue: Thread::Queue,
-      ).returns(T.nilable(Listener[T.nilable(Interface::DocumentSymbol)]))
+      ).returns(T.nilable(Listener[T::Array[Interface::DocumentSymbol]]))
     end
     def create_document_symbol_listener(emitter, message_queue); end
   end


### PR DESCRIPTION
The listener should be expected to return an array of `DocumentSymbol`, instead of a nilable one.

I tried to capture by making tests `typed: true`, but currently we can only create the test extension class with `Class.new(RubyLsp::Extension)`, which seems to Sorbet's ability to type check the method in tests.