### PR TITLE
FIX: make sure to specify sorbet-runtime version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-lsp (0.11.0)
       language_server-protocol (~> 3.17.0)
-      sorbet-runtime
+      sorbet-runtime (>= 0.5.5685)
       syntax_tree (>= 6.1.1, < 7)
       yarp (>= 0.12, < 0.13)
 

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("language_server-protocol", "~> 3.17.0")
-  s.add_dependency("sorbet-runtime")
+  s.add_dependency("sorbet-runtime", ">= 0.5.5685")
   s.add_dependency("syntax_tree", ">= 6.1.1", "< 7")
   s.add_dependency("yarp", ">= 0.12", "< 0.13")
 


### PR DESCRIPTION
### Motivation

I ran into an issue when older version of sorbet-runtime in my project's Gemfile.lock caused an error described [here](https://github.com/Shopify/vscode-ruby-lsp/issues/778)

### Implementation

The error stack trace pointed to sorbet-runtime
```
/Users/__redacted__/.rvm/gems/ruby-3.1.2/gems/ruby-lsp-0.9.4/lib/core_ext/uri.rb:10:in `from_path': wrong number of arguments (given 1, expected 0; required keyword: path) (ArgumentError)
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/gems/sorbet-runtime-0.5.5510/lib/types/private/methods/_methods.rb:240:in `call'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/gems/sorbet-runtime-0.5.5510/lib/types/private/methods/_methods.rb:240:in `block in _on_method_added'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/gems/ruby-lsp-0.9.4/lib/ruby_lsp/utils.rb:9:in `<module:RubyLsp>'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/gems/ruby-lsp-0.9.4/lib/ruby_lsp/utils.rb:4:in `<top (required)>'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/gems/ruby-lsp-0.9.4/lib/ruby_lsp/internal.rb:16:in `require'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/gems/ruby-lsp-0.9.4/lib/ruby_lsp/internal.rb:16:in `<top (required)>'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/gems/ruby-lsp-0.9.4/exe/ruby-lsp:80:in `require_relative'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/gems/ruby-lsp-0.9.4/exe/ruby-lsp:80:in `<top (required)>'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/bin/ruby-lsp:25:in `load'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/bin/ruby-lsp:25:in `<main>'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/bin/ruby_executable_hooks:22:in `eval'
	from /Users/__redacted__/.rvm/gems/ruby-3.1.2/bin/ruby_executable_hooks:22:in `<main>'
[Error - 10:46:20] Server initialization failed.
  Message: Pending response rejected since connection got disposed
  Code: -32097 
[Info  - 10:46:20] Connection to server got closed. Server will restart.
true
[Error - 10:46:20] Ruby LSP client: couldn't create connection to server.
  Message: Pending response rejected since connection got disposed
  Code: -32097 
```

### Automated Tests

I believe there are no tests covering this

### Manual Tests

You should have a Gemfile.lock with older sorbet-runtime version specified. In my case it was `0.5.5510`. Manually upgrading it to `0.5.11010` solved the issue for me. I see multiple versions specified in your Gemfile.lock, so this commit upgrades it to the latest one specified