### PR TITLE
Handle private constants in the index

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -167,12 +167,16 @@ module RubyIndexer
       sig { returns(T::Array[String]) }
       attr_reader :comments
 
+      sig { returns(Symbol) }
+      attr_accessor :visibility
+
       sig { params(name: String, file_path: String, location: YARP::Location, comments: T::Array[String]).void }
       def initialize(name, file_path, location, comments)
         @name = name
         @file_path = file_path
         @location = location
         @comments = comments
+        @visibility = T.let(:public, Symbol)
       end
 
       sig { returns(String) }

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -216,5 +216,28 @@ module RubyIndexer
       second_foo_entry = @index["Bar"][0]
       assert_equal("This is a Bar comment", second_foo_entry.comments.join("\n"))
     end
+
+    def test_private_class_and_module_indexing
+      index(<<~RUBY)
+        class A
+          class B; end
+          private_constant(:B)
+
+          module C; end
+          private_constant("C")
+
+          class D; end
+        end
+      RUBY
+
+      b_const = @index["A::B"].first
+      assert_equal(:private, b_const.visibility)
+
+      c_const = @index["A::C"].first
+      assert_equal(:private, c_const.visibility)
+
+      d_const = @index["A::D"].first
+      assert_equal(:public, d_const.visibility)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

First step for #966 

Start keeping track if an entry is private in the index.

### Implementation

I added a new visibility field, so that we can reuse eventually for methods too.

An interesting learning from playing around with `private_constant` is that you can only reference local constants with it. For example:

```ruby
module A
  class B
    CONST = 123
    private_constant(:CONST) # this is a valid reference
  end
  
  # this isn't. You need to be exactly in the same namespace or Ruby raises
  # constant A::B::CONST not defined
  private_constant("B::CONST")
end
```

### Automated Tests

Added tests.