### PR TITLE
Keep track of optional parameters

### DIFF
--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -70,6 +70,22 @@ module RubyIndexer
       assert_instance_of(Entry::RequiredParameter, parameter)
     end
 
+    def test_method_with_optional_parameters
+      index(<<~RUBY)
+        class Foo
+          def bar(a = 123)
+          end
+        end
+      RUBY
+
+      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      entry = T.must(@index["bar"].first)
+      assert_equal(1, entry.parameters.length)
+      parameter = entry.parameters.first
+      assert_equal(:a, parameter.name)
+      assert_instance_of(Entry::OptionalParameter, parameter)
+    end
+
     def test_keeps_track_of_method_owner
       index(<<~RUBY)
         class Foo


### PR DESCRIPTION
### Motivation

Step towards #899 

Start keeping track of optional method parameters.

### Implementation

Pretty clean, just started handling the optionals in the parameters node.

**Note**: we are not storing the default value of the parameter yet, but we may want to do so in the future. Especially when we have a reaching definitions implementation, we may be able to provide better type inference if we know the default values.

### Automated Tests

Added a test.