### PR TITLE
Start keeping a stack of namespaces instead of namespace names

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -320,24 +320,24 @@ module RubyIndexer
       sig { returns(String) }
       attr_reader :target
 
-      sig { returns(T::Array[String]) }
-      attr_reader :nesting
+      sig { returns(T.nilable(Namespace)) }
+      attr_reader :namespace
 
       sig do
         params(
           target: String,
-          nesting: T::Array[String],
+          namespace: T.nilable(Namespace),
           name: String,
           file_path: String,
           location: Prism::Location,
           comments: T::Array[String],
         ).void
       end
-      def initialize(target, nesting, name, file_path, location, comments) # rubocop:disable Metrics/ParameterLists
+      def initialize(target, namespace, name, file_path, location, comments) # rubocop:disable Metrics/ParameterLists
         super(name, file_path, location, comments)
 
         @target = target
-        @nesting = nesting
+        @namespace = namespace
       end
     end
 

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -255,7 +255,7 @@ module RubyIndexer
     # that doesn't exist, then we return the same UnresolvedAlias
     sig { params(entry: Entry::UnresolvedAlias).returns(T.any(Entry::Alias, Entry::UnresolvedAlias)) }
     def resolve_alias(entry)
-      target = resolve(entry.target, entry.nesting)
+      target = resolve(entry.target, Array(entry.namespace&.name))
       return entry unless target
 
       target_name = T.must(target.first).name

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -16,6 +16,35 @@ module RubyIndexer
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
     end
 
+    def test_nested_methods
+      index(<<~RUBY)
+        class Foo
+          module Bar
+            def bar
+            end
+          end
+        end
+      RUBY
+
+      assert_method_entry("bar", "Foo::Bar", Entry::InstanceMethod, "/fake/path/foo.rb:2-4:3-7")
+    end
+
+    def test_methods_after_nesting
+      index(<<~RUBY)
+        class Foo
+          module Bar
+            def bar
+            end
+          end
+
+          def foo
+          end
+        end
+      RUBY
+
+      assert_method_entry("foo", "Foo", Entry::InstanceMethod, "/fake/path/foo.rb:6-2:7-5")
+    end
+
     def test_singleton_method_using_self_receiver
       index(<<~RUBY)
         class Foo

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -15,6 +15,24 @@ module RubyIndexer
       @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), source)
     end
 
+    def assert_method_entry(expected_name, owner_name, type, expected_location)
+      entries = @index[expected_name]
+      refute_empty(entries, "Expected #{expected_name} to be indexed")
+
+      entry = entries.first
+      assert_instance_of(type, entry, "Expected #{expected_name} to be a #{type}")
+
+      owner = entry.owner
+      assert_equal(owner_name, owner.name)
+
+      location = entry.location
+      location_string =
+        "#{entry.file_path}:#{location.start_line - 1}-#{location.start_column}" \
+          ":#{location.end_line - 1}-#{location.end_column}"
+
+      assert_equal(expected_location, location_string)
+    end
+
     def assert_entry(expected_name, type, expected_location)
       entries = @index[expected_name]
       refute_empty(entries, "Expected #{expected_name} to be indexed")


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The current method collection was assigning the wrong owner for methods defined after a namespace was entered and then exited, since the `@current_owner` was not being "popped" at all.

For example:
```ruby
module Foo
  module Bar
  end

  def foo
  end
end
```
would end up assigning `Foo::Bar` as the owner of the method `foo`, when it should actually be `Foo`.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This allows us to use the same stack for both the constant and method collection. For constants, keeping the current namespace on the stack allows us to refer to the current namespace name instantly, without having to build it from the stack entries. For methods, we need to keep the current namespace on the stack so that we can properly find the owner, i.e. the namespace that the method is defined in.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
Added a few automated tests to test the initial symptom, plus a few edge cases.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
