### PR TITLE
Declare all default gem dependencies in the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 NON_WINDOWS_PLATFORMS = [:ruby] # C Ruby (MRI), Rubinius or TruffleRuby, but NOT Windows
 
 group :development do
-  gem "bundler", "~> 2.4.2"
   gem "debug", "~> 1.8", require: false
   gem "minitest", "~> 5.20"
   gem "minitest-reporters", "~> 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,19 @@ PATH
   remote: .
   specs:
     ruby-lsp (0.12.0)
+      bundler
+      cgi
+      did_you_mean (~> 1.6.3)
+      digest
+      fileutils
       language_server-protocol (~> 3.17.0)
+      pathname
       prism (>= 0.15.1, < 0.16)
+      set
       sorbet-runtime (>= 0.5.5685)
+      time
+      uri
+      yaml
 
 GEM
   remote: https://rubygems.org/
@@ -13,10 +23,15 @@ GEM
     ast (2.4.2)
     base64 (0.1.1)
     builder (3.2.4)
+    cgi (0.3.6)
+    date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    did_you_mean (1.6.3)
+    digest (3.1.1)
     erubi (1.12.0)
+    fileutils (1.7.0)
     io-console (0.6.0)
     irb (1.8.0)
       rdoc (~> 6.5)
@@ -36,6 +51,7 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    pathname (0.2.1)
     prettier_print (1.2.1)
     prism (0.15.1)
     psych (5.1.1)
@@ -76,6 +92,7 @@ GEM
       rubocop (>= 0.90.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    set (1.0.3)
     sorbet (0.5.11074)
       sorbet-static (= 0.5.11074)
     sorbet-runtime (0.5.11074)
@@ -102,7 +119,11 @@ GEM
       thor (>= 1.2.0)
       yard-sorbet
     thor (1.2.2)
+    time (0.2.2)
+      date
     unicode-display_width (2.5.0)
+    uri (0.12.1)
+    yaml (0.2.1)
     yard (0.9.34)
     yard-sorbet (0.8.1)
       sorbet-runtime (>= 0.5)
@@ -111,13 +132,11 @@ GEM
 
 PLATFORMS
   arm64-darwin
-  x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES
-  bundler (~> 2.4.2)
   debug (~> 1.8)
   minitest (~> 5.20)
   minitest-reporters (~> 1.6)
@@ -136,4 +155,4 @@ DEPENDENCIES
   tapioca (~> 0.11)
 
 BUNDLED WITH
-   2.4.10
+   2.4.21

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -3,6 +3,7 @@
 
 require "yaml"
 require "did_you_mean"
+require "pathname"
 
 require "ruby_indexer/lib/ruby_indexer/indexable_path"
 require "ruby_indexer/lib/ruby_indexer/visitor"

--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -14,6 +14,7 @@ require "bundler"
 require "uri"
 require "cgi"
 require "set"
+require "pathname"
 
 require "ruby-lsp"
 require "ruby_indexer/ruby_indexer"

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -17,9 +17,19 @@ Gem::Specification.new do |s|
   s.executables = ["ruby-lsp", "ruby-lsp-check", "ruby-lsp-doctor"]
   s.require_paths = ["lib"]
 
+  s.add_dependency("bundler")
+  s.add_dependency("cgi")
+  s.add_dependency("did_you_mean", "~> 1.6.3")
+  s.add_dependency("digest")
+  s.add_dependency("fileutils")
   s.add_dependency("language_server-protocol", "~> 3.17.0")
+  s.add_dependency("pathname")
   s.add_dependency("prism", ">= 0.15.1", "< 0.16")
+  s.add_dependency("set")
   s.add_dependency("sorbet-runtime", ">= 0.5.5685")
+  s.add_dependency("time")
+  s.add_dependency("uri")
+  s.add_dependency("yaml")
 
   s.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/vscode-ruby-lsp/issues/848

@paracycle pointed out that the rubygems issue is likely because we depend on many default gems, but don't have them declared as runtime dependencies in the gemspec.

I tested this and it does make the issue go away.

### Implementation

1. Declared all dependencies in the gemspec
2. Added two missing requires