### PR TITLE
Avoid indexing non-Ruby files added inside rubylibdir

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -120,7 +120,7 @@ module RubyIndexer
               IndexablePath.new(RbConfig::CONFIG["rubylibdir"], path)
             end,
           )
-        else
+        elsif pathname.extname == ".rb"
           # If the default_path is a Ruby file, we index it
           indexables << IndexablePath.new(RbConfig::CONFIG["rubylibdir"], default_path)
         end

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -84,6 +84,16 @@ module RubyIndexer
       )
     end
 
+    def test_indexables_does_not_include_non_ruby_files_inside_rubylibdir
+      path = Pathname.new(RbConfig::CONFIG["rubylibdir"]).join("extra_file.txt").to_s
+      FileUtils.touch(path)
+      indexables = @config.indexables
+
+      assert(indexables.none? { |indexable| indexable.full_path == path })
+    ensure
+      FileUtils.rm(T.must(path))
+    end
+
     def test_paths_are_unique
       @config.load_config
       indexables = @config.indexables


### PR DESCRIPTION
### Motivation

More context https://github.com/Shopify/ruby-lsp/issues/1164#issuecomment-1828421905.

Apparently, certain tools add extra non-Ruby files inside `rubylibdir`. I didn't expect tools to modify directories related to the Ruby installation - and I'd argue that it shouldn't be done.

That said, we need to protect the indexer against this type of thing so that it doesn't fail. We can't guarantee that other tools aren't going to insert random files inside `rubylibdir`.

### Implementation

Limit indexed files inside `rubylibdir` to only index Ruby files.

### Automated Tests

Added a test that fails without the fix.