### PR TITLE
Allow hover addons to specify documentation groups

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -121,7 +121,7 @@ module RubyLsp
         nesting: T::Array[String],
         index: RubyIndexer::Index,
         dispatcher: Prism::Dispatcher,
-      ).returns(T.nilable(Listener[T.nilable(Interface::Hover)]))
+      ).returns(T.nilable(Listener[T.nilable(T::Array[HoverResponse])]))
     end
     def create_hover_listener(nesting, index, dispatcher); end
 

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -290,6 +290,8 @@ module RubyLsp
         target = parent
       end
 
+      return unless target
+
       # Instantiate all listeners
       dispatcher = Prism::Dispatcher.new
       hover = Requests::Hover.new(@index, nesting, dispatcher)

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -165,7 +165,7 @@ module RubyLsp
           label_details: Interface::CompletionItemLabelDetails.new(
             description: entry.file_name,
           ),
-          documentation: markdown_from_index_entries(name, entry),
+          documentation: formatted_hover(markdown_from_index_entries(name, entry), node.location),
         )
       end
 
@@ -258,7 +258,7 @@ module RubyLsp
           label_details: Interface::CompletionItemLabelDetails.new(
             description: entries.map(&:file_name).join(","),
           ),
-          documentation: markdown_from_index_entries(real_name, entries),
+          documentation: formatted_hover(markdown_from_index_entries(real_name, entries), node.location),
         )
       end
 

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -92,4 +92,36 @@ module RubyLsp
       @configuration[:enableAll] || @configuration[feature]
     end
   end
+
+  class HoverResponse
+    extend T::Sig
+
+    CATEGORIES = T.let([:link, :documentation, :signature], T::Array[Symbol])
+
+    sig { returns(String) }
+    attr_reader :markdown_content
+
+    sig { params(category: Symbol, markdown_content: String).void }
+    def initialize(category, markdown_content)
+      raise ArgumentError, "Invalid category: #{category}" unless CATEGORIES.include?(category)
+
+      @category = category
+      @markdown_content = markdown_content
+    end
+
+    sig { returns(T::Boolean) }
+    def link?
+      @category == :link
+    end
+
+    sig { returns(T::Boolean) }
+    def documentation?
+      @category == :documentation
+    end
+
+    sig { returns(T::Boolean) }
+    def signature?
+      @category == :signature
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

One of the limitations we discussed about addons is that they can't decide how their content is inserted into the hover response.

Instead of making an ordering system, which is probably more complex and harder to control, I suggest that we use content categories so that addons can define how their response is merged.

I'd appreciate feedback on the approach.

### Implementation

The idea is that hover addons now just return a `HoverResponse`, which is just the markdown string with a category associated to it.

We then use the category to merge the contents into a final hover response and return that to the editor. I believe this is a decent way of providing flexibility while at the same time maintaining consistency regardless of which addons are available.

### Automated Tests

Enhanced our current test.