### PR TITLE
Update argument order for CodeLens initializer

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -97,7 +97,7 @@ module RubyLsp
         folding_range = Requests::FoldingRanges.new(document.parse_result.comments, emitter, @message_queue)
         document_symbol = Requests::DocumentSymbol.new(emitter, @message_queue)
         document_link = Requests::DocumentLink.new(uri, document.comments, emitter, @message_queue)
-        code_lens = Requests::CodeLens.new(uri, emitter, @message_queue, @test_library)
+        code_lens = Requests::CodeLens.new(uri, @test_library, emitter, @message_queue)
 
         semantic_highlighting = Requests::SemanticHighlighting.new(emitter, @message_queue)
         emitter.visit(document.tree)

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -31,8 +31,8 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :_response
 
-      sig { params(uri: URI::Generic, emitter: EventEmitter, message_queue: Thread::Queue, test_library: String).void }
-      def initialize(uri, emitter, message_queue, test_library)
+      sig { params(uri: URI::Generic, test_library: String, emitter: EventEmitter, message_queue: Thread::Queue).void }
+      def initialize(uri, test_library, emitter, message_queue)
         @uri = T.let(uri, URI::Generic)
         @test_library = T.let(test_library, String)
         @_response = T.let([], ResponseType)

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -12,7 +12,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "minitest")
+    listener = RubyLsp::Requests::CodeLens.new(uri, "minitest", emitter, @message_queue)
     emitter.visit(document.tree)
     listener.response
   end
@@ -28,7 +28,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "test-unit")
+    listener = RubyLsp::Requests::CodeLens.new(uri, "test-unit", emitter, @message_queue)
     emitter.visit(document.tree)
     response = listener.response
 
@@ -54,7 +54,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "unknown")
+    listener = RubyLsp::Requests::CodeLens.new(uri, "unknown", emitter, @message_queue)
     emitter.visit(document.tree)
     response = listener.response
 
@@ -72,7 +72,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "rspec")
+    listener = RubyLsp::Requests::CodeLens.new(uri, "rspec", emitter, @message_queue)
     emitter.visit(document.tree)
     response = listener.response
 
@@ -90,7 +90,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     document = RubyLsp::Document.new(source: source, version: 1, uri: uri)
 
     emitter = RubyLsp::EventEmitter.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, emitter, @message_queue, "minitest")
+    listener = RubyLsp::Requests::CodeLens.new(uri, "minitest", emitter, @message_queue)
     emitter.visit(document.tree)
     response = listener.response
 


### PR DESCRIPTION
### Motivation

For consistency across requests, we prefer each request initializer has `emitter` and `message_queue` as their final arguments.

### Implementation

Re-order the arugments.

### Automated Tests

Updated.

### Manual Tests

n/a.
