### PR TITLE
Use RuboCop's severity for all issues.

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -47,13 +47,10 @@ module RubyLsp
 
         sig { returns(Interface::Diagnostic) }
         def to_lsp_diagnostic
-          if @offense.correctable?
-            severity = RUBOCOP_TO_LSP_SEVERITY[@offense.severity.name]
-            message = @offense.message
-          else
-            severity = Constant::DiagnosticSeverity::WARNING
-            message = "#{@offense.message}\n\nThis offense is not auto-correctable.\n"
-          end
+          severity = RUBOCOP_TO_LSP_SEVERITY[@offense.severity.name]
+          message  = @offense.message
+
+          message += "\n\nThis offense is not auto-correctable.\n" unless @offense.correctable?
 
           Interface::Diagnostic.new(
             message: message,

--- a/test/expectations/diagnostics/if_inside_else.exp.json
+++ b/test/expectations/diagnostics/if_inside_else.exp.json
@@ -11,7 +11,7 @@
           "character": 14
         }
       },
-      "severity": 2,
+      "severity": 3,
       "code": "Sorbet/TrueSigil",
       "source": "RuboCop",
       "message": "Sorbet/TrueSigil: Sorbet sigil should be at least `true` got `false`.\n\nThis offense is not auto-correctable.\n",


### PR DESCRIPTION
### Motivation

Non auto-correctable RuboCop offenses were all flagged as WARNINGs rather than using the configured RuboCop severity [see issue](https://github.com/Shopify/ruby-lsp/issues/1057)

### Implementation

I pulled the logic for the severity outside the auto-correctable condition check.

### Automated Tests

I modified an existing test that relied on the old behavior to expect the new behavior.

### Manual Tests

I added an entry to a Gemfile for a ruby project I have that used the `path:` to link to my local instance of the gem. I was able to validate the new behavior in the context of VS Code.
