### PR TITLE
Do not try to resolve nesting for non-indexed top level constants

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -130,7 +130,7 @@ module RubyIndexer
       if name.start_with?("::")
         name = name.delete_prefix("::")
         results = @entries[name] || @entries[follow_aliased_namespace(name)]
-        return results.map { |e| e.is_a?(Entry::UnresolvedAlias) ? resolve_alias(e) : e } if results
+        return results&.map { |e| e.is_a?(Entry::UnresolvedAlias) ? resolve_alias(e) : e }
       end
 
       nesting.length.downto(0).each do |i|

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -178,5 +178,20 @@ module RubyIndexer
 
       assert_equal("Bar", entries.first.name)
     end
+
+    def test_resolving_aliases_to_non_existing_constants_with_conflicting_names
+      @index.index_single(IndexablePath.new("/fake", "/fake/path/foo.rb"), <<~RUBY)
+        module Foo
+          class Float < self
+            INFINITY = ::Float::INFINITY
+          end
+        end
+      RUBY
+
+      entry = @index.resolve("INFINITY", ["Foo", "Float"]).first
+      refute_nil(entry)
+
+      assert_instance_of(Index::Entry::UnresolvedAlias, entry)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

While benchmarking finding references https://github.com/Shopify/ruby-lsp/pull/1044#discussion_r1342777786, I stumbled upon this wildly fun bug in `resolve`.

If we have a constant alias that points to a constant with the exact same name on the top level that we have not indexed, then we would go into an infinite recursion loop.

### Implementation

The test example makes it a little bit clearer as to how this happened. The reason is because we would try to resolve `::Float::INFINITY`. Since it's a top level reference, we would delete the `::` prefix. However, we never indexed `Float::INFINITY` because that's defined in C and so we would not be able to find it in the index.

Because of the `if results` in the previous implementation, we would only return if we found something, which meant we continue down the resolve method. That would get into the nesting resolution logic, which would accidentally try to resolve `Float::Infinity` with nesting `Foo`, because we deleted the `::` prefix.

The fix is that we should always return the results directly for a top level reference and never try to solve the nesting.

### Automated Tests

Added a test that reproduces the issue.