### PR TITLE
Improve document symbols of singleton class operators and methods

### DIFF
--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -73,6 +73,8 @@ module RubyLsp
           :on_module_node_leave,
           :on_instance_variable_write_node_enter,
           :on_class_variable_write_node_enter,
+          :on_singleton_class_node_enter,
+          :on_singleton_class_node_leave,
         )
       end
 
@@ -100,6 +102,23 @@ module RubyLsp
 
       sig { params(node: Prism::ClassNode).void }
       def on_class_node_leave(node)
+        @stack.pop
+      end
+
+      sig { params(node: Prism::SingletonClassNode).void }
+      def on_singleton_class_node_enter(node)
+        expression = node.expression
+
+        @stack << create_document_symbol(
+          name: "<< #{expression.slice}",
+          kind: Constant::SymbolKind::NAMESPACE,
+          range_location: node.location,
+          selection_range_location: expression.location,
+        )
+      end
+
+      sig { params(node: Prism::SingletonClassNode).void }
+      def on_singleton_class_node_leave(node)
         @stack.pop
       end
 
@@ -163,10 +182,14 @@ module RubyLsp
       sig { params(node: Prism::DefNode).void }
       def on_def_node_enter(node)
         receiver = node.receiver
+        previous_symbol = @stack.last
 
         if receiver.is_a?(Prism::SelfNode)
           name = "self.#{node.name}"
-          kind = Constant::SymbolKind::METHOD
+          kind = Constant::SymbolKind::FUNCTION
+        elsif previous_symbol.is_a?(Interface::DocumentSymbol) && previous_symbol.name.start_with?("<<")
+          name = node.name.to_s
+          kind = Constant::SymbolKind::FUNCTION
         else
           name = node.name.to_s
           kind = name == "initialize" ? Constant::SymbolKind::CONSTRUCTOR : Constant::SymbolKind::METHOD

--- a/test/expectations/document_symbol/defs.exp.json
+++ b/test/expectations/document_symbol/defs.exp.json
@@ -2,7 +2,7 @@
   "result": [
     {
       "name": "self.foo",
-      "kind": 6,
+      "kind": 12,
       "range": {
         "start": {
           "line": 0,

--- a/test/expectations/document_symbol/sclass_operator.exp.json
+++ b/test/expectations/document_symbol/sclass_operator.exp.json
@@ -1,0 +1,132 @@
+{
+    "result": [
+        {
+            "name": "Foo",
+            "kind": 5,
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 0
+                },
+                "end": {
+                    "line": 8,
+                    "character": 3
+                }
+            },
+            "selectionRange": {
+                "start": {
+                    "line": 0,
+                    "character": 6
+                },
+                "end": {
+                    "line": 0,
+                    "character": 9
+                }
+            },
+            "children": [
+                {
+                    "name": "<< self",
+                    "kind": 3,
+                    "range": {
+                        "start": {
+                            "line": 1,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 1,
+                            "character": 11
+                        },
+                        "end": {
+                            "line": 1,
+                            "character": 15
+                        }
+                    },
+                    "children": [
+                        {
+                            "name": "bar",
+                            "kind": 12,
+                            "range": {
+                                "start": {
+                                    "line": 2,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 16
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 2,
+                                    "character": 8
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "character": 11
+                                }
+                            },
+                            "children": []
+                        }
+                    ]
+                },
+                {
+                    "name": "<< baz",
+                    "kind": 3,
+                    "range": {
+                        "start": {
+                            "line": 5,
+                            "character": 2
+                        },
+                        "end": {
+                            "line": 7,
+                            "character": 5
+                        }
+                    },
+                    "selectionRange": {
+                        "start": {
+                            "line": 5,
+                            "character": 11
+                        },
+                        "end": {
+                            "line": 5,
+                            "character": 14
+                        }
+                    },
+                    "children": [
+                        {
+                            "name": "qux",
+                            "kind": 12,
+                            "range": {
+                                "start": {
+                                    "line": 6,
+                                    "character": 4
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "character": 16
+                                }
+                            },
+                            "selectionRange": {
+                                "start": {
+                                    "line": 6,
+                                    "character": 8
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "character": 11
+                                }
+                            },
+                            "children": []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/test/fixtures/sclass_operator.rb
+++ b/test/fixtures/sclass_operator.rb
@@ -1,0 +1,9 @@
+class Foo
+  class << self
+    def bar; end
+  end
+
+  class << baz
+    def qux; end
+  end
+end


### PR DESCRIPTION
### Motivation

It was brought up that we weren't properly handling singleton class operator nodes in document symbol and indeed we were missing a few things. This PR addresses the singleton node aspects we were missing.

### Implementation

This PR
- Starts handling the `class << something` nodes and pushing symbols for it
- Starts prefixing methods defined inside these blocks with `(expression.)`, where the expression is the right hand side of `class <<`
- Changes the symbol kind of singleton methods from `method` to `function`, which better represents them and allows us to differentiate the two

### Automated Tests

Added a new fixture and fixed an existing one.