### PR TITLE
Add find_references to index

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -170,6 +170,16 @@ module RubyIndexer
       # If `path` is a directory, just ignore it and continue indexing
     end
 
+    # Finds references to a fully qualified name in all indexed files
+    sig { params(fully_qualified_name: String).returns(T::Array[Reference]) }
+    def find_references(fully_qualified_name)
+      @files_to_entries.flat_map do |path, _entries|
+        visitor = ReferencesVisitor.new(self, path, fully_qualified_name)
+        visitor.visit(YARP.parse(File.read(path)).value)
+        visitor.references
+      end
+    end
+
     # Follows aliases in a namespace. The algorithm keeps checking if the name is an alias and then recursively follows
     # it. The idea is that we test the name in parts starting from the complete name to the first namespace. For
     # `Foo::Bar::Baz`, we would test:

--- a/lib/ruby_indexer/lib/ruby_indexer/reference.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/reference.rb
@@ -1,0 +1,20 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyIndexer
+  class Reference
+    extend T::Sig
+
+    sig { returns(YARP::Location) }
+    attr_reader :location
+
+    sig { returns(String) }
+    attr_reader :file_path
+
+    sig { params(location: YARP::Location, file_path: String).void }
+    def initialize(location, file_path)
+      @location = location
+      @file_path = file_path
+    end
+  end
+end

--- a/lib/ruby_indexer/lib/ruby_indexer/references_visitor.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/references_visitor.rb
@@ -1,0 +1,63 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyIndexer
+  class ReferencesVisitor < YARP::Visitor
+    extend T::Sig
+
+    sig { returns(T::Array[Reference]) }
+    attr_reader :references
+
+    sig { params(index: Index, path: String, fully_qualified_name: String).void }
+    def initialize(index, path, fully_qualified_name)
+      @index = index
+      @path = path
+      @fully_qualified_name = fully_qualified_name
+      @nesting = T.let([], T::Array[String])
+      @references = T.let([], T::Array[Reference])
+      super()
+    end
+
+    sig { override.params(node: YARP::ConstantReadNode).void }
+    def visit_constant_read_node(node)
+      name = node.name.to_s
+      check_reference_for(name, node)
+    end
+
+    sig { override.params(node: YARP::ConstantPathNode).void }
+    def visit_constant_path_node(node)
+      name = node.slice
+      check_reference_for(name, node)
+    end
+
+    sig { override.params(node: YARP::ClassNode).void }
+    def visit_class_node(node)
+      name = node.constant_path.slice
+      @nesting << name
+      visit(node.body)
+      @nesting.pop
+    end
+
+    sig { override.params(node: YARP::ModuleNode).void }
+    def visit_module_node(node)
+      name = node.constant_path.slice
+      @nesting << name
+      visit(node.body)
+      @nesting.pop
+    end
+
+    private
+
+    sig { params(name: String, node: T.any(YARP::ConstantReadNode, YARP::ConstantPathNode)).void }
+    def check_reference_for(name, node)
+      entries = @index.resolve(name, @nesting)
+      return unless entries
+
+      first_entry = T.must(entries.first)
+      return if first_entry.visibility == :private && first_entry.name != "#{@nesting.join("::")}::#{name}"
+
+      entry_name = T.must(entries.first).name
+      @references << Reference.new(node.location, @path) if entry_name == @fully_qualified_name
+    end
+  end
+end

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -9,6 +9,8 @@ require "ruby_indexer/lib/ruby_indexer/visitor"
 require "ruby_indexer/lib/ruby_indexer/index"
 require "ruby_indexer/lib/ruby_indexer/configuration"
 require "ruby_indexer/lib/ruby_indexer/prefix_tree"
+require "ruby_indexer/lib/ruby_indexer/reference"
+require "ruby_indexer/lib/ruby_indexer/references_visitor"
 
 module RubyIndexer
   class << self

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -178,5 +178,16 @@ module RubyIndexer
 
       assert_equal("Bar", entries.first.name)
     end
+
+    def test_find_references
+      path = File.expand_path("test/fixtures/class_and_reference.rb")
+      @index.index_single(IndexablePath.new(nil, path))
+
+      references = @index.find_references("Foo")
+      refute_empty(references)
+
+      reference = references.first
+      assert_equal(path, reference.file_path)
+    end
   end
 end

--- a/lib/ruby_indexer/test/references_visitor_test.rb
+++ b/lib/ruby_indexer/test/references_visitor_test.rb
@@ -1,0 +1,84 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module RubyIndexer
+  class ReferencesVisitorTest < TestCase
+    extend T::Sig
+
+    def test_finding_constant_references
+      index(<<~RUBY)
+        class Foo
+        end
+      RUBY
+
+      visitor = ReferencesVisitor.new(@index, "fake.rb", "Foo")
+      visitor.visit(YARP.parse("Foo").value)
+      assert_reference(visitor, "0:0-0:3")
+    end
+
+    def test_finding_constant_path_references
+      index(<<~RUBY)
+        module Foo
+          class Bar
+          end
+        end
+      RUBY
+
+      visitor = ReferencesVisitor.new(@index, "fake.rb", "Foo::Bar")
+      visitor.visit(YARP.parse("Foo::Bar").value)
+      assert_reference(visitor, "0:0-0:8")
+    end
+
+    def test_ignores_invalid_private_constant_accesses
+      index(<<~RUBY)
+        module Foo
+          class Bar
+          end
+          private_constant :Bar
+        end
+      RUBY
+
+      visitor = ReferencesVisitor.new(@index, "fake.rb", "Foo::Bar")
+      visitor.visit(YARP.parse("Foo::Bar").value)
+      assert_empty(visitor.references)
+
+      visitor = ReferencesVisitor.new(@index, "fake.rb", "Foo::Bar")
+      visitor.visit(YARP.parse(<<~RUBY).value)
+        module Foo
+          Bar
+        end
+      RUBY
+      assert_reference(visitor, "1:2-1:5")
+    end
+
+    def test_does_not_count_declaration_as_a_reference
+      index(<<~RUBY)
+        class Foo
+        end
+      RUBY
+
+      visitor = ReferencesVisitor.new(@index, "fake.rb", "Foo")
+      visitor.visit(YARP.parse("class Foo; end").value)
+      assert_empty(visitor.references)
+    end
+
+    private
+
+    sig { params(visitor: ReferencesVisitor, location_string: String).void }
+    def assert_reference(visitor, location_string)
+      reference = T.must(visitor.references.first)
+      location = reference.location
+
+      start_part, end_part = location_string.split("-")
+      start_line, start_column = T.must(start_part).split(":").map(&:to_i)
+      end_line, end_column = T.must(end_part).split(":").map(&:to_i)
+
+      assert_equal(start_line, location.start_line - 1)
+      assert_equal(start_column, location.start_column)
+      assert_equal(end_line, location.end_line - 1)
+      assert_equal(end_column, location.end_column)
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

First step towards #202. At least for classes, modules and constants.

This PR adds a method to find references to a fully qualified name in the indexer, so that we can provide the references request.

### Implementation

The idea is that we go through all indexed file paths, using a new visitor to find references that match the given fully qualified name. We collect everything and return.

I find this implementation really interesting because it surfaces references in gems too. So, if you want to know how `ActiveRecord::Base` is used inside Rails, you can just ask for references on the class and it'll bring you results.

### Automated Tests

Added tests.