### PR TITLE
Fix `end` completion inside parenthesis or brackets

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -118,7 +118,7 @@ module RubyLsp
         current_line = @lines[@position[:line]]
         next_line = @lines[@position[:line] + 1]
 
-        if current_line.nil? || current_line.strip.empty?
+        if current_line.nil? || current_line.strip.empty? || current_line.include?(")") || current_line.include?("]")
           add_edit_with_text("\n")
           add_edit_with_text("#{indents}end")
           move_cursor_to(@position[:line], @indentation + 2)

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -407,4 +407,46 @@ class OnTypeFormattingTest < Minitest::Test
     ]
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
+
+  def test_completing_end_token_inside_parameters
+    document = RubyLsp::RubyDocument.new(source: +"foo(proc do\n)", version: 1, uri: URI("file:///fake.rb"))
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").run
+    expected_edits = [
+      {
+        range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
+        newText: "\n",
+      },
+      {
+        range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
+        newText: "end",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "$0",
+      },
+    ]
+    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
+
+  def test_completing_end_token_inside_brackets
+    document = RubyLsp::RubyDocument.new(source: +"foo[proc do\n]", version: 1, uri: URI("file:///fake.rb"))
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").run
+    expected_edits = [
+      {
+        range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
+        newText: "\n",
+      },
+      {
+        range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
+        newText: "end",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "$0",
+      },
+    ]
+    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
 end


### PR DESCRIPTION
### Motivation

In scenarios like
```ruby
foo(proc do
```

We were completing the `end` tokens incorrectly
```ruby
foo(proc do            
  )end
```

The real solution would be to explore #1008, but this PR fixes it temporarily while we don't fully investigate it.

### Implementation

Added another conditional to prevent us from putting the `end` token in the wrong place.

### Automated Tests

Added two new tests.