### PR TITLE
Exclude transitive development dependencies

### DIFF
--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -15,6 +15,8 @@ module RubyIndexer
 
       assert(indexables.none? { |indexable| indexable.full_path.include?("test/fixtures") })
       assert(indexables.none? { |indexable| indexable.full_path.include?("minitest-reporters") })
+      assert(indexables.none? { |indexable| indexable.full_path.include?("ansi") })
+      assert(indexables.any? { |indexable| indexable.full_path.include?("sorbet-runtime") })
       assert(indexables.none? { |indexable| indexable.full_path == __FILE__ })
     end
 


### PR DESCRIPTION
### Motivation

Previously, we were only automatically ignoring direct development dependencies. That's not ideal because transitive development dependencies are generally not wanted in indexing. This PR excludes transitive dependencies from the default indexing, to produce more accurate results and faster indexing times.

Devs can still manually include any development dependency through configuration if desired.

### Implementation

The logic is basically this:
1. Split all dependencies into development only and others
2. Create a list of gemspec dependencies for the current gem if you're working on one
3. Go through each transitive development dependency and check
    - Is this transitive dependency included in `others`? That means the transitive dependency is included directly as part of another group, so we can't exclude
    - Is this transitive dependency included as a transitive dependency of another gem that's not in the development group? In that case, the transitive gem is included outside of development and we can't exclude
    - Is the transitive dependency included as a gemspec dependency for the gem currently being worked on? If true, then we can't exclude
    - All other transitive dependencies are excluded

### Automated Tests

Enhanced our test to show that we're no longer including a transitive dependency, but still including gemspec dependencies.