### PR TITLE
Skip exclusion logic if `to_spec` returns `nil`

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -198,7 +198,11 @@ module RubyIndexer
       excluded.each do |dependency|
         next unless dependency.runtime?
 
-        dependency.to_spec.dependencies.each do |transitive_dependency|
+        # If the dependency is prerelease, to_spec may return `nil`
+        spec = dependency.to_spec
+        next unless spec
+
+        spec.dependencies.each do |transitive_dependency|
           # If the transitive dependency is included in other groups, skip it
           next if others.any? { |d| d.name == transitive_dependency.name }
 


### PR DESCRIPTION
### Motivation

Closes #1141

It's still a bit unclear to me why `to_spec` may return `nil` for prerelease gems. However, let's at least avoid breaking so that the LSP can boot properly.

### Implementation

Just started skipping if `to_spec` returns `nil`, which may happen if you have prerelease versions of gems.