### PR TITLE
Enable grouped Dependabot updates for minor and patch versions (excluding YARP)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     labels:
       - "dependencies"
       - "ruby"
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+        exclude-patterns:
+          - 'yarp'


### PR DESCRIPTION
### Motivation

The high volume of Dependency updates creates a lot of noise.

### Implementation

As per the docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

We are ignoring YARP for now since minor versions may contain breaking changes.

### Automated Tests

n/a

### Manual Tests

We will monitor this on the repo. Releases are still manual so it is low risk.
