### PR TITLE
Make the experimental flag install beta versions of the server

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -25,6 +25,13 @@ parser = OptionParser.new do |opts|
     options[:branch] = branch
   end
 
+  opts.on(
+    "--experimental",
+    "Run pre-release versions of the Ruby LSP",
+  ) do
+    options[:experimental] = true
+  end
+
   opts.on("-h", "--help", "Print this help") do
     puts opts.help
     puts
@@ -49,7 +56,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
   require_relative "../lib/ruby_lsp/setup_bundler"
 
   begin
-    bundle_gemfile, bundle_path, bundle_app_config = RubyLsp::SetupBundler.new(Dir.pwd, branch: options[:branch]).setup!
+    bundle_gemfile, bundle_path, bundle_app_config = RubyLsp::SetupBundler.new(Dir.pwd, **options).setup!
   rescue RubyLsp::SetupBundler::BundleNotLocked
     warn("Project contains a Gemfile, but no Gemfile.lock. Run `bundle install` to lock gems and restart the server")
     exit(78)


### PR DESCRIPTION
### Motivation

Instead of having the `branch` option to run the LSP from a branch, we can make the `experimental` flag install beta versions of the gem. This will help us get early feedback on non-stable features.

It's also easier to analyze in our metrics since they will have distinct version names.

### Implementation

Swapped the `branch` option for `experimental`. When the `experimental` flag is `true`, we run `bundle update ruby-lsp --pre`, which makes bundler accept prereleases.

### Automated Tests

Adapted tests.