### PR TITLE
Add YARP submodule update to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,16 @@ updates:
     groups:
       minor-and-patch:
         update-types:
-          - 'minor'
-          - 'patch'
+          - "minor"
+          - "patch"
         exclude-patterns:
-          - 'yarp'
+          - "yarp"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "Shopify/ruby-dev-exp"
+    labels:
+      - "dependencies"
+      - "fixtures"


### PR DESCRIPTION
### Motivation

Follow-up: https://github.com/Shopify/ruby-lsp/pull/788#issuecomment-1727935341

I believe it is important to keep this dependency up-to-date, since new code snippets are added [frequently](https://github.com/ruby/yarp/commits/main/test/yarp/fixtures). Like that, we can ensure that ruby-lsp keeps working even with edge-case syntax.

### Implementation

Add YARP submodule update to Dependabot following [this documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).

— configurations like `labels`/`schedule` can be challenged (`fixtures` is not existing, for example)
— `directory` must be the root, because it's search the submodule configuration file (`.gitmodules` [here](https://github.com/Shopify/ruby-lsp/blob/main/.gitmodules))

### Automated Tests

Not relevant. 

### Manual Tests

Tested on my fork: https://github.com/snutij/ruby-lsp/pull/5