### PR TITLE
Fix Prism fixtures path

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-YARP_FIXTURES_DIR=test/fixtures/yarp/test/yarp/fixtures
+PRISM_FIXTURES_DIR=test/fixtures/yarp/test/prism/fixtures
 
-if [ ! -d "$YARP_FIXTURES_DIR" ]; then
-    echo "$YARP_FIXTURES_DIR does not exist."
+if [ ! -d "$PRISM_FIXTURES_DIR" ]; then
+    echo "$PRISM_FIXTURES_DIR does not exist."
     echo "Please run 'git submodule update --init' to pull submodule fixtures."
     exit 1
 fi

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -5,7 +5,7 @@ class ExpectationsTestRunner < Minitest::Test
   TEST_EXP_DIR = "test/expectations"
   TEST_FIXTURES_DIR = "test/fixtures"
   TEST_RUBY_LSP_FIXTURES = File.join(TEST_FIXTURES_DIR, "*.rb")
-  TEST_YARP_FIXTURES = File.join(TEST_FIXTURES_DIR, "yarp/test/yarp/fixtures/**", "*.txt")
+  TEST_YARP_FIXTURES = File.join(TEST_FIXTURES_DIR, "yarp/test/prism/fixtures/**", "*.txt")
 
   class << self
     def expectations_tests(handler_class, expectation_suffix)
@@ -107,8 +107,8 @@ class ExpectationsTestRunner < Minitest::Test
     end
 
     # Ensure that the test name include path context to avoid duplicate
-    # from test/fixtures/yarp/test/yarp/fixtures/unparser/corpus/semantic/and.txt
-    # to test_fixtures_yarp_test_yarp_fixtures_unparser_corpus_semantic_and
+    # from test/fixtures/yarp/test/prism/fixtures/unparser/corpus/semantic/and.txt
+    # to test_fixtures_yarp_test_prism_fixtures_unparser_corpus_semantic_and
     def uniq_name_from_path(path)
       path.gsub("/", "_").gsub('.txt', '')
     end


### PR DESCRIPTION
### Motivation

Part of #1072

Our git submodule was already updated by dependabot and the internal folder was renamed to `prism`. We still need to rename the submodule itself, but this unblocks running `dev ci` locally.