### PR TITLE
Handle the receiver part of private_constant

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
@@ -69,6 +69,9 @@ module RubyIndexer
 
       return unless name
 
+      receiver = node.receiver
+      name = "#{receiver.slice}::#{name}" if receiver
+
       # The private_constant method does not resolve the constant name. It always points to a constant that needs to
       # exist in the current namespace
       entries = @index[fully_qualify_name(name)]

--- a/lib/ruby_indexer/test/constant_test.rb
+++ b/lib/ruby_indexer/test/constant_test.rb
@@ -151,14 +151,35 @@ module RubyIndexer
         end
       RUBY
 
-      b_const = @index["A::B::CONST_A"].first
+      a_const = @index["A::B::CONST_A"].first
+      assert_equal(:private, a_const.visibility)
+
+      b_const = @index["A::B::CONST_B"].first
       assert_equal(:private, b_const.visibility)
 
-      c_const = @index["A::B::CONST_B"].first
+      c_const = @index["A::B::CONST_C"].first
       assert_equal(:private, c_const.visibility)
+    end
 
-      d_const = @index["A::B::CONST_C"].first
-      assert_equal(:private, d_const.visibility)
+    def test_marking_constants_as_private_with_receiver
+      index(<<~RUBY)
+        module A
+          module B
+            CONST_A = 1
+            CONST_B = 2
+          end
+
+          B.private_constant(:CONST_A)
+        end
+
+        A::B.private_constant(:CONST_B)
+      RUBY
+
+      a_const = @index["A::B::CONST_A"].first
+      assert_equal(:private, a_const.visibility)
+
+      b_const = @index["A::B::CONST_B"].first
+      assert_equal(:private, b_const.visibility)
     end
   end
 end


### PR DESCRIPTION
### Motivation

On #1003, I missed the fact that you can use `private_constant` with a receiver. This PR just accounts for that as well.

### Implementation

We need to prepend the receiver as part of the name when it is present.

### Automated Tests

Added a test showing the behaviour and also fixed the variable names of the test above, which were incorrect.