### PR TITLE
Change require completion kind to file instead of reference

### DIFF
--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -174,13 +174,10 @@ module RubyLsp
         Interface::CompletionItem.new(
           label: label,
           text_edit: Interface::TextEdit.new(
-            range: Interface::Range.new(
-              start: Interface::Position.new(line: loc.start_line - 1, character: loc.start_column),
-              end: Interface::Position.new(line: loc.end_line - 1, character: loc.end_column),
-            ),
+            range: range_from_location(loc),
             new_text: label,
           ),
-          kind: Constant::CompletionItemKind::REFERENCE,
+          kind: Constant::CompletionItemKind::FILE,
         )
       end
 

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -574,7 +574,7 @@ class CompletionTest < Minitest::Test
         ),
         new_text: path,
       ),
-      kind: LanguageServer::Protocol::Constant::CompletionItemKind::REFERENCE,
+      kind: LanguageServer::Protocol::Constant::CompletionItemKind::FILE,
     )
   end
 end


### PR DESCRIPTION
### Motivation

Just a couple of small improvements I missed in #1203:

- We can just use `range_from_location` instead of instantiating a range manually
- The completion items for require paths are files not references
