### PR TITLE
Handle `#to_spec #=> nil` in `RubyIndexer::Configuration`

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -193,7 +193,7 @@ module RubyIndexer
       # When working on a gem, we need to make sure that its gemspec dependencies can't be excluded. This is necessary
       # because Bundler doesn't assign groups to gemspec dependencies
       this_gem = Bundler.definition.dependencies.find do |d|
-        d.to_spec.full_gem_path == Dir.pwd
+        d.to_spec&.full_gem_path == Dir.pwd
       rescue Gem::MissingSpecError
         false
       end


### PR DESCRIPTION
### Motivation

`ruby-lsp` would crash on boot if a prerelease gem is in the `Gemfile`.

<img width="1304" alt="Screenshot 2023-12-10 at 4 34 39 PM" src="https://github.com/Shopify/ruby-lsp/assets/205556/a24fe4e2-d821-4a2d-b9bb-bb74e39e02dc">

### Implementation

Add `&` to handle `nil` values.

### Automated Tests

-

### Manual Tests

I modified the installed gem and `ruby-lsp` boots without issue. 