### PR TITLE
Ignore nesting when resolving top level constants

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -127,6 +127,12 @@ module RubyIndexer
     # 3. Baz
     sig { params(name: String, nesting: T::Array[String]).returns(T.nilable(T::Array[Entry])) }
     def resolve(name, nesting)
+      if name.start_with?("::")
+        name = name.delete_prefix("::")
+        results = @entries[name] || @entries[follow_aliased_namespace(name)]
+        return results.map { |e| e.is_a?(Entry::UnresolvedAlias) ? resolve_alias(e) : e } if results
+      end
+
       nesting.length.downto(0).each do |i|
         namespace = T.must(nesting[0...i]).join("::")
         full_name = namespace.empty? ? name : "#{namespace}::#{name}"

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -158,5 +158,25 @@ module RubyIndexer
       results = @index.prefix_search("Ba", ["Foo"]).map { |entries| entries.map(&:name) }
       assert_equal([["Foo::Bar", "Foo::Bar"], ["Foo::Baz"]], results)
     end
+
+    def test_resolve_normalizes_top_level_names
+      @index.index_single(IndexablePath.new("/fake", "/fake/path/foo.rb"), <<~RUBY)
+        class Bar; end
+
+        module Foo
+          class Bar; end
+        end
+      RUBY
+
+      entries = @index.resolve("::Foo::Bar", [])
+      refute_nil(entries)
+
+      assert_equal("Foo::Bar", entries.first.name)
+
+      entries = @index.resolve("::Bar", ["Foo"])
+      refute_nil(entries)
+
+      assert_equal("Bar", entries.first.name)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/vscode-ruby-lsp/issues/811

If we're trying to resolve a top level constant reference (e.g.: `::Foo`), then we need to do two things:
1. Ignore the nesting, because it does not apply. It's a top level constant reference
2. Delete the `::` prefix since we don't include those when storing entries

### Implementation

Started ignoring the nesting and just searching for the top level name directly in resolve.

### Automated Tests

Added a test that fails without the fix.