### PR TITLE
Ignore default gems that are missing in the current platform

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -98,6 +98,10 @@ module RubyIndexer
         next if locked_gems&.any? do |locked_spec|
           locked_spec.name == short_name &&
             !Gem::Specification.find_by_name(short_name).full_gem_path.start_with?(RbConfig::CONFIG["rubylibprefix"])
+        rescue Gem::MissingSpecError
+          # If a default gem is scoped to a specific platform, then `find_by_name` will raise. We want to skip those
+          # cases
+          true
         end
 
         if pathname.directory?


### PR DESCRIPTION
### Motivation

Closes #1108

Bundler allows you to scope default gems only to a specific platform, so the invocation to `find_by_name` may fail if the gem is missing.

### Implementation

Similar to what we were already doing for regular gems. Just rescue the error and continue - since the gem is not available.