### PR TITLE
Remove `on_node` from folding range

### DIFF
--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -98,81 +98,92 @@ module RubyLsp
 
       sig { params(node: YARP::ArrayNode).void }
       def on_array(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::BlockNode).void }
       def on_block(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::CaseNode).void }
       def on_case(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::ClassNode).void }
       def on_class(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::ModuleNode).void }
       def on_module(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::ForNode).void }
       def on_for(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::HashNode).void }
       def on_hash(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::SingletonClassNode).void }
       def on_singleton_class(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::UnlessNode).void }
       def on_unless(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::UntilNode).void }
       def on_until(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::WhileNode).void }
       def on_while(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::ElseNode).void }
       def on_else(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::EnsureNode).void }
       def on_ensure(node)
+        emit_requires_range
         add_simple_range(node)
       end
 
       sig { params(node: YARP::BeginNode).void }
       def on_begin(node)
-        add_simple_range(node)
-      end
+        emit_requires_range
 
-      sig { params(node: YARP::Node).void }
-      def on_node(node)
-        emit_requires_range unless node.is_a?(YARP::CallNode)
+        add_simple_range(node)
       end
 
       sig { params(node: YARP::StringConcatNode).void }
       def on_string_concat(node)
+        emit_requires_range
         left = T.let(node.left, YARP::Node)
         left = left.left while left.is_a?(YARP::StringConcatNode)
 
@@ -181,6 +192,7 @@ module RubyLsp
 
       sig { params(node: YARP::DefNode).void }
       def on_def(node)
+        emit_requires_range
         params = node.parameters
         parameter_loc = params&.location
         location = node.location
@@ -203,6 +215,7 @@ module RubyLsp
           return
         end
 
+        emit_requires_range
         location = node.location
         add_lines_range(location.start_line, location.end_line - 1)
       end

--- a/test/expectations/folding_ranges/command_requires.exp.json
+++ b/test/expectations/folding_ranges/command_requires.exp.json
@@ -4,6 +4,11 @@
       "startLine": 0,
       "endLine": 3,
       "kind": "imports"
+    },
+    {
+      "startLine": 7,
+      "endLine": 8,
+      "kind": "imports"
     }
   ]
 }

--- a/test/fixtures/command_requires.rb
+++ b/test/fixtures/command_requires.rb
@@ -2,3 +2,8 @@ require "foo"
 require_relative "bar"
 
 require "baz"
+
+A.some_other_random_node
+
+require "qux"
+require_relative "quux"


### PR DESCRIPTION
### Motivation

Part of #1072

Remove `on_node` usage from folding range.

### Implementation

This actually caught a bug we had too. We defined the `on_node` method, but didn't actually register it on the event emitter.

The unfortunate part of the implementation is that we have to repeat `emit_requires_range` on every single event that isn't a require invocation.

### Automated Tests

Enhanced our existing test.