### PR TITLE
Upgrade prism requirement to v0.15.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-lsp (0.12.0)
       language_server-protocol (~> 3.17.0)
-      prism (>= 0.15, < 0.16)
+      prism (>= 0.15.1, < 0.16)
       sorbet-runtime (>= 0.5.5685)
 
 GEM
@@ -37,7 +37,7 @@ GEM
       ast (~> 2.4.1)
       racc
     prettier_print (1.2.1)
-    prism (0.15.0)
+    prism (0.15.1)
     psych (5.1.1)
       stringio
     racc (1.7.1)

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("language_server-protocol", "~> 3.17.0")
-  s.add_dependency("prism", ">= 0.15", "< 0.16")
+  s.add_dependency("prism", ">= 0.15.1", "< 0.16")
   s.add_dependency("sorbet-runtime", ">= 0.5.5685")
 
   s.required_ruby_version = ">= 3.0"


### PR DESCRIPTION
### Motivation

There's another compilation error happening when trying to release. v0.15.1 is supposed to fix it.
