### PR TITLE
Add fixture for class reference test

### DIFF
--- a/test/expectations/definition/class_reference.exp.json
+++ b/test/expectations/definition/class_reference.exp.json
@@ -1,14 +1,14 @@
 {
     "result": [
         {
-            "uri": "file:///ruby_lsp/event_emitter.rb",
+            "uri": "file:///fixtures/class_reference_target.rb",
             "range": {
                 "start": {
-                    "line": 20,
+                    "line": 4,
                     "character": 2
                 },
                 "end": {
-                    "line": 185,
+                    "line": 7,
                     "character": 4
                 }
             }

--- a/test/expectations/definition/constant_reference.exp.json
+++ b/test/expectations/definition/constant_reference.exp.json
@@ -1,0 +1,23 @@
+{
+    "result": [
+        {
+            "uri": "file:///fixtures/constant_reference_target.rb",
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 0
+                },
+                "end": {
+                    "line": 4,
+                    "character": 2
+                }
+            }
+        }
+    ],
+    "params": [
+        {
+            "line": 0,
+            "character": 12
+        }
+    ]
+}

--- a/test/fixtures/class_reference.rb
+++ b/test/fixtures/class_reference.rb
@@ -1,1 +1,1 @@
-emitter = RubyLsp::EventEmitter.new
+example = RubyLsp::ExampleClass.new

--- a/test/fixtures/class_reference_target.rb
+++ b/test/fixtures/class_reference_target.rb
@@ -1,0 +1,9 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  class ExampleClass
+    def foo
+    end
+  end
+end

--- a/test/fixtures/constant_reference.rb
+++ b/test/fixtures/constant_reference.rb
@@ -1,0 +1,1 @@
+example = Foo

--- a/test/fixtures/constant_reference_target.rb
+++ b/test/fixtures/constant_reference_target.rb
@@ -1,0 +1,5 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Foo
+end

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -15,11 +15,21 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     store.set(uri: URI("file:///folder/fake.rb"), source: source, version: 1)
     executor = RubyLsp::Executor.new(store, message_queue)
 
-    executor.instance_variable_get(:@index).index_single(
+    index = executor.instance_variable_get(:@index)
+    index.index_single(
       RubyIndexer::IndexablePath.new(
         nil,
         File.expand_path(
           "../../test/fixtures/class_reference_target.rb",
+          __dir__,
+        ),
+      ),
+    )
+    index.index_single(
+      RubyIndexer::IndexablePath.new(
+        nil,
+        File.expand_path(
+          "../../test/fixtures/constant_reference_target.rb",
           __dir__,
         ),
       ),

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -19,7 +19,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       RubyIndexer::IndexablePath.new(
         nil,
         File.expand_path(
-          "../../lib/ruby_lsp/event_emitter.rb",
+          "../../test/fixtures/class_reference_target.rb",
           __dir__,
         ),
       ),


### PR DESCRIPTION
### Motivation

Currently we test against Ruby LSP's own code, which means a change to the implementation which alters the length of the class will break the test.

### Implementation

Introduce a new fixture.

### Automated Tests

Updated

### Manual Tests

n/a
