### PR TITLE
Prevent GitHub Pages action running on forks

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'Shopify/ruby-lsp'
     name: Publish documentation website
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
For example: https://github.com/andyw8/ruby-lsp/actions/runs/6149555099/job/16685684449