### PR TITLE
feat: Add support for autocompleting HEREDOC delimiter

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -127,8 +127,9 @@ module RubyLsp
 
       sig { params(delimiter: String).void }
       def handle_heredoc_end(delimiter)
+        indents = " " * @indentation
         add_edit_with_text("\n")
-        add_edit_with_text(delimiter)
+        add_edit_with_text("#{indents}#{delimiter}")
         move_cursor_to(@position[:line], @indentation + 2)
       end
 

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -125,7 +125,7 @@ module RubyLsp
         end
       end
 
-      sig { void }
+      sig { params(delimiter: String).void }
       def handle_heredoc_end(delimiter)
         add_edit_with_text("\n")
         add_edit_with_text(delimiter)

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -51,8 +51,11 @@ module RubyLsp
           if (comment_match = @previous_line.match(/^#(\s*)/))
             handle_comment_line(T.must(comment_match[1]))
           elsif @document.syntax_error?
-            if /<<[-~]?(?<quote>['"`]?)(?<delimiter>\w+)\k<quote>/ =~ @previous_line # rubocop:disable Lint/UselessAssignment
-              handle_heredoc_end(delimiter)
+            match = /(?<=<<(-|~))(?<quote>['"`]?)(?<delimiter>\w+)\k<quote>/.match(@previous_line)
+            heredoc_delimiter = match && match.named_captures["delimiter"]
+
+            if heredoc_delimiter
+              handle_heredoc_end(heredoc_delimiter)
             else
               handle_statement_end
             end

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -62,7 +62,6 @@ module RubyLsp
         @edits
       end
 
-
       private
 
       sig { void }
@@ -126,6 +125,7 @@ module RubyLsp
         end
       end
 
+      sig { void }
       def handle_heredoc_end(delimiter)
         add_edit_with_text("\n")
         add_edit_with_text(delimiter)

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -389,7 +389,7 @@ class OnTypeFormattingTest < Minitest::Test
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
         newText: "$0",
-      }
+      },
     ]
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -363,4 +363,34 @@ class OnTypeFormattingTest < Minitest::Test
 
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
+
+  def test_adding_heredoc_delimiter
+    document = RubyLsp::Document.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "str = <<~STR",
+      }],
+      version: 2,
+    )
+    document.parse
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
+    expected_edits = [
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "\n",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "STR",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "$0",
+      }
+    ]
+    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
 end


### PR DESCRIPTION
### Motivation

We'd like to add support for autocompleting HEREDOC delimiters as requested in #1007 

### Implementation

We added to the `\n` branch of the case statement within the `run` method in the `OnTypeFormatting` class to compare our HEREDOC regex to the previous line. We handled that conditional with a new method to insert the delimiter. 

### Manual Tests

- Open a new Ruby file
- Type `str = <<~STR`
- Hit enter/return
- Observe that `STR` is added to the file.
