### PR TITLE
Use indexed paths to provide jump to require definition

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -28,7 +28,7 @@ module RubyIndexer
       @files_to_entries = T.let({}, T::Hash[String, T::Array[Entry]])
 
       # Holds all require paths for every indexed item so that we can provide autocomplete for requires
-      @require_paths_tree = T.let(PrefixTree[String].new, PrefixTree[String])
+      @require_paths_tree = T.let(PrefixTree[IndexablePath].new, PrefixTree[IndexablePath])
     end
 
     sig { params(indexable: IndexablePath).void }
@@ -73,7 +73,7 @@ module RubyIndexer
       @entries[fully_qualified_name.delete_prefix("::")]
     end
 
-    sig { params(query: String).returns(T::Array[String]) }
+    sig { params(query: String).returns(T::Array[IndexablePath]) }
     def search_require_paths(query)
       @require_paths_tree.search(query)
     end
@@ -147,7 +147,7 @@ module RubyIndexer
       visitor.run
 
       require_path = indexable_path.require_path
-      @require_paths_tree.insert(require_path, require_path) if require_path
+      @require_paths_tree.insert(require_path, indexable_path) if require_path
     rescue Errno::EISDIR
       # If `path` is a directory, just ignore it and continue indexing
     end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -136,7 +136,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_equal(["path/foo", "path/other_foo"], @index.search_require_paths("path"))
+      assert_equal(["path/foo", "path/other_foo"], @index.search_require_paths("path").map(&:require_path))
     end
 
     def test_searching_for_entries_based_on_prefix

--- a/lib/ruby_lsp/requests/path_completion.rb
+++ b/lib/ruby_lsp/requests/path_completion.rb
@@ -33,8 +33,8 @@ module RubyLsp
 
       sig { params(node: SyntaxTree::TStringContent).void }
       def on_tstring_content(node)
-        @index.search_require_paths(node.value).sort!.each do |path|
-          @response << build_completion(path, node)
+        @index.search_require_paths(node.value).map!(&:require_path).sort!.each do |path|
+          @response << build_completion(T.must(path), node)
         end
       end
 

--- a/test/expectations/definition/requires.exp.json
+++ b/test/expectations/definition/requires.exp.json
@@ -1,6 +1,6 @@
 {
     "result": {
-        "uri": "file:///ruby_lsp/utils.rb",
+        "uri": "file:///ruby_lsp/event_emitter.rb",
         "range": {
             "start": {
                 "line": 0,

--- a/test/fixtures/requires.rb
+++ b/test/fixtures/requires.rb
@@ -1,1 +1,1 @@
-require "ruby_lsp/utils"
+require "ruby_lsp/event_emitter"

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -105,7 +105,13 @@ class IntegrationTest < Minitest::Test
     initialize_lsp(["definition"])
     open_file_with("require 'ruby_lsp/utils'")
 
-    assert_telemetry("textDocument/didOpen")
+    read_response("textDocument/didOpen")
+
+    # Populate the index
+    send_request("initialized")
+    read_response("initialized")
+    # Read the response for the progress end notification
+    read_response("$/progress")
 
     response = make_request(
       "textDocument/definition",


### PR DESCRIPTION
### Motivation

Now that we have all require paths indexed, we do not need to search the `$LOAD_PATH` to find the location of a require to jump to. We can just access the index and jump directly.

### Implementation

Changed the require prefix tree from `String -> String` to `String -> IndexablePath`. We need to know the full path of an entry in order to jump to it.

Started looking for the path inside of the index.

### Automated Tests

I adapted existing tests and added a new one for jumping to a default require path, which we didn't support properly before.