### PR TITLE
Support typed: false files for completion requests

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -177,6 +177,16 @@ module RubyLsp
       [closest, parent, nesting.map { |n| n.constant_path.location.slice }]
     end
 
+    sig { returns(T::Boolean) }
+    def sigil_is_true_or_higher?
+      [/# typed: true/, /# typed: strict/, /# typed: strong/].any? { |pattern| pattern.match?(@source) }
+    end
+
+    sig { returns(T::Boolean) }
+    def typechecker_enabled?
+      DependencyDetector.instance.typechecker && sigil_is_true_or_higher?
+    end
+
     class Scanner
       extend T::Sig
 

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -515,7 +515,7 @@ module RubyLsp
       return unless target
 
       dispatcher = Prism::Dispatcher.new
-      listener = Requests::Completion.new(@index, nesting, dispatcher)
+      listener = Requests::Completion.new(@index, nesting, dispatcher, document.typechecker_enabled?)
       dispatcher.dispatch_once(target)
       listener.response
     end

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -536,6 +536,52 @@ class RubyDocumentTest < Minitest::Test
     assert_equal(value, document.cache_get("textDocument/semanticHighlighting"))
   end
 
+  def test_no_sigil
+    document = RubyLsp::RubyDocument.new(
+      source: +"# frozen_string_literal: true",
+      version: 1,
+      uri: URI("file:///foo/bar.rb"),
+    )
+    value = false
+
+    assert_equal(value, document.sigil_is_true_or_higher?)
+  end
+
+  def test_sigil_ignore
+    document = RubyLsp::RubyDocument.new(source: +"# typed: ignored", version: 1, uri: URI("file:///foo/bar.rb"))
+    value = false
+
+    assert_equal(value, document.sigil_is_true_or_higher?)
+  end
+
+  def test_sigil_false
+    document = RubyLsp::RubyDocument.new(source: +"# typed: false", version: 1, uri: URI("file:///foo/bar.rb"))
+    value = false
+
+    assert_equal(value, document.sigil_is_true_or_higher?)
+  end
+
+  def test_sigil_true
+    document = RubyLsp::RubyDocument.new(source: +"# typed: true", version: 1, uri: URI("file:///foo/bar.rb"))
+    value = true
+
+    assert_equal(value, document.sigil_is_true_or_higher?)
+  end
+
+  def test_sigil_strict
+    document = RubyLsp::RubyDocument.new(source: +"# typed: strict", version: 1, uri: URI("file:///foo/bar.rb"))
+    value = true
+
+    assert_equal(value, document.sigil_is_true_or_higher?)
+  end
+
+  def test_sigil_strong
+    document = RubyLsp::RubyDocument.new(source: +"# typed: strong", version: 1, uri: URI("file:///foo/bar.rb"))
+    value = true
+
+    assert_equal(value, document.sigil_is_true_or_higher?)
+  end
+
   private
 
   def assert_error_edit(actual, error_range)


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

related issue #1240 

This is makes it so that the LS will still return completion results in `typed: false` files. In these files sorbet provides no support.

We also still intend to address this in some other requests like hover and definition but figured we'd just start with this one. More PRs coming soon for those!

Credit also goes to @jscharf who paired on this with me :)
 
### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Pretty much just followed the directions given [here](https://github.com/Shopify/ruby-lsp/issues/1240#issuecomment-1843762085)

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

Yep!

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

Tested these changes on our internal project which has many typed: false files and it all works as expected!
