### PR TITLE
Require Set to Fix NameError

### DIFF
--- a/lib/ruby_lsp/parameter_scope.rb
+++ b/lib/ruby_lsp/parameter_scope.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "set"
+
 module RubyLsp
   class ParameterScope
     extend T::Sig


### PR DESCRIPTION
### Motivation

This gem was erroring out on my system because it couldn't find the Set constant.

```
Ruby LSP> Skipping lockfile copies because there's no top level bundle
Ruby LSP> Running bundle install for the custom bundle. This may take a while...
Resolving dependencies...
The Gemfile's dependencies are satisfied
Starting Ruby LSP...
Ruby LSP is ready
[Error - 8:17:11 AM] Request textDocument/documentSymbol failed.
  Message: #<NameError: uninitialized constant RubyLsp::ParameterScope::Set

      @parameters = T.let(Set.new, T::Set[Symbol])
                          ^^^>
  Code: -32603 
[object Object]
[Error - 8:17:11 AM] Request textDocument/documentLink failed.
  Message: #<NameError: uninitialized constant RubyLsp::ParameterScope::Set

      @parameters = T.let(Set.new, T::Set[Symbol])
                          ^^^>
  Code: -32603 
```

```
$ ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
$ ruby-lsp -v
0.11.1
```

### Implementation

To my knowledge [`Set`](https://github.com/ruby/ruby/blob/master/lib/set.rb) has always been part of the standard library and not Ruby base. However, if your development tools or bundle already requires it in a way that it is available in the environment - which most do - then you won't see the error.

### Automated Tests

Because most testing libraries already require `Set`, it is difficult to test using the standard tools.

### Manual Tests

Given you have opened VS Code in a minimal environment,
When `require "set"` is not in the file,
When you open a Ruby file in VS Code,
Then you will see a NameError and not see any LSP functionality.

Given you have opened VS Code in a minimal environment,
When `require "set"` is in the file,
When you open a Ruby file in VS Code,
Then you will not see any errors and the symbol table available in the Outline will populate
