### PR TITLE
Add inlay hint for omitted hash values

### DIFF
--- a/lib/ruby_lsp/requests/inlay_hints.rb
+++ b/lib/ruby_lsp/requests/inlay_hints.rb
@@ -18,6 +18,16 @@ module RubyLsp
     #   puts "handle some rescue"
     # end
     # ```
+    #
+    # # Example
+    #
+    # ```ruby
+    # var = "foo"
+    # {
+    #   var: var, # Label "var" goes here in cases where the value is omitted
+    #   a: "hello",
+    # }
+    # `
     class InlayHints < Listener
       extend T::Sig
       extend T::Generic
@@ -37,6 +47,7 @@ module RubyLsp
         @range = range
 
         dispatcher.register(self, :on_rescue_node_enter)
+        dispatcher.register(self, :on_implicit_node_enter)
       end
 
       sig { params(node: Prism::RescueNode).void }
@@ -51,6 +62,34 @@ module RubyLsp
           label: "StandardError",
           padding_left: true,
           tooltip: "StandardError is implied in a bare rescue",
+        )
+      end
+
+      sig { params(node: Prism::ImplicitNode).void }
+      def on_implicit_node_enter(node)
+        return unless visible?(node, @range)
+
+        node_value = node.value
+        loc = node.location
+        tooltip = ""
+        node_name = ""
+        case node_value
+        when Prism::CallNode
+          node_name = node_value.name
+          tooltip = "This is a method call. Method name: #{node_name}"
+        when Prism::ConstantReadNode
+          node_name = node_value.name
+          tooltip = "This is a constant: #{node_name}"
+        when Prism::LocalVariableReadNode
+          node_name = node_value.name
+          tooltip = "This is a local variable: #{node_name}"
+        end
+
+        @_response << Interface::InlayHint.new(
+          position: { line: loc.start_line - 1, character: loc.start_column + node_name.length + 1 },
+          label: node_name,
+          padding_left: true,
+          tooltip: tooltip,
         )
       end
     end

--- a/lib/ruby_lsp/requests/inlay_hints.rb
+++ b/lib/ruby_lsp/requests/inlay_hints.rb
@@ -27,7 +27,7 @@ module RubyLsp
     #   var: var, # Label "var" goes here in cases where the value is omitted
     #   a: "hello",
     # }
-    # `
+    # ```
     class InlayHints < Listener
       extend T::Sig
       extend T::Generic
@@ -46,8 +46,7 @@ module RubyLsp
         @_response = T.let([], ResponseType)
         @range = range
 
-        dispatcher.register(self, :on_rescue_node_enter)
-        dispatcher.register(self, :on_implicit_node_enter)
+        dispatcher.register(self, :on_rescue_node_enter, :on_implicit_node_enter)
       end
 
       sig { params(node: Prism::RescueNode).void }

--- a/test/expectations/inlay_hints/hash_literal_omitted_values.exp.json
+++ b/test/expectations/inlay_hints/hash_literal_omitted_values.exp.json
@@ -53,6 +53,24 @@
       "label": "hello",
       "tooltip": "This is a local variable: hello",
       "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 14,
+        "character": 8
+      },
+      "label": "foo",
+      "tooltip": "This is a method call. Method name: foo",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 16,
+        "character": 9
+      },
+      "label": "TEST",
+      "tooltip": "This is a constant: TEST",
+      "paddingLeft": true
     }
   ]
 }

--- a/test/expectations/inlay_hints/hash_literal_omitted_values.exp.json
+++ b/test/expectations/inlay_hints/hash_literal_omitted_values.exp.json
@@ -1,0 +1,58 @@
+{
+  "result": [
+    {
+      "position": {
+        "line": 2,
+        "character": 9
+      },
+      "label": "hello",
+      "tooltip": "This is a local variable: hello",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 5,
+        "character": 8
+      },
+      "label": "TEST",
+      "tooltip": "This is a constant: TEST",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 8,
+        "character": 7
+      },
+      "label": "foo",
+      "tooltip": "This is a method call. Method name: foo",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 11,
+        "character": 11
+      },
+      "label": "foo",
+      "tooltip": "This is a method call. Method name: foo",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 11,
+        "character": 18
+      },
+      "label": "TEST",
+      "tooltip": "This is a constant: TEST",
+      "paddingLeft": true
+    },
+    {
+      "position": {
+        "line": 11,
+        "character": 26
+      },
+      "label": "hello",
+      "tooltip": "This is a local variable: hello",
+      "paddingLeft": true
+    }
+  ]
+}

--- a/test/fixtures/hash_literal_omitted_values.rb
+++ b/test/fixtures/hash_literal_omitted_values.rb
@@ -10,4 +10,10 @@ module Foo
 
   def test(opts = {}); end
   test(foo:, TEST:, hello:)
+
+  {
+    foo:,
+    bar: "bar",
+    TEST:,
+  }
 end

--- a/test/fixtures/hash_literal_omitted_values.rb
+++ b/test/fixtures/hash_literal_omitted_values.rb
@@ -1,0 +1,13 @@
+module Foo
+  hello = "world"
+  {hello:}
+
+  TEST = "something"
+  {TEST:}
+
+  def foo; end
+  {foo:}
+
+  def test(opts = {}); end
+  test(foo:, TEST:, hello:)
+end


### PR DESCRIPTION
### Motivation

[In this discussion](https://github.com/Shopify/ruby-lsp/issues/1104#issuecomment-1766733528), @andyw8 mentions how we could add an inlay hint for an omitted hash value to be a bit clearer about what's going on.

### Implementation

- Followed how the inlay hint for implied `rescue StandardError` works
- I added an example but it's kind of hard to write out how it works... let me know if I could make it better
- I think there's only three Node types that `node.value` could be when the `node` is an `ImplicitNode` but let me know if I'm missing anything

### Automated Tests

I added some expectation tests!

### Manual Tests

You could test this by opening the `ruby-lsp` project in VS code, restart the extension so it loads the development version, and then write some code with implied hash values. This should do it:

```ruby
some_variable = "hello"
{some_variable:} # hint will be added here
```

### Also

❤️ 