### PR TITLE
Return early when following a non aliased name

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -182,6 +182,8 @@ module RubyIndexer
     # aliases, so we have to invoke `follow_aliased_namespace` again to check until we only return a real name
     sig { params(name: String).returns(String) }
     def follow_aliased_namespace(name)
+      return name if @entries[name]
+
       parts = name.split("::")
       real_parts = []
 


### PR DESCRIPTION
### Motivation

Closes #1062

Following aliased names is a very expensive operation because it needs to recursively resolve each aliased part of the name. However, we should avoid recursing if we already found the correct name - or if the name doesn't contain aliases at all.

### Implementation

Started returning early if the given name exists (which means there aren't any aliases in it). This is 10x faster for names that do not include any aliases - and certainly faster for names that are only partially aliased.