### PR TITLE
add documentation link to rubocop diagnostics

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -52,10 +52,17 @@ module RubyLsp
 
           message += "\n\nThis offense is not auto-correctable.\n" unless @offense.correctable?
 
+          cop = RuboCop::Cop::Registry.global.find_by_cop_name(@offense.cop_name)
+          code = if cop&.documentation_url
+            { value: @offense.cop_name, target: cop.documentation_url }
+          else
+            @offense.cop_name
+          end
+
           Interface::Diagnostic.new(
             message: message,
             source: "RuboCop",
-            code: @offense.cop_name,
+            code: code,
             severity: severity,
             range: Interface::Range.new(
               start: Interface::Position.new(

--- a/test/expectations/diagnostics/def_bad_formatting.exp.json
+++ b/test/expectations/diagnostics/def_bad_formatting.exp.json
@@ -61,7 +61,10 @@
         }
       },
       "severity": 3,
-      "code": "Style/FrozenStringLiteralComment",
+      "code": {
+        "value": "Style/FrozenStringLiteralComment",
+        "target": "https://docs.rubocop.org/rubocop/cops_style.html#stylefrozenstringliteralcomment"
+      },
       "source": "RuboCop",
       "message": "Style/FrozenStringLiteralComment: Missing frozen string literal comment.",
       "data": {
@@ -110,7 +113,10 @@
         }
       },
       "severity": 3,
-      "code": "Layout/EmptyLinesAroundMethodBody",
+      "code": {
+        "value": "Layout/EmptyLinesAroundMethodBody",
+        "target": "https://docs.rubocop.org/rubocop/cops_layout.html#layoutemptylinesaroundmethodbody"
+      },
       "source": "RuboCop",
       "message": "Layout/EmptyLinesAroundMethodBody: Extra empty line detected at method body beginning.",
       "data": {
@@ -159,7 +165,10 @@
         }
       },
       "severity": 3,
-      "code": "Layout/EmptyLines",
+      "code": {
+        "value": "Layout/EmptyLines",
+        "target": "https://docs.rubocop.org/rubocop/cops_layout.html#layoutemptylines"
+      },
       "source": "RuboCop",
       "message": "Layout/EmptyLines: Extra blank line detected.",
       "data": {
@@ -208,7 +217,10 @@
         }
       },
       "severity": 3,
-      "code": "Layout/IndentationWidth",
+      "code": {
+        "value": "Layout/IndentationWidth",
+        "target": "https://docs.rubocop.org/rubocop/cops_layout.html#layoutindentationwidth"
+      },
       "source": "RuboCop",
       "message": "Layout/IndentationWidth: Use 2 (not 0) spaces for indentation.",
       "data": {

--- a/test/expectations/diagnostics/if_inside_else.exp.json
+++ b/test/expectations/diagnostics/if_inside_else.exp.json
@@ -47,7 +47,10 @@
         }
       },
       "severity": 3,
-      "code": "Style/IfInsideElse",
+      "code": {
+        "value": "Style/IfInsideElse",
+        "target": "https://docs.rubocop.org/rubocop/cops_style.html#styleifinsideelse"
+      },
       "source": "RuboCop",
       "message": "Style/IfInsideElse: Convert `if` nested inside `else` to `elsif`.",
       "data": {


### PR DESCRIPTION
### Motivation

RuboCop has nice documentation for all its built-in rules. The doc url for each of these rules is programmatically available, and LSP diagnostics have a special slot designed exactly for this.*

![Screen Shot 2023-10-17 at 00 46 08](https://github.com/Shopify/ruby-lsp/assets/71686/cf11df22-660f-433f-8ba6-7bedb9211ca3)

*Not a lawyer, but I believe this is sufficient to mirandize the user against any subsequent autocorrections RuboCop may undertake.

### Implementation

Ideally RuboCop would attach this info to the offense, but for now I'm using the global cop registry to look up the documentation url at the time the diagnostic is generated. 

I don't _think_ this causes RuboCop to read YAML files from disk, change global state, or print things to stdout, but I have been burned in the past.

### Automated Tests

Yup.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

Rule w/ doc link:

1. Write some code that's in violation of a built-in RuboCop rule.
2. Mouse over that code.
3. See this, hopefully:

![Screen Shot 2023-10-17 at 00 46 08](https://github.com/Shopify/ruby-lsp/assets/71686/cf11df22-660f-433f-8ba6-7bedb9211ca3)

Rule w/o doc link:

In this repo

1. Add a Rake rule, e.g. `Rake/Desc: { Enabled: true }`
2. Open `Rakefile`
3. Add a task without a `desc`
4. Mouse over the task name
5. See this:

![Screen Shot 2023-10-17 at 00 45 56](https://github.com/Shopify/ruby-lsp/assets/71686/cc0cb5ea-d47b-4bbe-8988-bbb808e0134c)
