### PR TITLE
Refactor RuboCop diagnostics for better encapsulation

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -101,6 +101,25 @@ module RubyLsp
           @options[:stdin]
         end
 
+        class << self
+          extend T::Sig
+
+          sig { params(cop_name: String).returns(T.nilable(T.class_of(RuboCop::Cop::Base))) }
+          def find_cop_by_name(cop_name)
+            cop_registry[cop_name]&.first
+          end
+
+          private
+
+          sig { returns(T::Hash[String, [T.class_of(RuboCop::Cop::Base)]]) }
+          def cop_registry
+            @cop_registry ||= T.let(
+              RuboCop::Cop::Registry.global.to_h,
+              T.nilable(T::Hash[String, [T.class_of(RuboCop::Cop::Base)]]),
+            )
+          end
+        end
+
         private
 
         sig { params(_file: String, offenses: T::Array[RuboCop::Cop::Offense]).void }


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The code description addition for RuboCop diagnostics has added a cop lookup to the diagnostics runner, but I feel like that was an abstraction added at the wrong layer.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
What we really want to cache is the registry as a hash lookup but we want to do that as late as possible to ensure that we have loaded the full registry. For that reason, I moved the actual cop lookup by cop name to the RuboCop runner class as a class method, which uses a memoized registry hash under the hood. That makes sure that we cache the registry hash as late as possible.
    
This way, we can keep the code of the RuboCop diagnostics class clean and with less conditional code.
    
I've also taken the liberty to extract other calculation logic from inside the `to_lsp_diagnostic` method to separate methods, to make the intent more clear.
### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
No new tests, a straight-forward refactor.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
1. Create a RuboCop violation
2. Observe that the cop name in the hover dialog has a clickable link and the link takes you to the webpage for the specific cop.