### PR TITLE
Automatically bump version after release

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true
+          cache-version: 1
+
+      - name: Bump patch version
+        id: version
+        run: |
+          version=$(awk -F. '{$NF+=1}1' OFS=. VERSION)
+          echo "$version" > VERSION
+          bundle install
+          echo "VERSION=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Commit version
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git checkout -b automated-bump-version-${{ steps.version.outputs.VERSION }}
+          git add VERSION Gemfile.lock
+          git commit -m "Bump version to v${{ steps.version.outputs.VERSION }}"
+          git push origin automated-bump-version-${{ steps.version.outputs.VERSION }}
+
+      - name: Open pull request, approve and turn on auto-merge
+        uses: actions/github-script@v6
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const response = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: automated-bump-version-${{ steps.version.outputs.VERSION }},
+              base: main,
+              title: "Bump version to v${{ steps.version.outputs.VERSION }}"
+            });
+
+            const pullRequestId = response.data.id;
+            const pullRequestNumber = response.data.number;
+            console.log(`Created pull request ${pullRequestNumber}`);
+
+            await github.rest.pulls.createReview({
+              pull_number: pullRequestNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: 'APPROVE',
+            });
+            console.log(`Approved pull request ${pullRequestNumber}`);
+
+            const enableAutoMergeQuery = `mutation ($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+              enablePullRequestAutoMerge(input: {
+                pullRequestId: $pullRequestId,
+                mergeMethod: $mergeMethod
+              }) {
+                pullRequest {
+                  autoMergeRequest {
+                    enabledAt
+                    enabledBy {
+                      login
+                    }
+                  }
+                }
+              }
+            }`;
+
+            const data = {
+              pullRequestId: pullRequestId,
+              mergeMethod: 'MERGE',
+            };
+
+            await github.graphql(enableAutoMergeQuery, data);
+            console.log(`Enabled auto-merge for pull request ${pullRequestNumber}`);


### PR DESCRIPTION
### Motivation

In order to compare the performance of our latest release vs main, we need main to be eagerly updated with the next version number after a release happens. This PR adds automation to bump the patch version automatically after a release.

**NOTE**: it always bumps the patch version just so that we can have a different version show up in the metrics. It does not mean we can't manually change the version in case necessary.

### Implementation

The action
1. Bumps the version using awk
2. Runs bundle, creates a branch and commits both `VERSION` and `Gemfile.lock`
3. Creates a PR using that new branch
4. Approves and turns on auto-merge for the PR