### PR TITLE
Move provider definition to individual requests

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -663,81 +663,18 @@ module RubyLsp
         Hash.new(true)
       end
 
-      document_symbol_provider = if enabled_features["documentSymbols"]
-        Interface::DocumentSymbolClientCapabilities.new(
-          hierarchical_document_symbol_support: true,
-          symbol_kind: {
-            value_set: (Constant::SymbolKind::FILE..Constant::SymbolKind::TYPE_PARAMETER).to_a,
-          },
-        )
-      end
-
-      document_link_provider = if enabled_features["documentLink"]
-        Interface::DocumentLinkOptions.new(resolve_provider: false)
-      end
-
-      code_lens_provider = if enabled_features["codeLens"]
-        Interface::CodeLensOptions.new(resolve_provider: false)
-      end
-
-      hover_provider = if enabled_features["hover"]
-        Interface::HoverClientCapabilities.new(dynamic_registration: false)
-      end
-
-      folding_ranges_provider = if enabled_features["foldingRanges"]
-        Interface::FoldingRangeClientCapabilities.new(line_folding_only: true)
-      end
-
-      semantic_tokens_provider = if enabled_features["semanticHighlighting"]
-        Interface::SemanticTokensRegistrationOptions.new(
-          document_selector: { scheme: "file", language: "ruby" },
-          legend: Interface::SemanticTokensLegend.new(
-            token_types: Requests::SemanticHighlighting::TOKEN_TYPES.keys,
-            token_modifiers: Requests::SemanticHighlighting::TOKEN_MODIFIERS.keys,
-          ),
-          range: true,
-          full: { delta: false },
-        )
-      end
-
-      diagnostics_provider = if enabled_features["diagnostics"]
-        {
-          interFileDependencies: false,
-          workspaceDiagnostics: false,
-        }
-      end
-
-      on_type_formatting_provider = if enabled_features["onTypeFormatting"]
-        Interface::DocumentOnTypeFormattingOptions.new(
-          first_trigger_character: "{",
-          more_trigger_character: ["\n", "|", "d"],
-        )
-      end
-
-      code_action_provider = if enabled_features["codeActions"]
-        Interface::CodeActionOptions.new(resolve_provider: true)
-      end
-
-      inlay_hint_provider = if enabled_features["inlayHint"]
-        Interface::InlayHintOptions.new(resolve_provider: false)
-      end
-
-      completion_provider = if enabled_features["completion"]
-        Interface::CompletionOptions.new(
-          resolve_provider: false,
-          trigger_characters: ["/"],
-          completion_item: {
-            labelDetailsSupport: true,
-          },
-        )
-      end
-
-      signature_help_provider = if enabled_features["signatureHelp"]
-        # Identifier characters are automatically included, such as A-Z, a-z, 0-9, _, * or :
-        Interface::SignatureHelpOptions.new(
-          trigger_characters: ["(", " ", ","],
-        )
-      end
+      document_symbol_provider = Requests::DocumentSymbol.provider if enabled_features["documentSymbols"]
+      document_link_provider = Requests::DocumentLink.provider if enabled_features["documentLink"]
+      code_lens_provider = Requests::CodeLens.provider if enabled_features["codeLens"]
+      hover_provider = Requests::Hover.provider if enabled_features["hover"]
+      folding_ranges_provider = Requests::FoldingRanges.provider if enabled_features["foldingRanges"]
+      semantic_tokens_provider = Requests::SemanticHighlighting.provider if enabled_features["semanticHighlighting"]
+      diagnostics_provider = Requests::Diagnostics.provider if enabled_features["diagnostics"]
+      on_type_formatting_provider = Requests::OnTypeFormatting.provider if enabled_features["onTypeFormatting"]
+      code_action_provider = Requests::CodeActions.provider if enabled_features["codeActions"]
+      inlay_hint_provider = Requests::InlayHints.provider if enabled_features["inlayHint"]
+      completion_provider = Requests::Completion.provider if enabled_features["completion"]
+      signature_help_provider = Requests::SignatureHelp.provider if enabled_features["signatureHelp"]
 
       # Dynamically registered capabilities
       file_watching_caps = options.dig(:capabilities, :workspace, :didChangeWatchedFiles)

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -19,6 +19,15 @@ module RubyLsp
     class CodeActions
       extend T::Sig
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::CodeActionOptions) }
+        def provider
+          Interface::CodeActionOptions.new(resolve_provider: true)
+        end
+      end
+
       sig do
         params(
           document: Document,

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -26,6 +26,15 @@ module RubyLsp
       extend T::Sig
       extend T::Generic
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::CodeLensOptions) }
+        def provider
+          Interface::CodeLensOptions.new(resolve_provider: false)
+        end
+      end
+
       ResponseType = type_member { { fixed: T::Array[Interface::CodeLens] } }
 
       BASE_COMMAND = T.let(

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -26,6 +26,21 @@ module RubyLsp
       extend T::Sig
       extend T::Generic
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::CompletionOptions) }
+        def provider
+          Interface::CompletionOptions.new(
+            resolve_provider: false,
+            trigger_characters: ["/"],
+            completion_item: {
+              labelDetailsSupport: true,
+            },
+          )
+        end
+      end
+
       ResponseType = type_member { { fixed: T::Array[Interface::CompletionItem] } }
 
       sig { override.returns(ResponseType) }

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -21,6 +21,18 @@ module RubyLsp
     class Diagnostics
       extend T::Sig
 
+      class << self
+        extend T::Sig
+
+        sig { returns(T::Hash[Symbol, T::Boolean]) }
+        def provider
+          {
+            interFileDependencies: false,
+            workspaceDiagnostics: false,
+          }
+        end
+      end
+
       sig { params(document: Document).void }
       def initialize(document)
         @document = document

--- a/lib/ruby_lsp/requests/document_link.rb
+++ b/lib/ruby_lsp/requests/document_link.rb
@@ -22,6 +22,15 @@ module RubyLsp
       extend T::Sig
       extend T::Generic
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::DocumentLinkOptions) }
+        def provider
+          Interface::DocumentLinkOptions.new(resolve_provider: false)
+        end
+      end
+
       ResponseType = type_member { { fixed: T::Array[Interface::DocumentLink] } }
 
       GEM_TO_VERSION_MAP = T.let(

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -30,6 +30,20 @@ module RubyLsp
       extend T::Sig
       extend T::Generic
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::DocumentSymbolClientCapabilities) }
+        def provider
+          Interface::DocumentSymbolClientCapabilities.new(
+            hierarchical_document_symbol_support: true,
+            symbol_kind: {
+              value_set: (Constant::SymbolKind::FILE..Constant::SymbolKind::TYPE_PARAMETER).to_a,
+            },
+          )
+        end
+      end
+
       ResponseType = type_member { { fixed: T::Array[Interface::DocumentSymbol] } }
 
       ATTR_ACCESSORS = T.let([:attr_reader, :attr_writer, :attr_accessor].freeze, T::Array[Symbol])

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -19,6 +19,15 @@ module RubyLsp
       extend T::Sig
       extend T::Generic
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::FoldingRangeClientCapabilities) }
+        def provider
+          Interface::FoldingRangeClientCapabilities.new(line_folding_only: true)
+        end
+      end
+
       ResponseType = type_member { { fixed: T::Array[Interface::FoldingRange] } }
 
       sig { params(comments: T::Array[Prism::Comment], dispatcher: Prism::Dispatcher).void }

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -17,6 +17,15 @@ module RubyLsp
       extend T::Sig
       extend T::Generic
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::HoverClientCapabilities) }
+        def provider
+          Interface::HoverClientCapabilities.new(dynamic_registration: false)
+        end
+      end
+
       ResponseType = type_member { { fixed: T.nilable(Interface::Hover) } }
 
       ALLOWED_TARGETS = T.let(

--- a/lib/ruby_lsp/requests/inlay_hints.rb
+++ b/lib/ruby_lsp/requests/inlay_hints.rb
@@ -40,6 +40,15 @@ module RubyLsp
       extend T::Sig
       extend T::Generic
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::InlayHintOptions) }
+        def provider
+          Interface::InlayHintOptions.new(resolve_provider: false)
+        end
+      end
+
       ResponseType = type_member { { fixed: T::Array[Interface::InlayHint] } }
 
       RESCUE_STRING_LENGTH = T.let("rescue".length, Integer)

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -18,6 +18,18 @@ module RubyLsp
     class OnTypeFormatting
       extend T::Sig
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::DocumentOnTypeFormattingOptions) }
+        def provider
+          Interface::DocumentOnTypeFormattingOptions.new(
+            first_trigger_character: "{",
+            more_trigger_character: ["\n", "|", "d"],
+          )
+        end
+      end
+
       END_REGEXES = T.let(
         [
           /\b(if|unless|for|while|class|module|until|def|case)\b.*/,

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -22,6 +22,23 @@ module RubyLsp
       extend T::Sig
       extend T::Generic
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::SemanticTokensRegistrationOptions) }
+        def provider
+          Interface::SemanticTokensRegistrationOptions.new(
+            document_selector: { scheme: "file", language: "ruby" },
+            legend: Interface::SemanticTokensLegend.new(
+              token_types: Requests::SemanticHighlighting::TOKEN_TYPES.keys,
+              token_modifiers: Requests::SemanticHighlighting::TOKEN_MODIFIERS.keys,
+            ),
+            range: true,
+            full: { delta: false },
+          )
+        end
+      end
+
       ResponseType = type_member { { fixed: T::Array[SemanticToken] } }
 
       TOKEN_TYPES = T.let(

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -26,6 +26,18 @@ module RubyLsp
       extend T::Sig
       extend T::Generic
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::SignatureHelpOptions) }
+        def provider
+          # Identifier characters are automatically included, such as A-Z, a-z, 0-9, _, * or :
+          Interface::SignatureHelpOptions.new(
+            trigger_characters: ["(", " ", ","],
+          )
+        end
+      end
+
       ResponseType = type_member { { fixed: T.nilable(T.any(Interface::SignatureHelp, T::Hash[Symbol, T.untyped])) } }
 
       sig { override.returns(ResponseType) }


### PR DESCRIPTION
### Motivation

While working on #1247, I found that we try to access some request's constants directly from the executor for building the providers. I think this is a leaky abstraction and requests should simply have a `provider` method to return the associated options or provider.

### Implementation

1. Define a `Request.provider` method on request classes that need a provider
2. Simply call the method from the executor

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
