### PR TITLE
Create custom cop to ensure match between listener and handler

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,24 +2,25 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 require:
- - rubocop-sorbet
- - rubocop-minitest
- - rubocop-rake
- - ./lib/rubocop/cop/ruby_lsp/use_language_server_aliases
+  - rubocop-sorbet
+  - rubocop-minitest
+  - rubocop-rake
+  - ./lib/rubocop/cop/ruby_lsp/use_language_server_aliases
+  - ./lib/rubocop/cop/ruby_lsp/use_register_with_handler_method
 
 AllCops:
   NewCops: disable
   SuggestExtensions: false
   TargetRubyVersion: 3.0
   Exclude:
-  - "vendor/**/*"
-  - "features/**/*"
-  - "test/fixtures/**/*"
-  - "test/expectations/**/*"
+    - "vendor/**/*"
+    - "features/**/*"
+    - "test/fixtures/**/*"
+    - "test/expectations/**/*"
 
 Naming/FileName:
   Exclude:
-  - "lib/ruby-lsp.rb"
+    - "lib/ruby-lsp.rb"
 
 RubyLsp/UseLanguageServerAliases:
   Exclude:

--- a/lib/rubocop/cop/ruby_lsp/use_register_with_handler_method.rb
+++ b/lib/rubocop/cop/ruby_lsp/use_register_with_handler_method.rb
@@ -1,0 +1,125 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "rubocop"
+require "sorbet-runtime"
+
+module RuboCop
+  module Cop
+    module RubyLsp
+      # Avoid using register without method handler, or handler without register.
+      #
+      # @example
+      # # Register without method handler.
+      #
+      # # bad
+      # class MyListener < Listener
+      #   def initialize(dispatcher)
+      #     super()
+      #     dispatcher.register(
+      #       self,
+      #       :on_string_node_enter,
+      #     )
+      #   end
+      # end
+      #
+      # # good
+      # class MyListener < Listener
+      #   def initialize(dispatcher)
+      #     super()
+      #     dispatcher.register(
+      #       self,
+      #       :on_string_node_enter,
+      #     )
+      #   end
+      #
+      #   def on_string_node_enter(dispatcher)
+      #   end
+      # end
+      #
+      # @example
+      # # Method handler without register.
+      #
+      # # bad
+      # class MyListener < Listener
+      #   def initialize(dispatcher)
+      #     super()
+      #     dispatcher.register(
+      #       self,
+      #     )
+      #   end
+      #
+      #   def on_string_node_enter(dispatcher)
+      #   end
+      # end
+      #
+      # # good
+      # class MyListener < Listener
+      #   def initialize(dispatcher)
+      #     super()
+      #     dispatcher.register(
+      #       self,
+      #       :on_string_node_enter,
+      #     )
+      #   end
+      #
+      #   def on_string_node_enter(dispatcher)
+      #   end
+      # end
+      class UseRegisterWithHandlerMethod < RuboCop::Cop::Base
+        extend T::Sig
+
+        MSG_MISSING_HANDLER = "Registered to `%{listener}` without a handler defined."
+        MSG_MISSING_LISTENER = "Created a handler without registering the associated `%{listener}` event."
+
+        def_node_search(
+          :find_all_listeners,
+          "(send
+            (_ :dispatcher) :register
+            (self)
+            $(sym _)+)",
+        )
+
+        def_node_search(
+          :find_all_handlers,
+          "$(def [_ #valid_event_name?] (args (arg _)) ...)",
+        )
+
+        def on_new_investigation
+          return if processed_source.blank?
+
+          listeners = find_all_listeners(processed_source.ast).flat_map { |listener| listener }
+          handlers = find_all_handlers(processed_source.ast).flat_map { |handler| handler }
+
+          add_offense_to_listeners_without_handler(listeners, handlers)
+          add_offense_handlers_without_listener(listeners, handlers)
+        end
+
+        private
+
+        sig { params(event_name: Symbol).returns(T::Boolean) }
+        def valid_event_name?(event_name)
+          /^on_.*(node_enter|node_leave)$/.match?(event_name)
+        end
+
+        sig { params(listeners: T::Array[RuboCop::AST::SymbolNode], handlers: T::Array[RuboCop::AST::DefNode]).void }
+        def add_offense_to_listeners_without_handler(listeners, handlers)
+          return if listeners.none?
+
+          listeners
+            .filter { |node| handlers.map(&:method_name).none?(node.value) }
+            .each { |node| add_offense(node, message: format(MSG_MISSING_HANDLER, listener: node.value)) }
+        end
+
+        sig { params(listeners: T::Array[RuboCop::AST::SymbolNode], handlers: T::Array[RuboCop::AST::DefNode]).void }
+        def add_offense_handlers_without_listener(listeners, handlers)
+          return if handlers.none?
+
+          handlers
+            .filter { |node| listeners.map(&:value).none?(node.method_name) }
+            .each { |node| add_offense(node, message: format(MSG_MISSING_LISTENER, listener: node.method_name)) }
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/ruby_lsp/use_register_with_handler_method.rb
+++ b/lib/rubocop/cop/ruby_lsp/use_register_with_handler_method.rb
@@ -7,10 +7,10 @@ require "sorbet-runtime"
 module RuboCop
   module Cop
     module RubyLsp
-      # Avoid using register without method handler, or handler without register.
+      # Avoid using register without handler method, or handler without register.
       #
       # @example
-      # # Register without method handler.
+      # # Register without handler method.
       #
       # # bad
       # class MyListener < Listener
@@ -33,12 +33,12 @@ module RuboCop
       #     )
       #   end
       #
-      #   def on_string_node_enter(dispatcher)
+      #   def on_string_node_enter(node)
       #   end
       # end
       #
       # @example
-      # # Method handler without register.
+      # # Handler method without register.
       #
       # # bad
       # class MyListener < Listener
@@ -49,7 +49,7 @@ module RuboCop
       #     )
       #   end
       #
-      #   def on_string_node_enter(dispatcher)
+      #   def on_string_node_enter(node)
       #   end
       # end
       #
@@ -63,7 +63,7 @@ module RuboCop
       #     )
       #   end
       #
-      #   def on_string_node_enter(dispatcher)
+      #   def on_string_node_enter(node)
       #   end
       # end
       class UseRegisterWithHandlerMethod < RuboCop::Cop::Base

--- a/sorbet/rbi/shims/use_register_with_handler_method.rbi
+++ b/sorbet/rbi/shims/use_register_with_handler_method.rbi
@@ -1,0 +1,12 @@
+# typed: true
+
+class RuboCop::Cop::RubyLsp::UseRegisterWithHandlerMethod
+  sig { void }
+  def on_new_investigation; end
+
+  sig { params(ast: T.untyped).returns(T::Array[RuboCop::AST::SymbolNode]) }
+  def find_all_listeners(ast); end
+
+  sig { params(ast: T.untyped).returns(T::Array[RuboCop::AST::DefNode]) }
+  def find_all_handlers(ast); end
+end

--- a/test/rubocop/cop/ruby_lsp/use_register_with_handler_method_test.rb
+++ b/test/rubocop/cop/ruby_lsp/use_register_with_handler_method_test.rb
@@ -10,10 +10,6 @@ class UseRegisterWithHandlerMethodTest < Minitest::Test
   include RuboCop::Minitest::AssertOffense
 
   def setup
-    # Reload because Rubocop is unloaded by test/requests/formatting_test.rb
-    # assert_offense calls RuboCop::RSpec::ExpectOffense::AnnotatedSource
-    require "rubocop/rspec/expect_offense"
-
     @cop = ::RuboCop::Cop::RubyLsp::UseRegisterWithHandlerMethod.new
   end
 

--- a/test/rubocop/cop/ruby_lsp/use_register_with_handler_method_test.rb
+++ b/test/rubocop/cop/ruby_lsp/use_register_with_handler_method_test.rb
@@ -1,0 +1,128 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "rubocop-minitest"
+require "rubocop/minitest/assert_offense"
+
+class UseRegisterWithHandlerMethodTest < Minitest::Test
+  include RuboCop::Minitest::AssertOffense
+
+  def setup
+    # Reload because Rubocop is unloaded by test/requests/formatting_test.rb
+    # assert_offense calls RuboCop::RSpec::ExpectOffense::AnnotatedSource
+    require "rubocop/rspec/expect_offense"
+
+    @cop = ::RuboCop::Cop::RubyLsp::UseRegisterWithHandlerMethod.new
+  end
+
+  def test_registers_offense_when_use_listener_without_handler
+    assert_offense(<<~RUBY)
+       class MyListener < Listener
+        def initialize(dispatcher)
+          super()
+          dispatcher.register(
+            self,
+            :on_string_node_enter,
+            ^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Registered to `on_string_node_enter` without a handler defined.
+
+          )
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_use_handler_without_listener
+    assert_offense(<<~RUBY)
+       class MyListener < Listener
+        def initialize(dispatcher)
+          super()
+          dispatcher.register(
+            self,
+          )
+        end
+
+        def on_string_node_enter(node)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Created a handler without registering the associated `on_string_node_enter` event.
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_when_both_are_mismatching
+    assert_offense(<<~RUBY)
+       class MyListener < Listener
+        def initialize(dispatcher)
+          super()
+          dispatcher.register(
+            self,
+            :on_string_node_enter,
+            ^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Registered to `on_string_node_enter` without a handler defined.
+          )
+        end
+
+        def on_string_node_leave(node)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Created a handler without registering the associated `on_string_node_leave` event.
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_multiple_offenses_for_listeners
+    assert_offense(<<~RUBY)
+       class MyListener < Listener
+        def initialize(dispatcher)
+          super()
+          dispatcher.register(
+            self,
+            :on_string_node_enter,
+            ^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Registered to `on_string_node_enter` without a handler defined.
+            :on_string_node_leave,
+            ^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Registered to `on_string_node_leave` without a handler defined.
+            :on_constant_path_node_enter
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Registered to `on_constant_path_node_enter` without a handler defined.
+          )
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_multiple_offenses_for_handlers
+    assert_offense(<<~RUBY)
+       class MyListener < Listener
+        def initialize(dispatcher)
+          super()
+          dispatcher.register(
+            self,
+          )
+        end
+        def on_string_node_enter(node)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Created a handler without registering the associated `on_string_node_enter` event.
+        end
+        def on_string_node_leave(node)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Created a handler without registering the associated `on_string_node_leave` event.
+        end
+        def on_constant_path_node_enter(node)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/UseRegisterWithHandlerMethod: Created a handler without registering the associated `on_constant_path_node_enter` event.
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_when_using_listener_with_handler
+    assert_no_offenses(<<~RUBY)
+       class MyListener < Listener
+        def initialize(dispatcher)
+          super()
+          dispatcher.register(
+            self,
+            :on_string_node_enter
+          )
+        end
+        def on_string_node_enter(node)
+        end
+      end
+    RUBY
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ $VERBOSE = nil unless ENV["VERBOSE"] || ENV["CI"]
 
 require_relative "../lib/ruby_lsp/internal"
 require_relative "../lib/rubocop/cop/ruby_lsp/use_language_server_aliases"
+require_relative "../lib/rubocop/cop/ruby_lsp/use_register_with_handler_method"
 
 require "minitest/autorun"
 require "minitest/reporters"


### PR DESCRIPTION
### Motivation

Closes: #1080 

Add a custom cop to ensure match between listeners and handler methods in request.

### Implementation

— Find all listeners and handlers with [def_node_search](https://www.rubydoc.info/gems/rubocop-ast/RuboCop/AST/NodePattern/Macros#def_node_search-instance_method)
— Find all mismatch in listeners
— Find all mismatch in handlers
— Add offense for those mismatch

### Automated Tests

Specific tests are added to the cop, if you see any missing cases, feel free to raise the point 👍 

### Manual Tests

Checkout this branch and in a request try to make a mismatch, actually there is no error, so you'll have to create one.

For example, in the `completion` request: 

<img width="614" alt="image" src="https://github.com/Shopify/ruby-lsp/assets/38727166/50a286f7-0ae4-437b-b7b4-a32fd7392985">