### PR TITLE
Make folding range a listener

### DIFF
--- a/lib/ruby_lsp/event_emitter.rb
+++ b/lib/ruby_lsp/event_emitter.rb
@@ -251,5 +251,101 @@ module RubyLsp
       @listeners[:on_block_local_variable]&.each { |l| T.unsafe(l).on_block_local_variable(node) }
       super
     end
+
+    sig { override.params(node: YARP::IfNode).void }
+    def visit_if_node(node)
+      @listeners[:on_if]&.each { |l| T.unsafe(l).on_if(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::InNode).void }
+    def visit_in_node(node)
+      @listeners[:on_in]&.each { |l| T.unsafe(l).on_in(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::WhenNode).void }
+    def visit_when_node(node)
+      @listeners[:on_when]&.each { |l| T.unsafe(l).on_when(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::InterpolatedStringNode).void }
+    def visit_interpolated_string_node(node)
+      @listeners[:on_interpolated_string]&.each { |l| T.unsafe(l).on_interpolated_string(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::ArrayNode).void }
+    def visit_array_node(node)
+      @listeners[:on_array]&.each { |l| T.unsafe(l).on_array(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::CaseNode).void }
+    def visit_case_node(node)
+      @listeners[:on_case]&.each { |l| T.unsafe(l).on_case(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::ForNode).void }
+    def visit_for_node(node)
+      @listeners[:on_for]&.each { |l| T.unsafe(l).on_for(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::HashNode).void }
+    def visit_hash_node(node)
+      @listeners[:on_hash]&.each { |l| T.unsafe(l).on_hash(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::SingletonClassNode).void }
+    def visit_singleton_class_node(node)
+      @listeners[:on_singleton_class]&.each { |l| T.unsafe(l).on_singleton_class(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::UnlessNode).void }
+    def visit_unless_node(node)
+      @listeners[:on_unless]&.each { |l| T.unsafe(l).on_unless(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::UntilNode).void }
+    def visit_until_node(node)
+      @listeners[:on_until]&.each { |l| T.unsafe(l).on_until(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::WhileNode).void }
+    def visit_while_node(node)
+      @listeners[:on_while]&.each { |l| T.unsafe(l).on_while(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::ElseNode).void }
+    def visit_else_node(node)
+      @listeners[:on_else]&.each { |l| T.unsafe(l).on_else(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::EnsureNode).void }
+    def visit_ensure_node(node)
+      @listeners[:on_ensure]&.each { |l| T.unsafe(l).on_ensure(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::BeginNode).void }
+    def visit_begin_node(node)
+      @listeners[:on_begin]&.each { |l| T.unsafe(l).on_begin(node) }
+      super
+    end
+
+    sig { override.params(node: YARP::StringConcatNode).void }
+    def visit_string_concat_node(node)
+      @listeners[:on_string_concat]&.each { |l| T.unsafe(l).on_string_concat(node) }
+      super
+    end
   end
 end

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -15,23 +15,196 @@ module RubyLsp
     #   puts "Hello"
     # end # <-- folding range end
     # ```
-    class FoldingRanges < BaseRequest
+    class FoldingRanges < Listener
       extend T::Sig
+      extend T::Generic
 
-      sig { params(document: Document).void }
-      def initialize(document)
-        super
+      ResponseType = type_member { { fixed: T::Array[Interface::FoldingRange] } }
 
-        @ranges = T.let([], T::Array[Interface::FoldingRange])
+      sig { params(comments: T::Array[YARP::Comment], emitter: EventEmitter, queue: Thread::Queue).void }
+      def initialize(comments, emitter, queue)
+        super(emitter, queue)
+
+        @_response = T.let([], ResponseType)
         @requires = T.let([], T::Array[YARP::CallNode])
+        @finalized_response = T.let(false, T::Boolean)
+        @comments = comments
+
+        emitter.register(
+          self,
+          :on_if,
+          :on_in,
+          :on_rescue,
+          :on_when,
+          :on_interpolated_string,
+          :on_array,
+          :on_block,
+          :on_case,
+          :on_class,
+          :on_module,
+          :on_for,
+          :on_hash,
+          :on_singleton_class,
+          :on_unless,
+          :on_until,
+          :on_while,
+          :on_else,
+          :on_ensure,
+          :on_begin,
+          :on_string_concat,
+          :on_def,
+          :on_call,
+        )
       end
 
-      sig { override.returns(T.all(T::Array[Interface::FoldingRange], Object)) }
-      def run
-        visit(@document.tree)
-        push_comment_ranges
-        emit_requires_range
-        @ranges
+      sig { override.returns(ResponseType) }
+      def _response
+        unless @finalized_response
+          push_comment_ranges
+          emit_requires_range
+          @finalized_response = true
+        end
+
+        @_response
+      end
+
+      sig { params(node: YARP::IfNode).void }
+      def on_if(node)
+        add_statements_range(node)
+      end
+
+      sig { params(node: YARP::InNode).void }
+      def on_in(node)
+        add_statements_range(node)
+      end
+
+      sig { params(node: YARP::RescueNode).void }
+      def on_rescue(node)
+        add_statements_range(node)
+      end
+
+      sig { params(node: YARP::WhenNode).void }
+      def on_when(node)
+        add_statements_range(node)
+      end
+
+      sig { params(node: YARP::InterpolatedStringNode).void }
+      def on_interpolated_string(node)
+        opening_loc = node.opening_loc
+        closing_loc = node.closing_loc
+
+        add_lines_range(opening_loc.start_line, closing_loc.end_line - 1) if opening_loc && closing_loc
+      end
+
+      sig { params(node: YARP::ArrayNode).void }
+      def on_array(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::BlockNode).void }
+      def on_block(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::CaseNode).void }
+      def on_case(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::ClassNode).void }
+      def on_class(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::ModuleNode).void }
+      def on_module(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::ForNode).void }
+      def on_for(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::HashNode).void }
+      def on_hash(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::SingletonClassNode).void }
+      def on_singleton_class(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::UnlessNode).void }
+      def on_unless(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::UntilNode).void }
+      def on_until(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::WhileNode).void }
+      def on_while(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::ElseNode).void }
+      def on_else(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::EnsureNode).void }
+      def on_ensure(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::BeginNode).void }
+      def on_begin(node)
+        add_simple_range(node)
+      end
+
+      sig { params(node: YARP::Node).void }
+      def on_node(node)
+        emit_requires_range unless node.is_a?(YARP::CallNode)
+      end
+
+      sig { params(node: YARP::StringConcatNode).void }
+      def on_string_concat(node)
+        left = T.let(node.left, YARP::Node)
+        left = left.left while left.is_a?(YARP::StringConcatNode)
+
+        add_lines_range(left.location.start_line, node.right.location.end_line - 1)
+      end
+
+      sig { params(node: YARP::DefNode).void }
+      def on_def(node)
+        params = node.parameters
+        parameter_loc = params&.location
+        location = node.location
+
+        if params && parameter_loc.end_line > location.start_line
+          # Multiline parameters
+          add_lines_range(location.start_line, parameter_loc.end_line)
+          add_lines_range(parameter_loc.end_line + 1, location.end_line - 1)
+        else
+          add_lines_range(location.start_line, location.end_line - 1)
+        end
+      end
+
+      sig { params(node: YARP::CallNode).void }
+      def on_call(node)
+        # If we find a require, don't visit the child nodes (prevent `super`), so that we can keep accumulating into
+        # the `@requires` array and then push the range whenever we find a node that isn't a CallNode
+        if require?(node)
+          @requires << node
+          return
+        end
+
+        location = node.location
+        add_lines_range(location.start_line, location.end_line - 1)
       end
 
       private
@@ -39,14 +212,14 @@ module RubyLsp
       sig { void }
       def push_comment_ranges
         # Group comments that are on consecutive lines and then push ranges for each group that has at least 2 comments
-        @document.parse_result.comments.chunk_while do |this, other|
+        @comments.chunk_while do |this, other|
           this.location.end_line + 1 == other.location.start_line
         end.each do |chunk|
           next if chunk.length == 1
 
-          @ranges << Interface::FoldingRange.new(
-            start_line: chunk.first.location.start_line - 1,
-            end_line: chunk.last.location.end_line - 1,
+          @_response << Interface::FoldingRange.new(
+            start_line: T.must(chunk.first).location.start_line - 1,
+            end_line: T.must(chunk.last).location.end_line - 1,
             kind: "comment",
           )
         end
@@ -55,7 +228,7 @@ module RubyLsp
       sig { void }
       def emit_requires_range
         if @requires.length > 1
-          @ranges << Interface::FoldingRange.new(
+          @_response << Interface::FoldingRange.new(
             start_line: T.must(@requires.first).location.start_line - 1,
             end_line: T.must(@requires.last).location.end_line - 1,
             kind: "imports",
@@ -63,70 +236,6 @@ module RubyLsp
         end
 
         @requires.clear
-      end
-
-      sig { override.params(node: T.nilable(YARP::Node)).void }
-      def visit(node)
-        emit_requires_range unless node.is_a?(YARP::CallNode)
-
-        case node
-        when YARP::ArrayNode, YARP::BlockNode, YARP::CaseNode, YARP::ClassNode, YARP::ForNode, YARP::HashNode,
-          YARP::ModuleNode, YARP::SingletonClassNode, YARP::UnlessNode, YARP::UntilNode, YARP::WhileNode,
-          YARP::ElseNode, YARP::EnsureNode, YARP::BeginNode
-
-          location = node.location
-          add_lines_range(location.start_line, location.end_line - 1)
-        when YARP::InterpolatedStringNode
-          opening_loc = node.opening_loc
-          closing_loc = node.closing_loc
-
-          add_lines_range(opening_loc.start_line, closing_loc.end_line - 1) if opening_loc && closing_loc
-        when YARP::IfNode, YARP::InNode, YARP::RescueNode, YARP::WhenNode
-          add_statements_range(node)
-        when YARP::CallNode
-          # If we find a require, don't visit the child nodes (prevent `super`), so that we can keep accumulating into
-          # the `@requires` array and then push the range whenever we find a node that isn't a CallNode
-          if require?(node)
-            @requires << node
-            return
-          end
-
-          location = node.location
-          add_lines_range(location.start_line, location.end_line - 1)
-
-          receiver = node.receiver
-          visit(receiver) if receiver && !same_lines?(receiver, node)
-
-          block = node.block
-          if block
-            same_lines?(block, node) ? visit(block.body) : visit(block)
-          end
-
-          arguments = node.arguments
-          visit(arguments) if arguments && !same_lines?(arguments, node)
-
-          return
-        when YARP::DefNode
-          params = node.parameters
-          parameter_loc = params&.location
-          location = node.location
-
-          if params && parameter_loc.end_line > location.start_line
-            # Multiline parameters
-            add_lines_range(location.start_line, parameter_loc.end_line)
-            add_lines_range(parameter_loc.end_line + 1, location.end_line - 1)
-          else
-            add_lines_range(location.start_line, location.end_line - 1)
-          end
-
-          visit(node.body)
-          return
-        when YARP::StringConcatNode
-          add_string_concat(node)
-          return
-        end
-
-        super
       end
 
       sig { params(node: YARP::CallNode).returns(T::Boolean) }
@@ -143,14 +252,6 @@ module RubyLsp
         arguments.length == 1 && arguments.first.is_a?(YARP::StringNode)
       end
 
-      sig { params(node: YARP::Node, other: YARP::Node).returns(T::Boolean) }
-      def same_lines?(node, other)
-        loc = node.location
-        other_loc = other.location
-
-        loc.start_line == other_loc.start_line && loc.end_line == other_loc.end_line
-      end
-
       sig { params(node: T.any(YARP::IfNode, YARP::InNode, YARP::RescueNode, YARP::WhenNode)).void }
       def add_statements_range(node)
         statements = node.statements
@@ -162,19 +263,17 @@ module RubyLsp
         add_lines_range(node.location.start_line, T.must(body.last).location.end_line)
       end
 
-      sig { params(node: YARP::StringConcatNode).void }
-      def add_string_concat(node)
-        left = T.let(node.left, YARP::Node)
-        left = left.left while left.is_a?(YARP::StringConcatNode)
-
-        add_lines_range(left.location.start_line, node.right.location.end_line - 1)
+      sig { params(node: YARP::Node).void }
+      def add_simple_range(node)
+        location = node.location
+        add_lines_range(location.start_line, location.end_line - 1)
       end
 
       sig { params(start_line: Integer, end_line: Integer).void }
       def add_lines_range(start_line, end_line)
         return if start_line >= end_line
 
-        @ranges << Interface::FoldingRange.new(
+        @_response << Interface::FoldingRange.new(
           start_line: start_line - 1,
           end_line: end_line - 1,
           kind: "region",

--- a/test/expectations/folding_ranges/block_with_class.exp.json
+++ b/test/expectations/folding_ranges/block_with_class.exp.json
@@ -6,6 +6,16 @@
             "kind": "region"
         },
         {
+            "startLine": 0,
+            "endLine": 3,
+            "kind": "region"
+        },
+        {
+            "startLine": 1,
+            "endLine": 2,
+            "kind": "region"
+        },
+        {
             "startLine": 1,
             "endLine": 2,
             "kind": "region"

--- a/test/expectations/folding_ranges/block_with_class_no_parens.exp.json
+++ b/test/expectations/folding_ranges/block_with_class_no_parens.exp.json
@@ -6,6 +6,16 @@
             "kind": "region"
         },
         {
+            "startLine": 0,
+            "endLine": 3,
+            "kind": "region"
+        },
+        {
+            "startLine": 1,
+            "endLine": 2,
+            "kind": "region"
+        },
+        {
             "startLine": 1,
             "endLine": 2,
             "kind": "region"

--- a/test/expectations/folding_ranges/do_blocks.exp.json
+++ b/test/expectations/folding_ranges/do_blocks.exp.json
@@ -4,6 +4,11 @@
       "startLine": 0,
       "endLine": 1,
       "kind": "region"
+    },
+    {
+      "startLine": 0,
+      "endLine": 1,
+      "kind": "region"
     }
   ]
 }

--- a/test/expectations/folding_ranges/lambdas.exp.json
+++ b/test/expectations/folding_ranges/lambdas.exp.json
@@ -4,6 +4,11 @@
       "startLine": 0,
       "endLine": 1,
       "kind": "region"
+    },
+    {
+      "startLine": 0,
+      "endLine": 1,
+      "kind": "region"
     }
   ]
 }

--- a/test/expectations/folding_ranges/multiline_block.exp.json
+++ b/test/expectations/folding_ranges/multiline_block.exp.json
@@ -4,6 +4,11 @@
       "startLine": 0,
       "endLine": 1,
       "kind": "region"
+    },
+    {
+      "startLine": 0,
+      "endLine": 1,
+      "kind": "region"
     }
   ]
 }

--- a/test/requests/folding_ranges_expectations_test.rb
+++ b/test/requests/folding_ranges_expectations_test.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"
@@ -6,4 +6,17 @@ require "expectations/expectations_test_runner"
 
 class FoldingRangesExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::FoldingRanges, "folding_ranges"
+
+  def run_expectations(source)
+    message_queue = Thread::Queue.new
+    uri = URI("file://#{@_path}")
+    document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
+
+    emitter = RubyLsp::EventEmitter.new
+    listener = RubyLsp::Requests::FoldingRanges.new(document.parse_result.comments, emitter, message_queue)
+    emitter.visit(document.tree)
+    listener.response
+  ensure
+    T.must(message_queue).close
+  end
 end


### PR DESCRIPTION
### Motivation

Closes #677
Closes #610
Closes #750

After migrating to YARP, turning folding range into a listener became a little easier.

### Implementation

Since we discovered that the clients dedup many responses, I think we should avoid extra complexity in the server just to avoid duplicate items. Some tests now include a few duplicates, but this allows us to get a clean listener implementation for folding range.

In terms of the migration, the only odd thing for this one is that we need to emit partial ranges and collect comments after receiving all events. I did this in the `_response` implementation, let me know if you have concerns.

### Automated Tests

Updated the tests where duplication happens.