### PR TITLE
Show indexing percentage on progress notifications

### DIFF
--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -110,6 +110,10 @@ class ExecutorTest < Minitest::Test
 
   def test_initialized_populates_index
     @executor.execute({ method: "initialized", params: {} })
+
+    assert_equal("$/progress", @message_queue.pop.message)
+    assert_equal("$/progress", @message_queue.pop.message)
+
     index = @executor.instance_variable_get(:@index)
     refute_empty(index.instance_variable_get(:@entries))
   end
@@ -205,7 +209,6 @@ class ExecutorTest < Minitest::Test
 
       # Account for starting and ending the progress notifications during initialized
       assert_equal("window/workDoneProgress/create", @message_queue.pop.message)
-      assert_equal("$/progress", @message_queue.pop.message)
       assert_equal("$/progress", @message_queue.pop.message)
 
       notification = T.must(@message_queue.pop)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -100,7 +100,10 @@ class IntegrationTest < Minitest::Test
     open_file_with("require 'ruby_lsp/utils'")
 
     # Populate the index
-    make_request("initialized")
+    send_request("initialized")
+
+    # There's no easy way to know when indexing finished. Here we just sleep until it's done
+    sleep(5)
 
     response = make_request(
       "textDocument/definition",
@@ -338,8 +341,10 @@ class IntegrationTest < Minitest::Test
     open_file_with("class Foo\nend")
 
     # Populate the index
-    make_request("initialized")
+    send_request("initialized")
 
+    # There's no easy way to know when indexing finished. Here we just sleep until it's done
+    sleep(5)
     response = make_request("workspace/symbol", {})
     refute_empty(response[:result])
   end
@@ -386,6 +391,9 @@ class IntegrationTest < Minitest::Test
           experimentalFeaturesEnabled: experimental_features_enabled,
           formatter: "rubocop",
         },
+        capabilities: {
+          window: { workDoneProgress: false },
+        },
       },
     )[:result]
 
@@ -401,8 +409,6 @@ class IntegrationTest < Minitest::Test
 
     enabled_providers = enabled_features.map { |feature| FEATURE_TO_PROVIDER[feature] }
     assert_equal([:positionEncoding, :textDocumentSync, *enabled_providers], response[:capabilities].keys)
-    read_response("window/workDoneProgress/create")
-    read_response("$/progress")
   end
 
   def open_file_with(content)


### PR DESCRIPTION
### Motivation

This PR makes indexing run concurrently in a thread and takes advantage of that to display concrete progress to the user.

The advantages of doing this are:

- Indexing concurrently means that we'll not block handling requests until done - because Ruby will naturally switch between threads for us. This means that
    - Initial requests will not be delayed for as long as they are now
    - Asking the server to shutdown during indexing will actually work, because we'll be able to handle the shutdown request
- Showing the exact progress in terms of percentage gives users a better hint to know when we'll be done indexing

### Implementation

There are two parts to the implementation:

1. Added an optional block to `Index#index_all`. If the block is passed, it gets invoked every time we complete 1% of the total number of files. The block also controls whether we continue or stop indexing, by returning `true` or `false`. This is used so that we can handle shutdowns that happen during indexing gracefully
2. The second part is just putting the invocation to `index_all` in a thread that keeps sending notifications back to the editor

### Automated Tests

Tweaked relevant tests.

### Manual Tests

1. Start the LSP on this branch
2. Verify that the progress notification on the status bar shows the progress percentage