### PR TITLE
Fix Indexing Gemspec Awareness Bug

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -179,7 +179,12 @@ module RubyIndexer
 
       # When working on a gem, we need to make sure that its gemspec dependencies can't be excluded. This is necessary
       # because Bundler doesn't assign groups to gemspec dependencies
-      this_gem = Bundler.definition.dependencies.find { |d| d.to_spec.full_gem_path == Dir.pwd }
+      this_gem = Bundler.definition.dependencies.find do |d|
+        d.to_spec.full_gem_path == Dir.pwd
+      rescue Gem::MissingSpecError
+        false
+      end
+
       others.concat(this_gem.to_spec.dependencies) if this_gem
 
       excluded.each do |dependency|


### PR DESCRIPTION
### Motivation

Solves #1059

Fixes an issue in which the Indexer would hang on startup of the Ruby LSP.

### Implementation

Rescued an error that occurred [here](https://github.com/Shopify/ruby-lsp/blob/1922f0c26ad4d8c3dfd7a3c8ca830a940ab7df95/lib/ruby_indexer/lib/ruby_indexer/configuration.rb#L182), such that it no longer halts execution of the initial indexing request.

### Automated Tests

I was looking for some tests around gemspec awareness in the `configuration_spec` file, but I couldn't find anything. I'd like to add a test if there's an appropriate place to do so.

### Manual Tests

1. Boot up a rails app that does not download `tzinfo-data` as a dependency, despite being included in the bundle
2. Confirm the indexing request works correctly and completes with features that depend on the index working correctly.