### PR TITLE
Add title to RDoc website

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ end
 
 RDoc::Task.new do |rdoc|
   rdoc.main = "README.md"
+  rdoc.title = "Ruby LSP documentation"
   rdoc.rdoc_files.include("*.md", "lib/**/*.rb")
   rdoc.rdoc_dir = "docs"
   rdoc.markup = "markdown"


### PR DESCRIPTION
### Motivation

If we don't explicitly set a title, it defaults to `RDoc documentation`. We should set the title to be related to the Ruby LSP to improve SEO.