### PR TITLE
Eagerly instantiate RubyIndexer::Configuration

### DIFF
--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -12,12 +12,12 @@ require "ruby_indexer/lib/ruby_indexer/configuration"
 require "ruby_indexer/lib/ruby_indexer/prefix_tree"
 
 module RubyIndexer
+  @configuration = T.let(Configuration.new, Configuration)
+
   class << self
     extend T::Sig
 
     sig { returns(Configuration) }
-    def configuration
-      @configuration ||= T.let(Configuration.new, T.nilable(Configuration))
-    end
+    attr_reader :configuration
   end
 end


### PR DESCRIPTION
### Motivation

In #1141, if you take a look at the provided backtrace you'll see that we're instantiating a configuration object from https://github.com/Shopify/ruby-lsp/blob/604fe8a39d361cf57a83405afc2bcb6a8dbe46f3/lib/ruby_indexer/lib/ruby_indexer/visitor.rb#L248

This is happening because we're now running indexing in a separate thread. If watched file modification notifications come in at the start of indexing, the configuration object may not be instantiated yet because `||=` is not thread safe.

### Implementation

There's no point in using that memoization since we always want to instantiate the configuration object. We can just do it eagerly.