### PR TITLE
Remove comment continuation anchor

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -139,7 +139,6 @@ module RubyLsp
       sig { params(spaces: String).void }
       def handle_comment_line(spaces)
         add_edit_with_text("##{spaces}")
-        move_cursor_to(@position[:line], @indentation + spaces.size + 1)
       end
 
       sig { params(text: String, position: Document::PositionShape).void }

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -209,10 +209,6 @@ class OnTypeFormattingTest < Minitest::Test
         range: { start: { line: 0, character: 14 }, end: { line: 0, character: 14 } },
         newText: "#    ",
       },
-      {
-        range: { start: { line: 0, character: 9 }, end: { line: 0, character: 9 } },
-        newText: "$0",
-      },
     ]
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
@@ -253,10 +249,6 @@ class OnTypeFormattingTest < Minitest::Test
         range: { start: { line: 0, character: 14 }, end: { line: 0, character: 14 } },
         newText: "#    ",
       },
-      {
-        range: { start: { line: 0, character: 9 }, end: { line: 0, character: 9 } },
-        newText: "$0",
-      },
     ]
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
@@ -281,10 +273,6 @@ class OnTypeFormattingTest < Minitest::Test
       {
         range: { start: { line: 0, character: 7 }, end: { line: 0, character: 7 } },
         newText: "# ",
-      },
-      {
-        range: { start: { line: 0, character: 2 }, end: { line: 0, character: 2 } },
-        newText: "$0",
       },
     ]
     assert_equal(expected_edits.to_json, T.must(edits).to_json)


### PR DESCRIPTION
### Motivation

The anchor is only necessary if we need to move the cursor to a different position than the one where the edit finishes. This is never the case for comment continuation.

I noticed this after the recent bug fixes for indentation on the extension side, which are now making the comment continuation indent twice.

### Implementation

Removed the anchor since we don't actually need to change the final cursor position.

### Automated Tests

Updated the tests.