### PR TITLE
Avoid Bundler platform issues by moving sorbet out of development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,10 +19,11 @@ group :development do
   gem "rubocop-minitest", "~> 0.33.0", require: false
   gem "rubocop-rake", "~> 0.6.0", require: false
   gem "rubocop-sorbet", "~> 0.7", require: false
-  gem "sorbet-static-and-runtime", platforms: NON_WINDOWS_PLATFORMS
   gem "tapioca", "~> 0.11", require: false, platforms: NON_WINDOWS_PLATFORMS
   gem "rdoc", require: false
   gem "psych", "~> 5.1", require: false
 
   gem "syntax_tree", ">= 6.1.1", "< 7"
 end
+
+gem "sorbet-static-and-runtime", platforms: NON_WINDOWS_PLATFORMS


### PR DESCRIPTION
### Motivation

Due to recent changes in Bundler, it is causing platforms to be removed:

https://github.com/dependabot/dependabot-core/issues/8444

(can replicate locally with `bundle update --bundler`).

### Implementation

Avoid having `sorbet` in a group in the `Gemfile`. Since this a gem, the `gemspec` is sufficient to declare development vs runtime dependencies.

I initially tried complete removing the `development` group but it's causing some failures in `lib/ruby_indexer/test/configuration_test.rb`, so this is a less disruptive approach for now.

### Automated Tests

n/a

### Manual Tests

n/a
