### PR TITLE
No-op unnecessary visits that may exist in class/module statements

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/visitor.rb
@@ -132,6 +132,77 @@ module RubyIndexer
       end
     end
 
+    # The following visits are made no-oped intentionally, because we do not want to continue visiting down child nodes
+    # that are not relevant for the index
+
+    # Local variables
+
+    sig { override.params(node: Prism::LocalVariableWriteNode).void }
+    def visit_local_variable_write_node(node); end
+
+    sig { override.params(node: Prism::LocalVariableOrWriteNode).void }
+    def visit_local_variable_or_write_node(node); end
+
+    sig { override.params(node: Prism::LocalVariableAndWriteNode).void }
+    def visit_local_variable_and_write_node(node); end
+
+    sig { override.params(node: Prism::LocalVariableOperatorWriteNode).void }
+    def visit_local_variable_operator_write_node(node); end
+
+    sig { override.params(node: Prism::LocalVariableTargetNode).void }
+    def visit_local_variable_target_node(node); end
+
+    # Instance variables
+
+    sig { override.params(node: Prism::InstanceVariableWriteNode).void }
+    def visit_instance_variable_write_node(node); end
+
+    sig { override.params(node: Prism::InstanceVariableOrWriteNode).void }
+    def visit_instance_variable_or_write_node(node); end
+
+    sig { override.params(node: Prism::InstanceVariableAndWriteNode).void }
+    def visit_instance_variable_and_write_node(node); end
+
+    sig { override.params(node: Prism::InstanceVariableOperatorWriteNode).void }
+    def visit_instance_variable_operator_write_node(node); end
+
+    sig { override.params(node: Prism::InstanceVariableTargetNode).void }
+    def visit_instance_variable_target_node(node); end
+
+    # Class variables
+
+    sig { override.params(node: Prism::ClassVariableWriteNode).void }
+    def visit_class_variable_write_node(node); end
+
+    sig { override.params(node: Prism::ClassVariableOrWriteNode).void }
+    def visit_class_variable_or_write_node(node); end
+
+    sig { override.params(node: Prism::ClassVariableAndWriteNode).void }
+    def visit_class_variable_and_write_node(node); end
+
+    sig { override.params(node: Prism::ClassVariableOperatorWriteNode).void }
+    def visit_class_variable_operator_write_node(node); end
+
+    sig { override.params(node: Prism::ClassVariableTargetNode).void }
+    def visit_class_variable_target_node(node); end
+
+    # Global variables
+
+    sig { override.params(node: Prism::GlobalVariableWriteNode).void }
+    def visit_global_variable_write_node(node); end
+
+    sig { override.params(node: Prism::GlobalVariableOrWriteNode).void }
+    def visit_global_variable_or_write_node(node); end
+
+    sig { override.params(node: Prism::GlobalVariableAndWriteNode).void }
+    def visit_global_variable_and_write_node(node); end
+
+    sig { override.params(node: Prism::GlobalVariableOperatorWriteNode).void }
+    def visit_global_variable_operator_write_node(node); end
+
+    sig { override.params(node: Prism::GlobalVariableTargetNode).void }
+    def visit_global_variable_target_node(node); end
+
     private
 
     sig { params(node: Prism::CallNode).void }
@@ -204,20 +275,20 @@ module RubyIndexer
     sig { params(node: Prism::ModuleNode).void }
     def add_module_entry(node)
       name = node.constant_path.location.slice
-      return visit_child_nodes(node) unless /^[A-Z:]/.match?(name)
+      return visit(node.body) unless /^[A-Z:]/.match?(name)
 
       comments = collect_comments(node)
 
       @index << Entry::Module.new(fully_qualify_name(name), @file_path, node.location, comments)
       @stack << name
-      visit_child_nodes(node)
+      visit(node.body)
       @stack.pop
     end
 
     sig { params(node: Prism::ClassNode).void }
     def add_class_entry(node)
       name = node.constant_path.location.slice
-      return visit_child_nodes(node) unless /^[A-Z:]/.match?(name)
+      return visit(node.body) unless /^[A-Z:]/.match?(name)
 
       comments = collect_comments(node)
 


### PR DESCRIPTION
### Motivation

Closes #1164

The linked issue uncovered an interesting problem. The `unicode_normalize/table.rb` file bundled with Ruby has a local variable in the statements of a module with a gigantic amount of string concatenations - so many that the visitor throws a stack too deep error due to the recursive visits.

For this PR, I'm no-oping any visits we may find in the bodies of classes and modules, which will prevent this issue and speed up indexing.

For the long term, we may want to consider not using the visitor for indexing, since we can never really know what gems are going to do. If `unicode_normalize/table.rb` was using a constant with that many string concatenations instead of a local variable, this solution would simply not work.

If we switch to a non-recursive indexing method, like using an event/node queue, we may be able to get better performance and prevent issues like these. However, that's a significant refactor, so for the time being I'm suggesting we just no-op unnecessary visits.

### Implementation

No-oped unnecessary visits for nodes we may commonly find on the bodies of classes and modules.

### Automated Tests

Created a test that throws the stack error if we accidentally try to visit the variables.