### PR TITLE
Disregard quotes in string node location for require path completion

### DIFF
--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -168,10 +168,16 @@ module RubyLsp
 
       sig { params(label: String, node: Prism::StringNode).returns(Interface::CompletionItem) }
       def build_completion(label, node)
+        # We should use the content location as we only replace the content and not the delimiters of the string
+        loc = node.content_loc
+
         Interface::CompletionItem.new(
           label: label,
           text_edit: Interface::TextEdit.new(
-            range: range_from_node(node),
+            range: Interface::Range.new(
+              start: Interface::Position.new(line: loc.start_line - 1, character: loc.start_column),
+              end: Interface::Position.new(line: loc.end_line - 1, character: loc.end_column),
+            ),
             new_text: label,
           ),
           kind: Constant::CompletionItemKind::REFERENCE,

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -24,14 +24,8 @@ class CompletionTest < Minitest::Test
     RUBY
 
     end_char = T.must(document.source.rindex('"'))
-    start_position = {
-      line: 0,
-      character: T.must(document.source.index('"')),
-    }
-    end_position = {
-      line: 0,
-      character: end_char + 1,
-    }
+    start_position = { line: 0, character: T.must(document.source.index('"')) + 1 }
+    end_position = { line: 0, character: end_char }
 
     result = with_file_structure do
       @store.set(uri: @uri, source: document.source, version: 1)
@@ -61,14 +55,8 @@ class CompletionTest < Minitest::Test
     RUBY
 
     end_char = T.must(document.source.rindex('"'))
-    start_position = {
-      line: 0,
-      character: T.must(document.source.index('"')),
-    }
-    end_position = {
-      line: 0,
-      character: end_char + 1,
-    }
+    start_position = { line: 0, character: T.must(document.source.index('"')) + 1 }
+    end_position = { line: 0, character: end_char }
 
     result = with_file_structure do
       @store.set(uri: @uri, source: document.source, version: 1)
@@ -98,14 +86,8 @@ class CompletionTest < Minitest::Test
     RUBY
 
     end_char = T.must(document.source.rindex('"'))
-    start_position = {
-      line: 0,
-      character: T.must(document.source.index('"')),
-    }
-    end_position = {
-      line: 0,
-      character: end_char + 1,
-    }
+    start_position = { line: 0, character: T.must(document.source.index('"')) + 1 }
+    end_position = { line: 0, character: end_char }
 
     result = with_file_structure do
       @store.set(uri: @uri, source: document.source, version: 1)
@@ -135,14 +117,8 @@ class CompletionTest < Minitest::Test
     RUBY
 
     end_char = T.must(document.source.rindex('"'))
-    start_position = {
-      line: 0,
-      character: T.must(document.source.index('"')),
-    }
-    end_position = {
-      line: 0,
-      character: end_char + 1,
-    }
+    start_position = { line: 0, character: T.must(document.source.index('"')) + 1 }
+    end_position = { line: 0, character: end_char }
 
     result = with_file_structure do
       @store.set(uri: @uri, source: document.source, version: 1)


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/vscode-ruby-lsp/issues/900

Finally managed to figure out what was wrong with our require path completion. Prism includes a string's quotes as part of their location, but we only want to replace the contents of the string.

Because of this off by one discrepancy, the range we were returning to the editor didn't fully match the replacement and VS Code refused to apply the completion.

### Implementation

We need to add one to the start character and remove one from the end character to account for the quotes.

### Automated Tests

Fixed the tests, which I mistakenly changed during the Prism migration.