### PR TITLE
Remove dependency on syntax_tree

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,6 @@ group :development do
   gem "tapioca", "~> 0.11", require: false, platforms: NON_WINDOWS_PLATFORMS
   gem "rdoc", require: false
   gem "psych", "~> 5.1", require: false
+
+  gem "syntax_tree", ">= 6.1.1", "< 7"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     ruby-lsp (0.11.0)
       language_server-protocol (~> 3.17.0)
       sorbet-runtime (>= 0.5.5685)
-      syntax_tree (>= 6.1.1, < 7)
       yarp (>= 0.12, < 0.13)
 
 GEM
@@ -132,6 +131,7 @@ DEPENDENCIES
   rubocop-sorbet (~> 0.7)
   ruby-lsp!
   sorbet-static-and-runtime
+  syntax_tree (>= 6.1.1, < 7)
   tapioca (~> 0.11)
 
 BUNDLED WITH

--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
-require "syntax_tree"
 require "yarp"
 require "language_server-protocol"
 require "bundler"

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -29,12 +29,7 @@ module RubyLsp
       class Error < StandardError; end
       class InvalidFormatter < StandardError; end
 
-      @formatters = T.let(
-        {
-          "syntax_tree" => Support::SyntaxTreeFormattingRunner.instance,
-        },
-        T::Hash[String, Support::FormatterRunner],
-      )
+      @formatters = T.let({}, T::Hash[String, Support::FormatterRunner])
 
       class << self
         extend T::Sig
@@ -50,6 +45,10 @@ module RubyLsp
 
       if defined?(Support::RuboCopFormattingRunner)
         register_formatter("rubocop", Support::RuboCopFormattingRunner.instance)
+      end
+
+      if defined?(Support::SyntaxTreeFormattingRunner)
+        register_formatter("syntax_tree", Support::SyntaxTreeFormattingRunner.instance)
       end
 
       extend T::Sig

--- a/lib/ruby_lsp/requests/support/syntax_tree_formatting_runner.rb
+++ b/lib/ruby_lsp/requests/support/syntax_tree_formatting_runner.rb
@@ -1,7 +1,13 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "syntax_tree/cli"
+begin
+  require "syntax_tree"
+  require "syntax_tree/cli"
+rescue LoadError
+  return
+end
+
 require "singleton"
 
 module RubyLsp

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency("language_server-protocol", "~> 3.17.0")
   s.add_dependency("sorbet-runtime", ">= 0.5.5685")
-  s.add_dependency("syntax_tree", ">= 6.1.1", "< 7")
   s.add_dependency("yarp", ">= 0.12", "< 0.13")
 
   s.required_ruby_version = ">= 3.0"


### PR DESCRIPTION
### Motivation

I noticed that we forgot to remove our dependency on Syntax Tree during the YARP migration. Now that we use YARP for the foundational part of the functionality, we should treat Syntax Tree like any other formatter.

If the gem is available in the bundle, we use register it as a possible formatter.

### Implementation

Used the same technique we use for RuboCop. We try to require the gem. If it's there, it becomes an available formatter. Otherwise, we just ignore it.

I removed the Syntax Tree dependency and moved it to the Gemfile, since we need it for testing purposes.