### PR TITLE
Return server information on initalize request

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -581,7 +581,7 @@ module RubyLsp
       # notification
     end
 
-    sig { params(options: T::Hash[Symbol, T.untyped]).returns(Interface::InitializeResult) }
+    sig { params(options: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
     def initialize_request(options)
       @store.clear
 
@@ -718,7 +718,7 @@ module RubyLsp
 
       begin_progress("indexing-progress", "Ruby LSP: indexing files")
 
-      Interface::InitializeResult.new(
+      {
         capabilities: Interface::ServerCapabilities.new(
           text_document_sync: Interface::TextDocumentSyncOptions.new(
             change: Constant::TextDocumentSyncKind::INCREMENTAL,
@@ -742,7 +742,12 @@ module RubyLsp
           definition_provider: enabled_features["definition"],
           workspace_symbol_provider: enabled_features["workspaceSymbol"],
         ),
-      )
+        serverInfo: {
+          name: "Ruby LSP",
+          version: VERSION,
+        },
+        formatter: @store.formatter,
+      }
     end
 
     sig { void }

--- a/lib/ruby_lsp/requests/support/dependency_detector.rb
+++ b/lib/ruby_lsp/requests/support/dependency_detector.rb
@@ -66,7 +66,6 @@ module RubyLsp
 
     sig { returns(T::Array[String]) }
     def dependencies
-      # NOTE: If changing this behaviour, it's likely that the VS Code extension will also need changed.
       @dependencies ||= T.let(
         begin
           Bundler.with_original_env { Bundler.default_gemfile }

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -108,6 +108,33 @@ class ExecutorTest < Minitest::Test
     assert_includes("utf-16", hash.dig("capabilities", "positionEncoding"))
   end
 
+  def test_server_info_includes_version
+    response = @executor.execute({
+      method: "initialize",
+      params: {
+        initializationOptions: {},
+        capabilities: {},
+      },
+    }).response
+
+    hash = JSON.parse(response.to_json)
+    assert_equal(RubyLsp::VERSION, hash.dig("serverInfo", "version"))
+  end
+
+  def test_server_info_includes_formatter
+    RubyLsp::DependencyDetector.instance.expects(:detected_formatter).returns("rubocop")
+    response = @executor.execute({
+      method: "initialize",
+      params: {
+        initializationOptions: {},
+        capabilities: {},
+      },
+    }).response
+
+    hash = JSON.parse(response.to_json)
+    assert_equal("rubocop", hash.dig("formatter"))
+  end
+
   def test_initialized_populates_index
     @executor.execute({ method: "initialized", params: {} })
 


### PR DESCRIPTION
### Motivation

See the explanation in https://github.com/Shopify/vscode-ruby-lsp/pull/907.

### Implementation

Return server version and detected formatter in the initialize result. Unfortunately, the `language-server_protocol` gem doesn't have good support for LSP types that accept arbitrary key value pairs, so I had to change the result into a regular hash.

### Automated Tests

Added tests.