### PR TITLE
Choose other test framework when ruby-lsp-rails not present

### DIFF
--- a/lib/ruby_lsp/requests/support/dependency_detector.rb
+++ b/lib/ruby_lsp/requests/support/dependency_detector.rb
@@ -40,7 +40,7 @@ module RubyLsp
     def detect_test_library
       # A Rails app may have a dependency on minitest, but we would instead want to use the Rails test runner provided
       # by ruby-lsp-rails.
-      if direct_dependency?(/^rails$/)
+      if direct_dependency?(/^rails$/) && direct_dependency?(/^ruby-lsp-rails$/)
         "rails"
       # NOTE: Intentionally ends with $ to avoid mis-matching minitest-reporters, etc. in a Rails app.
       elsif direct_dependency?(/^minitest$/)

--- a/test/requests/support/dependency_detector_test.rb
+++ b/test/requests/support/dependency_detector_test.rb
@@ -37,10 +37,16 @@ module RubyLsp
       assert(DependencyDetector.instance.direct_dependency?(/^prism$/))
     end
 
-    def test_detects_rails_if_both_rails_and_minitest_are_present
-      stub_dependencies("minitest" => "1.2.3", "rails" => "1.2.3")
+    def test_detects_rails_if_rails_and_minitest_and_ruby_lsp_rails_are_present
+      stub_dependencies("minitest" => "1.2.3", "rails" => "1.2.3", "ruby-lsp-rails" => "1.2.3")
 
       assert_equal("rails", DependencyDetector.instance.detected_test_library)
+    end
+
+    def test_detects_rails_if_both_rails_and_minitest_are_present_but_not_ruby_lsp_rails
+      stub_dependencies("minitest" => "1.2.3", "rails" => "1.2.3")
+
+      assert_equal("minitest", DependencyDetector.instance.detected_test_library)
     end
 
     def test_direct_dependency_returns_false_outside_of_bundle


### PR DESCRIPTION
### Motivation

ruby-lsp chooses 'rails' framework when rails is present in the gem dependencies list, so that ruby-lsp-rails can add its own testing commands. But this can be confusing if somebody installs ruby-lsp without also installing ruby-lsp-rails on a rails project, because the test commands will not show up at all. Ideally a dialogue in the relevant extension would prompt the user to install ruby-lsp-rails, but ruby-lsp should select the available testing framework.

### Implementation

If ruby-lsp-rails is not present look for minitest or test-unit instead.

### Automated Tests

I updated the tests to handle the new case. There is one failing test that was preexisting.

### Manual Tests

I tested this inside Vscode
