### PR TITLE
Use a queue instead of visitor for indexing

### DIFF
--- a/exe/ruby-lsp-doctor
+++ b/exe/ruby-lsp-doctor
@@ -10,6 +10,6 @@ RubyIndexer.configuration.indexables.each do |indexable|
   puts "indexing: #{indexable.full_path}"
   content = File.read(indexable.full_path)
   result = Prism.parse(content)
-  visitor = RubyIndexer::IndexVisitor.new(index, result, indexable.full_path)
-  result.value.accept(visitor)
+  collector = RubyIndexer::Collector.new(index, result, indexable.full_path)
+  collector.collect(result.value)
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -180,8 +180,8 @@ module RubyIndexer
     def index_single(indexable_path, source = nil)
       content = source || File.read(indexable_path.full_path)
       result = Prism.parse(content)
-      visitor = IndexVisitor.new(self, result, indexable_path.full_path)
-      result.value.accept(visitor)
+      collector = Collector.new(self, result, indexable_path.full_path)
+      collector.collect(result.value)
 
       require_path = indexable_path.require_path
       @require_paths_tree.insert(require_path, indexable_path) if require_path

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -5,7 +5,7 @@ require "yaml"
 require "did_you_mean"
 
 require "ruby_indexer/lib/ruby_indexer/indexable_path"
-require "ruby_indexer/lib/ruby_indexer/visitor"
+require "ruby_indexer/lib/ruby_indexer/collector"
 require "ruby_indexer/lib/ruby_indexer/index"
 require "ruby_indexer/lib/ruby_indexer/entry"
 require "ruby_indexer/lib/ruby_indexer/configuration"

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -193,5 +193,28 @@ module RubyIndexer
 
       assert_instance_of(Entry::UnresolvedAlias, entry)
     end
+
+    def test_visitor_does_not_visit_unnecessary_nodes
+      concats = (0...10_000).map do |i|
+        <<~STRING
+          "string#{i}" \\
+        STRING
+      end.join
+
+      index(<<~RUBY)
+        module Foo
+          local_var = #{concats}
+            "final"
+          @class_instance_var = #{concats}
+            "final"
+          @@class_var = #{concats}
+            "final"
+          $global_var = #{concats}
+            "final"
+          CONST = #{concats}
+            "final"
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Closes #1164

This is an alternative to #1170.

Although using visitors allows us to neatly organize our code, for performance critical operations like indexing we pay a significant price due to the recursive visits. In the associated issue, we do so much recursion we actually raise a stack error.

To prevent these issues in the future, I believe it would be worth using a queue mechanism only for the indexer (LSP requests will remain as visitors).

This not only fixes the issue of hitting too many levels and raising stack errors, but it also speeds up indexing significantly (25% on a few benchmarks I ran).

### Feedback

Do people agree with switching from visitor to queue for the indexer? Any major concerns?

### Implementation

Turned our index visitor into a collector using a queue. The code style is, of course, not as neatly organized - but it's also not terrible.

### Automated Tests

Added a test that currently raises the stack error on main.