### PR TITLE
Unset deployment mode on version bump automation

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -25,6 +25,8 @@ jobs:
         run: |
           version=$(awk -F. '{$NF+=1}1' OFS=. VERSION)
           echo "$version" > VERSION
+          // We need to unset deployment mode because it won't allow for modifications to `Gemfile.lock`
+          bundle config unset deployment
           bundle install
           echo "VERSION=$version" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
### Motivation

Our automatic version bump automation is failing when running bundle install to lock the new version in `Gemfile.lock`. The reason is because bundler won't allow the lockfile to be modified in deployment mode, which is the default for GH actions. We need to unset that in order to appropriately bump the version.