### PR TITLE
Add Folding Ranges for Lambda Literals

### DIFF
--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -54,6 +54,7 @@ module RubyLsp
           :on_string_concat_node_enter,
           :on_def_node_enter,
           :on_call_node_enter,
+          :on_lambda_node_enter,
         )
       end
 
@@ -200,6 +201,11 @@ module RubyLsp
 
         location = node.location
         add_lines_range(location.start_line, location.end_line - 1)
+      end
+
+      sig { params(node: Prism::LambdaNode).void }
+      def on_lambda_node_enter(node)
+        add_simple_range(node)
       end
 
       private

--- a/test/expectations/folding_ranges/lambda_literal_braces.exp.json
+++ b/test/expectations/folding_ranges/lambda_literal_braces.exp.json
@@ -1,0 +1,9 @@
+{
+  "result": [
+    {
+      "startLine": 0,
+      "endLine": 1,
+      "kind": "region"
+    }
+  ]
+}

--- a/test/expectations/folding_ranges/lambda_literal_do_end.exp.json
+++ b/test/expectations/folding_ranges/lambda_literal_do_end.exp.json
@@ -1,0 +1,9 @@
+{
+  "result": [
+    {
+      "startLine": 0,
+      "endLine": 1,
+      "kind": "region"
+    }
+  ]
+}

--- a/test/fixtures/lambda_literal_braces.rb
+++ b/test/fixtures/lambda_literal_braces.rb
@@ -1,0 +1,3 @@
+lambda = ->(item) {
+  puts item
+}

--- a/test/fixtures/lambda_literal_do_end.rb
+++ b/test/fixtures/lambda_literal_do_end.rb
@@ -1,0 +1,3 @@
+lambda = ->(item) do
+  puts item
+end


### PR DESCRIPTION
### Motivation

Lambda literals like the one below don't show folding ranges.

```ruby
lambda = ->(item) do
  puts item
end
```

### Implementation

This PR hooks on `Prism::LambdaNode` enter event and add a simple handle,  like the one for blocks.

### Automated Tests

Yes, I wrote expectations.  

### Manual Tests

1. Open the editor with this build
2. Ensure that the server is active
3.  Write the following code:

```ruby
lambda = ->(item) do
  puts item
end
```
4. And ensure that the folding region appears.