### PR TITLE
Track block parameters

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -116,6 +116,11 @@ module RubyIndexer
       DEFAULT_NAME = T.let(:"<anonymous keyword splat>", Symbol)
     end
 
+    # A block method parameter, e.g. `def foo(&block)`
+    class BlockParameter < Parameter
+      DEFAULT_NAME = T.let(:"<anonymous block>", Symbol)
+    end
+
     class Member < Entry
       extend T::Sig
       extend T::Helpers
@@ -233,6 +238,9 @@ module RubyIndexer
 
           parameters << RequiredParameter.new(name: name)
         end
+
+        block = parameters_node.block
+        parameters << BlockParameter.new(name: block.name || BlockParameter::DEFAULT_NAME) if block
 
         parameters
       end

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -185,6 +185,30 @@ module RubyIndexer
       assert_instance_of(Entry::RequiredParameter, param)
     end
 
+    def test_method_with_block_parameters
+      index(<<~RUBY)
+        class Foo
+          def bar(&block)
+          end
+
+          def baz(&)
+          end
+        end
+      RUBY
+
+      entry = T.must(@index["bar"].first)
+      param = entry.parameters.first
+      assert_equal(:block, param.name)
+      assert_instance_of(Entry::BlockParameter, param)
+
+      entry = T.must(@index["baz"].first)
+      assert_equal(1, entry.parameters.length)
+
+      param = entry.parameters.first
+      assert_equal(Entry::BlockParameter::DEFAULT_NAME, param.name)
+      assert_instance_of(Entry::BlockParameter, param)
+    end
+
     def test_method_with_anonymous_rest_parameters
       index(<<~RUBY)
         class Foo


### PR DESCRIPTION
### Motivation

Step towards #899 

In #1228 I said it finished all parameter types, but I forgot blocks. This PR starts tracking them.

### Implementation

Used the same approach for anonymous blocks as the one we're using for anonymous rest parameters.

### Automated Tests

Added a test.