### PR TITLE
match rubocop diagnostic severities

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -9,9 +9,9 @@ module RubyLsp
 
         RUBOCOP_TO_LSP_SEVERITY = T.let(
           {
-            convention: Constant::DiagnosticSeverity::INFORMATION,
-            info: Constant::DiagnosticSeverity::INFORMATION,
+            info: Constant::DiagnosticSeverity::HINT,
             refactor: Constant::DiagnosticSeverity::INFORMATION,
+            convention: Constant::DiagnosticSeverity::INFORMATION,
             warning: Constant::DiagnosticSeverity::WARNING,
             error: Constant::DiagnosticSeverity::ERROR,
             fatal: Constant::DiagnosticSeverity::ERROR,


### PR DESCRIPTION
### Motivation

Rubocop has an `info` severity level (which doesn't fail a lint check, see https://github.com/rubocop/rubocop/pull/9391), which I think should be given a light treatment in a code editor. As an example, I have the `LineLength` cop set to this severity level. Here's the existing behavior:

<img width="974" alt="Screenshot 2023-10-16 at 11 53 07 AM" src="https://github.com/Shopify/ruby-lsp/assets/2966419/32184b72-f40d-4325-bcfe-4f46244aacae">

And here's the new behavior:

<img width="968" alt="Screenshot 2023-10-16 at 12 09 14 PM" src="https://github.com/Shopify/ruby-lsp/assets/2966419/6810db83-04ea-40b7-82e7-44d658eacc2f">


### Implementation

I matched the rubocop diagnostic severities (see here: https://github.com/rubocop/rubocop/blob/affbe3b3a66ce15534021548e282270c4a688962/lib/rubocop/lsp/severity.rb#L8-L15).

### Automated Tests

The existing code was untested.

### Manual Tests

I tested this in my own project with the appropriate rubocop setting.
