### PR TITLE
Run version bump workflow on tag creation

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - v*
 
 jobs:
   publish:


### PR DESCRIPTION
### Motivation

The latest release didn't trigger this action automatically. I assume the reason is because a GitHub release created automatically by another action can't trigger it.

I suggest switching to tag creation, so that it matches what we have for GitHub release creation.