### PR TITLE
Move ownership of message_queue from listeners to addon

### DIFF
--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -17,8 +17,6 @@ end
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "ruby_lsp/internal"
 
-RubyLsp::Addon.load_addons
-
 T::Utils.run_all_sig_blocks
 
 files = Dir.glob("#{Dir.pwd}/**/*.rb")
@@ -28,6 +26,7 @@ puts "Verifying that all automatic LSP requests execute successfully. This may t
 errors = {}
 store = RubyLsp::Store.new
 message_queue = Thread::Queue.new
+RubyLsp::Addon.load_addons(message_queue)
 executor = RubyLsp::Executor.new(store, message_queue)
 
 files.each_with_index do |file, index|

--- a/lib/ruby_lsp/listener.rb
+++ b/lib/ruby_lsp/listener.rb
@@ -14,10 +14,9 @@ module RubyLsp
 
     abstract!
 
-    sig { params(dispatcher: Prism::Dispatcher, message_queue: Thread::Queue).void }
-    def initialize(dispatcher, message_queue)
+    sig { params(dispatcher: Prism::Dispatcher).void }
+    def initialize(dispatcher)
       @dispatcher = dispatcher
-      @message_queue = message_queue
     end
 
     sig { returns(ResponseType) }
@@ -43,8 +42,8 @@ module RubyLsp
     # When inheriting from ExtensibleListener, the `super` of constructor must be called **after** the subclass's own
     # ivars have been initialized. This is because the constructor of ExtensibleListener calls
     # `initialize_external_listener` which may depend on the subclass's ivars.
-    sig { params(dispatcher: Prism::Dispatcher, message_queue: Thread::Queue).void }
-    def initialize(dispatcher, message_queue)
+    sig { params(dispatcher: Prism::Dispatcher).void }
+    def initialize(dispatcher)
       super
       @response_merged = T.let(false, T::Boolean)
       @external_listeners = T.let(

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -47,8 +47,8 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :_response
 
-      sig { params(uri: URI::Generic, dispatcher: Prism::Dispatcher, message_queue: Thread::Queue).void }
-      def initialize(uri, dispatcher, message_queue)
+      sig { params(uri: URI::Generic, dispatcher: Prism::Dispatcher).void }
+      def initialize(uri, dispatcher)
         @uri = T.let(uri, URI::Generic)
         @_response = T.let([], ResponseType)
         @path = T.let(uri.to_standardized_path, T.nilable(String))
@@ -58,7 +58,7 @@ module RubyLsp
         @group_id = T.let(1, Integer)
         @group_id_stack = T.let([], T::Array[Integer])
 
-        super(dispatcher, message_queue)
+        super(dispatcher)
 
         dispatcher.register(
           self,
@@ -152,7 +152,7 @@ module RubyLsp
 
       sig { override.params(addon: Addon).returns(T.nilable(Listener[ResponseType])) }
       def initialize_external_listener(addon)
-        addon.create_code_lens_listener(@uri, @dispatcher, @message_queue)
+        addon.create_code_lens_listener(@uri, @dispatcher)
       end
 
       sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -36,11 +36,10 @@ module RubyLsp
           index: RubyIndexer::Index,
           nesting: T::Array[String],
           dispatcher: Prism::Dispatcher,
-          message_queue: Thread::Queue,
         ).void
       end
-      def initialize(index, nesting, dispatcher, message_queue)
-        super(dispatcher, message_queue)
+      def initialize(index, nesting, dispatcher)
+        super(dispatcher)
         @_response = T.let([], ResponseType)
         @index = index
         @nesting = nesting

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -37,16 +37,15 @@ module RubyLsp
           nesting: T::Array[String],
           index: RubyIndexer::Index,
           dispatcher: Prism::Dispatcher,
-          message_queue: Thread::Queue,
         ).void
       end
-      def initialize(uri, nesting, index, dispatcher, message_queue)
+      def initialize(uri, nesting, index, dispatcher)
         @uri = uri
         @nesting = nesting
         @index = index
         @_response = T.let(nil, ResponseType)
 
-        super(dispatcher, message_queue)
+        super(dispatcher)
 
         dispatcher.register(
           self,
@@ -58,7 +57,7 @@ module RubyLsp
 
       sig { override.params(addon: Addon).returns(T.nilable(RubyLsp::Listener[ResponseType])) }
       def initialize_external_listener(addon)
-        addon.create_definition_listener(@uri, @nesting, @index, @dispatcher, @message_queue)
+        addon.create_definition_listener(@uri, @nesting, @index, @dispatcher)
       end
 
       sig { override.params(other: Listener[ResponseType]).returns(T.self_type) }

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -114,11 +114,10 @@ module RubyLsp
           target: T.nilable(Prism::Node),
           parent: T.nilable(Prism::Node),
           dispatcher: Prism::Dispatcher,
-          message_queue: Thread::Queue,
         ).void
       end
-      def initialize(target, parent, dispatcher, message_queue)
-        super(dispatcher, message_queue)
+      def initialize(target, parent, dispatcher)
+        super(dispatcher)
 
         @_response = T.let([], T::Array[Interface::DocumentHighlight])
 

--- a/lib/ruby_lsp/requests/document_link.rb
+++ b/lib/ruby_lsp/requests/document_link.rb
@@ -80,11 +80,10 @@ module RubyLsp
           uri: URI::Generic,
           comments: T::Array[Prism::Comment],
           dispatcher: Prism::Dispatcher,
-          message_queue: Thread::Queue,
         ).void
       end
-      def initialize(uri, comments, dispatcher, message_queue)
-        super(dispatcher, message_queue)
+      def initialize(uri, comments, dispatcher)
+        super(dispatcher)
 
         # Match the version based on the version in the RBI file name. Notice that the `@` symbol is sanitized to `%40`
         # in the URI

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -49,8 +49,8 @@ module RubyLsp
       sig { override.returns(T::Array[Interface::DocumentSymbol]) }
       attr_reader :_response
 
-      sig { params(dispatcher: Prism::Dispatcher, message_queue: Thread::Queue).void }
-      def initialize(dispatcher, message_queue)
+      sig { params(dispatcher: Prism::Dispatcher).void }
+      def initialize(dispatcher)
         @root = T.let(SymbolHierarchyRoot.new, SymbolHierarchyRoot)
         @_response = T.let(@root.children, T::Array[Interface::DocumentSymbol])
         @stack = T.let(
@@ -80,7 +80,7 @@ module RubyLsp
 
       sig { override.params(addon: Addon).returns(T.nilable(Listener[ResponseType])) }
       def initialize_external_listener(addon)
-        addon.create_document_symbol_listener(@dispatcher, @message_queue)
+        addon.create_document_symbol_listener(@dispatcher)
       end
 
       # Merges responses from other listeners

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -21,9 +21,9 @@ module RubyLsp
 
       ResponseType = type_member { { fixed: T::Array[Interface::FoldingRange] } }
 
-      sig { params(comments: T::Array[Prism::Comment], dispatcher: Prism::Dispatcher, queue: Thread::Queue).void }
-      def initialize(comments, dispatcher, queue)
-        super(dispatcher, queue)
+      sig { params(comments: T::Array[Prism::Comment], dispatcher: Prism::Dispatcher).void }
+      def initialize(comments, dispatcher)
+        super(dispatcher)
 
         @_response = T.let([], ResponseType)
         @requires = T.let([], T::Array[Prism::CallNode])

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -37,15 +37,14 @@ module RubyLsp
           index: RubyIndexer::Index,
           nesting: T::Array[String],
           dispatcher: Prism::Dispatcher,
-          message_queue: Thread::Queue,
         ).void
       end
-      def initialize(index, nesting, dispatcher, message_queue)
+      def initialize(index, nesting, dispatcher)
         @index = index
         @nesting = nesting
         @_response = T.let(nil, ResponseType)
 
-        super(dispatcher, message_queue)
+        super(dispatcher)
         dispatcher.register(
           self,
           :on_constant_read_node_enter,
@@ -57,7 +56,7 @@ module RubyLsp
 
       sig { override.params(addon: Addon).returns(T.nilable(Listener[ResponseType])) }
       def initialize_external_listener(addon)
-        addon.create_hover_listener(@nesting, @index, @dispatcher, @message_queue)
+        addon.create_hover_listener(@nesting, @index, @dispatcher)
       end
 
       # Merges responses from other hover listeners

--- a/lib/ruby_lsp/requests/inlay_hints.rb
+++ b/lib/ruby_lsp/requests/inlay_hints.rb
@@ -39,9 +39,9 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :_response
 
-      sig { params(range: T::Range[Integer], dispatcher: Prism::Dispatcher, message_queue: Thread::Queue).void }
-      def initialize(range, dispatcher, message_queue)
-        super(dispatcher, message_queue)
+      sig { params(range: T::Range[Integer], dispatcher: Prism::Dispatcher).void }
+      def initialize(range, dispatcher)
+        super(dispatcher)
 
         @_response = T.let([], ResponseType)
         @range = range

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -107,15 +107,9 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :_response
 
-      sig do
-        params(
-          dispatcher: Prism::Dispatcher,
-          message_queue: Thread::Queue,
-          range: T.nilable(T::Range[Integer]),
-        ).void
-      end
-      def initialize(dispatcher, message_queue, range: nil)
-        super(dispatcher, message_queue)
+      sig { params(dispatcher: Prism::Dispatcher, range: T.nilable(T::Range[Integer])).void }
+      def initialize(dispatcher, range: nil)
+        super(dispatcher)
 
         @_response = T.let([], ResponseType)
         @range = range

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -9,7 +9,7 @@ module RubyLsp
       @addon = Class.new(Addon) do
         attr_reader :activated
 
-        def activate
+        def activate(message_queue)
           @activated = true
         end
 
@@ -42,7 +42,7 @@ module RubyLsp
 
     def test_load_addons_returns_errors
       Class.new(Addon) do
-        def activate
+        def activate(message_queue)
           raise StandardError, "Failed to activate"
         end
 
@@ -51,8 +51,10 @@ module RubyLsp
         end
       end
 
-      Addon.load_addons
+      queue = Thread::Queue.new
+      Addon.load_addons(queue)
       error_addon = T.must(Addon.addons.find(&:error?))
+      queue.close
 
       assert_predicate(error_addon, :error?)
       assert_equal(<<~MESSAGE, error_addon.formatted_errors)

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -12,7 +12,7 @@ class ExpectationsTestRunner < Minitest::Test
       execute_request = if handler_class < RubyLsp::Listener
         <<~RUBY
           dispatcher = Prism::Dispatcher.new
-          listener = #{handler_class}.new(dispatcher, @message_queue)
+          listener = #{handler_class}.new(dispatcher)
           dispatcher.dispatch(document.tree)
           listener.response
         RUBY
@@ -22,14 +22,6 @@ class ExpectationsTestRunner < Minitest::Test
 
       class_eval(<<~RB, __FILE__, __LINE__ + 1)
         module ExpectationsRunnerMethods
-          def setup
-            @message_queue = Thread::Queue.new
-          end
-
-          def teardown
-            @message_queue.close
-          end
-
           def run_expectations(source)
             params = @__params&.any? ? @__params : default_args
             document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -13,7 +13,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     dispatcher = Prism::Dispatcher.new
     stub_test_library("minitest")
-    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher, @message_queue)
+    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher)
     dispatcher.dispatch(document.tree)
     listener.response
   end
@@ -30,7 +30,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
 
     dispatcher = Prism::Dispatcher.new
-    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher, @message_queue)
+    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher)
     dispatcher.dispatch(document.tree)
     response = listener.response
 
@@ -57,7 +57,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     dispatcher = Prism::Dispatcher.new
     stub_test_library("unknown")
-    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher, @message_queue)
+    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher)
     dispatcher.dispatch(document.tree)
     response = listener.response
 
@@ -76,7 +76,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     dispatcher = Prism::Dispatcher.new
     stub_test_library("rspec")
-    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher, @message_queue)
+    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher)
     dispatcher.dispatch(document.tree)
     response = listener.response
 
@@ -95,7 +95,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     dispatcher = Prism::Dispatcher.new
     stub_test_library("minitest")
-    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher, @message_queue)
+    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher)
     dispatcher.dispatch(document.tree)
     response = listener.response
 
@@ -125,20 +125,20 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
   def create_code_lens_addon
     Class.new(RubyLsp::Addon) do
-      def activate; end
+      def activate(message_queue); end
 
       def name
         "CodeLensAddon"
       end
 
-      def create_code_lens_listener(uri, dispatcher, message_queue)
+      def create_code_lens_listener(uri, dispatcher)
         raise "uri can't be nil" unless uri
 
         klass = Class.new(RubyLsp::Listener) do
           attr_reader :_response
 
-          def initialize(uri, dispatcher, message_queue)
-            super(dispatcher, message_queue)
+          def initialize(uri, dispatcher)
+            super(dispatcher)
             dispatcher.register(self, :on_class_node_enter)
           end
 
@@ -155,7 +155,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
           end
         end
 
-        T.unsafe(klass).new(uri, dispatcher, message_queue)
+        T.unsafe(klass).new(uri, dispatcher)
       end
     end
   end

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -327,18 +327,18 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
 
   def create_definition_addon
     Class.new(RubyLsp::Addon) do
-      def activate; end
+      def activate(message_queue); end
 
       def name
         "Definition Addon"
       end
 
-      def create_definition_listener(uri, nesting, index, dispatcher, message_queue)
+      def create_definition_listener(uri, nesting, index, dispatcher)
         klass = Class.new(RubyLsp::Listener) do
           attr_reader :_response
 
-          def initialize(uri, _, _, dispatcher, message_queue)
-            super(dispatcher, message_queue)
+          def initialize(uri, _, _, dispatcher)
+            super(dispatcher)
             @uri = uri
             dispatcher.register(self, :on_constant_read_node_enter)
           end
@@ -358,7 +358,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
           end
         end
 
-        T.unsafe(klass).new(uri, nesting, index, dispatcher, message_queue)
+        T.unsafe(klass).new(uri, nesting, index, dispatcher)
       end
     end
   end

--- a/test/requests/document_highlight_expectations_test.rb
+++ b/test/requests/document_highlight_expectations_test.rb
@@ -15,7 +15,7 @@ class DocumentHighlightExpectationsTest < ExpectationsTestRunner
 
     dispatcher = Prism::Dispatcher.new
 
-    listener = RubyLsp::Requests::DocumentHighlight.new(target, parent, dispatcher, @message_queue)
+    listener = RubyLsp::Requests::DocumentHighlight.new(target, parent, dispatcher)
     dispatcher.dispatch(document.tree)
     listener.response
   end

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -21,16 +21,13 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
   end
 
   def run_expectations(source)
-    message_queue = Thread::Queue.new
     uri = URI("file://#{@_path}")
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
 
     dispatcher = Prism::Dispatcher.new
-    listener = RubyLsp::Requests::DocumentLink.new(uri, document.comments, dispatcher, message_queue)
+    listener = RubyLsp::Requests::DocumentLink.new(uri, document.comments, dispatcher)
     dispatcher.dispatch(document.tree)
     listener.response
-  ensure
-    T.must(message_queue).close
   end
 
   private

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -28,17 +28,17 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
 
   def create_document_symbol_addon
     Class.new(RubyLsp::Addon) do
-      def activate; end
+      def activate(message_queue); end
 
       def name
         "Document SymbolsAddon"
       end
 
-      def create_document_symbol_listener(dispatcher, message_queue)
+      def create_document_symbol_listener(dispatcher)
         klass = Class.new(RubyLsp::Listener) do
           attr_reader :_response
 
-          def initialize(dispatcher, message_queue)
+          def initialize(dispatcher)
             super
             dispatcher.register(self, :on_call_node_enter)
           end
@@ -58,7 +58,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
           end
         end
 
-        klass.new(dispatcher, message_queue)
+        klass.new(dispatcher)
       end
     end
   end

--- a/test/requests/folding_ranges_expectations_test.rb
+++ b/test/requests/folding_ranges_expectations_test.rb
@@ -8,15 +8,12 @@ class FoldingRangesExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::FoldingRanges, "folding_ranges"
 
   def run_expectations(source)
-    message_queue = Thread::Queue.new
     uri = URI("file://#{@_path}")
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
 
     dispatcher = Prism::Dispatcher.new
-    listener = RubyLsp::Requests::FoldingRanges.new(document.parse_result.comments, dispatcher, message_queue)
+    listener = RubyLsp::Requests::FoldingRanges.new(document.parse_result.comments, dispatcher)
     dispatcher.dispatch(document.tree)
     listener.response
-  ensure
-    T.must(message_queue).close
   end
 end

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -178,17 +178,17 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
   def create_hover_addon
     Class.new(RubyLsp::Addon) do
-      def activate; end
+      def activate(message_queue); end
 
       def name
         "HoverAddon"
       end
 
-      def create_hover_listener(nesting, index, dispatcher, message_queue)
+      def create_hover_listener(nesting, index, dispatcher)
         klass = Class.new(RubyLsp::Listener) do
           attr_reader :_response
 
-          def initialize(dispatcher, message_queue)
+          def initialize(dispatcher)
             super
             dispatcher.register(self, :on_constant_read_node_enter)
           end
@@ -203,7 +203,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
           end
         end
 
-        klass.new(dispatcher, message_queue)
+        klass.new(dispatcher)
       end
     end
   end

--- a/test/requests/inlay_hints_expectations_test.rb
+++ b/test/requests/inlay_hints_expectations_test.rb
@@ -8,17 +8,14 @@ class InlayHintsExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::InlayHints, "inlay_hints"
 
   def run_expectations(source)
-    message_queue = Thread::Queue.new
     params = @__params&.any? ? @__params : default_args
     uri = URI("file://#{@_path}")
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
 
     dispatcher = Prism::Dispatcher.new
-    listener = RubyLsp::Requests::InlayHints.new(params.first, dispatcher, message_queue)
+    listener = RubyLsp::Requests::InlayHints.new(params.first, dispatcher)
     dispatcher.dispatch(document.tree)
     listener.response
-  ensure
-    T.must(message_queue).close
   end
 
   def default_args

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -8,7 +8,6 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::SemanticHighlighting, "semantic_highlighting"
 
   def run_expectations(source)
-    message_queue = Thread::Queue.new
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
     range = @__params&.any? ? @__params.first : nil
 
@@ -19,16 +18,10 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
     end
 
     dispatcher = Prism::Dispatcher.new
-    listener = RubyLsp::Requests::SemanticHighlighting.new(
-      dispatcher,
-      message_queue,
-      range: processed_range,
-    )
+    listener = RubyLsp::Requests::SemanticHighlighting.new(dispatcher, range: processed_range)
 
     dispatcher.dispatch(document.tree)
     RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode(listener.response)
-  ensure
-    T.must(message_queue).close
   end
 
   def assert_expectations(source, expected)


### PR DESCRIPTION
### Motivation

Closes #1205

We initially put the ownership of the message queue on listeners. That wasn't the best design for a few reasons:

1. It forces every listener to receive the message queue even if it won't use it
2. Addons don't have a non-hacky way of keeping a reference to the message queue if they need to send async responses back to the editor (which would be necessary for a typechecker or any slow computing of diagnostics)

If we invert the ownership, then the addon can decide when to use the message queue. It still allows addons to use is in listeners if desired, but gives enough flexibility for returning async responses.

We realized the need for these changes when hacking on a Steep addon.

### Implementation

The first commit has the actual change and the second one just fixes all declarations and call sites.

The idea is that we send the message queue during addon activation instead of passing it to all listeners. Then the addon can store the queue in an instance variable and reuse it.

### Automated Tests

Adjusted tests.