### PR TITLE
Fixed neovim config: diagnostic now clears on fix

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -45,12 +45,13 @@ local function setup_diagnostics(client, buffer)
         local err_msg = string.format("diagnostics error - %s", vim.inspect(err))
         vim.lsp.log.error(err_msg)
       end
-      if not result then
-        return
+      local diagnostic_items = {}
+      if result then
+        diagnostic_items = result.items
       end
       vim.lsp.diagnostic.on_publish_diagnostics(
         nil,
-        vim.tbl_extend("keep", params, { diagnostics = result.items }),
+        vim.tbl_extend("keep", params, { diagnostics = diagnostic_items }),
         { client_id = client.id }
       )
     end)


### PR DESCRIPTION
### Motivation

The existing Neovim config has a problem: diagnostics won't clear even after the problem being fixed. 

### Implementation

Tweak the neovim config so it will report properly empty diagnostic result to LSP client. 

### Automated Tests

N/A - just document change.

### Manual Tests

* Open a single ruby file.
* Make a syntax error
* Confirm the diagnostic result to show up. 
* Now fix the error.
* Confirm the diagnostic result to disappear. 
