### PR TITLE
Migrate DocumentLink request to YARP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       language_server-protocol (~> 3.17.0)
       sorbet-runtime
       syntax_tree (>= 6.1.1, < 7)
-      yarp (>= 0.11, < 0.13)
+      yarp (>= 0.12, < 0.13)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -37,7 +37,7 @@ module RubyLsp
       @parse_result.value
     end
 
-    # sig { returns(YARP::ProgramNode) }
+    sig { returns(T::Array[YARP::Comment]) }
     def comments
       @parse_result.comments
     end

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -30,6 +30,7 @@ module RubyLsp
       @uri = T.let(uri, URI::Generic)
       @unparsed_edits = T.let([], T::Array[EditShape])
       @parse_result = T.let(YARP.parse(@source), YARP::ParseResult)
+      @parse_result.attach_comments!
     end
 
     sig { returns(YARP::ProgramNode) }

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -30,12 +30,16 @@ module RubyLsp
       @uri = T.let(uri, URI::Generic)
       @unparsed_edits = T.let([], T::Array[EditShape])
       @parse_result = T.let(YARP.parse(@source), YARP::ParseResult)
-      @parse_result.attach_comments!
     end
 
     sig { returns(YARP::ProgramNode) }
     def tree
       @parse_result.value
+    end
+
+    # sig { returns(YARP::ProgramNode) }
+    def comments
+      @parse_result.comments
     end
 
     sig { params(other: Document).returns(T::Boolean) }

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -97,7 +97,7 @@ module RubyLsp
         # Run listeners for the document
         emitter = EventEmitter.new
         document_symbol = Requests::DocumentSymbol.new(emitter, @message_queue)
-        document_link = Requests::DocumentLink.new(uri, emitter, document.comments, @message_queue)
+        document_link = Requests::DocumentLink.new(uri, document.comments, emitter, @message_queue)
         code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, @test_library)
 
         semantic_highlighting = Requests::SemanticHighlighting.new(emitter, @message_queue)

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -97,7 +97,7 @@ module RubyLsp
         # Run listeners for the document
         emitter = EventEmitter.new
         document_symbol = Requests::DocumentSymbol.new(emitter, @message_queue)
-        document_link = Requests::DocumentLink.new(uri, emitter, @message_queue)
+        document_link = Requests::DocumentLink.new(uri, emitter, @message_queue, document.comments)
         code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, @test_library)
 
         semantic_highlighting = Requests::SemanticHighlighting.new(emitter, @message_queue)

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -97,7 +97,7 @@ module RubyLsp
         # Run listeners for the document
         emitter = EventEmitter.new
         document_symbol = Requests::DocumentSymbol.new(emitter, @message_queue)
-        document_link = Requests::DocumentLink.new(uri, emitter, @message_queue, document.comments)
+        document_link = Requests::DocumentLink.new(uri, emitter, document.comments, @message_queue)
         code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, @test_library)
 
         semantic_highlighting = Requests::SemanticHighlighting.new(emitter, @message_queue)

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency("language_server-protocol", "~> 3.17.0")
   s.add_dependency("sorbet-runtime")
   s.add_dependency("syntax_tree", ">= 6.1.1", "< 7")
-  s.add_dependency("yarp", ">= 0.11", "< 0.13")
+  s.add_dependency("yarp", ">= 0.12", "< 0.13")
 
   s.required_ruby_version = ">= 3.0"
 end

--- a/test/expectations/document_link/source_comment.exp.json
+++ b/test/expectations/document_link/source_comment.exp.json
@@ -41,6 +41,76 @@
             },
             "target": "file://BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#39",
             "tooltip": "Jump to BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#39"
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 12,
+                    "character": 0
+                },
+                "end": {
+                    "line": 12,
+                    "character": 44
+                }
+            },
+            "target": "file://BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#1",
+            "tooltip": "Jump to BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#1"
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 16,
+                    "character": 0
+                },
+                "end": {
+                    "line": 16,
+                    "character": 44
+                }
+            },
+            "target": "file://BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#2",
+            "tooltip": "Jump to BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#2"
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 20,
+                    "character": 0
+                },
+                "end": {
+                    "line": 20,
+                    "character": 44
+                }
+            },
+            "target": "file://BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#3",
+            "tooltip": "Jump to BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#3"
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 0
+                },
+                "end": {
+                    "line": 24,
+                    "character": 44
+                }
+            },
+            "target": "file://BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#4",
+            "tooltip": "Jump to BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#4"
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 27,
+                    "character": 0
+                },
+                "end": {
+                    "line": 27,
+                    "character": 44
+                }
+            },
+            "target": "file://BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#5",
+            "tooltip": "Jump to BUNDLER_PATH/gems/syntax_tree-SYNTAX_TREE_VERSION/lib/syntax_tree.rb#5"
         }
     ]
 }

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -50,9 +50,6 @@ class ExpectationsTestRunner < Minitest::Test
       RB
 
       Dir.glob(TEST_FIXTURES_GLOB).each do |path|
-        # temporarily skip until we figure out comment handling
-        next if handler_class == RubyLsp::Requests::DocumentLink && path == "test/fixtures/source_comment.rb"
-
         test_name = File.basename(path, ".rb")
 
         expectations_dir = File.join(TEST_EXP_DIR, expectation_suffix)

--- a/test/fixtures/source_comment.rb
+++ b/test/fixtures/source_comment.rb
@@ -10,6 +10,24 @@ end
 def baz
 end
 
+# source://syntax_tree//lib/syntax_tree.rb#1
+class Foo
+end
+
+# source://syntax_tree//lib/syntax_tree.rb#2
+class Foo::Bar
+end
+
+# source://syntax_tree//lib/syntax_tree.rb#3
+module Foo
+end
+
+# source://syntax_tree//lib/syntax_tree.rb#4
+FOO = 1
+
+# source://syntax_tree//lib/syntax_tree.rb#5
+FOO::BAR = 1
+
 # source://deleted//lib/foo.rb.rb#1
 def baz
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -149,7 +149,6 @@ class IntegrationTest < Minitest::Test
   end
 
   def test_document_link
-    skip
     initialize_lsp(["documentLink"])
     open_file_with(<<~DOC)
       # source://syntax_tree/#{Gem::Specification.find_by_name("syntax_tree").version}/lib/syntax_tree.rb#39

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -26,7 +26,7 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::DocumentLink.new(uri, emitter, message_queue, document.comments)
+    listener = RubyLsp::Requests::DocumentLink.new(uri, document.comments, emitter, message_queue)
     emitter.visit(document.tree)
     listener.response
   ensure

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -26,7 +26,7 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::DocumentLink.new(uri, emitter, message_queue)
+    listener = RubyLsp::Requests::DocumentLink.new(uri, emitter, message_queue, document.comments)
     emitter.visit(document.tree)
     listener.response
   ensure


### PR DESCRIPTION
### Motivation

Partially addresses https://github.com/Shopify/ruby-lsp/issues/449

### Implementation

The previous approach was based on parsing the document for comments, but with YARP we don't have a Comment node, so instead we visit the critical nodes and then check for attached comments.

### Automated Tests

I added extra examples to the existing fixtures.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
