### PR TITLE
Index singleton methods with `class << self`

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
@@ -132,16 +132,19 @@ module RubyIndexer
     def visit_def_node(node)
       method_name = node.name.to_s
       comments = collect_comments(node)
-      case node.receiver
+      entry_class = case node.receiver
       when nil
-        @index << if @singleton
-          Entry::SingletonMethod.new(method_name, @file_path, node.location, comments, node.parameters)
+        if @singleton
+          Entry::SingletonMethod
         else
-          Entry::InstanceMethod.new(method_name, @file_path, node.location, comments, node.parameters)
+          Entry::InstanceMethod
         end
       when Prism::SelfNode
-        @index << Entry::SingletonMethod.new(method_name, @file_path, node.location, comments, node.parameters)
+        Entry::SingletonMethod
+      else
+        return
       end
+      @index << entry_class.new(method_name, @file_path, node.location, comments, node.parameters)
     end
 
     private

--- a/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
@@ -10,7 +10,7 @@ module RubyIndexer
       @index = index
       @file_path = file_path
       @stack = T.let([], T::Array[String])
-      @singleton = T.let(false, T::Boolean)
+      @singleton_class = T.let(false, T::Boolean)
       @comments_by_line = T.let(
         parse_result.comments.to_h do |c|
           [c.location.start_line, c]
@@ -28,9 +28,9 @@ module RubyIndexer
 
     sig { override.params(node: Prism::SingletonClassNode).void }
     def visit_singleton_class_node(node)
-      @singleton = true
+      @singleton_class = true
       super
-      @singleton = false
+      @singleton_class = false
     end
 
     sig { override.params(node: Prism::ModuleNode).void }
@@ -134,7 +134,7 @@ module RubyIndexer
       comments = collect_comments(node)
       entry_class = case node.receiver
       when nil
-        if @singleton
+        if @singleton_class # i.e. `class << self`
           Entry::SingletonMethod
         else
           Entry::InstanceMethod

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -48,6 +48,19 @@ module RubyIndexer
       assert_entry("bar", Entry::SingletonMethod, "/fake/path/foo.rb:3-6:4-9")
     end
 
+    def test_singleton_method_with_named_class
+      index(<<~RUBY)
+        class Foo; end
+
+        class << Foo
+          def bar
+          end
+        end
+      RUBY
+
+      assert_entry("bar", Entry::SingletonMethod, "/fake/path/foo.rb:3-2:4-5")
+    end
+
     def test_singleton_method_using_class
       index(<<~RUBY)
         class Foo

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -16,7 +16,39 @@ module RubyIndexer
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
     end
 
-    def test_singleton_method_using_self_receiver
+    def test_singleton_method_using_class_self
+      index(<<~RUBY)
+        class Foo
+          class << self
+            def bar
+            end
+          end
+
+          def baz
+          end
+        end
+      RUBY
+
+      assert_entry("bar", Entry::SingletonMethod, "/fake/path/foo.rb:2-4:3-7")
+      assert_entry("baz", Entry::InstanceMethod, "/fake/path/foo.rb:6-2:7-5")
+    end
+
+    def test_singleton_method_using_class_self_with_nesting
+      index(<<~RUBY)
+        class Foo
+          class << self
+            class Nested
+              def bar
+              end
+            end
+          end
+        end
+      RUBY
+
+      assert_entry("bar", Entry::SingletonMethod, "/fake/path/foo.rb:3-6:4-9")
+    end
+
+    def test_singleton_method_using_class
       index(<<~RUBY)
         class Foo
           def self.bar


### PR DESCRIPTION
### Motivation

Currently we only support indexing singleton methods defined as `self.foo`.

### Implementation

We need to keep track of whether we are within a singleton class node, so I added a new instance variable to track that.

### Automated Tests

Added

### Manual Tests

- [x] run against `Shopify/shopify` to ensure no crashes.
