### PR TITLE
Index parent classes

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -286,6 +286,11 @@ module RubyIndexer
       end
 
       class Namespace < Entry
+        extend T::Sig
+        extend T::Helpers
+
+        abstract!
+
         sig { returns(String) }
         def short_name
           T.must(@name.split("::").last)
@@ -296,6 +301,26 @@ module RubyIndexer
       end
 
       class Class < Namespace
+        extend T::Sig
+
+        # The unresolved name of the parent class. This may return `nil`, which indicates the lack of an explicit parent
+        # and therefore ::Object is the correct parent class
+        sig { returns(T.nilable(String)) }
+        attr_reader :parent_class
+
+        sig do
+          params(
+            name: String,
+            file_path: String,
+            location: Prism::Location,
+            comments: T::Array[String],
+            parent_class: T.nilable(String),
+          ).void
+        end
+        def initialize(name, file_path, location, comments, parent_class)
+          super(name, file_path, location, comments)
+          @parent_class = T.let(parent_class, T.nilable(String))
+        end
       end
 
       class Constant < Entry


### PR DESCRIPTION
### Motivation

Keep track of the unresolved names of parent classes inside class entries. The reason it's unresolved is similar to the alias problem:

```ruby
# File 1
#
# If we haven't indexed `Baz` yet, there's no way to determine if this is
# `Foo::Baz` or `Baz`
module Foo
  class Bar < Baz
  end
end
```
Therefore, we need to resolve parent classes lazily, just like we do for constant aliases.

**Notes**:

- Modules can't have parent classes, so this is only for classes
- Other ancestors will be handled in subsequent PRs (includes, prepends, extends)

### Implementation

Added a new `parent_class` field for class entries and started using it when indexing.

### Automated Tests

Added tests.