### PR TITLE
Verify indexing on `ruby-lsp-check` and against Prism fixtures

### DIFF
--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -50,13 +50,30 @@ end
 puts "\n"
 message_queue.close
 
+# Indexing
+puts "Verifying that indexing executes successfully. This may take a while..."
+
+index = RubyIndexer::Index.new
+indexables = RubyIndexer.configuration.indexables
+
+indexables.each_with_index do |indexable, i|
+  result = Prism.parse(File.read(indexable.full_path))
+  collector = RubyIndexer::Collector.new(index, result, indexable.full_path)
+  collector.collect(result.value)
+rescue => e
+  errors[indexable.full_path] = e
+ensure
+  print("\033[M\033[0KIndexed #{i + 1}/#{indexables.length}") unless ENV["CI"]
+end
+puts "\n"
+
 if errors.empty?
-  puts "All automatic LSP requests executed successfully"
+  puts "All operations completed successfully!"
   exit
 end
 
 puts <<~ERRORS
-  Errors while executing requests:
+  Errors while executing:
 
   #{errors.map { |file, error| "#{file}: #{error.message}" }.join("\n")}
 ERRORS

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -246,5 +246,16 @@ module RubyIndexer
       entry = T.must(entries.first).first
       assert_equal("baz", entry.name)
     end
+
+    def test_indexing_prism_fixtures_succeeds
+      fixtures = Dir.glob("test/fixtures/prism/test/prism/fixtures/**/*.txt")
+
+      fixtures.each do |fixture|
+        indexable_path = IndexablePath.new("", fixture)
+        @index.index_single(indexable_path)
+      end
+
+      refute_empty(@index.instance_variable_get(:@entries))
+    end
   end
 end


### PR DESCRIPTION
### Motivation

While working on #1224, I realized that we're not trying to index the LSP's own code or the Prism fixtures.

I think doing that on CI will be of great help to ensure that we're not breaking on syntax that's not as common.

### Implementation

Started indexing the LSP's own codebase in `ruby-lsp-check`.

### Automated Tests

Added a test to index every Prism fixture, which contains some pretty obscure scenarios for valid syntax.