### PR TITLE
Upgrade to Prism v0.19

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,9 @@
   "[ruby]": {
     "editor.defaultFormatter": "Shopify.ruby-lsp",
   },
+  "search.exclude": {
+    "**/test/fixtures/prism": true
+  },
   "cSpell.languageSettings": [
     {
       "languageId": "*",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-lsp (0.13.1)
       language_server-protocol (~> 3.17.0)
-      prism (>= 0.18.0, < 0.19)
+      prism (>= 0.19.0, < 0.20)
       sorbet-runtime (>= 0.5.5685)
 
 GEM
@@ -36,14 +36,14 @@ GEM
       ast (~> 2.4.1)
       racc
     prettier_print (1.2.1)
-    prism (0.18.0)
+    prism (0.19.0)
     psych (5.1.1.1)
       stringio
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)
-    rbi (0.1.5)
-      prism (>= 0.18.0, < 0.19)
+    rbi (0.1.6)
+      prism (>= 0.18.0, < 0.20)
       sorbet-runtime (>= 0.5.9204)
     rdoc (6.6.0)
       psych (>= 4.0.0)

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -247,7 +247,7 @@ module RubyIndexer
 
         rest = parameters_node.rest
 
-        if rest
+        if rest.is_a?(Prism::RestParameterNode)
           rest_name = rest.name || RestParameter::DEFAULT_NAME
           parameters << RestParameter.new(name: rest_name)
         end
@@ -287,6 +287,8 @@ module RubyIndexer
             name = rest.expression&.slice
             names << (rest.operator == "*" ? "*#{name}".to_sym : name&.to_sym)
           end
+
+          names << nil if rest.is_a?(Prism::ImplicitRestNode)
 
           names.concat(node.rights.map { |parameter_node| parameter_name(parameter_node) })
 

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("language_server-protocol", "~> 3.17.0")
-  s.add_dependency("prism", ">= 0.18.0", "< 0.19")
+  s.add_dependency("prism", ">= 0.19.0", "< 0.20")
   s.add_dependency("sorbet-runtime", ">= 0.5.5685")
 
   s.required_ruby_version = ">= 3.0"

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -24,6 +24,6 @@ class DiagnosticsTest < Minitest::Test
     diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(document).run)
 
     assert_equal(2, diagnostics.length)
-    assert_equal("Expected an `end` to close the `def` statement", T.must(diagnostics.last).message)
+    assert_equal("expected an `end` to close the `def` statement", T.must(diagnostics.last).message)
   end
 end

--- a/test/requests/show_syntax_tree_test.rb
+++ b/test/requests/show_syntax_tree_test.rb
@@ -27,24 +27,25 @@ class ShowSyntaxTreeTest < Minitest::Test
           @ StatementsNode (location: (1,0)-(1,6))
           └── body: (length: 1)
               └── @ CallNode (location: (1,0)-(1,6))
+                  ├── flags: ∅
                   ├── receiver: ∅
                   ├── call_operator_loc: ∅
+                  ├── name: :foo
                   ├── message_loc: (1,0)-(1,3) = "foo"
                   ├── opening_loc: ∅
                   ├── arguments: ∅
                   ├── closing_loc: ∅
-                  ├── block:
-                  │   @ BlockNode (location: (1,4)-(1,6))
-                  │   ├── locals: []
-                  │   ├── parameters: ∅
-                  │   ├── body:
-                  │   │   @ StatementsNode (location: (1,4)-(1,6))
-                  │   │   └── body: (length: 1)
-                  │   │       └── @ MissingNode (location: (1,4)-(1,6))
-                  │   ├── opening_loc: (1,4)-(1,6) = "do"
-                  │   └── closing_loc: (1,6)-(1,6) = ""
-                  ├── flags: ∅
-                  └── name: :foo
+                  └── block:
+                      @ BlockNode (location: (1,4)-(1,6))
+                      ├── locals: []
+                      ├── locals_body_index: 0
+                      ├── parameters: ∅
+                      ├── body:
+                      │   @ StatementsNode (location: (1,4)-(1,6))
+                      │   └── body: (length: 1)
+                      │       └── @ MissingNode (location: (1,4)-(1,6))
+                      ├── opening_loc: (1,4)-(1,6) = "do"
+                      └── closing_loc: (1,6)-(1,6) = ""
     AST
   end
 


### PR DESCRIPTION
### Motivation

Upgrade to the latest Prism. The only change that impacted us is the new `ImplicitRestNode`, but it's a simple fix.

I also excluded the `test/fixtures/prism` directory from the VS Code search since we don't usually search for files there and it pollutes the results when searching for Ruby LSP files.