### PR TITLE
Set the Bundler UI level to silent to prevent output to stdout

### DIFF
--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -29,3 +29,5 @@ require "ruby_lsp/ruby_document"
 require "ruby_lsp/store"
 require "ruby_lsp/addon"
 require "ruby_lsp/requests/support/rubocop_runner"
+
+Bundler.ui.level = :silent

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -12,6 +12,8 @@ require "time"
 # the Ruby LSP without including the gem in their application's Gemfile while at the same time giving us access to the
 # exact locked versions of dependencies.
 
+Bundler.ui.level = :silent
+
 module RubyLsp
   class SetupBundler
     extend T::Sig


### PR DESCRIPTION
### Motivation

Fixes https://github.com/Shopify/vscode-ruby-lsp/issues/850

If users have Bundler's logging level configured to `info` or `debug`, internals will print to stdout and mess up the client/server communication. This happens when invoking methods like `Bundler.locked_gems` or `specs`. Here's an [example](https://github.com/rubygems/rubygems/blob/8a6b180d0ae5f14239506ac0469933ca062a8b47/bundler/lib/bundler/definition.rb#L292).

We use these methods in two places

- For setting up the custom bundle (which should hopefully go away as soon as bundler-compose is stable for usage
- For figuring out which gems to index (won't go away)

### Implementation

Set the Bundler UI level to `silent` so that it does not print anything regardless of user configurations. One of them will go away once we move to `bundler-compose` and just the one in `internal` will remain.