### PR TITLE
Use workspace uri sent by client instead of Dir.pwd

### DIFF
--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -32,12 +32,7 @@ module RubyLsp
       def run
         # Running RuboCop is slow, so to avoid excessive runs we only do so if the file is syntactically valid
         return syntax_error_diagnostics if @document.syntax_error?
-
         return unless defined?(Support::RuboCopDiagnosticsRunner)
-
-        # Don't try to run RuboCop diagnostics for files outside the current working directory
-        path = @uri.to_standardized_path
-        return unless path.nil? || path.start_with?(T.must(WORKSPACE_URI.to_standardized_path))
 
         Support::RuboCopDiagnosticsRunner.instance.run(@uri, @document).map!(&:to_lsp_diagnostic)
       end

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -64,11 +64,6 @@ module RubyLsp
       sig { override.returns(T.nilable(T.all(T::Array[Interface::TextEdit], Object))) }
       def run
         return if @formatter == "none"
-
-        # Don't try to format files outside the current working directory
-        path = @uri.to_standardized_path
-        return unless path.nil? || path.start_with?(T.must(WORKSPACE_URI.to_standardized_path))
-
         return if @document.syntax_error?
 
         formatted_text = formatted_file

--- a/lib/ruby_lsp/requests/support/syntax_tree_formatting_runner.rb
+++ b/lib/ruby_lsp/requests/support/syntax_tree_formatting_runner.rb
@@ -34,15 +34,10 @@ module RubyLsp
 
         sig { override.params(uri: URI::Generic, document: Document).returns(T.nilable(String)) }
         def run(uri, document)
-          relative_path = Pathname.new(T.must(uri.to_standardized_path || uri.opaque))
-            .relative_path_from(T.must(WORKSPACE_URI.to_standardized_path))
-          return if @options.ignore_files.any? { |pattern| File.fnmatch(pattern, relative_path) }
+          path = uri.to_standardized_path
+          return if path && @options.ignore_files.any? { |pattern| File.fnmatch?("*/#{pattern}", path) }
 
-          SyntaxTree.format(
-            document.source,
-            @options.print_width,
-            options: @options.formatter_options,
-          )
+          SyntaxTree.format(document.source, @options.print_width, options: @options.formatter_options)
         end
       end
     end

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -17,6 +17,9 @@ module RubyLsp
     sig { returns(T::Boolean) }
     attr_accessor :experimental_features
 
+    sig { returns(URI::Generic) }
+    attr_accessor :workspace_uri
+
     sig { void }
     def initialize
       @state = T.let({}, T::Hash[String, Document])
@@ -24,6 +27,7 @@ module RubyLsp
       @formatter = T.let("auto", String)
       @supports_progress = T.let(true, T::Boolean)
       @experimental_features = T.let(false, T::Boolean)
+      @workspace_uri = T.let(URI::Generic.from_path(path: Dir.pwd), URI::Generic)
     end
 
     sig { params(uri: URI::Generic).returns(Document) }

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -4,10 +4,6 @@
 module RubyLsp
   # Used to indicate that a request shouldn't return a response
   VOID = T.let(Object.new.freeze, Object)
-
-  # This freeze is not redundant since the interpolated string is mutable
-  WORKSPACE_URI = T.let(URI::Generic.from_path(path: Dir.pwd), URI::Generic)
-
   BUNDLE_PATH = T.let(
     begin
       Bundler.bundle_path.to_s

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -175,6 +175,35 @@ class ExecutorTest < Minitest::Test
     )
   end
 
+  def test_returns_nil_diagnostics_and_formatting_for_files_outside_workspace
+    @executor.execute({
+      method: "initialize",
+      params: {
+        initializationOptions: { enabledFeatures: ["formatting", "diagnostics"] },
+        capabilities: { general: { positionEncodings: ["utf-8"] } },
+        workspaceFolders: [{ uri: URI::Generic.from_path(path: Dir.pwd).to_standardized_path }],
+      },
+    })
+
+    result = @executor.execute({
+      method: "textDocument/formatting",
+      params: {
+        textDocument: { uri: "file:///foo.rb" },
+      },
+    })
+
+    assert_nil(result.response)
+
+    result = @executor.execute({
+      method: "textDocument/diagnostic",
+      params: {
+        textDocument: { uri: "file:///foo.rb" },
+      },
+    })
+
+    assert_nil(result.response)
+  end
+
   def test_did_close_clears_diagnostics
     uri = URI("file:///foo.rb")
     @store.set(uri: uri, source: "", version: 1)

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -16,16 +16,6 @@ class DiagnosticsTest < Minitest::Test
     assert_empty(result)
   end
 
-  def test_returns_nil_if_document_is_not_in_project_folder
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///some/other/folder/file.rb"))
-      def foo
-      wrong_indent
-      end
-    RUBY
-
-    assert_nil(RubyLsp::Requests::Diagnostics.new(document).run)
-  end
-
   def test_returns_syntax_error_diagnostics
     document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///fake/file.rb"))
       def foo

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -109,16 +109,6 @@ class FormattingTest < Minitest::Test
     assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run)
   end
 
-  def test_returns_nil_if_document_is_not_in_project_folder
-    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI("file:///fake.rb"))
-      class Foo
-      def foo
-      end
-      end
-    RUBY
-    assert_nil(RubyLsp::Requests::Formatting.new(document).run)
-  end
-
   def test_allows_specifying_formatter
     SyntaxTree
       .expects(:format)

--- a/test/requests/workspace_symbol_test.rb
+++ b/test/requests/workspace_symbol_test.rb
@@ -54,10 +54,7 @@ class WorkspaceSymbolTest < Minitest::Test
   def test_matches_only_gem_symbols_if_typechecker_is_present
     # reset the singleton so that the stub is not used
     Singleton.__init__(RubyLsp::DependencyDetector)
-    indexable = RubyIndexer::IndexablePath.new(
-      nil,
-      "#{RubyLsp::WORKSPACE_URI.to_standardized_path}/workspace_symbol_foo.rb",
-    )
+    indexable = RubyIndexer::IndexablePath.new(nil, "#{Dir.pwd}/workspace_symbol_foo.rb")
 
     @index.index_single(indexable, <<~RUBY)
       class Foo; end


### PR DESCRIPTION
### Motivation

Closes #1174

We were previously using `Dir.pwd` to determine the workspace URI where the server is running. This works for most cases since it will return the real directory where the server process is being executed.

However, if someone uses a symlink as the project root, then `Dir.pwd` will never work because it always returns the real path after following the link.

### Implementation

The specification actually prescribes that the client should inform the server about the workspace URI, so we should just use what the client gives us.

I removed the `WORKSPACE_URI` constant and started saving the value passed by the client in `Store`.

I also moved our check to return early one level above. The `Executor` now does the URI check and returns early in formatting and diagnostic so that we don't accidentally format gem source files. That way, we don't have to pass the workspace uri around as arguments.

The last change is to remove the workspace URI usage in the Syntax Tree formatter runner. Syntax Tree uses relative path glob patterns to ignore files for formatting. Previously, we were converting the file path into a relative path and then checking using `fnmatch`. Instead of doing that, we're now adding a wildcard to the beginning of every pattern, so that we match absolute paths and remove the need for the workspace URI constant.

### Automated Tests

Moved the relevant tests into executor_test.