### PR TITLE
Make Definition extensible

### DIFF
--- a/lib/ruby_lsp/extension.rb
+++ b/lib/ruby_lsp/extension.rb
@@ -133,5 +133,17 @@ module RubyLsp
       ).returns(T.nilable(Listener[T::Array[Interface::DocumentSymbol]]))
     end
     def create_document_symbol_listener(emitter, message_queue); end
+
+    # Creates a new Definition listener. This method is invoked on every Definition request
+    sig do
+      overridable.params(
+        uri: URI::Generic,
+        nesting: T::Array[String],
+        index: RubyIndexer::Index,
+        emitter: EventEmitter,
+        message_queue: Thread::Queue,
+      ).returns(T.nilable(Listener[T.nilable(T.any(T::Array[Interface::Location], Interface::Location))]))
+    end
+    def create_definition_listener(uri, nesting, index, emitter, message_queue); end
   end
 end


### PR DESCRIPTION
### Motivation

This is part of https://github.com/Shopify/ruby-lsp/issues/808

### Implementation

1. Make `Definition` inherit `ExtensibleListener`
2. Implement all the required interfaces + move `super` call of the constructor after other ivars are initialised 
3. Add `Extension#create_definition_listener`

### Automated Tests

I added 1 test for the extension. But given `Definition#merge_response!` needs to handle a few more cases for combination of response types (`nil | Location | Array of Location`), we **could** use more tests cover them.

However, all the cases should already be checked by Sorbet and it'd be very lengthy to make tests populate different definition results **while** calling extensions. So I'm not sure if it'd be worth the effort.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
