### PR TITLE
Use Ruby to bump version in workflow

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Version bump
 
 on:
   push:
@@ -23,9 +23,11 @@ jobs:
       - name: Bump patch version
         id: version
         run: |
-          version=$(awk -F. '{$NF+=1}1' OFS=. VERSION)
-          echo "$version" > VERSION
-          // We need to unset deployment mode because it won't allow for modifications to `Gemfile.lock`
+          version=$(ruby -e 'major, minor, patch = File.read("VERSION").split(".").map(&:to_i)
+                    new_version = "#{major}.#{minor}.#{patch + 1}"
+                    File.write("VERSION", "#{new_version}\n")
+                    print(new_version)')
+
           bundle config unset deployment
           bundle install
           echo "VERSION=$version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Motivation

Our workflow to bump the version automatically failed again https://github.com/Shopify/ruby-lsp/actions/runs/6486332799/job/17614311626.

I give up on using AWK, let's just use Ruby to bump the version. Also, put a proper name in the workflow.