### PR TITLE
Support methods invoked on self

### DIFF
--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -127,7 +127,7 @@ module RubyLsp
       sig { params(node: Prism::CallNode).void }
       def on_call_node_enter(node)
         return if DependencyDetector.instance.typechecker
-        return if node.receiver
+        return unless self_receiver?(node)
 
         name = node.message
         return unless name

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -102,8 +102,7 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode).void }
       def handle_method_definition(node)
-        receiver = node.receiver
-        return if receiver && !receiver.is_a?(Prism::SelfNode)
+        return unless self_receiver?(node)
 
         message = node.message
         return unless message

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -102,7 +102,8 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode).void }
       def handle_method_definition(node)
-        return if node.receiver
+        receiver = node.receiver
+        return if receiver && !receiver.is_a?(Prism::SelfNode)
 
         message = node.message
         return unless message

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -99,7 +99,9 @@ module RubyLsp
       sig { params(node: Prism::CallNode).void }
       def on_call_node_enter(node)
         return if DependencyDetector.instance.typechecker
-        return if node.receiver
+
+        receiver = node.receiver
+        return if receiver && !receiver.is_a?(Prism::SelfNode)
 
         message = node.message
         return unless message

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -99,9 +99,7 @@ module RubyLsp
       sig { params(node: Prism::CallNode).void }
       def on_call_node_enter(node)
         return if DependencyDetector.instance.typechecker
-
-        receiver = node.receiver
-        return if receiver && !receiver.is_a?(Prism::SelfNode)
+        return unless self_receiver?(node)
 
         message = node.message
         return unless message

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -75,6 +75,12 @@ module RubyLsp
             !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])
         end
 
+        sig { params(node: Prism::CallNode).returns(T::Boolean) }
+        def self_receiver?(node)
+          receiver = node.receiver
+          receiver.nil? || receiver.is_a?(Prism::SelfNode)
+        end
+
         sig do
           params(
             title: String,

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -66,7 +66,18 @@ module RubyLsp
           )
         end
 
-        sig { params(title: String, entries: T::Array[RubyIndexer::Entry]).returns(Interface::MarkupContent) }
+        sig { params(file_path: String).returns(T.nilable(T::Boolean)) }
+        def defined_in_gem?(file_path)
+          DependencyDetector.instance.typechecker && BUNDLE_PATH && !file_path.start_with?(T.must(BUNDLE_PATH)) &&
+            !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])
+        end
+
+        sig do
+          params(
+            title: String,
+            entries: T.any(T::Array[RubyIndexer::Entry], RubyIndexer::Entry),
+          ).returns(Interface::MarkupContent)
+        end
         def markdown_from_index_entries(title, entries)
           markdown_title = "```ruby\n#{title}\n```"
           definitions = []

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -9,6 +9,9 @@ module RubyLsp
         # https://github.com/Shopify/ruby-lsp-rails, or addons by created by developers outside of Shopify, so be
         # cautious of changing anything.
         extend T::Sig
+        extend T::Helpers
+
+        requires_ancestor { Kernel }
 
         sig { params(node: Prism::Node).returns(Interface::Range) }
         def range_from_node(node)
@@ -82,7 +85,7 @@ module RubyLsp
           markdown_title = "```ruby\n#{title}\n```"
           definitions = []
           content = +""
-          entries.each do |entry|
+          Array(entries).each do |entry|
             loc = entry.location
 
             # We always handle locations as zero based. However, for file links in Markdown we need them to be one

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -73,6 +73,8 @@ module RubyLsp
           Constant::SymbolKind::NAMESPACE
         when RubyIndexer::Entry::Constant
           Constant::SymbolKind::CONSTANT
+        when RubyIndexer::Entry::Method
+          entry.name == "initialize" ? Constant::SymbolKind::CONSTRUCTOR : Constant::SymbolKind::METHOD
         end
       end
     end

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -20,6 +20,7 @@ module RubyLsp
     #
     class WorkspaceSymbol
       extend T::Sig
+      include Support::Common
 
       sig { params(query: T.nilable(String), index: RubyIndexer::Index).void }
       def initialize(query, index)
@@ -29,21 +30,11 @@ module RubyLsp
 
       sig { returns(T::Array[Interface::WorkspaceSymbol]) }
       def run
-        bundle_path = begin
-          Bundler.bundle_path.to_s
-        rescue Bundler::GemfileNotFound
-          nil
-        end
-
         @index.fuzzy_search(@query).filter_map do |entry|
           # If the project is using Sorbet, we let Sorbet handle symbols defined inside the project itself and RBIs, but
           # we still return entries defined in gems to allow developers to jump directly to the source
           file_path = entry.file_path
-          if DependencyDetector.instance.typechecker && bundle_path && !file_path.start_with?(bundle_path) &&
-              !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])
-
-            next
-          end
+          next if defined_in_gem?(file_path)
 
           # We should never show private symbols when searching the entire workspace
           next if entry.visibility == :private

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -8,6 +8,15 @@ module RubyLsp
   # This freeze is not redundant since the interpolated string is mutable
   WORKSPACE_URI = T.let(URI::Generic.from_path(path: Dir.pwd), URI::Generic)
 
+  BUNDLE_PATH = T.let(
+    begin
+      Bundler.bundle_path.to_s
+    rescue Bundler::GemfileNotFound
+      nil
+    end,
+    T.nilable(String),
+  )
+
   # A notification to be sent to the client
   class Message
     extend T::Sig

--- a/sorbet/config
+++ b/sorbet/config
@@ -2,3 +2,4 @@
 .
 --ignore=vendor/
 --ignore=test/fixtures/
+--enable-experimental-requires-ancestor

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -257,6 +257,40 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     T.must(message_queue).close
   end
 
+  def test_jumping_to_method_method_calls_on_explicit_self
+    message_queue = Thread::Queue.new
+    store = RubyLsp::Store.new
+
+    uri = URI("file:///folder/fake.rb")
+    source = <<~RUBY
+      class A
+        def bar
+          self.foo
+        end
+
+        def foo; end
+      end
+    RUBY
+
+    store.set(uri: uri, source: source, version: 1)
+
+    executor = RubyLsp::Executor.new(store, message_queue)
+
+    executor.instance_variable_get(:@index).index_single(
+      RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source
+    )
+
+    stub_no_typechecker
+    response = executor.execute({
+      method: "textDocument/definition",
+      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: { character: 9, line: 2 } },
+    }).response
+
+    assert_equal(uri.to_s, response.attributes[:uri])
+  ensure
+    T.must(message_queue).close
+  end
+
   def test_jumping_to_method_definitions_when_declaration_does_not_exist
     message_queue = Thread::Queue.new
     store = RubyLsp::Store.new

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -61,6 +61,38 @@ class HoverExpectationsTest < ExpectationsTestRunner
     T.must(message_queue).close
   end
 
+  def test_hovering_methods_defined_on_self
+    message_queue = Thread::Queue.new
+    store = RubyLsp::Store.new
+
+    uri = URI("file:///fake.rb")
+    source = <<~RUBY
+      class A
+        # Hello from `foo`
+        def foo; end
+
+        def bar
+          foo
+        end
+      end
+    RUBY
+    store.set(uri: uri, source: source, version: 1)
+
+    executor = RubyLsp::Executor.new(store, message_queue)
+    index = executor.instance_variable_get(:@index)
+    index.index_single(RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source)
+
+    stub_no_typechecker
+    response = executor.execute({
+      method: "textDocument/hover",
+      params: { textDocument: { uri: uri }, position: { character: 4, line: 5 } },
+    }).response
+
+    assert_match("Hello from `foo`", response.contents.value)
+  ensure
+    T.must(message_queue).close
+  end
+
   def test_hovering_over_private_constant_from_different_namespace
     message_queue = Thread::Queue.new
     store = RubyLsp::Store.new

--- a/test/requests/workspace_symbol_test.rb
+++ b/test/requests/workspace_symbol_test.rb
@@ -105,4 +105,16 @@ class WorkspaceSymbolTest < Minitest::Test
     assert_equal(1, result.length)
     assert_equal("Foo", T.must(result.first).name)
   end
+
+  def test_returns_method_symbols
+    @index.index_single(RubyIndexer::IndexablePath.new(nil, "/fake.rb"), <<~RUBY)
+      class Foo
+        def bar; end
+      end
+    RUBY
+
+    result = RubyLsp::Requests::WorkspaceSymbol.new("bar", @index).run.first
+    assert_equal("bar", T.must(result).name)
+    assert_equal(RubyLsp::Constant::SymbolKind::METHOD, T.must(result).kind)
+  end
 end

--- a/test/requests/workspace_symbol_test.rb
+++ b/test/requests/workspace_symbol_test.rb
@@ -109,6 +109,7 @@ class WorkspaceSymbolTest < Minitest::Test
   def test_returns_method_symbols
     @index.index_single(RubyIndexer::IndexablePath.new(nil, "/fake.rb"), <<~RUBY)
       class Foo
+        def initialize; end
         def bar; end
       end
     RUBY
@@ -116,5 +117,9 @@ class WorkspaceSymbolTest < Minitest::Test
     result = RubyLsp::Requests::WorkspaceSymbol.new("bar", @index).run.first
     assert_equal("bar", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::METHOD, T.must(result).kind)
+
+    result = RubyLsp::Requests::WorkspaceSymbol.new("initialize", @index).run.first
+    assert_equal("initialize", T.must(result).name)
+    assert_equal(RubyLsp::Constant::SymbolKind::CONSTRUCTOR, T.must(result).kind)
   end
 end


### PR DESCRIPTION
### Motivation

Big step towards #899 

I got frustrated that we keep getting feedback about missing method support and powered through some basic implementations.

This PR adds support for

- Workspace symbols (for all methods)
- Definition, completion and hover for methods invoked directly on `self` (since the receiver is known)

We are not taking inheritance into account yet, this is just a first step. The same ideas from this PR can be applied to singleton methods once #1113 is merged.

Then we'll just be missing inheritance and methods with unknown receivers.

### Implementation

I recommend reviewing per commit. For the most part, all implementations just use `resolve_method` or check method owners when necessary.

The only exception is workspace symbol. We were just not supporting the method kind, which completely implements the functionality.

### Automated Tests

Added tests for all of these.