### PR TITLE
Improve performance of computing indexables

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -67,8 +67,12 @@ module RubyIndexer
 
       # Add user specified patterns
       indexables = @included_patterns.flat_map do |pattern|
+        load_path_entry = T.let(nil, T.nilable(String))
+
         Dir.glob(pattern, File::FNM_PATHNAME | File::FNM_EXTGLOB).map! do |path|
-          load_path_entry = $LOAD_PATH.find { |load_path| path.start_with?(load_path) }
+          # All entries for the same pattern match the same $LOAD_PATH entry. Since searching the $LOAD_PATH for every
+          # entry is expensive, we memoize it for the entire pattern
+          load_path_entry ||= $LOAD_PATH.find { |load_path| path.start_with?(load_path) }
           IndexablePath.new(load_path_entry, path)
         end
       end

--- a/lib/ruby_indexer/lib/ruby_indexer/indexable_path.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/indexable_path.rb
@@ -21,7 +21,7 @@ module RubyIndexer
     def initialize(load_path_entry, full_path)
       @full_path = full_path
       @require_path = T.let(
-        load_path_entry ? Pathname.new(full_path).relative_path_from(load_path_entry).to_s.delete_suffix(".rb") : nil,
+        load_path_entry ? full_path.delete_prefix("#{load_path_entry}/").delete_suffix(".rb") : nil,
         T.nilable(String),
       )
     end


### PR DESCRIPTION
### Motivation

We were spending considerable time doing two things: searching for the right entry in the $LOAD_PATH for files and instantiating `IndexablePath` entries. This PR the performance of both and shoves a few more seconds for indexing Core.

### Implementation

For finding the right entry in the `$LOAD_PATH`, we don't have to do the lookup for every single file. All files for the same pattern will certainly match the same `$LOAD_PATH` entry, so we can just memoize and reset for each pattern.

For the indexable paths, we were using `Pathname#relative_path_from` to remove the `$LOAD_PATH` part of the full file path. However, that's a bit wasteful. The method does a lot more work than just deleting the path's prefix and we end up spending a lot of time matching regexes. I switched to just deleting the prefix directly.