### PR TITLE
Allow the LSP to work with YARP v0.13 as well

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,5 @@ group :development do
   gem "rdoc", require: false
   gem "psych", "~> 5.1", require: false
 
-  gem "rbi", github: "Shopify/rbi", branch: "vs/move_to_prism"
   gem "syntax_tree", ">= 6.1.1", "< 7"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/Shopify/rbi.git
-  revision: d32ad8e95ff8c31eed5cdc6ce4881cc88ecf7fd2
-  branch: vs/move_to_prism
-  specs:
-    rbi (0.1.1)
-      prism (>= 0.14.0)
-      sorbet-runtime (>= 0.5.9204)
-
 PATH
   remote: .
   specs:
@@ -52,6 +43,9 @@ GEM
     racc (1.7.1)
     rainbow (3.1.1)
     rake (13.0.6)
+    rbi (0.1.1)
+      sorbet-runtime (>= 0.5.9204)
+      yarp (>= 0.11.0)
     rdoc (6.5.0)
       psych (>= 4.0.0)
     regexp_parser (2.8.2)
@@ -113,6 +107,7 @@ GEM
     yard-sorbet (0.8.1)
       sorbet-runtime (>= 0.5)
       yard (>= 0.9)
+    yarp (0.13.0)
 
 PLATFORMS
   arm64-darwin
@@ -129,7 +124,6 @@ DEPENDENCIES
   mocha (~> 2.1)
   psych (~> 5.1)
   rake (~> 13.0)
-  rbi!
   rdoc
   rubocop (~> 1.57)
   rubocop-minitest (~> 0.32.2)

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -74,8 +74,8 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode).void }
       def on_call_node_enter(node)
-        message = node.name
-        return unless message == :require || message == :require_relative
+        message = node.name.to_s
+        return unless message == "require" || message == "require_relative"
 
         arguments = node.arguments
         return unless arguments
@@ -84,7 +84,7 @@ module RubyLsp
         return unless argument.is_a?(Prism::StringNode)
 
         case message
-        when :require
+        when "require"
           entry = @index.search_require_paths(argument.content).find do |indexable_path|
             indexable_path.require_path == argument.content
           end
@@ -100,7 +100,7 @@ module RubyLsp
               ),
             )
           end
-        when :require_relative
+        when "require_relative"
           required_file = "#{argument.content}.rb"
           path = @uri.to_standardized_path
           current_folder = path ? Pathname.new(CGI.unescape(path)).dirname : Dir.pwd

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -32,7 +32,7 @@ module RubyLsp
 
       ResponseType = type_member { { fixed: T::Array[Interface::DocumentSymbol] } }
 
-      ATTR_ACCESSORS = T.let([:attr_reader, :attr_writer, :attr_accessor].freeze, T::Array[Symbol])
+      ATTR_ACCESSORS = T.let(["attr_reader", "attr_writer", "attr_accessor"].freeze, T::Array[String])
 
       class SymbolHierarchyRoot
         extend T::Sig
@@ -105,7 +105,7 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode).void }
       def on_call_node_enter(node)
-        return unless ATTR_ACCESSORS.include?(node.name) && node.receiver.nil?
+        return unless ATTR_ACCESSORS.include?(node.name.to_s) && node.receiver.nil?
 
         arguments = node.arguments
         return unless arguments

--- a/lib/ruby_lsp/requests/support/sorbet.rb
+++ b/lib/ruby_lsp/requests/support/sorbet.rb
@@ -10,34 +10,34 @@ module RubyLsp
 
           ANNOTATIONS = T.let(
             {
-              abstract!: Annotation.new(arity: 0),
-              absurd: Annotation.new(arity: 1, receiver: true),
-              all: Annotation.new(arity: (2..), receiver: true),
-              any: Annotation.new(arity: (2..), receiver: true),
-              assert_type!: Annotation.new(arity: 2, receiver: true),
-              attached_class: Annotation.new(arity: 0, receiver: true),
-              bind: Annotation.new(arity: 2, receiver: true),
-              cast: Annotation.new(arity: 2, receiver: true),
-              class_of: Annotation.new(arity: 1, receiver: true),
-              enums: Annotation.new(arity: 0),
-              interface!: Annotation.new(arity: 0),
-              let: Annotation.new(arity: 2, receiver: true),
-              mixes_in_class_methods: Annotation.new(arity: 1),
-              must: Annotation.new(arity: 1, receiver: true),
-              must_because: Annotation.new(arity: 1, receiver: true),
-              nilable: Annotation.new(arity: 1, receiver: true),
-              noreturn: Annotation.new(arity: 0, receiver: true),
-              requires_ancestor: Annotation.new(arity: 0),
-              reveal_type: Annotation.new(arity: 1, receiver: true),
-              sealed!: Annotation.new(arity: 0),
-              self_type: Annotation.new(arity: 0, receiver: true),
-              sig: Annotation.new(arity: 0),
-              type_member: Annotation.new(arity: (0..1)),
-              type_template: Annotation.new(arity: 0),
-              unsafe: Annotation.new(arity: 1),
-              untyped: Annotation.new(arity: 0, receiver: true),
+              "abstract!" => Annotation.new(arity: 0),
+              "absurd" => Annotation.new(arity: 1, receiver: true),
+              "all" => Annotation.new(arity: (2..), receiver: true),
+              "any" => Annotation.new(arity: (2..), receiver: true),
+              "assert_type!" => Annotation.new(arity: 2, receiver: true),
+              "attached_class" => Annotation.new(arity: 0, receiver: true),
+              "bind" => Annotation.new(arity: 2, receiver: true),
+              "cast" => Annotation.new(arity: 2, receiver: true),
+              "class_of" => Annotation.new(arity: 1, receiver: true),
+              "enums" => Annotation.new(arity: 0),
+              "interface!" => Annotation.new(arity: 0),
+              "let" => Annotation.new(arity: 2, receiver: true),
+              "mixes_in_class_methods" => Annotation.new(arity: 1),
+              "must" => Annotation.new(arity: 1, receiver: true),
+              "must_because" => Annotation.new(arity: 1, receiver: true),
+              "nilable" => Annotation.new(arity: 1, receiver: true),
+              "noreturn" => Annotation.new(arity: 0, receiver: true),
+              "requires_ancestor" => Annotation.new(arity: 0),
+              "reveal_type" => Annotation.new(arity: 1, receiver: true),
+              "sealed!" => Annotation.new(arity: 0),
+              "self_type" => Annotation.new(arity: 0, receiver: true),
+              "sig" => Annotation.new(arity: 0),
+              "type_member" => Annotation.new(arity: (0..1)),
+              "type_template" => Annotation.new(arity: 0),
+              "unsafe" => Annotation.new(arity: 1),
+              "untyped" => Annotation.new(arity: 0, receiver: true),
             },
-            T::Hash[Symbol, Annotation],
+            T::Hash[String, Annotation],
           )
 
           sig do
@@ -46,7 +46,7 @@ module RubyLsp
             ).returns(T::Boolean)
           end
           def annotation?(node)
-            !!ANNOTATIONS[node.name]&.match?(node)
+            !!ANNOTATIONS[node.name.to_s]&.match?(node)
           end
         end
       end

--- a/test/requests/show_syntax_tree_test.rb
+++ b/test/requests/show_syntax_tree_test.rb
@@ -20,6 +20,8 @@ class ShowSyntaxTreeTest < Minitest::Test
       params: { textDocument: { uri: "file:///fake.rb" } },
     }).response
 
+    call_node_name = RUBY_PLATFORM.match?(/(mswin|mingw)/) ? ":foo" : "\"foo\""
+
     assert_equal(<<~AST, response[:ast])
       @ ProgramNode (location: (1,0)-(1,6))
       ├── locals: []
@@ -44,7 +46,7 @@ class ShowSyntaxTreeTest < Minitest::Test
                   │   ├── opening_loc: (1,4)-(1,6) = "do"
                   │   └── closing_loc: (1,6)-(1,6) = ""
                   ├── flags: ∅
-                  └── name: :foo
+                  └── name: #{call_node_name}
     AST
   end
 


### PR DESCRIPTION
### Motivation

YARP v0.13 exports a file named `prism`. When both Prism v0.14 and YARP v0.13 are in the same bundle, that causes a conflict and we end up requiring the wrong version of the Prism gem, which leads to issues related to the breaking change with call node names.

This PR just ensures we can work with YARP v0.13 in case it is present in the bundle.
