### PR TITLE
Provide nesting and the index for hover extensions

### DIFF
--- a/SERVER_EXTENSIONS.md
+++ b/SERVER_EXTENSIONS.md
@@ -115,11 +115,13 @@ module RubyLsp
 
       sig do
         override.params(
+          nesting: T::Array[String],
+          index: RubyIndexer::Index,
           emitter: EventEmitter,
           message_queue: Thread::Queue,
         ).returns(T.nilable(Listener[T.nilable(Interface::Hover)]))
       end
-      def create_hover_listener(emitter, message_queue)
+      def create_hover_listener(nesting, index emitter, message_queue)
         # Use the listener factory methods to instantiate listeners with parameters sent by the LSP combined with any
         # pre-computed information in the extension. These factory methods are invoked on every request
         Hover.new(@config, emitter, message_queue)

--- a/lib/ruby_lsp/extension.rb
+++ b/lib/ruby_lsp/extension.rb
@@ -119,11 +119,13 @@ module RubyLsp
     # Creates a new Hover listener. This method is invoked on every Hover request
     sig do
       overridable.params(
+        nesting: T::Array[String],
+        index: RubyIndexer::Index,
         emitter: EventEmitter,
         message_queue: Thread::Queue,
       ).returns(T.nilable(Listener[T.nilable(Interface::Hover)]))
     end
-    def create_hover_listener(emitter, message_queue); end
+    def create_hover_listener(nesting, index, emitter, message_queue); end
 
     # Creates a new DocumentSymbol listener. This method is invoked on every DocumentSymbol request
     sig do

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -51,7 +51,7 @@ module RubyLsp
 
       sig { override.params(extension: RubyLsp::Extension).returns(T.nilable(Listener[ResponseType])) }
       def initialize_external_listener(extension)
-        extension.create_hover_listener(@emitter, @message_queue)
+        extension.create_hover_listener(@nesting, @index, @emitter, @message_queue)
       end
 
       # Merges responses from other hover listeners

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -61,7 +61,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
         "HoverExtension"
       end
 
-      def create_hover_listener(emitter, message_queue)
+      def create_hover_listener(nesting, index, emitter, message_queue)
         klass = Class.new(RubyLsp::Listener) do
           attr_reader :_response
 


### PR DESCRIPTION
### Motivation

Now that we have the index, I was thinking that we can finally fix this bug https://github.com/Shopify/ruby-lsp-rails/issues/7. However, I noticed we are not providing the nesting and the index to hover extensions (since they were added later).

We need to provide this so that hover extensions can get the fully qualified name of the target and inspect the index.

### Implementation

Just started passing nesting and index to the hover extensions. We'll probably want to ship this with the YARP changes so group breaking changes.