### PR TITLE
Handle namespace aliases in completion

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -164,8 +164,6 @@ module RubyIndexer
       # If `path` is a directory, just ignore it and continue indexing
     end
 
-    private
-
     # Follows aliases in a namespace. The algorithm keeps checking if the name is an alias and then recursively follows
     # it. The idea is that we test the name in parts starting from the complete name to the first namespace. For
     # `Foo::Bar::Baz`, we would test:
@@ -205,6 +203,8 @@ module RubyIndexer
 
       real_parts.join("::")
     end
+
+    private
 
     # Attempts to resolve an UnresolvedAlias into a resolved Alias. If the unresolved alias is pointing to a constant
     # that doesn't exist, then we return the same UnresolvedAlias


### PR DESCRIPTION
### Motivation

Closes #908 

This PR starts handling constants that alias namespaces in completion. This is important to cover this use case:

```ruby
module A
  module B
    class Something
    end
  end
end

ALIAS = A

# When the user types the `S` character,  we should show `Something` as a suggestion.
# We can only do that if we properly resolve aliases, because `ALIAS::B::Something` doesn't
# actually exist, it's `A::B::Something` that does
ALIAS::B::S 
```

### Implementation

1. Made `follow_aliased_namespace` a public method (GitHub is just showing the moved `private`)
2. Started following aliases for the namespace of constant path nodes. Since the final part of the name is always incomplete during the completion request, we only care about resolving aliases in the namespace. For example, when providing completion for `A::B::C`, we only need to resolve `A::B` since the `C` part is not yet fully typed
3. We perform the prefix search using the resolved name, with no aliases. However, the completion text that we insert needs to maintain the alias being used. I accounted for that by making a few tweaks

### Automated Tests

Added two tests that demonstrate the desired behaviour.