### PR TITLE
Use a needs_parsing boolean instead of unparsed edits array

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -28,7 +28,7 @@ module RubyLsp
       @source = T.let(source, String)
       @version = T.let(version, Integer)
       @uri = T.let(uri, URI::Generic)
-      @unparsed_edits = T.let([], T::Array[EditShape])
+      @needs_parsing = T.let(false, T::Boolean)
       @parse_result = T.let(YARP.parse(@source), YARP::ParseResult)
     end
 
@@ -87,15 +87,15 @@ module RubyLsp
       end
 
       @version = version
-      @unparsed_edits.concat(edits)
+      @needs_parsing = true
       @cache.clear
     end
 
     sig { void }
     def parse
-      return if @unparsed_edits.empty?
+      return unless @needs_parsing
 
-      @unparsed_edits.clear
+      @needs_parsing = false
       @parse_result = YARP.parse(@source)
     end
 


### PR DESCRIPTION
### Motivation

I was looking at this code and there's really no reason why we need the `unparsed_edits` array. We only use it to signal that there has been a new edit to a document and that it needs to be parsed, which can be achieve by just using a boolean.

### Implementation

Switched to use a boolean to indicate whether we need to parse the document or not.

### Automated Tests

Our existing test was weak, so I improved the verification to make sure we aren't parsing if no edits were made.