### PR TITLE
Respect local bundler configuration

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -49,7 +49,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
   require_relative "../lib/ruby_lsp/setup_bundler"
 
   begin
-    bundle_gemfile, bundle_path = RubyLsp::SetupBundler.new(Dir.pwd, branch: options[:branch]).setup!
+    bundle_gemfile, bundle_path, bundle_app_config = RubyLsp::SetupBundler.new(Dir.pwd, branch: options[:branch]).setup!
   rescue RubyLsp::SetupBundler::BundleNotLocked
     warn("Project contains a Gemfile, but no Gemfile.lock. Run `bundle install` to lock gems and restart the server")
     exit(78)
@@ -57,6 +57,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
 
   env = { "BUNDLE_GEMFILE" => bundle_gemfile }
   env["BUNDLE_PATH"] = bundle_path if bundle_path
+  env["BUNDLE_APP_CONFIG"] = bundle_app_config if bundle_app_config
   exit exec(env, "bundle exec ruby-lsp #{original_args.join(" ")}")
 end
 


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/662, Closes https://github.com/Shopify/vscode-ruby-lsp/issues/597

For local Bundler configuration, it uses the relative path considering `BUNDLE_GEMFILE`. For example, if the root of the project is `rails`, then it'll be in `rails/.bundle`.

Because we set `BUNDLE_GEMFILE` to the custom bundle, then it'll use the relative path based on that, resulting in `rails/.ruby-lsp/.bundle`, which is incorrect.

### Implementation

When we are setting up the custom bundle, we need to check if the current project has a `.bundle` folder. In that case, we can set `BUNDLE_APP_CONFIG` to the absolute path to that folder to avoid having bundler incorrectly set it inside the `.ruby-lsp` folder.

### Automated Tests

Added a test demonstrating the behavior.