### PR TITLE
Migrate code lens to yarp

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -51,18 +51,15 @@ module RubyLsp
           :on_class,
           :after_class,
           :on_def,
-          :on_command,
-          :after_command,
           :on_call,
           :after_call,
-          :on_vcall,
         )
       end
 
-      sig { params(node: SyntaxTree::ClassDeclaration).void }
+      sig { params(node: YARP::ClassNode).void }
       def on_class(node)
         @visibility_stack.push(["public", "public"])
-        class_name = node.constant.constant.value
+        class_name = node.constant_path.slice
         @class_stack.push(class_name)
 
         if @path && class_name.end_with?("Test")
@@ -75,20 +72,20 @@ module RubyLsp
         end
       end
 
-      sig { params(node: SyntaxTree::ClassDeclaration).void }
+      sig { params(node: YARP::ClassNode).void }
       def after_class(node)
         @visibility_stack.pop
         @class_stack.pop
       end
 
-      sig { params(node: SyntaxTree::DefNode).void }
+      sig { params(node: YARP::DefNode).void }
       def on_def(node)
         class_name = @class_stack.last
         return unless class_name&.end_with?("Test")
 
         visibility, _ = @visibility_stack.last
         if visibility == "public"
-          method_name = node.name.value
+          method_name = node.name
           if @path && method_name.start_with?("test_")
             add_test_code_lens(
               node,
@@ -100,53 +97,39 @@ module RubyLsp
         end
       end
 
-      sig { params(node: SyntaxTree::Command).void }
-      def on_command(node)
-        node_message = node.message.value
-        if ACCESS_MODIFIERS.include?(node_message) && node.arguments.parts.any?
-          visibility, _ = @visibility_stack.pop
-          @visibility_stack.push([node_message, visibility])
-        elsif @path&.include?("Gemfile") && node_message.include?("gem") && node.arguments.parts.any?
-          remote = resolve_gem_remote(node)
+      sig { params(node: YARP::CallNode).void }
+      def on_call(node)
+        name = node.name
+        arguments = node.arguments
+
+        # If we found `private` by itself or `private def foo`
+        if ACCESS_MODIFIERS.include?(name)
+          if arguments.nil?
+            @visibility_stack.pop
+            @visibility_stack.push([name, name])
+          elsif arguments.arguments.first.is_a?(YARP::DefNode)
+            visibility, _ = @visibility_stack.pop
+            @visibility_stack.push([name, visibility])
+          end
+
+          return
+        end
+
+        if @path&.include?("Gemfile") && name == "gem" && arguments
+          first_argument = arguments.arguments.first
+          return unless first_argument.is_a?(YARP::StringNode)
+
+          remote = resolve_gem_remote(first_argument)
           return unless remote
 
           add_open_gem_remote_code_lens(node, remote)
         end
       end
 
-      sig { params(node: SyntaxTree::Command).void }
-      def after_command(node)
-        _, prev_visibility = @visibility_stack.pop
-        @visibility_stack.push([prev_visibility, prev_visibility])
-      end
-
-      sig { params(node: SyntaxTree::CallNode).void }
-      def on_call(node)
-        ident = node.message if node.message.is_a?(SyntaxTree::Ident)
-
-        if ident
-          ident_value = T.cast(ident, SyntaxTree::Ident).value
-          if ACCESS_MODIFIERS.include?(ident_value)
-            visibility, _ = @visibility_stack.pop
-            @visibility_stack.push([ident_value, visibility])
-          end
-        end
-      end
-
-      sig { params(node: SyntaxTree::CallNode).void }
+      sig { params(node: YARP::CallNode).void }
       def after_call(node)
         _, prev_visibility = @visibility_stack.pop
         @visibility_stack.push([prev_visibility, prev_visibility])
-      end
-
-      sig { params(node: SyntaxTree::VCall).void }
-      def on_vcall(node)
-        vcall_value = node.value.value
-
-        if ACCESS_MODIFIERS.include?(vcall_value)
-          @visibility_stack.pop
-          @visibility_stack.push([vcall_value, vcall_value])
-        end
       end
 
       sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }
@@ -157,7 +140,7 @@ module RubyLsp
 
       private
 
-      sig { params(node: SyntaxTree::Node, name: String, command: String, kind: Symbol).void }
+      sig { params(node: YARP::Node, name: String, command: String, kind: Symbol).void }
       def add_test_code_lens(node, name:, command:, kind:)
         # don't add code lenses if the test library is not supported or unknown
         return unless SUPPORTED_TEST_LIBRARIES.include?(@test_library) && @path
@@ -199,15 +182,9 @@ module RubyLsp
         )
       end
 
-      sig { params(node: SyntaxTree::Command).returns(T.nilable(String)) }
-      def resolve_gem_remote(node)
-        gem_statement = node.arguments.parts.first
-        return unless gem_statement.is_a?(SyntaxTree::StringLiteral)
-
-        gem_name = gem_statement.parts.first
-        return unless gem_name.is_a?(SyntaxTree::TStringContent)
-
-        spec = Gem::Specification.stubs.find { |gem| gem.name == gem_name.value }&.to_spec
+      sig { params(gem_name: YARP::StringNode).returns(T.nilable(String)) }
+      def resolve_gem_remote(gem_name)
+        spec = Gem::Specification.stubs.find { |gem| gem.name == gem_name.content }&.to_spec
         return if spec.nil?
 
         [spec.homepage, spec.metadata["source_code_uri"]].compact.find do |page|
@@ -237,7 +214,7 @@ module RubyLsp
         command
       end
 
-      sig { params(node: SyntaxTree::Command, remote: String).void }
+      sig { params(node: YARP::CallNode, remote: String).void }
       def add_open_gem_remote_code_lens(node, remote)
         @response << create_code_lens(
           node,

--- a/test/expectations/code_lens/Gemfile.exp.json
+++ b/test/expectations/code_lens/Gemfile.exp.json
@@ -8,13 +8,15 @@
         },
         "end": {
           "line": 0,
-          "character": 21
+          "character": 20
         }
       },
       "command": {
         "title": "Open remote",
         "command": "rubyLsp.openLink",
-        "arguments": ["https://github.com/ruby/rake"]
+        "arguments": [
+          "https://github.com/ruby/rake"
+        ]
       },
       "data": {
         "type": "link"
@@ -28,13 +30,15 @@
         },
         "end": {
           "line": 1,
-          "character": 51
+          "character": 50
         }
       },
       "command": {
         "title": "Open remote",
         "command": "rubyLsp.openLink",
-        "arguments": ["https://github.com/rubocop/rubocop-minitest"]
+        "arguments": [
+          "https://github.com/rubocop/rubocop-minitest"
+        ]
       },
       "data": {
         "type": "link"
@@ -48,13 +52,15 @@
         },
         "end": {
           "line": 5,
-          "character": 39
+          "character": 38
         }
       },
       "command": {
         "title": "Open remote",
         "command": "rubyLsp.openLink",
-        "arguments": ["https://github.com/ruby/debug"]
+        "arguments": [
+          "https://github.com/ruby/debug"
+        ]
       },
       "data": {
         "type": "link"

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -8,7 +8,7 @@
         },
         "end": {
           "line": 22,
-          "character": 3
+          "character": 2
         }
       },
       "command": {
@@ -22,7 +22,7 @@
             "start_line": 0,
             "start_column": 0,
             "end_line": 22,
-            "end_column": 3
+            "end_column": 2
           }
         ]
       },
@@ -39,7 +39,7 @@
         },
         "end": {
           "line": 22,
-          "character": 3
+          "character": 2
         }
       },
       "command": {
@@ -53,7 +53,7 @@
             "start_line": 0,
             "start_column": 0,
             "end_line": 22,
-            "end_column": 3
+            "end_column": 2
           }
         ]
       },
@@ -70,7 +70,7 @@
         },
         "end": {
           "line": 22,
-          "character": 3
+          "character": 2
         }
       },
       "command": {
@@ -84,7 +84,7 @@
             "start_line": 0,
             "start_column": 0,
             "end_line": 22,
-            "end_column": 3
+            "end_column": 2
           }
         ]
       },
@@ -101,7 +101,7 @@
         },
         "end": {
           "line": 5,
-          "character": 22
+          "character": 21
         }
       },
       "command": {
@@ -115,7 +115,7 @@
             "start_line": 5,
             "start_column": 2,
             "end_line": 5,
-            "end_column": 22
+            "end_column": 21
           }
         ]
       },
@@ -132,7 +132,7 @@
         },
         "end": {
           "line": 5,
-          "character": 22
+          "character": 21
         }
       },
       "command": {
@@ -146,7 +146,7 @@
             "start_line": 5,
             "start_column": 2,
             "end_line": 5,
-            "end_column": 22
+            "end_column": 21
           }
         ]
       },
@@ -163,7 +163,7 @@
         },
         "end": {
           "line": 5,
-          "character": 22
+          "character": 21
         }
       },
       "command": {
@@ -177,321 +177,321 @@
             "start_line": 5,
             "start_column": 2,
             "end_line": 5,
+            "end_column": 21
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 9
+        },
+        "end": {
+          "line": 9,
+          "character": 36
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public_command",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_command/",
+          {
+            "start_line": 9,
+            "start_column": 9,
+            "end_line": 9,
+            "end_column": 36
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 9
+        },
+        "end": {
+          "line": 9,
+          "character": 36
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public_command",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_command/",
+          {
+            "start_line": 9,
+            "start_column": 9,
+            "end_line": 9,
+            "end_column": 36
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 9
+        },
+        "end": {
+          "line": 9,
+          "character": 36
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public_command",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_command/",
+          {
+            "start_line": 9,
+            "start_column": 9,
+            "end_line": 9,
+            "end_column": 36
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 9
+        },
+        "end": {
+          "line": 11,
+          "character": 36
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_another_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_another_public/",
+          {
+            "start_line": 11,
+            "start_column": 9,
+            "end_line": 11,
+            "end_column": 36
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 9
+        },
+        "end": {
+          "line": 11,
+          "character": 36
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_another_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_another_public/",
+          {
+            "start_line": 11,
+            "start_column": 9,
+            "end_line": 11,
+            "end_column": 36
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 11,
+          "character": 9
+        },
+        "end": {
+          "line": 11,
+          "character": 36
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_another_public",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_another_public/",
+          {
+            "start_line": 11,
+            "start_column": 9,
+            "end_line": 11,
+            "end_column": 36
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 2
+        },
+        "end": {
+          "line": 17,
+          "character": 27
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public_vcall",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_vcall/",
+          {
+            "start_line": 17,
+            "start_column": 2,
+            "end_line": 17,
+            "end_column": 27
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 2
+        },
+        "end": {
+          "line": 17,
+          "character": 27
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public_vcall",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_vcall/",
+          {
+            "start_line": 17,
+            "start_column": 2,
+            "end_line": 17,
+            "end_column": 27
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 2
+        },
+        "end": {
+          "line": 17,
+          "character": 27
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_public_vcall",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_vcall/",
+          {
+            "start_line": 17,
+            "start_column": 2,
+            "end_line": 17,
+            "end_column": 27
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 19,
+          "character": 2
+        },
+        "end": {
+          "line": 19,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_tests.rb",
+          "test_with_q?",
+          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_with_q\\?/",
+          {
+            "start_line": 19,
+            "start_column": 2,
+            "end_line": 19,
             "end_column": 22
           }
         ]
       },
       "data": {
-        "type": "debug",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 9,
-          "character": 9
-        },
-        "end": {
-          "line": 9,
-          "character": 37
-        }
-      },
-      "command": {
-        "title": "Run",
-        "command": "rubyLsp.runTest",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_public_command",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_command/",
-          {
-            "start_line": 9,
-            "start_column": 9,
-            "end_line": 9,
-            "end_column": 37
-          }
-        ]
-      },
-      "data": {
-        "type": "test",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 9,
-          "character": 9
-        },
-        "end": {
-          "line": 9,
-          "character": 37
-        }
-      },
-      "command": {
-        "title": "Run In Terminal",
-        "command": "rubyLsp.runTestInTerminal",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_public_command",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_command/",
-          {
-            "start_line": 9,
-            "start_column": 9,
-            "end_line": 9,
-            "end_column": 37
-          }
-        ]
-      },
-      "data": {
-        "type": "test_in_terminal",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 9,
-          "character": 9
-        },
-        "end": {
-          "line": 9,
-          "character": 37
-        }
-      },
-      "command": {
-        "title": "Debug",
-        "command": "rubyLsp.debugTest",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_public_command",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_command/",
-          {
-            "start_line": 9,
-            "start_column": 9,
-            "end_line": 9,
-            "end_column": 37
-          }
-        ]
-      },
-      "data": {
-        "type": "debug",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 11,
-          "character": 9
-        },
-        "end": {
-          "line": 11,
-          "character": 37
-        }
-      },
-      "command": {
-        "title": "Run",
-        "command": "rubyLsp.runTest",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_another_public",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_another_public/",
-          {
-            "start_line": 11,
-            "start_column": 9,
-            "end_line": 11,
-            "end_column": 37
-          }
-        ]
-      },
-      "data": {
-        "type": "test",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 11,
-          "character": 9
-        },
-        "end": {
-          "line": 11,
-          "character": 37
-        }
-      },
-      "command": {
-        "title": "Run In Terminal",
-        "command": "rubyLsp.runTestInTerminal",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_another_public",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_another_public/",
-          {
-            "start_line": 11,
-            "start_column": 9,
-            "end_line": 11,
-            "end_column": 37
-          }
-        ]
-      },
-      "data": {
-        "type": "test_in_terminal",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 11,
-          "character": 9
-        },
-        "end": {
-          "line": 11,
-          "character": 37
-        }
-      },
-      "command": {
-        "title": "Debug",
-        "command": "rubyLsp.debugTest",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_another_public",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_another_public/",
-          {
-            "start_line": 11,
-            "start_column": 9,
-            "end_line": 11,
-            "end_column": 37
-          }
-        ]
-      },
-      "data": {
-        "type": "debug",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 17,
-          "character": 2
-        },
-        "end": {
-          "line": 17,
-          "character": 28
-        }
-      },
-      "command": {
-        "title": "Run",
-        "command": "rubyLsp.runTest",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_public_vcall",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_vcall/",
-          {
-            "start_line": 17,
-            "start_column": 2,
-            "end_line": 17,
-            "end_column": 28
-          }
-        ]
-      },
-      "data": {
-        "type": "test",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 17,
-          "character": 2
-        },
-        "end": {
-          "line": 17,
-          "character": 28
-        }
-      },
-      "command": {
-        "title": "Run In Terminal",
-        "command": "rubyLsp.runTestInTerminal",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_public_vcall",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_vcall/",
-          {
-            "start_line": 17,
-            "start_column": 2,
-            "end_line": 17,
-            "end_column": 28
-          }
-        ]
-      },
-      "data": {
-        "type": "test_in_terminal",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 17,
-          "character": 2
-        },
-        "end": {
-          "line": 17,
-          "character": 28
-        }
-      },
-      "command": {
-        "title": "Debug",
-        "command": "rubyLsp.debugTest",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_public_vcall",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_vcall/",
-          {
-            "start_line": 17,
-            "start_column": 2,
-            "end_line": 17,
-            "end_column": 28
-          }
-        ]
-      },
-      "data": {
-        "type": "debug",
-        "kind": "example"
-      }
-    },
-    {
-      "range": {
-        "start": {
-          "line": 19,
-          "character": 2
-        },
-        "end": {
-          "line": 19,
-          "character": 23
-        }
-      },
-      "command": {
-        "title": "Run",
-        "command": "rubyLsp.runTest",
-        "arguments": [
-          "/fixtures/minitest_tests.rb",
-          "test_with_q?",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_with_q\\?/",
-          {
-            "start_line": 19,
-            "start_column": 2,
-            "end_line": 19,
-            "end_column": 23
-          }
-        ]
-      },
-      "data": {
         "type": "test",
         "kind": "example"
       }
@@ -504,7 +504,7 @@
         },
         "end": {
           "line": 19,
-          "character": 23
+          "character": 22
         }
       },
       "command": {
@@ -518,7 +518,7 @@
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
-            "end_column": 23
+            "end_column": 22
           }
         ]
       },
@@ -535,7 +535,7 @@
         },
         "end": {
           "line": 19,
-          "character": 23
+          "character": 22
         }
       },
       "command": {
@@ -549,7 +549,7 @@
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
-            "end_column": 23
+            "end_column": 22
           }
         ]
       },
@@ -566,7 +566,7 @@
         },
         "end": {
           "line": 32,
-          "character": 3
+          "character": 2
         }
       },
       "command": {
@@ -580,7 +580,7 @@
             "start_line": 24,
             "start_column": 0,
             "end_line": 32,
-            "end_column": 3
+            "end_column": 2
           }
         ]
       },
@@ -597,7 +597,7 @@
         },
         "end": {
           "line": 32,
-          "character": 3
+          "character": 2
         }
       },
       "command": {
@@ -611,7 +611,7 @@
             "start_line": 24,
             "start_column": 0,
             "end_line": 32,
-            "end_column": 3
+            "end_column": 2
           }
         ]
       },
@@ -628,7 +628,7 @@
         },
         "end": {
           "line": 32,
-          "character": 3
+          "character": 2
         }
       },
       "command": {
@@ -642,7 +642,7 @@
             "start_line": 24,
             "start_column": 0,
             "end_line": 32,
-            "end_column": 3
+            "end_column": 2
           }
         ]
       },
@@ -659,7 +659,7 @@
         },
         "end": {
           "line": 25,
-          "character": 22
+          "character": 21
         }
       },
       "command": {
@@ -673,7 +673,7 @@
             "start_line": 25,
             "start_column": 2,
             "end_line": 25,
-            "end_column": 22
+            "end_column": 21
           }
         ]
       },
@@ -690,7 +690,7 @@
         },
         "end": {
           "line": 25,
-          "character": 22
+          "character": 21
         }
       },
       "command": {
@@ -704,7 +704,7 @@
             "start_line": 25,
             "start_column": 2,
             "end_line": 25,
-            "end_column": 22
+            "end_column": 21
           }
         ]
       },
@@ -721,7 +721,7 @@
         },
         "end": {
           "line": 25,
-          "character": 22
+          "character": 21
         }
       },
       "command": {
@@ -735,7 +735,7 @@
             "start_line": 25,
             "start_column": 2,
             "end_line": 25,
-            "end_column": 22
+            "end_column": 21
           }
         ]
       },
@@ -752,7 +752,7 @@
         },
         "end": {
           "line": 31,
-          "character": 24
+          "character": 23
         }
       },
       "command": {
@@ -766,7 +766,7 @@
             "start_line": 31,
             "start_column": 2,
             "end_line": 31,
-            "end_column": 24
+            "end_column": 23
           }
         ]
       },
@@ -783,7 +783,7 @@
         },
         "end": {
           "line": 31,
-          "character": 24
+          "character": 23
         }
       },
       "command": {
@@ -797,7 +797,7 @@
             "start_line": 31,
             "start_column": 2,
             "end_line": 31,
-            "end_column": 24
+            "end_column": 23
           }
         ]
       },
@@ -814,7 +814,7 @@
         },
         "end": {
           "line": 31,
-          "character": 24
+          "character": 23
         }
       },
       "command": {
@@ -828,7 +828,7 @@
             "start_line": 31,
             "start_column": 2,
             "end_line": 31,
-            "end_column": 24
+            "end_column": 23
           }
         ]
       },

--- a/test/expectations/code_lens/nested_minitest_tests.exp.json
+++ b/test/expectations/code_lens/nested_minitest_tests.exp.json
@@ -8,7 +8,7 @@
         },
         "end": {
           "line": 20,
-          "character": 3
+          "character": 2
         }
       },
       "command": {
@@ -22,7 +22,7 @@
             "start_line": 0,
             "start_column": 0,
             "end_line": 20,
-            "end_column": 3
+            "end_column": 2
           }
         ]
       },
@@ -39,7 +39,7 @@
         },
         "end": {
           "line": 20,
-          "character": 3
+          "character": 2
         }
       },
       "command": {
@@ -53,7 +53,7 @@
             "start_line": 0,
             "start_column": 0,
             "end_line": 20,
-            "end_column": 3
+            "end_column": 2
           }
         ]
       },
@@ -70,7 +70,7 @@
         },
         "end": {
           "line": 20,
-          "character": 3
+          "character": 2
         }
       },
       "command": {
@@ -84,7 +84,7 @@
             "start_line": 0,
             "start_column": 0,
             "end_line": 20,
-            "end_column": 3
+            "end_column": 2
           }
         ]
       },
@@ -101,7 +101,7 @@
         },
         "end": {
           "line": 1,
-          "character": 22
+          "character": 21
         }
       },
       "command": {
@@ -115,7 +115,7 @@
             "start_line": 1,
             "start_column": 2,
             "end_line": 1,
-            "end_column": 22
+            "end_column": 21
           }
         ]
       },
@@ -132,7 +132,7 @@
         },
         "end": {
           "line": 1,
-          "character": 22
+          "character": 21
         }
       },
       "command": {
@@ -146,7 +146,7 @@
             "start_line": 1,
             "start_column": 2,
             "end_line": 1,
-            "end_column": 22
+            "end_column": 21
           }
         ]
       },
@@ -163,7 +163,7 @@
         },
         "end": {
           "line": 1,
-          "character": 22
+          "character": 21
         }
       },
       "command": {
@@ -177,7 +177,7 @@
             "start_line": 1,
             "start_column": 2,
             "end_line": 1,
-            "end_column": 22
+            "end_column": 21
           }
         ]
       },
@@ -194,7 +194,7 @@
         },
         "end": {
           "line": 9,
-          "character": 5
+          "character": 4
         }
       },
       "command": {
@@ -208,7 +208,7 @@
             "start_line": 5,
             "start_column": 2,
             "end_line": 9,
-            "end_column": 5
+            "end_column": 4
           }
         ]
       },
@@ -225,7 +225,7 @@
         },
         "end": {
           "line": 9,
-          "character": 5
+          "character": 4
         }
       },
       "command": {
@@ -239,7 +239,7 @@
             "start_line": 5,
             "start_column": 2,
             "end_line": 9,
-            "end_column": 5
+            "end_column": 4
           }
         ]
       },
@@ -256,7 +256,7 @@
         },
         "end": {
           "line": 9,
-          "character": 5
+          "character": 4
         }
       },
       "command": {
@@ -270,7 +270,7 @@
             "start_line": 5,
             "start_column": 2,
             "end_line": 9,
-            "end_column": 5
+            "end_column": 4
           }
         ]
       },
@@ -287,7 +287,7 @@
         },
         "end": {
           "line": 6,
-          "character": 24
+          "character": 23
         }
       },
       "command": {
@@ -301,7 +301,7 @@
             "start_line": 6,
             "start_column": 4,
             "end_line": 6,
-            "end_column": 24
+            "end_column": 23
           }
         ]
       },
@@ -318,7 +318,7 @@
         },
         "end": {
           "line": 6,
-          "character": 24
+          "character": 23
         }
       },
       "command": {
@@ -332,7 +332,7 @@
             "start_line": 6,
             "start_column": 4,
             "end_line": 6,
-            "end_column": 24
+            "end_column": 23
           }
         ]
       },
@@ -349,7 +349,7 @@
         },
         "end": {
           "line": 6,
-          "character": 24
+          "character": 23
         }
       },
       "command": {
@@ -363,7 +363,7 @@
             "start_line": 6,
             "start_column": 4,
             "end_line": 6,
-            "end_column": 24
+            "end_column": 23
           }
         ]
       },
@@ -380,7 +380,7 @@
         },
         "end": {
           "line": 15,
-          "character": 5
+          "character": 4
         }
       },
       "command": {
@@ -394,7 +394,7 @@
             "start_line": 13,
             "start_column": 2,
             "end_line": 15,
-            "end_column": 5
+            "end_column": 4
           }
         ]
       },
@@ -411,7 +411,7 @@
         },
         "end": {
           "line": 15,
-          "character": 5
+          "character": 4
         }
       },
       "command": {
@@ -425,7 +425,7 @@
             "start_line": 13,
             "start_column": 2,
             "end_line": 15,
-            "end_column": 5
+            "end_column": 4
           }
         ]
       },
@@ -442,7 +442,7 @@
         },
         "end": {
           "line": 15,
-          "character": 5
+          "character": 4
         }
       },
       "command": {
@@ -456,7 +456,7 @@
             "start_line": 13,
             "start_column": 2,
             "end_line": 15,
-            "end_column": 5
+            "end_column": 4
           }
         ]
       },
@@ -473,7 +473,7 @@
         },
         "end": {
           "line": 14,
-          "character": 24
+          "character": 23
         }
       },
       "command": {
@@ -487,7 +487,7 @@
             "start_line": 14,
             "start_column": 4,
             "end_line": 14,
-            "end_column": 24
+            "end_column": 23
           }
         ]
       },
@@ -504,7 +504,7 @@
         },
         "end": {
           "line": 14,
-          "character": 24
+          "character": 23
         }
       },
       "command": {
@@ -518,7 +518,7 @@
             "start_line": 14,
             "start_column": 4,
             "end_line": 14,
-            "end_column": 24
+            "end_column": 23
           }
         ]
       },
@@ -535,7 +535,7 @@
         },
         "end": {
           "line": 14,
-          "character": 24
+          "character": 23
         }
       },
       "command": {
@@ -549,7 +549,7 @@
             "start_line": 14,
             "start_column": 4,
             "end_line": 14,
-            "end_column": 24
+            "end_column": 23
           }
         ]
       },
@@ -566,7 +566,7 @@
         },
         "end": {
           "line": 19,
-          "character": 28
+          "character": 27
         }
       },
       "command": {
@@ -580,7 +580,7 @@
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
-            "end_column": 28
+            "end_column": 27
           }
         ]
       },
@@ -597,7 +597,7 @@
         },
         "end": {
           "line": 19,
-          "character": 28
+          "character": 27
         }
       },
       "command": {
@@ -611,7 +611,7 @@
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
-            "end_column": 28
+            "end_column": 27
           }
         ]
       },
@@ -628,7 +628,7 @@
         },
         "end": {
           "line": 19,
-          "character": 28
+          "character": 27
         }
       },
       "command": {
@@ -642,7 +642,7 @@
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
-            "end_column": 28
+            "end_column": 27
           }
         ]
       },

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 require "expectations/expectations_test_runner"
 
 class CodeLensExpectationsTest < ExpectationsTestRunner
-  # expectations_tests RubyLsp::Requests::CodeLens, "code_lens"
+  expectations_tests RubyLsp::Requests::CodeLens, "code_lens"
 
   def run_expectations(source)
     uri = URI("file://#{@_path}")
@@ -18,8 +18,6 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
   end
 
   def test_command_generation_for_test_unit
-    skip
-
     source = <<~RUBY
       class FooTest < Test::Unit::TestCase
         def test_bar; end
@@ -46,8 +44,6 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
   end
 
   def test_no_code_lens_for_unknown_test_framework
-    skip
-
     source = <<~RUBY
       class FooTest < Test::Unit::TestCase
         def test_bar; end
@@ -66,8 +62,6 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
   end
 
   def test_no_code_lens_for_rspec
-    skip
-
     source = <<~RUBY
       class FooTest < Test::Unit::TestCase
         def test_bar; end
@@ -86,8 +80,6 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
   end
 
   def test_no_code_lens_for_unsaved_files
-    skip
-
     source = <<~RUBY
       class FooTest < Test::Unit::TestCase
         def test_bar; end
@@ -106,7 +98,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
   end
 
   def test_code_lens_extensions
-    skip
+    skip("Skipped until all automatic requests are migrated")
 
     source = <<~RUBY
       class Test < Minitest::Test; end
@@ -151,7 +143,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
             @response = [RubyLsp::Interface::CodeLens.new(
               range: range_from_node(node),
               command: RubyLsp::Interface::Command.new(
-                title: "Run #{node.constant.constant.value}",
+                title: "Run #{node.constant_path.slice}",
                 command: "rubyLsp.runTest",
               ),
             )]


### PR DESCRIPTION
### Motivation

Migrate CodeLens to YARP.

### Implementation

Pretty standard. The most complicated part was merging `command` and `vcall` since they are now just `call`.

### Automated Tests

All tests are passing except the one that requires all automatic requests to work before succeeding.