### PR TITLE
Keep track of method owners and add resolve_method

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -101,6 +101,9 @@ module RubyIndexer
       sig { returns(T::Array[Parameter]) }
       attr_reader :parameters
 
+      sig { returns(T.nilable(Entry::Namespace)) }
+      attr_reader :owner
+
       sig do
         params(
           name: String,
@@ -108,11 +111,13 @@ module RubyIndexer
           location: Prism::Location,
           comments: T::Array[String],
           parameters_node: T.nilable(Prism::ParametersNode),
+          owner: T.nilable(Entry::Namespace),
         ).void
       end
-      def initialize(name, file_path, location, comments, parameters_node)
+      def initialize(name, file_path, location, comments, parameters_node, owner) # rubocop:disable Metrics/ParameterLists
         super(name, file_path, location, comments)
         @parameters = T.let(list_params(parameters_node), T::Array[Parameter])
+        @owner = owner
       end
 
       private

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -216,5 +216,35 @@ module RubyIndexer
         end
       RUBY
     end
+
+    def test_resolve_method_with_known_receiver
+      index(<<~RUBY)
+        module Foo
+          module Bar
+            def baz; end
+          end
+        end
+      RUBY
+
+      entry = T.must(@index.resolve_method("baz", "Foo::Bar"))
+      assert_equal("baz", entry.name)
+      assert_equal("Foo::Bar", T.must(entry.owner).name)
+    end
+
+    def test_prefix_search_for_methods
+      index(<<~RUBY)
+        module Foo
+          module Bar
+            def baz; end
+          end
+        end
+      RUBY
+
+      entries = @index.prefix_search("ba")
+      refute_empty(entries)
+
+      entry = T.must(entries.first).first
+      assert_equal("baz", entry.name)
+    end
   end
 end

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -69,5 +69,19 @@ module RubyIndexer
       assert_equal(:"(a, (b, ))", parameter.name)
       assert_instance_of(Entry::RequiredParameter, parameter)
     end
+
+    def test_keeps_track_of_method_owner
+      index(<<~RUBY)
+        class Foo
+          def bar
+          end
+        end
+      RUBY
+
+      entry = T.must(@index["bar"].first)
+      owner_name = T.must(entry.owner).name
+
+      assert_equal("Foo", owner_name)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Step towards #899 

To provide method related features, we will need to

- Keep track of method owners
- Have an API on the index to resolve methods
- Allow prefix searches without nesting (since we search methods based on their names and the nesting is not relevant)

### Implementation

- Started keeping track of method owners
- Added a `resolve_method` API, which receives the name of the method and the resolved fully qualified name of the receiver. If the method exists in that receiver, then it is returned
- Started allowing prefix searches without nesting

### Automated Tests

Added tests.