### PR TITLE
Add lib to LOAD_PATH instead of using require_relative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
         run: bundle exec rake
 
       - name: Run index troubleshooting tool
-        run: ./exe/ruby-lsp-doctor
+        run: bundle exec ruby-lsp-doctor

--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -78,7 +78,8 @@ rescue
   nil
 end
 
-require_relative "../lib/ruby_lsp/internal"
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require "ruby_lsp/internal"
 
 if options[:debug]
   if ["x64-mingw-ucrt", "x64-mingw32"].include?(RUBY_PLATFORM)

--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -14,7 +14,8 @@ rescue
   nil
 end
 
-require_relative "../lib/ruby_lsp/internal"
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require "ruby_lsp/internal"
 
 RubyLsp::Addon.load_addons
 

--- a/exe/ruby-lsp-doctor
+++ b/exe/ruby-lsp-doctor
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "bundler/setup"
-
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "ruby_lsp/internal"
 
 index = RubyIndexer::Index.new


### PR DESCRIPTION
### Motivation

We sometimes get errors in our telemetry that look like this

```
cannot load such file -- ruby_lsp/requests/completion
```

It doesn't happen very often and I'm not sure what scenario causes the Ruby LSP's lib directory to not be in the `$LOAD_PATH`.

Also, the new `ruby-lsp-doctor` executable was requiring bundler setup, but executables shouldn't do that. Users decide if they want to execute it standalone or through bundler, by using `bundle exec ruby-lsp-doctor` vs `ruby-lsp-doctor`.

### Implementation

I believe just unshifting the `$LOAD_PATH` with the lib directory should be enough to fix these. Also, removed the `bundler/setup` from `ruby-lsp-doctor`.

### Manual Tests

For the `ruby-lsp`:

1. Start the LSP on this branch
2. Verify that it boots properly and that functionality is showing up

For the `ruby-lsp-doctor`:
1. Go to a different project, like Tapioca - which has different versions of gems that the Ruby LSP depends on
2. Run `ruby-lsp-doctor` using this branch
3. Verify that this error doesn't occurr
```
You have already activated sorbet-runtime 0.5.11090, but your Gemfile requires sorbet-runtime 0.5.11089. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
```