### PR TITLE
Invert response merging responsibility

### DIFF
--- a/SERVER_EXTENSIONS.md
+++ b/SERVER_EXTENSIONS.md
@@ -127,7 +127,7 @@ module RubyLsp
     end
 
     # All listeners have to inherit from ::RubyLsp::Listener
-    class Hover < ::RubyLsp::Listener
+    class Hover < ::RubyLsp::ExtensionListener
       extend T::Sig
       extend T::Generic
 
@@ -215,7 +215,7 @@ indicate progress. To send notifications, all listeners have access to the messa
 notifications to the client.
 
 ```ruby
-class MyListener < ::RubyLsp::Listener
+class MyListener < ::RubyLsp::ExtensionListener
   def initialize(emitter, message_queue)
     super
 

--- a/lib/ruby_lsp/check_docs.rb
+++ b/lib/ruby_lsp/check_docs.rb
@@ -54,7 +54,7 @@ module RubyLsp
       features = ObjectSpace.each_object(Class).filter_map do |k|
         klass = T.unsafe(k)
         klass if klass < Requests::BaseRequest ||
-          (klass < Listener && klass != ExtensibleListener)
+          (klass < Listener && klass != ExtensibleListener && klass != ExtensionListener)
       end
 
       missing_docs = T.let(Hash.new { |h, k| h[k] = [] }, T::Hash[String, T::Array[String]])

--- a/lib/ruby_lsp/check_docs.rb
+++ b/lib/ruby_lsp/check_docs.rb
@@ -53,8 +53,8 @@ module RubyLsp
       # documented
       features = ObjectSpace.each_object(Class).filter_map do |k|
         klass = T.unsafe(k)
-        klass if klass < RubyLsp::Requests::BaseRequest ||
-          (klass < RubyLsp::Listener && klass != RubyLsp::ExtensibleListener)
+        klass if klass < Requests::BaseRequest ||
+          (klass < Listener && klass != ExtensibleListener)
       end
 
       missing_docs = T.let(Hash.new { |h, k| h[k] = [] }, T::Hash[String, T::Array[String]])

--- a/lib/ruby_lsp/extension.rb
+++ b/lib/ruby_lsp/extension.rb
@@ -112,7 +112,7 @@ module RubyLsp
         uri: URI::Generic,
         emitter: EventEmitter,
         message_queue: Thread::Queue,
-      ).returns(T.nilable(Listener[T::Array[Interface::CodeLens]]))
+      ).returns(T.nilable(ExtensionListener[T::Array[Interface::CodeLens]]))
     end
     def create_code_lens_listener(uri, emitter, message_queue); end
 
@@ -121,7 +121,7 @@ module RubyLsp
       overridable.params(
         emitter: EventEmitter,
         message_queue: Thread::Queue,
-      ).returns(T.nilable(Listener[T.nilable(Interface::Hover)]))
+      ).returns(T.nilable(ExtensionListener[T.nilable(Interface::Hover)]))
     end
     def create_hover_listener(emitter, message_queue); end
 
@@ -130,7 +130,7 @@ module RubyLsp
       overridable.params(
         emitter: EventEmitter,
         message_queue: Thread::Queue,
-      ).returns(T.nilable(Listener[T::Array[Interface::DocumentSymbol]]))
+      ).returns(T.nilable(ExtensionListener[T::Array[Interface::DocumentSymbol]]))
     end
     def create_document_symbol_listener(emitter, message_queue); end
 
@@ -142,7 +142,7 @@ module RubyLsp
         index: RubyIndexer::Index,
         emitter: EventEmitter,
         message_queue: Thread::Queue,
-      ).returns(T.nilable(Listener[T.nilable(T.any(T::Array[Interface::Location], Interface::Location))]))
+      ).returns(T.nilable(ExtensionListener[T.nilable(T.any(T::Array[Interface::Location], Interface::Location))]))
     end
     def create_definition_listener(uri, nesting, index, emitter, message_queue); end
   end

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -146,15 +146,9 @@ module RubyLsp
         end
       end
 
-      sig { override.params(extension: RubyLsp::Extension).returns(T.nilable(Listener[ResponseType])) }
+      sig { override.params(extension: RubyLsp::Extension).returns(T.nilable(ExtensionListener[ResponseType])) }
       def initialize_external_listener(extension)
         extension.create_code_lens_listener(@uri, @emitter, @message_queue)
-      end
-
-      sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }
-      def merge_response!(other)
-        @_response.concat(other.response)
-        self
       end
 
       private

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -46,25 +46,9 @@ module RubyLsp
         emitter.register(self, :on_command, :on_const, :on_const_path_ref)
       end
 
-      sig { override.params(ext: Extension).returns(T.nilable(RubyLsp::Listener[ResponseType])) }
+      sig { override.params(ext: Extension).returns(T.nilable(RubyLsp::ExtensionListener[ResponseType])) }
       def initialize_external_listener(ext)
         ext.create_definition_listener(@uri, @nesting, @index, @emitter, @message_queue)
-      end
-
-      sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }
-      def merge_response!(other)
-        other_response = other._response
-
-        case @_response
-        when Interface::Location
-          @_response = [@_response, *other_response]
-        when Array
-          @_response.concat(Array(other_response))
-        when nil
-          @_response = other_response
-        end
-
-        self
       end
 
       sig { params(node: SyntaxTree::ConstPathRef).void }

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -75,16 +75,9 @@ module RubyLsp
         )
       end
 
-      sig { override.params(extension: RubyLsp::Extension).returns(T.nilable(Listener[ResponseType])) }
+      sig { override.params(extension: RubyLsp::Extension).returns(T.nilable(ExtensionListener[ResponseType])) }
       def initialize_external_listener(extension)
         extension.create_document_symbol_listener(@emitter, @message_queue)
-      end
-
-      # Merges responses from other listeners
-      sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }
-      def merge_response!(other)
-        @_response.concat(other.response)
-        self
       end
 
       sig { params(node: SyntaxTree::ClassDeclaration).void }

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -49,24 +49,9 @@ module RubyLsp
         emitter.register(self, :on_const_path_ref, :on_const)
       end
 
-      sig { override.params(extension: RubyLsp::Extension).returns(T.nilable(Listener[ResponseType])) }
+      sig { override.params(extension: RubyLsp::Extension).returns(T.nilable(ExtensionListener[ResponseType])) }
       def initialize_external_listener(extension)
         extension.create_hover_listener(@emitter, @message_queue)
-      end
-
-      # Merges responses from other hover listeners
-      sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }
-      def merge_response!(other)
-        other_response = other.response
-        return self unless other_response
-
-        if @_response.nil?
-          @_response = other.response
-        else
-          @_response.contents.value << "\n\n" << other_response.contents.value
-        end
-
-        self
       end
 
       sig { params(node: SyntaxTree::ConstPathRef).void }

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -1,170 +1,172 @@
 # typed: true
 # frozen_string_literal: true
 
-class ExpectationsTestRunner < Minitest::Test
-  TEST_EXP_DIR = "test/expectations"
-  TEST_FIXTURES_DIR = "test/fixtures"
-  TEST_FIXTURES_GLOB = File.join(TEST_FIXTURES_DIR, "**", "*.rb")
+module RubyLsp
+  class ExpectationsTestRunner < Minitest::Test
+    TEST_EXP_DIR = "test/expectations"
+    TEST_FIXTURES_DIR = "test/fixtures"
+    TEST_FIXTURES_GLOB = File.join(TEST_FIXTURES_DIR, "**", "*.rb")
 
-  class << self
-    def expectations_tests(handler_class, expectation_suffix)
-      execute_request = if handler_class < RubyLsp::Listener
-        <<~RUBY
-          emitter = RubyLsp::EventEmitter.new
-          listener = #{handler_class}.new(emitter, @message_queue)
-          emitter.visit(document.tree)
-          listener.response
-        RUBY
-      else
-        "#{handler_class}.new(document, *params).run"
-      end
-
-      class_eval(<<~RB, __FILE__, __LINE__ + 1)
-        module ExpectationsRunnerMethods
-          def setup
-            @message_queue = Thread::Queue.new
-          end
-
-          def teardown
-            @message_queue.close
-          end
-
-          def run_expectations(source)
-            params = @__params&.any? ? @__params : default_args
-            document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
-            #{execute_request}
-          end
-
-          def assert_expectations(source, expected)
-            parsed_expected = JSON.parse(expected)
-            actual = run_expectations(source)
-            assert_equal(parsed_expected["result"], JSON.parse(actual.to_json))
-          end
-
-          def default_args
-            []
-          end
-        end
-
-        include ExpectationsRunnerMethods
-      RB
-
-      Dir.glob(TEST_FIXTURES_GLOB).each do |path|
-        test_name = File.basename(path, ".rb")
-
-        expectations_dir = File.join(TEST_EXP_DIR, expectation_suffix)
-        unless File.directory?(expectations_dir)
-          raise "Expectations directory #{expectations_dir} does not exist"
-        end
-
-        expectation_glob = Dir.glob(File.join(expectations_dir, "#{test_name}.exp.{rb,json}"))
-        if expectation_glob.size == 1
-          expectation_path = expectation_glob.first
-        elsif expectation_glob.size > 1
-          raise "multiple expectations for #{test_name}"
-        end
-
-        required_ruby_version = ruby_requirement_magic_comment_version(path)
-        if required_ruby_version && RUBY_VERSION < required_ruby_version
-          class_eval(<<~RB, __FILE__, __LINE__ + 1)
-            def test_#{expectation_suffix}__#{test_name}
-              skip "Fixture requires Ruby v#{required_ruby_version} while currently running v#{RUBY_VERSION}"
-            end
-          RB
-        elsif expectation_path && File.file?(expectation_path)
-          class_eval(<<~RB, __FILE__, __LINE__ + 1)
-            def test_#{expectation_suffix}__#{test_name}
-              @_path = "#{path}"
-              source = File.read(@_path)
-              expected = File.read("#{expectation_path}")
-              initialize_params(expected)
-              assert_expectations(source, expected)
-            end
-          RB
+    class << self
+      def expectations_tests(handler_class, expectation_suffix)
+        execute_request = if handler_class < Listener
+          <<~RUBY
+            emitter = EventEmitter.new
+            listener = #{handler_class}.new(emitter, @message_queue)
+            emitter.visit(document.tree)
+            listener.response
+          RUBY
         else
-          class_eval(<<~RB, __FILE__, __LINE__ + 1)
-            def test_#{expectation_suffix}__#{test_name}__does_not_raise
-              @_path = "#{path}"
-              source = File.read(@_path)
-              run_expectations(source)
-            end
-          RB
+          "#{handler_class}.new(document, *params).run"
         end
+
+        class_eval(<<~RB, __FILE__, __LINE__ + 1)
+          module ExpectationsRunnerMethods
+            def setup
+              @message_queue = Thread::Queue.new
+            end
+
+            def teardown
+              @message_queue.close
+            end
+
+            def run_expectations(source)
+              params = @__params&.any? ? @__params : default_args
+              document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
+              #{execute_request}
+            end
+
+            def assert_expectations(source, expected)
+              parsed_expected = JSON.parse(expected)
+              actual = run_expectations(source)
+              assert_equal(parsed_expected["result"], JSON.parse(actual.to_json))
+            end
+
+            def default_args
+              []
+            end
+          end
+
+          include ExpectationsRunnerMethods
+        RB
+
+        Dir.glob(TEST_FIXTURES_GLOB).each do |path|
+          test_name = File.basename(path, ".rb")
+
+          expectations_dir = File.join(TEST_EXP_DIR, expectation_suffix)
+          unless File.directory?(expectations_dir)
+            raise "Expectations directory #{expectations_dir} does not exist"
+          end
+
+          expectation_glob = Dir.glob(File.join(expectations_dir, "#{test_name}.exp.{rb,json}"))
+          if expectation_glob.size == 1
+            expectation_path = expectation_glob.first
+          elsif expectation_glob.size > 1
+            raise "multiple expectations for #{test_name}"
+          end
+
+          required_ruby_version = ruby_requirement_magic_comment_version(path)
+          if required_ruby_version && RUBY_VERSION < required_ruby_version
+            class_eval(<<~RB, __FILE__, __LINE__ + 1)
+              def test_#{expectation_suffix}__#{test_name}
+                skip "Fixture requires Ruby v#{required_ruby_version} while currently running v#{RUBY_VERSION}"
+              end
+            RB
+          elsif expectation_path && File.file?(expectation_path)
+            class_eval(<<~RB, __FILE__, __LINE__ + 1)
+              def test_#{expectation_suffix}__#{test_name}
+                @_path = "#{path}"
+                source = File.read(@_path)
+                expected = File.read("#{expectation_path}")
+                initialize_params(expected)
+                assert_expectations(source, expected)
+              end
+            RB
+          else
+            class_eval(<<~RB, __FILE__, __LINE__ + 1)
+              def test_#{expectation_suffix}__#{test_name}__does_not_raise
+                @_path = "#{path}"
+                source = File.read(@_path)
+                run_expectations(source)
+              end
+            RB
+          end
+        end
+      end
+
+      def ruby_requirement_magic_comment_version(fixture_path)
+        File.read(fixture_path)
+          .lines
+          .first
+          &.match(/^#\s*required_ruby_version:\s*(?<version>\d+\.\d+(\.\d+)?)$/)
+          &.named_captures
+          &.fetch("version")
       end
     end
 
-    def ruby_requirement_magic_comment_version(fixture_path)
-      File.read(fixture_path)
-        .lines
-        .first
-        &.match(/^#\s*required_ruby_version:\s*(?<version>\d+\.\d+(\.\d+)?)$/)
-        &.named_captures
-        &.fetch("version")
-    end
-  end
+    private
 
-  private
+    def test_extension(extension_creation_method, source:)
+      DependencyDetector.const_set(:HAS_TYPECHECKER, false)
+      message_queue = Thread::Queue.new
 
-  def test_extension(extension_creation_method, source:)
-    RubyLsp::DependencyDetector.const_set(:HAS_TYPECHECKER, false)
-    message_queue = Thread::Queue.new
+      send(extension_creation_method)
 
-    send(extension_creation_method)
+      store = Store.new
+      uri = URI::Generic.from_path(path: "/fake.rb")
+      store.set(uri: uri, source: source, version: 1)
 
-    store = RubyLsp::Store.new
-    uri = URI::Generic.from_path(path: "/fake.rb")
-    store.set(uri: uri, source: source, version: 1)
+      executor = Executor.new(store, message_queue)
+      executor.instance_variable_get(:@index).index_single(
+        RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)),
+        source,
+      )
 
-    executor = RubyLsp::Executor.new(store, message_queue)
-    executor.instance_variable_get(:@index).index_single(
-      RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)),
-      source,
-    )
-
-    yield(executor)
-  ensure
-    RubyLsp::Extension.extensions.clear
-    RubyLsp::DependencyDetector.const_set(:HAS_TYPECHECKER, true)
-    T.must(message_queue).close
-  end
-
-  def diff(expected, actual)
-    res = super
-    return unless res
-
-    begin
-      # If the values are JSON we want to pretty print them
-      expected_obj = { "result" => expected }
-      expected_obj["params"] = @__params if @__params
-
-      actual_obj = { "result" => actual }
-      actual_obj["params"] = @__params if @__params
-
-      $stderr.puts "########## Expected ##########"
-      $stderr.puts JSON.pretty_generate(expected_obj)
-      $stderr.puts "##########  Actual  ##########"
-      $stderr.puts JSON.pretty_generate(actual_obj)
-      $stderr.puts "##############################"
-    rescue
-      # Values are not JSON, just print the raw values
-      $stderr.puts "########## Expected ##########"
-      $stderr.puts expected
-      $stderr.puts "##########  Actual  ##########"
-      $stderr.puts actual
-      $stderr.puts "##############################"
+      yield(executor)
+    ensure
+      Extension.extensions.clear
+      DependencyDetector.const_set(:HAS_TYPECHECKER, true)
+      T.must(message_queue).close
     end
 
-    res
-  end
+    def diff(expected, actual)
+      res = super
+      return unless res
 
-  def json_expectations(expected_json_string)
-    return {} if expected_json_string.empty?
+      begin
+        # If the values are JSON we want to pretty print them
+        expected_obj = { "result" => expected }
+        expected_obj["params"] = @__params if @__params
 
-    JSON.parse(expected_json_string)["result"]
-  end
+        actual_obj = { "result" => actual }
+        actual_obj["params"] = @__params if @__params
 
-  def initialize_params(expected)
-    parsed_expected = JSON.parse(expected, symbolize_names: true)
-    @__params = parsed_expected[:params] || []
+        $stderr.puts "########## Expected ##########"
+        $stderr.puts JSON.pretty_generate(expected_obj)
+        $stderr.puts "##########  Actual  ##########"
+        $stderr.puts JSON.pretty_generate(actual_obj)
+        $stderr.puts "##############################"
+      rescue
+        # Values are not JSON, just print the raw values
+        $stderr.puts "########## Expected ##########"
+        $stderr.puts expected
+        $stderr.puts "##########  Actual  ##########"
+        $stderr.puts actual
+        $stderr.puts "##############################"
+      end
+
+      res
+    end
+
+    def json_expectations(expected_json_string)
+      return {} if expected_json_string.empty?
+
+      JSON.parse(expected_json_string)["result"]
+    end
+
+    def initialize_params(expected)
+      parsed_expected = JSON.parse(expected, symbolize_names: true)
+      @__params = parsed_expected[:params] || []
+    end
   end
 end

--- a/test/requests/code_action_resolve_expectations_test.rb
+++ b/test/requests/code_action_resolve_expectations_test.rb
@@ -4,69 +4,71 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class CodeActionResolveExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::CodeActionResolve, "code_action_resolve"
+module RubyLsp
+  class CodeActionResolveExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::CodeActionResolve, "code_action_resolve"
 
-  def run_expectations(source)
-    params = @__params&.any? ? @__params : default_args
-    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
+    def run_expectations(source)
+      params = @__params&.any? ? @__params : default_args
+      document = Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
 
-    RubyLsp::Requests::CodeActionResolve.new(document, params).run
-  end
+      Requests::CodeActionResolve.new(document, params).run
+    end
 
-  def assert_expectations(source, expected)
-    actual = run_expectations(source)
-    assert_equal(build_code_action(json_expectations(expected)), JSON.parse(actual.to_json))
-  end
+    def assert_expectations(source, expected)
+      actual = run_expectations(source)
+      assert_equal(build_code_action(json_expectations(expected)), JSON.parse(actual.to_json))
+    end
 
-  private
+    private
 
-  def default_args
-    {
-      data: {
-        range: {
-          start: { line: 0, character: 1 },
-          end: { line: 0, character: 2 },
+    def default_args
+      {
+        data: {
+          range: {
+            start: { line: 0, character: 1 },
+            end: { line: 0, character: 2 },
+          },
+          uri: "file:///fake",
         },
-        uri: "file:///fake",
-      },
-    }
-  end
+      }
+    end
 
-  def build_code_action(expectation)
-    result = LanguageServer::Protocol::Interface::CodeAction.new(
-      title: expectation["title"],
-      edit: LanguageServer::Protocol::Interface::WorkspaceEdit.new(
-        document_changes: [
-          LanguageServer::Protocol::Interface::TextDocumentEdit.new(
-            text_document: LanguageServer::Protocol::Interface::OptionalVersionedTextDocumentIdentifier.new(
-              uri: "file:///fake",
-              version: nil,
+    def build_code_action(expectation)
+      result = Interface::CodeAction.new(
+        title: expectation["title"],
+        edit: Interface::WorkspaceEdit.new(
+          document_changes: [
+            Interface::TextDocumentEdit.new(
+              text_document: Interface::OptionalVersionedTextDocumentIdentifier.new(
+                uri: "file:///fake",
+                version: nil,
+              ),
+              edits: build_text_edits(expectation.dig("edit", "documentChanges", 0, "edits") || []),
             ),
-            edits: build_text_edits(expectation.dig("edit", "documentChanges", 0, "edits") || []),
-          ),
-        ],
-      ),
-    )
-
-    JSON.parse(result.to_json)
-  end
-
-  def build_text_edits(edits)
-    edits.map do |edit|
-      range = edit["range"]
-      new_text = edit["newText"]
-      LanguageServer::Protocol::Interface::TextEdit.new(
-        range: LanguageServer::Protocol::Interface::Range.new(
-          start: LanguageServer::Protocol::Interface::Position.new(
-            line: range.dig("start", "line"), character: range.dig("start", "character"),
-          ),
-          end: LanguageServer::Protocol::Interface::Position.new(
-            line: range.dig("end", "line"), character: range.dig("end", "character"),
-          ),
+          ],
         ),
-        new_text: new_text,
       )
+
+      JSON.parse(result.to_json)
+    end
+
+    def build_text_edits(edits)
+      edits.map do |edit|
+        range = edit["range"]
+        new_text = edit["newText"]
+        Interface::TextEdit.new(
+          range: Interface::Range.new(
+            start: Interface::Position.new(
+              line: range.dig("start", "line"), character: range.dig("start", "character"),
+            ),
+            end: Interface::Position.new(
+              line: range.dig("end", "line"), character: range.dig("end", "character"),
+            ),
+          ),
+          new_text: new_text,
+        )
+      end
     end
   end
 end

--- a/test/requests/code_actions_expectations_test.rb
+++ b/test/requests/code_actions_expectations_test.rb
@@ -4,83 +4,85 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class CodeActionsExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::CodeActions, "code_actions"
+module RubyLsp
+  class CodeActionsExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::CodeActions, "code_actions"
 
-  def run_expectations(source)
-    params = @__params&.any? ? @__params : default_args
-    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake"))
-    result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::CodeAction]))
+    def run_expectations(source)
+      params = @__params&.any? ? @__params : default_args
+      document = Document.new(source: source, version: 1, uri: URI("file:///fake"))
+      result = T.let(nil, T.nilable(T::Array[Interface::CodeAction]))
 
-    stdout, _ = capture_io do
-      result = RubyLsp::Requests::CodeActions.new(
-        document,
-        params[:range],
-        params[:context],
-      ).run
+      stdout, _ = capture_io do
+        result = Requests::CodeActions.new(
+          document,
+          params[:range],
+          params[:context],
+        ).run
+      end
+
+      assert_empty(stdout)
+      result
     end
 
-    assert_empty(stdout)
-    result
-  end
+    def assert_expectations(source, expected)
+      actual = run_expectations(source)
+      assert_equal(map_actions(json_expectations(expected)), JSON.parse(actual.to_json))
+    end
 
-  def assert_expectations(source, expected)
-    actual = run_expectations(source)
-    assert_equal(map_actions(json_expectations(expected)), JSON.parse(actual.to_json))
-  end
+    private
 
-  private
+    def default_args
+      {
+        range: {
+          start: { line: 0, character: 0 }, end: { line: 1, character: 1 },
+        },
+        context: {
+          diagnostics: [],
+        },
+      }
+    end
 
-  def default_args
-    {
-      range: {
-        start: { line: 0, character: 0 }, end: { line: 1, character: 1 },
-      },
-      context: {
-        diagnostics: [],
-      },
-    }
-  end
+    def map_actions(expectation)
+      quickfixes = expectation
+        .select { |action| action["kind"] == "quickfix" }
+        .map { |action| code_action_for_diagnostic(action) }
+      refactors = expectation
+        .select { |action| action["kind"].start_with?("refactor") }
+        .map { |action| code_action_for_refactor(action) }
+      result = [*quickfixes, *refactors]
 
-  def map_actions(expectation)
-    quickfixes = expectation
-      .select { |action| action["kind"] == "quickfix" }
-      .map { |action| code_action_for_diagnostic(action) }
-    refactors = expectation
-      .select { |action| action["kind"].start_with?("refactor") }
-      .map { |action| code_action_for_refactor(action) }
-    result = [*quickfixes, *refactors]
+      JSON.parse(result.to_json)
+    end
 
-    JSON.parse(result.to_json)
-  end
-
-  def code_action_for_diagnostic(diagnostic)
-    LanguageServer::Protocol::Interface::CodeAction.new(
-      title: diagnostic["title"],
-      kind: LanguageServer::Protocol::Constant::CodeActionKind::QUICK_FIX,
-      edit: LanguageServer::Protocol::Interface::WorkspaceEdit.new(
-        document_changes: [
-          LanguageServer::Protocol::Interface::TextDocumentEdit.new(
-            text_document: LanguageServer::Protocol::Interface::OptionalVersionedTextDocumentIdentifier.new(
-              uri: "file:///fake",
-              version: nil,
+    def code_action_for_diagnostic(diagnostic)
+      LanguageServer::Protocol::Interface::CodeAction.new(
+        title: diagnostic["title"],
+        kind: LanguageServer::Protocol::Constant::CodeActionKind::QUICK_FIX,
+        edit: LanguageServer::Protocol::Interface::WorkspaceEdit.new(
+          document_changes: [
+            LanguageServer::Protocol::Interface::TextDocumentEdit.new(
+              text_document: LanguageServer::Protocol::Interface::OptionalVersionedTextDocumentIdentifier.new(
+                uri: "file:///fake",
+                version: nil,
+              ),
+              edits: diagnostic["edit"]["documentChanges"].first["edits"],
             ),
-            edits: diagnostic["edit"]["documentChanges"].first["edits"],
-          ),
-        ],
-      ),
-      is_preferred: true,
-    )
-  end
+          ],
+        ),
+        is_preferred: true,
+      )
+    end
 
-  def code_action_for_refactor(refactor)
-    LanguageServer::Protocol::Interface::CodeAction.new(
-      title: refactor["title"],
-      kind: LanguageServer::Protocol::Constant::CodeActionKind::REFACTOR_EXTRACT,
-      data: {
-        range: refactor.dig("data", "range"),
-        uri: refactor.dig("data", "uri"),
-      },
-    )
+    def code_action_for_refactor(refactor)
+      LanguageServer::Protocol::Interface::CodeAction.new(
+        title: refactor["title"],
+        kind: LanguageServer::Protocol::Constant::CodeActionKind::REFACTOR_EXTRACT,
+        data: {
+          range: refactor.dig("data", "range"),
+          uri: refactor.dig("data", "uri"),
+        },
+      )
+    end
   end
 end

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -129,7 +129,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
       def create_code_lens_listener(uri, emitter, message_queue)
         raise "uri can't be nil" unless uri
 
-        klass = Class.new(RubyLsp::Listener) do
+        klass = Class.new(RubyLsp::ExtensionListener) do
           attr_reader :_response
 
           def initialize(uri, emitter, message_queue)
@@ -138,7 +138,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
           end
 
           def on_class(node)
-            T.bind(self, RubyLsp::Listener[T.untyped])
+            T.bind(self, RubyLsp::ExtensionListener[T.untyped])
 
             @_response = [RubyLsp::Interface::CodeLens.new(
               range: range_from_syntax_tree_node(node),
@@ -147,6 +147,10 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
                 command: "rubyLsp.runTest",
               ),
             )]
+          end
+
+          def merge_response(current_response)
+            current_response.concat(@_response)
           end
         end
 

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -4,157 +4,159 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class CodeLensExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::CodeLens, "code_lens"
+module RubyLsp
+  class CodeLensExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::CodeLens, "code_lens"
 
-  def run_expectations(source)
-    uri = URI("file://#{@_path}")
-    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
+    def run_expectations(source)
+      uri = URI("file://#{@_path}")
+      document = Document.new(source: source, version: 1, uri: uri)
 
-    emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "minitest")
-    emitter.visit(document.tree)
-    listener.response
-  end
-
-  def test_command_generation_for_test_unit
-    source = <<~RUBY
-      class FooTest < Test::Unit::TestCase
-        def test_bar; end
-      end
-    RUBY
-    uri = URI("file:///fake.rb")
-
-    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
-
-    emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "test-unit")
-    emitter.visit(document.tree)
-    response = listener.response
-
-    assert_equal(6, response.size)
-
-    assert_equal("Run In Terminal", T.must(response[1]).command.title)
-    assert_equal("bundle exec ruby -Itest /fake.rb --testcase /FooTest/", T.must(response[1]).command.arguments[2])
-    assert_equal("Run In Terminal", T.must(response[4]).command.title)
-    assert_equal(
-      "bundle exec ruby -Itest /fake.rb --testcase /FooTest/ --name test_bar",
-      T.must(response[4]).command.arguments[2],
-    )
-  end
-
-  def test_no_code_lens_for_unknown_test_framework
-    source = <<~RUBY
-      class FooTest < Test::Unit::TestCase
-        def test_bar; end
-      end
-    RUBY
-    uri = URI("file:///fake.rb")
-
-    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
-
-    emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "unknown")
-    emitter.visit(document.tree)
-    response = listener.response
-
-    assert_empty(response)
-  end
-
-  def test_no_code_lens_for_rspec
-    source = <<~RUBY
-      class FooTest < Test::Unit::TestCase
-        def test_bar; end
-      end
-    RUBY
-    uri = URI("file:///fake.rb")
-
-    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
-
-    emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "rspec")
-    emitter.visit(document.tree)
-    response = listener.response
-
-    assert_empty(response)
-  end
-
-  def test_no_code_lens_for_unsaved_files
-    source = <<~RUBY
-      class FooTest < Test::Unit::TestCase
-        def test_bar; end
-      end
-    RUBY
-    uri = URI::Generic.build(scheme: "untitled", opaque: "Untitled-1")
-
-    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
-
-    emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "minitest")
-    emitter.visit(document.tree)
-    response = listener.response
-
-    assert_empty(response)
-  end
-
-  def test_code_lens_extensions
-    source = <<~RUBY
-      class Test < Minitest::Test; end
-    RUBY
-
-    test_extension(:create_code_lens_extension, source: source) do |executor|
-      response = executor.execute({
-        method: "textDocument/codeLens",
-        params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 1, character: 2 } },
-      }).response
-
-      assert_equal(response.size, 4)
-      assert_match("Run", response[0].command.title)
-      assert_match("Run In Terminal", response[1].command.title)
-      assert_match("Debug", response[2].command.title)
-      assert_match("Run Test", response[3].command.title)
+      emitter = EventEmitter.new
+      listener = Requests::CodeLens.new(uri, emitter, @message_queue, "minitest")
+      emitter.visit(document.tree)
+      listener.response
     end
-  end
 
-  private
+    def test_command_generation_for_test_unit
+      source = <<~RUBY
+        class FooTest < Test::Unit::TestCase
+          def test_bar; end
+        end
+      RUBY
+      uri = URI("file:///fake.rb")
 
-  def create_code_lens_extension
-    Class.new(RubyLsp::Extension) do
-      def activate; end
+      document = Document.new(source: source, version: 1, uri: uri)
 
-      def name
-        "CodeLensExtension"
+      emitter = EventEmitter.new
+      listener = Requests::CodeLens.new(uri, emitter, @message_queue, "test-unit")
+      emitter.visit(document.tree)
+      response = listener.response
+
+      assert_equal(6, response.size)
+
+      assert_equal("Run In Terminal", T.must(response[1]).command.title)
+      assert_equal("bundle exec ruby -Itest /fake.rb --testcase /FooTest/", T.must(response[1]).command.arguments[2])
+      assert_equal("Run In Terminal", T.must(response[4]).command.title)
+      assert_equal(
+        "bundle exec ruby -Itest /fake.rb --testcase /FooTest/ --name test_bar",
+        T.must(response[4]).command.arguments[2],
+      )
+    end
+
+    def test_no_code_lens_for_unknown_test_framework
+      source = <<~RUBY
+        class FooTest < Test::Unit::TestCase
+          def test_bar; end
+        end
+      RUBY
+      uri = URI("file:///fake.rb")
+
+      document = Document.new(source: source, version: 1, uri: uri)
+
+      emitter = EventEmitter.new
+      listener = Requests::CodeLens.new(uri, emitter, @message_queue, "unknown")
+      emitter.visit(document.tree)
+      response = listener.response
+
+      assert_empty(response)
+    end
+
+    def test_no_code_lens_for_rspec
+      source = <<~RUBY
+        class FooTest < Test::Unit::TestCase
+          def test_bar; end
+        end
+      RUBY
+      uri = URI("file:///fake.rb")
+
+      document = Document.new(source: source, version: 1, uri: uri)
+
+      emitter = EventEmitter.new
+      listener = Requests::CodeLens.new(uri, emitter, @message_queue, "rspec")
+      emitter.visit(document.tree)
+      response = listener.response
+
+      assert_empty(response)
+    end
+
+    def test_no_code_lens_for_unsaved_files
+      source = <<~RUBY
+        class FooTest < Test::Unit::TestCase
+          def test_bar; end
+        end
+      RUBY
+      uri = URI::Generic.build(scheme: "untitled", opaque: "Untitled-1")
+
+      document = Document.new(source: source, version: 1, uri: uri)
+
+      emitter = EventEmitter.new
+      listener = Requests::CodeLens.new(uri, emitter, @message_queue, "minitest")
+      emitter.visit(document.tree)
+      response = listener.response
+
+      assert_empty(response)
+    end
+
+    def test_code_lens_extensions
+      source = <<~RUBY
+        class Test < Minitest::Test; end
+      RUBY
+
+      test_extension(:create_code_lens_extension, source: source) do |executor|
+        response = executor.execute({
+          method: "textDocument/codeLens",
+          params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 1, character: 2 } },
+        }).response
+
+        assert_equal(response.size, 4)
+        assert_match("Run", response[0].command.title)
+        assert_match("Run In Terminal", response[1].command.title)
+        assert_match("Debug", response[2].command.title)
+        assert_match("Run Test", response[3].command.title)
       end
+    end
 
-      def create_code_lens_listener(uri, emitter, message_queue)
-        raise "uri can't be nil" unless uri
+    private
 
-        klass = Class.new(RubyLsp::ExtensionListener) do
-          attr_reader :_response
+    def create_code_lens_extension
+      Class.new(Extension) do
+        def activate; end
 
-          def initialize(uri, emitter, message_queue)
-            super(emitter, message_queue)
-            emitter.register(self, :on_class)
-          end
-
-          def on_class(node)
-            T.bind(self, RubyLsp::ExtensionListener[T.untyped])
-
-            @_response = [RubyLsp::Interface::CodeLens.new(
-              range: range_from_syntax_tree_node(node),
-              command: RubyLsp::Interface::Command.new(
-                title: "Run #{node.constant.constant.value}",
-                command: "rubyLsp.runTest",
-              ),
-            )]
-          end
-
-          def merge_response(current_response)
-            current_response.concat(@_response)
-          end
+        def name
+          "CodeLensExtension"
         end
 
-        T.unsafe(klass).new(uri, emitter, message_queue)
+        def create_code_lens_listener(uri, emitter, message_queue)
+          raise "uri can't be nil" unless uri
+
+          klass = Class.new(ExtensionListener) do
+            attr_reader :_response
+
+            def initialize(uri, emitter, message_queue)
+              super(emitter, message_queue)
+              emitter.register(self, :on_class)
+            end
+
+            def on_class(node)
+              T.bind(self, ExtensionListener[T.untyped])
+
+              @_response = [Interface::CodeLens.new(
+                range: range_from_syntax_tree_node(node),
+                command: Interface::Command.new(
+                  title: "Run #{node.constant.constant.value}",
+                  command: "rubyLsp.runTest",
+                ),
+              )]
+            end
+
+            def merge_response(current_response)
+              current_response.concat(@_response)
+            end
+          end
+
+          T.unsafe(klass).new(uri, emitter, message_queue)
+        end
       end
     end
   end

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -172,7 +172,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       end
 
       def create_definition_listener(uri, nesting, index, emitter, message_queue)
-        klass = Class.new(RubyLsp::Listener) do
+        klass = Class.new(RubyLsp::ExtensionListener) do
           attr_reader :_response
 
           def initialize(uri, _, _, emitter, message_queue)
@@ -193,6 +193,10 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
                 end: RubyLsp::Interface::Position.new(line: location.end_line - 1, character: location.end_column),
               ),
             )
+          end
+
+          def merge_response(current_response)
+            current_response << @_response
           end
         end
 

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -4,142 +4,18 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class DefinitionExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::Definition, "definition"
+module RubyLsp
+  class DefinitionExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::Definition, "definition"
 
-  def run_expectations(source)
-    message_queue = Thread::Queue.new
-    position = @__params&.first || { character: 0, line: 0 }
+    def run_expectations(source)
+      message_queue = Thread::Queue.new
+      position = @__params&.first || { character: 0, line: 0 }
 
-    store = RubyLsp::Store.new
-    store.set(uri: URI("file:///folder/fake.rb"), source: source, version: 1)
-    executor = RubyLsp::Executor.new(store, message_queue)
+      store = Store.new
+      store.set(uri: URI("file:///folder/fake.rb"), source: source, version: 1)
+      executor = Executor.new(store, message_queue)
 
-    index = executor.instance_variable_get(:@index)
-    index.index_single(
-      RubyIndexer::IndexablePath.new(
-        "#{Dir.pwd}/lib",
-        File.expand_path(
-          "../../test/fixtures/class_reference_target.rb",
-          __dir__,
-        ),
-      ),
-    )
-    index.index_single(
-      RubyIndexer::IndexablePath.new(
-        nil,
-        File.expand_path(
-          "../../test/fixtures/constant_reference_target.rb",
-          __dir__,
-        ),
-      ),
-    )
-    index.index_single(
-      RubyIndexer::IndexablePath.new(
-        "#{Dir.pwd}/lib",
-        File.expand_path(
-          "../../lib/ruby_lsp/event_emitter.rb",
-          __dir__,
-        ),
-      ),
-    )
-
-    begin
-      # We need to pretend that Sorbet is not a dependency or else we can't properly test
-      RubyLsp::DependencyDetector.const_set(:HAS_TYPECHECKER, false)
-      response = executor.execute({
-        method: "textDocument/definition",
-        params: { textDocument: { uri: "file:///folder/fake.rb" }, position: position },
-      }).response
-    ensure
-      RubyLsp::DependencyDetector.const_set(:HAS_TYPECHECKER, true)
-    end
-
-    case response
-    when RubyLsp::Interface::Location
-      attributes = response.attributes
-      fake_path = attributes[:uri].split("/").last(2).join("/")
-      response.instance_variable_set(:@attributes, attributes.merge("uri" => "file:///#{fake_path}"))
-    when Array
-      response.each do |location|
-        attributes = T.let(location.attributes, T.untyped)
-        fake_path = T.let(attributes[:uri].split("/").last(2).join("/"), String)
-        location.instance_variable_set(:@attributes, attributes.merge("uri" => "file:///#{fake_path}"))
-      end
-    end
-
-    response
-  ensure
-    T.must(message_queue).close
-  end
-
-  def test_jumping_to_default_gems
-    message_queue = Thread::Queue.new
-    position = { character: 0, line: 0 }
-
-    path = "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb"
-    uri = URI::Generic.from_path(path: path)
-
-    store = RubyLsp::Store.new
-    store.set(uri: URI("file:///folder/fake.rb"), source: <<~RUBY, version: 1)
-      Pathname
-    RUBY
-
-    executor = RubyLsp::Executor.new(store, message_queue)
-    executor.instance_variable_get(:@index).index_single(
-      RubyIndexer::IndexablePath.new(
-        nil,
-        T.must(uri.to_standardized_path),
-      ),
-    )
-
-    response = executor.execute({
-      method: "textDocument/definition",
-      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: position },
-    }).response
-
-    refute_empty(response)
-  ensure
-    T.must(message_queue).close
-  end
-
-  def test_jumping_to_default_require_of_a_gem
-    message_queue = Thread::Queue.new
-
-    store = RubyLsp::Store.new
-    store.set(uri: URI("file:///folder/fake.rb"), source: <<~RUBY, version: 1)
-      require "bundler"
-    RUBY
-
-    executor = RubyLsp::Executor.new(store, message_queue)
-
-    uri = URI::Generic.from_path(path: "#{RbConfig::CONFIG["rubylibdir"]}/bundler.rb")
-    executor.instance_variable_get(:@index).index_single(
-      RubyIndexer::IndexablePath.new(RbConfig::CONFIG["rubylibdir"], T.must(uri.to_standardized_path)),
-    )
-
-    Dir.glob("#{RbConfig::CONFIG["rubylibdir"]}/bundler/*.rb").each do |path|
-      executor.instance_variable_get(:@index).index_single(
-        RubyIndexer::IndexablePath.new(RbConfig::CONFIG["rubylibdir"], path),
-      )
-    end
-
-    response = executor.execute({
-      method: "textDocument/definition",
-      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: { character: 10, line: 0 } },
-    }).response
-
-    assert_equal(uri.to_s, response.attributes[:uri])
-  ensure
-    T.must(message_queue).close
-  end
-
-  def test_definition_extensions
-    source = <<~RUBY
-      RubyLsp
-    RUBY
-
-    test_extension(:create_definition_extension, source: source) do |executor|
       index = executor.instance_variable_get(:@index)
       index.index_single(
         RubyIndexer::IndexablePath.new(
@@ -150,57 +26,183 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
           ),
         ),
       )
-      response = executor.execute({
-        method: "textDocument/definition",
-        params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 0, character: 0 } },
-      }).response
+      index.index_single(
+        RubyIndexer::IndexablePath.new(
+          nil,
+          File.expand_path(
+            "../../test/fixtures/constant_reference_target.rb",
+            __dir__,
+          ),
+        ),
+      )
+      index.index_single(
+        RubyIndexer::IndexablePath.new(
+          "#{Dir.pwd}/lib",
+          File.expand_path(
+            "../../lib/ruby_lsp/event_emitter.rb",
+            __dir__,
+          ),
+        ),
+      )
 
-      assert_equal(2, response.size)
-      assert_match("class_reference_target.rb", response[0].uri)
-      assert_match("generated_by_extension.rb", response[1].uri)
-    end
-  end
-
-  private
-
-  def create_definition_extension
-    Class.new(RubyLsp::Extension) do
-      def activate; end
-
-      def name
-        "Definition Extension"
+      begin
+        # We need to pretend that Sorbet is not a dependency or else we can't properly test
+        DependencyDetector.const_set(:HAS_TYPECHECKER, false)
+        response = executor.execute({
+          method: "textDocument/definition",
+          params: { textDocument: { uri: "file:///folder/fake.rb" }, position: position },
+        }).response
+      ensure
+        DependencyDetector.const_set(:HAS_TYPECHECKER, true)
       end
 
-      def create_definition_listener(uri, nesting, index, emitter, message_queue)
-        klass = Class.new(RubyLsp::ExtensionListener) do
-          attr_reader :_response
+      case response
+      when Interface::Location
+        attributes = response.attributes
+        fake_path = attributes[:uri].split("/").last(2).join("/")
+        response.instance_variable_set(:@attributes, attributes.merge("uri" => "file:///#{fake_path}"))
+      when Array
+        response.each do |location|
+          attributes = T.let(location.attributes, T.untyped)
+          fake_path = T.let(attributes[:uri].split("/").last(2).join("/"), String)
+          location.instance_variable_set(:@attributes, attributes.merge("uri" => "file:///#{fake_path}"))
+        end
+      end
 
-          def initialize(uri, _, _, emitter, message_queue)
-            super(emitter, message_queue)
-            @uri = uri
-            emitter.register(self, :on_const)
-          end
+      response
+    ensure
+      T.must(message_queue).close
+    end
 
-          def on_const(node)
-            location = node.location
-            @_response = RubyLsp::Interface::Location.new(
-              uri: "file:///generated_by_extension.rb",
-              range: RubyLsp::Interface::Range.new(
-                start: RubyLsp::Interface::Position.new(
-                  line: location.start_line - 1,
-                  character: location.start_column,
-                ),
-                end: RubyLsp::Interface::Position.new(line: location.end_line - 1, character: location.end_column),
-              ),
-            )
-          end
+    def test_jumping_to_default_gems
+      message_queue = Thread::Queue.new
+      position = { character: 0, line: 0 }
 
-          def merge_response(current_response)
-            current_response << @_response
-          end
+      path = "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb"
+      uri = URI::Generic.from_path(path: path)
+
+      store = Store.new
+      store.set(uri: URI("file:///folder/fake.rb"), source: <<~RUBY, version: 1)
+        Pathname
+      RUBY
+
+      executor = Executor.new(store, message_queue)
+      executor.instance_variable_get(:@index).index_single(
+        RubyIndexer::IndexablePath.new(
+          nil,
+          T.must(uri.to_standardized_path),
+        ),
+      )
+
+      response = executor.execute({
+        method: "textDocument/definition",
+        params: { textDocument: { uri: "file:///folder/fake.rb" }, position: position },
+      }).response
+
+      refute_empty(response)
+    ensure
+      T.must(message_queue).close
+    end
+
+    def test_jumping_to_default_require_of_a_gem
+      message_queue = Thread::Queue.new
+
+      store = Store.new
+      store.set(uri: URI("file:///folder/fake.rb"), source: <<~RUBY, version: 1)
+        require "bundler"
+      RUBY
+
+      executor = Executor.new(store, message_queue)
+
+      uri = URI::Generic.from_path(path: "#{RbConfig::CONFIG["rubylibdir"]}/bundler.rb")
+      executor.instance_variable_get(:@index).index_single(
+        RubyIndexer::IndexablePath.new(RbConfig::CONFIG["rubylibdir"], T.must(uri.to_standardized_path)),
+      )
+
+      Dir.glob("#{RbConfig::CONFIG["rubylibdir"]}/bundler/*.rb").each do |path|
+        executor.instance_variable_get(:@index).index_single(
+          RubyIndexer::IndexablePath.new(RbConfig::CONFIG["rubylibdir"], path),
+        )
+      end
+
+      response = executor.execute({
+        method: "textDocument/definition",
+        params: { textDocument: { uri: "file:///folder/fake.rb" }, position: { character: 10, line: 0 } },
+      }).response
+
+      assert_equal(uri.to_s, response.attributes[:uri])
+    ensure
+      T.must(message_queue).close
+    end
+
+    def test_definition_extensions
+      source = <<~RUBY
+        RubyLsp
+      RUBY
+
+      test_extension(:create_definition_extension, source: source) do |executor|
+        index = executor.instance_variable_get(:@index)
+        index.index_single(
+          RubyIndexer::IndexablePath.new(
+            "#{Dir.pwd}/lib",
+            File.expand_path(
+              "../../test/fixtures/class_reference_target.rb",
+              __dir__,
+            ),
+          ),
+        )
+        response = executor.execute({
+          method: "textDocument/definition",
+          params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 0, character: 0 } },
+        }).response
+
+        assert_equal(2, response.size)
+        assert_match("class_reference_target.rb", response[0].uri)
+        assert_match("generated_by_extension.rb", response[1].uri)
+      end
+    end
+
+    private
+
+    def create_definition_extension
+      Class.new(Extension) do
+        def activate; end
+
+        def name
+          "Definition Extension"
         end
 
-        T.unsafe(klass).new(uri, nesting, index, emitter, message_queue)
+        def create_definition_listener(uri, nesting, index, emitter, message_queue)
+          klass = Class.new(ExtensionListener) do
+            attr_reader :_response
+
+            def initialize(uri, _, _, emitter, message_queue)
+              super(emitter, message_queue)
+              @uri = uri
+              emitter.register(self, :on_const)
+            end
+
+            def on_const(node)
+              location = node.location
+              @_response = Interface::Location.new(
+                uri: "file:///generated_by_extension.rb",
+                range: Interface::Range.new(
+                  start: Interface::Position.new(
+                    line: location.start_line - 1,
+                    character: location.start_column,
+                  ),
+                  end: Interface::Position.new(line: location.end_line - 1, character: location.end_column),
+                ),
+              )
+            end
+
+            def merge_response(current_response)
+              current_response << @_response
+            end
+          end
+
+          T.unsafe(klass).new(uri, nesting, index, emitter, message_queue)
+        end
       end
     end
   end

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -4,66 +4,68 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class DiagnosticsExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::Diagnostics, "diagnostics"
+module RubyLsp
+  class DiagnosticsExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::Diagnostics, "diagnostics"
 
-  def run_expectations(source)
-    document = RubyLsp::Document.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    RubyLsp::Requests::Diagnostics.new(document).run
-    result = T.let(nil, T.nilable(T::Array[RubyLsp::Requests::Support::RuboCopDiagnostic]))
+    def run_expectations(source)
+      document = Document.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
+      Requests::Diagnostics.new(document).run
+      result = T.let(nil, T.nilable(T::Array[Requests::Support::RuboCopDiagnostic]))
 
-    stdout, _ = capture_io do
-      result = T.cast(
-        RubyLsp::Requests::Diagnostics.new(document).run,
-        T::Array[RubyLsp::Requests::Support::RuboCopDiagnostic],
-      )
+      stdout, _ = capture_io do
+        result = T.cast(
+          Requests::Diagnostics.new(document).run,
+          T::Array[Requests::Support::RuboCopDiagnostic],
+        )
+      end
+
+      assert_empty(stdout)
+
+      # On Windows, RuboCop will complain that the file is missing a carriage return at the end. We need to ignore these
+      T.must(result).map(&:to_lsp_diagnostic).reject { |diagnostic| diagnostic.code == "Layout/EndOfLine" }
     end
 
-    assert_empty(stdout)
+    def assert_expectations(source, expected)
+      actual = T.let(run_expectations(source), T::Array[LanguageServer::Protocol::Interface::Diagnostic])
 
-    # On Windows, RuboCop will complain that the file is missing a carriage return at the end. We need to ignore these
-    T.must(result).map(&:to_lsp_diagnostic).reject { |diagnostic| diagnostic.code == "Layout/EndOfLine" }
-  end
+      # Sanitize the URI keys so that it matches file:///fake and not a real path in the user machine
+      actual.each do |diagnostic|
+        attributes = diagnostic.attributes
 
-  def assert_expectations(source, expected)
-    actual = T.let(run_expectations(source), T::Array[LanguageServer::Protocol::Interface::Diagnostic])
+        text_document_identifier = attributes[:data][:code_action]
+          .attributes[:edit]
+          .attributes[:documentChanges][0]
+          .attributes[:textDocument]
 
-    # Sanitize the URI keys so that it matches file:///fake and not a real path in the user machine
-    actual.each do |diagnostic|
-      attributes = diagnostic.attributes
+        text_document_identifier.instance_variable_set(:@attributes, { uri: "file:///fake", version: nil })
+      end
 
-      text_document_identifier = attributes[:data][:code_action]
-        .attributes[:edit]
-        .attributes[:documentChanges][0]
-        .attributes[:textDocument]
-
-      text_document_identifier.instance_variable_set(:@attributes, { uri: "file:///fake", version: nil })
+      assert_equal(JSON.parse(map_diagnostics(json_expectations(expected))), JSON.parse(actual.to_json))
     end
 
-    assert_equal(JSON.parse(map_diagnostics(json_expectations(expected))), JSON.parse(actual.to_json))
-  end
+    private
 
-  private
-
-  def map_diagnostics(diagnostics)
-    diagnostics.map do |diagnostic|
-      LanguageServer::Protocol::Interface::Diagnostic.new(
-        message: diagnostic["message"],
-        source: "RuboCop",
-        code: diagnostic["code"],
-        severity: diagnostic["severity"],
-        range: LanguageServer::Protocol::Interface::Range.new(
-          start: LanguageServer::Protocol::Interface::Position.new(
-            line: diagnostic["range"]["start"]["line"],
-            character: diagnostic["range"]["start"]["character"],
+    def map_diagnostics(diagnostics)
+      diagnostics.map do |diagnostic|
+        LanguageServer::Protocol::Interface::Diagnostic.new(
+          message: diagnostic["message"],
+          source: "RuboCop",
+          code: diagnostic["code"],
+          severity: diagnostic["severity"],
+          range: LanguageServer::Protocol::Interface::Range.new(
+            start: LanguageServer::Protocol::Interface::Position.new(
+              line: diagnostic["range"]["start"]["line"],
+              character: diagnostic["range"]["start"]["character"],
+            ),
+            end: LanguageServer::Protocol::Interface::Position.new(
+              line: diagnostic["range"]["end"]["line"],
+              character: diagnostic["range"]["end"]["character"],
+            ),
           ),
-          end: LanguageServer::Protocol::Interface::Position.new(
-            line: diagnostic["range"]["end"]["line"],
-            character: diagnostic["range"]["end"]["character"],
-          ),
-        ),
-        data: diagnostic["data"],
-      )
-    end.to_json
+          data: diagnostic["data"],
+        )
+      end.to_json
+    end
   end
 end

--- a/test/requests/document_highlight_expectations_test.rb
+++ b/test/requests/document_highlight_expectations_test.rb
@@ -4,23 +4,25 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class DocumentHighlightExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::DocumentHighlight, "document_highlight"
+module RubyLsp
+  class DocumentHighlightExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::DocumentHighlight, "document_highlight"
 
-  def run_expectations(source)
-    uri = URI("file://#{@_path}")
-    params = @__params&.any? ? @__params : default_args
-    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
-    target, parent = document.locate_node(params.first)
+    def run_expectations(source)
+      uri = URI("file://#{@_path}")
+      params = @__params&.any? ? @__params : default_args
+      document = Document.new(source: source, version: 1, uri: uri)
+      target, parent = document.locate_node(params.first)
 
-    emitter = RubyLsp::EventEmitter.new
+      emitter = EventEmitter.new
 
-    listener = RubyLsp::Requests::DocumentHighlight.new(target, parent, emitter, @message_queue)
-    emitter.visit(document.tree)
-    listener.response
-  end
+      listener = Requests::DocumentHighlight.new(target, parent, emitter, @message_queue)
+      emitter.visit(document.tree)
+      listener.response
+    end
 
-  def default_args
-    [{ character: 0, line: 0 }]
+    def default_args
+      [{ character: 0, line: 0 }]
+    end
   end
 end

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -35,7 +35,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
       end
 
       def create_document_symbol_listener(emitter, message_queue)
-        klass = Class.new(RubyLsp::Listener) do
+        klass = Class.new(RubyLsp::ExtensionListener) do
           attr_reader :_response
 
           def initialize(emitter, message_queue)
@@ -44,7 +44,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
           end
 
           def on_command(node)
-            T.bind(self, RubyLsp::Listener[T.untyped])
+            T.bind(self, RubyLsp::ExtensionListener[T.untyped])
             message_value = node.message.value
             return unless message_value == "test" && node.arguments.parts.any?
 
@@ -57,6 +57,10 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
               selection_range: range_from_syntax_tree_node(node),
               range: range_from_syntax_tree_node(node),
             )]
+          end
+
+          def merge_response(current_response)
+            current_response.concat(@_response)
           end
         end
 

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -4,67 +4,69 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class DocumentSymbolExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::DocumentSymbol, "document_symbol"
+module RubyLsp
+  class DocumentSymbolExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::DocumentSymbol, "document_symbol"
 
-  def test_document_symbol_extensions
-    source = <<~RUBY
-      test "foo" do
+    def test_document_symbol_extensions
+      source = <<~RUBY
+        test "foo" do
+        end
+      RUBY
+
+      test_extension(:create_document_symbol_extension, source: source) do |executor|
+        response = executor.execute({
+          method: "textDocument/documentSymbol",
+          params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 0, character: 1 } },
+        }).response
+
+        assert_equal("foo", response.first.name)
+        assert_equal(LanguageServer::Protocol::Constant::SymbolKind::METHOD, response.first.kind)
       end
-    RUBY
-
-    test_extension(:create_document_symbol_extension, source: source) do |executor|
-      response = executor.execute({
-        method: "textDocument/documentSymbol",
-        params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 0, character: 1 } },
-      }).response
-
-      assert_equal("foo", response.first.name)
-      assert_equal(LanguageServer::Protocol::Constant::SymbolKind::METHOD, response.first.kind)
     end
-  end
 
-  private
+    private
 
-  def create_document_symbol_extension
-    Class.new(RubyLsp::Extension) do
-      def activate; end
+    def create_document_symbol_extension
+      Class.new(Extension) do
+        def activate; end
 
-      def name
-        "Document SymbolsExtension"
-      end
-
-      def create_document_symbol_listener(emitter, message_queue)
-        klass = Class.new(RubyLsp::ExtensionListener) do
-          attr_reader :_response
-
-          def initialize(emitter, message_queue)
-            super
-            emitter.register(self, :on_command)
-          end
-
-          def on_command(node)
-            T.bind(self, RubyLsp::ExtensionListener[T.untyped])
-            message_value = node.message.value
-            return unless message_value == "test" && node.arguments.parts.any?
-
-            first_argument = node.arguments.parts.first
-            test_name = first_argument.parts.map(&:value).join
-
-            @_response = [RubyLsp::Interface::DocumentSymbol.new(
-              name: test_name,
-              kind: LanguageServer::Protocol::Constant::SymbolKind::METHOD,
-              selection_range: range_from_syntax_tree_node(node),
-              range: range_from_syntax_tree_node(node),
-            )]
-          end
-
-          def merge_response(current_response)
-            current_response.concat(@_response)
-          end
+        def name
+          "Document SymbolsExtension"
         end
 
-        klass.new(emitter, message_queue)
+        def create_document_symbol_listener(emitter, message_queue)
+          klass = Class.new(ExtensionListener) do
+            attr_reader :_response
+
+            def initialize(emitter, message_queue)
+              super
+              emitter.register(self, :on_command)
+            end
+
+            def on_command(node)
+              T.bind(self, ExtensionListener[T.untyped])
+              message_value = node.message.value
+              return unless message_value == "test" && node.arguments.parts.any?
+
+              first_argument = node.arguments.parts.first
+              test_name = first_argument.parts.map(&:value).join
+
+              @_response = [Interface::DocumentSymbol.new(
+                name: test_name,
+                kind: LanguageServer::Protocol::Constant::SymbolKind::METHOD,
+                selection_range: range_from_syntax_tree_node(node),
+                range: range_from_syntax_tree_node(node),
+              )]
+            end
+
+            def merge_response(current_response)
+              current_response.concat(@_response)
+            end
+          end
+
+          klass.new(emitter, message_queue)
+        end
       end
     end
   end

--- a/test/requests/folding_ranges_expectations_test.rb
+++ b/test/requests/folding_ranges_expectations_test.rb
@@ -4,6 +4,8 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class FoldingRangesExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::FoldingRanges, "folding_ranges"
+module RubyLsp
+  class FoldingRangesExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::FoldingRanges, "folding_ranges"
+  end
 end

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -4,25 +4,27 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class FormattingExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::Formatting, "formatting"
+module RubyLsp
+  class FormattingExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::Formatting, "formatting"
 
-  def run_expectations(source)
-    document = RubyLsp::Document.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run&.first&.new_text
-  end
-
-  def assert_expectations(source, expected)
-    result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::TextEdit]))
-
-    stdout, _ = capture_io do
-      result = run_expectations(source)
+    def run_expectations(source)
+      document = Document.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
+      Requests::Formatting.new(document, formatter: "rubocop").run&.first&.new_text
     end
 
-    assert_empty(stdout)
-    assert_equal(expected, result)
-  end
+    def assert_expectations(source, expected)
+      result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::TextEdit]))
 
-  def initialize_params(_expected)
+      stdout, _ = capture_io do
+        result = run_expectations(source)
+      end
+
+      assert_empty(stdout)
+      assert_equal(expected, result)
+    end
+
+    def initialize_params(_expected)
+    end
   end
 end

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -62,7 +62,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
       end
 
       def create_hover_listener(emitter, message_queue)
-        klass = Class.new(RubyLsp::Listener) do
+        klass = Class.new(RubyLsp::ExtensionListener) do
           attr_reader :_response
 
           def initialize(emitter, message_queue)
@@ -71,12 +71,16 @@ class HoverExpectationsTest < ExpectationsTestRunner
           end
 
           def on_const(node)
-            T.bind(self, RubyLsp::Listener[T.untyped])
+            T.bind(self, RubyLsp::ExtensionListener[T.untyped])
             contents = RubyLsp::Interface::MarkupContent.new(
               kind: "markdown",
               value: "Hello from middleware: #{node.value}",
             )
             @_response = RubyLsp::Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
+          end
+
+          def merge_response(current_response)
+            current_response.contents.value << "\n\n#{@_response.contents.value}"
           end
         end
 

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -4,87 +4,89 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class HoverExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::Hover, "hover"
+module RubyLsp
+  class HoverExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::Hover, "hover"
 
-  def run_expectations(source)
-    message_queue = Thread::Queue.new
-    position = @__params&.first || { character: 0, line: 0 }
+    def run_expectations(source)
+      message_queue = Thread::Queue.new
+      position = @__params&.first || { character: 0, line: 0 }
 
-    uri = URI("file:///fake.rb")
-    store = RubyLsp::Store.new
-    store.set(uri: uri, source: source, version: 1)
+      uri = URI("file:///fake.rb")
+      store = Store.new
+      store.set(uri: uri, source: source, version: 1)
 
-    executor = RubyLsp::Executor.new(store, message_queue)
-    index = executor.instance_variable_get(:@index)
-    index.index_single(RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source)
+      executor = Executor.new(store, message_queue)
+      index = executor.instance_variable_get(:@index)
+      index.index_single(RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source)
 
-    begin
-      # We need to pretend that Sorbet is not a dependency or else we can't properly test
-      RubyLsp::DependencyDetector.const_set(:HAS_TYPECHECKER, false)
-      executor.execute({
-        method: "textDocument/hover",
-        params: { textDocument: { uri: uri }, position: position },
-      }).response
-    ensure
-      RubyLsp::DependencyDetector.const_set(:HAS_TYPECHECKER, true)
-      T.must(message_queue).close
-    end
-  end
-
-  def test_hover_extensions
-    source = <<~RUBY
-      # Hello
-      class Post
+      begin
+        # We need to pretend that Sorbet is not a dependency or else we can't properly test
+        DependencyDetector.const_set(:HAS_TYPECHECKER, false)
+        executor.execute({
+          method: "textDocument/hover",
+          params: { textDocument: { uri: uri }, position: position },
+        }).response
+      ensure
+        DependencyDetector.const_set(:HAS_TYPECHECKER, true)
+        T.must(message_queue).close
       end
-
-      Post
-    RUBY
-
-    test_extension(:create_hover_extension, source: source) do |executor|
-      response = executor.execute({
-        method: "textDocument/hover",
-        params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 4, character: 0 } },
-      }).response
-
-      assert_match("Hello\n\nHello from middleware: Post", response.contents.value)
     end
-  end
 
-  private
-
-  def create_hover_extension
-    Class.new(RubyLsp::Extension) do
-      def activate; end
-
-      def name
-        "HoverExtension"
-      end
-
-      def create_hover_listener(emitter, message_queue)
-        klass = Class.new(RubyLsp::ExtensionListener) do
-          attr_reader :_response
-
-          def initialize(emitter, message_queue)
-            super
-            emitter.register(self, :on_const)
-          end
-
-          def on_const(node)
-            T.bind(self, RubyLsp::ExtensionListener[T.untyped])
-            contents = RubyLsp::Interface::MarkupContent.new(
-              kind: "markdown",
-              value: "Hello from middleware: #{node.value}",
-            )
-            @_response = RubyLsp::Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
-          end
-
-          def merge_response(current_response)
-            current_response.contents.value << "\n\n#{@_response.contents.value}"
-          end
+    def test_hover_extensions
+      source = <<~RUBY
+        # Hello
+        class Post
         end
 
-        klass.new(emitter, message_queue)
+        Post
+      RUBY
+
+      test_extension(:create_hover_extension, source: source) do |executor|
+        response = executor.execute({
+          method: "textDocument/hover",
+          params: { textDocument: { uri: "file:///fake.rb" }, position: { line: 4, character: 0 } },
+        }).response
+
+        assert_match("Hello\n\nHello from middleware: Post", response.contents.value)
+      end
+    end
+
+    private
+
+    def create_hover_extension
+      Class.new(Extension) do
+        def activate; end
+
+        def name
+          "HoverExtension"
+        end
+
+        def create_hover_listener(emitter, message_queue)
+          klass = Class.new(ExtensionListener) do
+            attr_reader :_response
+
+            def initialize(emitter, message_queue)
+              super
+              emitter.register(self, :on_const)
+            end
+
+            def on_const(node)
+              T.bind(self, ExtensionListener[T.untyped])
+              contents = Interface::MarkupContent.new(
+                kind: "markdown",
+                value: "Hello from middleware: #{node.value}",
+              )
+              @_response = Interface::Hover.new(range: range_from_syntax_tree_node(node), contents: contents)
+            end
+
+            def merge_response(current_response)
+              current_response.contents.value << "\n\n#{@_response.contents.value}"
+            end
+          end
+
+          klass.new(emitter, message_queue)
+        end
       end
     end
   end

--- a/test/requests/inlay_hints_expectations_test.rb
+++ b/test/requests/inlay_hints_expectations_test.rb
@@ -4,24 +4,26 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class InlayHintsExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::InlayHints, "inlay_hints"
+module RubyLsp
+  class InlayHintsExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::InlayHints, "inlay_hints"
 
-  def run_expectations(source)
-    message_queue = Thread::Queue.new
-    params = @__params&.any? ? @__params : default_args
-    uri = URI("file://#{@_path}")
-    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
+    def run_expectations(source)
+      message_queue = Thread::Queue.new
+      params = @__params&.any? ? @__params : default_args
+      uri = URI("file://#{@_path}")
+      document = Document.new(source: source, version: 1, uri: uri)
 
-    emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::InlayHints.new(params.first, emitter, message_queue)
-    emitter.visit(document.tree)
-    listener.response
-  ensure
-    T.must(message_queue).close
-  end
+      emitter = EventEmitter.new
+      listener = Requests::InlayHints.new(params.first, emitter, message_queue)
+      emitter.visit(document.tree)
+      listener.response
+    ensure
+      T.must(message_queue).close
+    end
 
-  def default_args
-    [0..20]
+    def default_args
+      [0..20]
+    end
   end
 end

--- a/test/requests/selection_ranges_expectations_test.rb
+++ b/test/requests/selection_ranges_expectations_test.rb
@@ -4,21 +4,23 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class SelectionRangesExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::SelectionRanges, "selection_ranges"
+module RubyLsp
+  class SelectionRangesExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::SelectionRanges, "selection_ranges"
 
-  def run_expectations(source)
-    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
-    actual = RubyLsp::Requests::SelectionRanges.new(document).run
-    params = @__params&.any? ? @__params : default_args
+    def run_expectations(source)
+      document = Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
+      actual = Requests::SelectionRanges.new(document).run
+      params = @__params&.any? ? @__params : default_args
 
-    filtered = params.map { |position| actual.find { |range| range.cover?(position) } }
-    filtered
-  end
+      filtered = params.map { |position| actual.find { |range| range.cover?(position) } }
+      filtered
+    end
 
-  private
+    private
 
-  def default_args
-    [{ line: 0, character: 0 }]
+    def default_args
+      [{ line: 0, character: 0 }]
+    end
   end
 end

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -4,51 +4,53 @@
 require "test_helper"
 require "expectations/expectations_test_runner"
 
-class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
-  expectations_tests RubyLsp::Requests::SemanticHighlighting, "semantic_highlighting"
+module RubyLsp
+  class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
+    expectations_tests Requests::SemanticHighlighting, "semantic_highlighting"
 
-  def run_expectations(source)
-    message_queue = Thread::Queue.new
-    document = RubyLsp::Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
-    range = @__params&.any? ? @__params.first : nil
+    def run_expectations(source)
+      message_queue = Thread::Queue.new
+      document = Document.new(source: source, version: 1, uri: URI("file:///fake.rb"))
+      range = @__params&.any? ? @__params.first : nil
 
-    if range
-      start_line = range.dig(:start, :line)
-      end_line = range.dig(:end, :line)
-      processed_range = start_line..end_line
+      if range
+        start_line = range.dig(:start, :line)
+        end_line = range.dig(:end, :line)
+        processed_range = start_line..end_line
+      end
+
+      emitter = EventEmitter.new
+      listener = Requests::SemanticHighlighting.new(
+        emitter,
+        message_queue,
+        range: processed_range,
+      )
+
+      emitter.visit(document.tree)
+      Requests::Support::SemanticTokenEncoder.new.encode(listener.response)
+    ensure
+      T.must(message_queue).close
     end
 
-    emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::SemanticHighlighting.new(
-      emitter,
-      message_queue,
-      range: processed_range,
-    )
-
-    emitter.visit(document.tree)
-    RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode(listener.response)
-  ensure
-    T.must(message_queue).close
-  end
-
-  def assert_expectations(source, expected)
-    actual = run_expectations(source).data
-    assert_equal(json_expectations(expected).to_json, decode_tokens(actual).to_json)
-  end
-
-  private
-
-  def decode_tokens(array)
-    tokens = []
-    array.each_slice(5) do |token|
-      tokens << {
-        delta_line: token[0],
-        delta_start_char: token[1],
-        length: token[2],
-        token_type: token[3],
-        token_modifiers: token[4],
-      }
+    def assert_expectations(source, expected)
+      actual = run_expectations(source).data
+      assert_equal(json_expectations(expected).to_json, decode_tokens(actual).to_json)
     end
-    tokens
+
+    private
+
+    def decode_tokens(array)
+      tokens = []
+      array.each_slice(5) do |token|
+        tokens << {
+          delta_line: token[0],
+          delta_start_char: token[1],
+          length: token[2],
+          token_type: token[3],
+          token_modifiers: token[4],
+        }
+      end
+      tokens
+    end
   end
 end


### PR DESCRIPTION
### Motivation

This PR proposes a way to invert the responsibility for response merging, so that extensions have more control over how they merge themselves into the final result.

### Implementation

The idea is that merging the response is no longer implemented in our base listeners. They're instead implemented in extension listeners.

To make sure that extensions are doing the right thing, we created a separate class `ExtensionListener`, which should be the only one used by extensions. We also marked our other listener classes as private constants, so that only the Ruby LSP can use them.

Let me know what you folks think of the design. This gives more power to extensions, but of course they may accidentally mutate the response in a weird way.

As a follow up, we could write response wrappers for the requests we allow extending, where we hide the original response to minimize potential impact.

### Automated Tests

Because `Listener` is now a private constant, I suggest we namespace all of our tests with `RubyLsp`. It makes it easier to refer to constants inside the namespace anyyway.