### PR TITLE
Remove node override selection ranges

### DIFF
--- a/lib/ruby_lsp/requests/selection_ranges.rb
+++ b/lib/ruby_lsp/requests/selection_ranges.rb
@@ -40,10 +40,7 @@ module RubyLsp
           node, parent = queue.shift
           next unless node
 
-          range = RubyLsp::Requests::Support::SelectionRange.new(
-            range: range_from_location(node.location),
-            parent: parent,
-          )
+          range = Support::SelectionRange.new(range: range_from_location(node.location), parent: parent)
           T.unsafe(queue).unshift(*node.child_nodes.map { |child| [child, range] })
           @ranges.unshift(range)
         end

--- a/test/expectations/selection_ranges/array_literal_oneline.exp.json
+++ b/test/expectations/selection_ranges/array_literal_oneline.exp.json
@@ -38,6 +38,30 @@
                             "line": 0,
                             "character": 10
                         }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "character": 10
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 0,
+                                    "character": 10
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/begin_rescue_ensure.exp.json
+++ b/test/expectations/selection_ranges/begin_rescue_ensure.exp.json
@@ -20,8 +20,8 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 4,
-                        "character": 0
+                        "line": 5,
+                        "character": 2
                     },
                     "end": {
                         "line": 5,
@@ -31,7 +31,7 @@
                 "parent": {
                     "range": {
                         "start": {
-                            "line": 2,
+                            "line": 4,
                             "character": 0
                         },
                         "end": {
@@ -42,12 +42,48 @@
                     "parent": {
                         "range": {
                             "start": {
-                                "line": 0,
+                                "line": 2,
                                 "character": 0
                             },
                             "end": {
-                                "line": 8,
-                                "character": 3
+                                "line": 5,
+                                "character": 18
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "character": 3
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "character": 3
+                                    }
+                                },
+                                "parent": {
+                                    "range": {
+                                        "start": {
+                                            "line": 0,
+                                            "character": 0
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "character": 3
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/test/expectations/selection_ranges/case_when.exp.json
+++ b/test/expectations/selection_ranges/case_when.exp.json
@@ -20,8 +20,8 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 1,
-                        "character": 0
+                        "line": 2,
+                        "character": 2
                     },
                     "end": {
                         "line": 2,
@@ -31,12 +31,48 @@
                 "parent": {
                     "range": {
                         "start": {
-                            "line": 0,
+                            "line": 1,
                             "character": 0
                         },
                         "end": {
-                            "line": 5,
-                            "character": 3
+                            "line": 2,
+                            "character": 13
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 5,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "character": 3
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "character": 3
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/test/expectations/selection_ranges/class_declaration.exp.json
+++ b/test/expectations/selection_ranges/class_declaration.exp.json
@@ -20,23 +20,71 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 1,
-                        "character": 2
+                        "line": 2,
+                        "character": 4
                     },
                     "end": {
-                        "line": 3,
-                        "character": 5
+                        "line": 2,
+                        "character": 17
                     }
                 },
                 "parent": {
                     "range": {
                         "start": {
-                            "line": 0,
-                            "character": 0
+                            "line": 1,
+                            "character": 2
                         },
                         "end": {
-                            "line": 4,
-                            "character": 3
+                            "line": 3,
+                            "character": 5
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 2
+                            },
+                            "end": {
+                                "line": 3,
+                                "character": 5
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "character": 3
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "character": 3
+                                    }
+                                },
+                                "parent": {
+                                    "range": {
+                                        "start": {
+                                            "line": 0,
+                                            "character": 0
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "character": 3
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/test/expectations/selection_ranges/class_declaration_nested.exp.json
+++ b/test/expectations/selection_ranges/class_declaration_nested.exp.json
@@ -16,6 +16,30 @@
                     "line": 2,
                     "character": 3
                 }
+            },
+            "parent": {
+                "range": {
+                    "start": {
+                        "line": 0,
+                        "character": 0
+                    },
+                    "end": {
+                        "line": 2,
+                        "character": 3
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 3
+                        }
+                    }
+                }
             }
         }
     ]

--- a/test/expectations/selection_ranges/def.exp.json
+++ b/test/expectations/selection_ranges/def.exp.json
@@ -20,12 +20,48 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 0
+                        "line": 1,
+                        "character": 2
                     },
                     "end": {
-                        "line": 3,
-                        "character": 3
+                        "line": 2,
+                        "character": 10
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 3,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/def_endless.exp.json
+++ b/test/expectations/selection_ranges/def_endless.exp.json
@@ -16,6 +16,30 @@
                     "line": 2,
                     "character": 12
                 }
+            },
+            "parent": {
+                "range": {
+                    "start": {
+                        "line": 2,
+                        "character": 0
+                    },
+                    "end": {
+                        "line": 2,
+                        "character": 12
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 2,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 12
+                        }
+                    }
+                }
             }
         }
     ]

--- a/test/expectations/selection_ranges/def_multiline_params.exp.json
+++ b/test/expectations/selection_ranges/def_multiline_params.exp.json
@@ -38,6 +38,30 @@
                             "line": 6,
                             "character": 3
                         }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 6,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/def_oneline.exp.json
+++ b/test/expectations/selection_ranges/def_oneline.exp.json
@@ -16,6 +16,30 @@
                     "line": 0,
                     "character": 12
                 }
+            },
+            "parent": {
+                "range": {
+                    "start": {
+                        "line": 0,
+                        "character": 0
+                    },
+                    "end": {
+                        "line": 2,
+                        "character": 12
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 12
+                        }
+                    }
+                }
             }
         }
     ]

--- a/test/expectations/selection_ranges/def_require_name_parameter.exp.json
+++ b/test/expectations/selection_ranges/def_require_name_parameter.exp.json
@@ -16,6 +16,30 @@
                     "line": 1,
                     "character": 3
                 }
+            },
+            "parent": {
+                "range": {
+                    "start": {
+                        "line": 0,
+                        "character": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "character": 3
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "character": 3
+                        }
+                    }
+                }
             }
         }
     ]

--- a/test/expectations/selection_ranges/defs.exp.json
+++ b/test/expectations/selection_ranges/defs.exp.json
@@ -16,6 +16,30 @@
                     "line": 3,
                     "character": 3
                 }
+            },
+            "parent": {
+                "range": {
+                    "start": {
+                        "line": 0,
+                        "character": 0
+                    },
+                    "end": {
+                        "line": 3,
+                        "character": 3
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 3
+                        }
+                    }
+                }
             }
         }
     ]

--- a/test/expectations/selection_ranges/defs_multiline_params.exp.json
+++ b/test/expectations/selection_ranges/defs_multiline_params.exp.json
@@ -38,6 +38,30 @@
                             "line": 6,
                             "character": 3
                         }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 6,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/do_blocks.exp.json
+++ b/test/expectations/selection_ranges/do_blocks.exp.json
@@ -27,6 +27,30 @@
                         "line": 2,
                         "character": 3
                     }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 3
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/test/expectations/selection_ranges/ensure.exp.json
+++ b/test/expectations/selection_ranges/ensure.exp.json
@@ -20,23 +20,59 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 2,
-                        "character": 0
+                        "line": 3,
+                        "character": 2
                     },
                     "end": {
-                        "line": 4,
-                        "character": 3
+                        "line": 3,
+                        "character": 15
                     }
                 },
                 "parent": {
                     "range": {
                         "start": {
-                            "line": 0,
+                            "line": 2,
                             "character": 0
                         },
                         "end": {
                             "line": 4,
                             "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 4,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "character": 3
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "character": 3
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/test/expectations/selection_ranges/for.exp.json
+++ b/test/expectations/selection_ranges/for.exp.json
@@ -20,12 +20,48 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 0
+                        "line": 1,
+                        "character": 2
                     },
                     "end": {
-                        "line": 2,
-                        "character": 3
+                        "line": 1,
+                        "character": 14
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/hash_literal.exp.json
+++ b/test/expectations/selection_ranges/hash_literal.exp.json
@@ -49,6 +49,30 @@
                                 "line": 3,
                                 "character": 1
                             }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "character": 1
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "character": 1
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/test/expectations/selection_ranges/hash_literal_oneline.exp.json
+++ b/test/expectations/selection_ranges/hash_literal_oneline.exp.json
@@ -49,6 +49,30 @@
                                 "line": 0,
                                 "character": 18
                             }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 0,
+                                    "character": 18
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "character": 18
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/test/expectations/selection_ranges/heredoc.exp.json
+++ b/test/expectations/selection_ranges/heredoc.exp.json
@@ -20,12 +20,60 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 0
+                        "line": 1,
+                        "character": 13
                     },
                     "end": {
-                        "line": 2,
-                        "character": 0
+                        "line": 1,
+                        "character": 18
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 1,
+                            "character": 11
+                        },
+                        "end": {
+                            "line": 1,
+                            "character": 19
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "character": 10
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 0,
+                                    "character": 10
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "character": 10
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/if.exp.json
+++ b/test/expectations/selection_ranges/if.exp.json
@@ -20,12 +20,48 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 0
+                        "line": 1,
+                        "character": 2
                     },
                     "end": {
-                        "line": 2,
-                        "character": 3
+                        "line": 1,
+                        "character": 15
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/if_elsif_else.exp.json
+++ b/test/expectations/selection_ranges/if_elsif_else.exp.json
@@ -20,18 +20,18 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 4,
-                        "character": 0
+                        "line": 5,
+                        "character": 2
                     },
                     "end": {
-                        "line": 6,
-                        "character": 3
+                        "line": 5,
+                        "character": 11
                     }
                 },
                 "parent": {
                     "range": {
                         "start": {
-                            "line": 2,
+                            "line": 4,
                             "character": 0
                         },
                         "end": {
@@ -42,12 +42,48 @@
                     "parent": {
                         "range": {
                             "start": {
-                                "line": 0,
+                                "line": 2,
                                 "character": 0
                             },
                             "end": {
                                 "line": 6,
                                 "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "character": 3
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "character": 3
+                                    }
+                                },
+                                "parent": {
+                                    "range": {
+                                        "start": {
+                                            "line": 0,
+                                            "character": 0
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "character": 3
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/test/expectations/selection_ranges/if_elsif_else_empty.exp.json
+++ b/test/expectations/selection_ranges/if_elsif_else_empty.exp.json
@@ -38,6 +38,30 @@
                             "line": 3,
                             "character": 3
                         }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 3,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/lambdas.exp.json
+++ b/test/expectations/selection_ranges/lambdas.exp.json
@@ -20,23 +20,59 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 7
+                        "line": 1,
+                        "character": 2
                     },
                     "end": {
-                        "line": 2,
-                        "character": 1
+                        "line": 1,
+                        "character": 11
                     }
                 },
                 "parent": {
                     "range": {
                         "start": {
                             "line": 0,
-                            "character": 0
+                            "character": 7
                         },
                         "end": {
                             "line": 2,
                             "character": 1
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 1
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 1
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "character": 1
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/test/expectations/selection_ranges/module_declaration.exp.json
+++ b/test/expectations/selection_ranges/module_declaration.exp.json
@@ -20,12 +20,48 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 0
+                        "line": 1,
+                        "character": 2
                     },
                     "end": {
-                        "line": 6,
-                        "character": 3
+                        "line": 5,
+                        "character": 5
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 6,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/multiline_arrays.exp.json
+++ b/test/expectations/selection_ranges/multiline_arrays.exp.json
@@ -38,6 +38,30 @@
                             "line": 3,
                             "character": 1
                         }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 3,
+                                "character": 1
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "character": 1
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/multiline_block.exp.json
+++ b/test/expectations/selection_ranges/multiline_block.exp.json
@@ -27,6 +27,30 @@
                         "line": 2,
                         "character": 1
                     }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 1
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 1
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/test/expectations/selection_ranges/multiline_invocation.exp.json
+++ b/test/expectations/selection_ranges/multiline_invocation.exp.json
@@ -60,6 +60,30 @@
                                     "line": 3,
                                     "character": 1
                                 }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "character": 1
+                                    }
+                                },
+                                "parent": {
+                                    "range": {
+                                        "start": {
+                                            "line": 0,
+                                            "character": 0
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "character": 1
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/test/expectations/selection_ranges/nested_invocation.exp.json
+++ b/test/expectations/selection_ranges/nested_invocation.exp.json
@@ -60,6 +60,30 @@
                                     "line": 5,
                                     "character": 1
                                 }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "character": 1
+                                    }
+                                },
+                                "parent": {
+                                    "range": {
+                                        "start": {
+                                            "line": 0,
+                                            "character": 0
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "character": 1
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/test/expectations/selection_ranges/nested_invocation_no_parenthesis.exp.json
+++ b/test/expectations/selection_ranges/nested_invocation_no_parenthesis.exp.json
@@ -60,6 +60,30 @@
                                     "line": 3,
                                     "character": 1
                                 }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "character": 1
+                                    }
+                                },
+                                "parent": {
+                                    "range": {
+                                        "start": {
+                                            "line": 0,
+                                            "character": 0
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "character": 1
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/test/expectations/selection_ranges/pattern_matching.exp.json
+++ b/test/expectations/selection_ranges/pattern_matching.exp.json
@@ -20,8 +20,8 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 1,
-                        "character": 0
+                        "line": 2,
+                        "character": 2
                     },
                     "end": {
                         "line": 2,
@@ -31,12 +31,48 @@
                 "parent": {
                     "range": {
                         "start": {
-                            "line": 0,
+                            "line": 1,
                             "character": 0
                         },
                         "end": {
-                            "line": 5,
-                            "character": 3
+                            "line": 2,
+                            "character": 10
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 5,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "character": 3
+                                }
+                            },
+                            "parent": {
+                                "range": {
+                                    "start": {
+                                        "line": 0,
+                                        "character": 0
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "character": 3
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/test/expectations/selection_ranges/rescue_multiple.exp.json
+++ b/test/expectations/selection_ranges/rescue_multiple.exp.json
@@ -38,6 +38,30 @@
                             "line": 2,
                             "character": 3
                         }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/sclass.exp.json
+++ b/test/expectations/selection_ranges/sclass.exp.json
@@ -20,12 +20,48 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 0
+                        "line": 1,
+                        "character": 2
                     },
                     "end": {
-                        "line": 4,
-                        "character": 3
+                        "line": 3,
+                        "character": 5
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 4,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 4,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/string_concat.exp.json
+++ b/test/expectations/selection_ranges/string_concat.exp.json
@@ -38,6 +38,30 @@
                             "line": 2,
                             "character": 7
                         }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 7
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 7
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/unless.exp.json
+++ b/test/expectations/selection_ranges/unless.exp.json
@@ -20,12 +20,48 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 0
+                        "line": 1,
+                        "character": 2
                     },
                     "end": {
-                        "line": 2,
-                        "character": 3
+                        "line": 1,
+                        "character": 13
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/until.exp.json
+++ b/test/expectations/selection_ranges/until.exp.json
@@ -20,12 +20,48 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 0
+                        "line": 1,
+                        "character": 2
                     },
                     "end": {
-                        "line": 2,
-                        "character": 3
+                        "line": 1,
+                        "character": 14
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/expectations/selection_ranges/while.exp.json
+++ b/test/expectations/selection_ranges/while.exp.json
@@ -20,12 +20,48 @@
             "parent": {
                 "range": {
                     "start": {
-                        "line": 0,
-                        "character": 0
+                        "line": 1,
+                        "character": 2
                     },
                     "end": {
-                        "line": 2,
-                        "character": 3
+                        "line": 1,
+                        "character": 14
+                    }
+                },
+                "parent": {
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 3
+                        }
+                    },
+                    "parent": {
+                        "range": {
+                            "start": {
+                                "line": 0,
+                                "character": 0
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 3
+                            }
+                        },
+                        "parent": {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 3
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -305,8 +305,8 @@ class IntegrationTest < Minitest::Test
     )
 
     assert_equal(
-      { range: { start: { line: 0, character: 0 }, end: { line: 1, character: 3 } } },
-      response[:result].first,
+      { start: { line: 0, character: 0 }, end: { line: 1, character: 3 } },
+      response[:result].first[:range],
     )
   end
 


### PR DESCRIPTION
### Motivation

Part of #1072 

Since we're already going to have to change the implementation on selection range, I think it's worth matching what the [specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_selectionRange) and make selection ranges match the AST exactly.

This simplifies the request and better conforms to the spec.

### Implementation

Since we can't override `visit` anymore, it's not possible to implement this request with a visitor unfortunately. We use a queueing mechanism instead where we keep track of the current node and its parent and push ranges for all of the nodes

### Automated Tests

Fixed the tests to match the new behaviour.