### PR TITLE
Reduce `Completion#top_level?` complexity

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -95,7 +95,7 @@ module RubyIndexer
     # ```
     sig { params(query: String, nesting: T::Array[String]).returns(T::Array[T::Array[Entry]]) }
     def prefix_search(query, nesting)
-      results = (nesting.length + 1).downto(0).flat_map do |i|
+      results = nesting.length.downto(0).flat_map do |i|
         prefix = T.must(nesting[0...i]).join("::")
         namespaced_query = prefix.empty? ? query : "#{prefix}::#{query}"
         @entries_tree.search(namespaced_query)


### PR DESCRIPTION
### Motivation

Closes #1062 (again 😅)

We were spending an abnormal amount of time trying to figure out if we needed to dereference a constant because of a conflict.

For example

```ruby
class Bar; end

module Foo
  class Bar; end

  # When completion is triggered here for `Bar`, we need to use `::Bar` or else it conflicts
  # with `Foo::Bar`
  B
end

# When completion is triggered here, then we can use `Bar`
B
```

### Implementation

Instead of checking all possible entries for conflicts, we can just check if there are any conflicts when combining the suggestion name with the nesting.

I also removed an incorrect `+1` on the prefix search implementation. There's no need for that `+1`.

### Automated Tests

Added more tests.