### PR TITLE
Add `ruby-lsp-doctor` tool for troubleshooting indexing problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,6 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake
+
+      - name: Run index troubleshooting tool
+        run: ./exe/ruby-lsp-doctor

--- a/exe/ruby-lsp-doctor
+++ b/exe/ruby-lsp-doctor
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+
+require "ruby_lsp/internal"
+
+index = RubyIndexer::Index.new
+
+RubyIndexer.configuration.indexables.each do |indexable|
+  puts "indexing: #{indexable.full_path}"
+  content = File.read(indexable.full_path)
+  result = Prism.parse(content)
+  visitor = RubyIndexer::IndexVisitor.new(index, result, indexable.full_path)
+  result.value.accept(visitor)
+end

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("lib/**/*.rb") + ["README.md", "VERSION", "LICENSE.txt"]
   s.bindir = "exe"
-  s.executables = ["ruby-lsp", "ruby-lsp-check"]
+  s.executables = ["ruby-lsp", "ruby-lsp-check", "ruby-lsp-index-info"]
   s.require_paths = ["lib"]
 
   s.add_dependency("language_server-protocol", "~> 3.17.0")


### PR DESCRIPTION
### Motivation

We have a script for troubleshooting issues related to indexing, but it's sensitive to the version of Ruby LSP is use, so https://github.com/Shopify/ruby-lsp/issues/1115 had a lot of back-and-forward. To make things easier in future, let's ship a command people can easily run.

### Implementation

Adapted from https://github.com/Shopify/ruby-lsp/issues/1063#issuecomment-1749018562

### Automated Tests

I added a step to CI.

### Manual Tests

Run `./exe/ruby-lsp-index-info`.
