### PR TITLE
Use token for RBI update

### DIFF
--- a/.github/workflows/dependabot_update_rbis.yml
+++ b/.github/workflows/dependabot_update_rbis.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
       - name: Get Ruby version from dev.yml
         id: ruby
         shell: ruby -ryaml {0}


### PR DESCRIPTION
### Motivation

Make use of the token added in https://github.com/Shopify/github-actions-access-provider/pull/1097.

### Implementation

n/a

### Automated Tests

n/a

### Manual Tests

Will verify after merge.
