### PR TITLE
Support running tests in Rails engines 

### DIFF
--- a/lib/ruby_lsp/listeners/code_lens.rb
+++ b/lib/ruby_lsp/listeners/code_lens.rb
@@ -198,7 +198,14 @@ module RubyLsp
 
       sig { params(class_name: String, method_name: T.nilable(String)).returns(String) }
       def generate_test_command(class_name:, method_name: nil)
-        command = BASE_COMMAND + T.must(@path)
+        cd_command =
+          if DependencyDetector.instance.direct_dependency?(/^rails$/) && T.must(@path).include?("/engines/")
+            engine_name = T.must(T.must(@path).split("/engines/").last).split("/").first
+            "cd engines/#{engine_name} && "
+          else
+            ""
+          end
+        command = cd_command + BASE_COMMAND + T.must(@path)
 
         case DependencyDetector.instance.detected_test_library
         when "minitest"
@@ -213,6 +220,10 @@ module RubyLsp
           if method_name
             command += " --name " + Shellwords.escape(method_name)
           end
+        end
+
+        unless cd_command.empty?
+          command += " && cd ../.."
         end
 
         command

--- a/lib/ruby_lsp/listeners/code_lens.rb
+++ b/lib/ruby_lsp/listeners/code_lens.rb
@@ -177,11 +177,14 @@ module RubyLsp
           data: { type: "test_in_terminal", **grouping_data },
         )
 
+        shell_escaped_arguments = arguments.clone
+        shell_escaped_arguments[2] = Shellwords.escape(shell_escaped_arguments[2])
+
         @_response << create_code_lens(
           node,
           title: "Debug",
           command_name: "rubyLsp.debugTest",
-          arguments: arguments,
+          arguments: shell_escaped_arguments,
           data: { type: "debug", **grouping_data },
         )
       end

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -83,7 +83,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/minitest_tests.rb\\ --name\\ /Test/",
           {
             "start_line": 0,
             "start_column": 0,
@@ -180,7 +180,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "test_public",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/minitest_tests.rb\\ --name\\ /Test\\\\\\#test_public/",
           {
             "start_line": 5,
             "start_column": 2,
@@ -276,7 +276,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "test_public_command",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_command/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/minitest_tests.rb\\ --name\\ /Test\\\\\\#test_public_command/",
           {
             "start_line": 9,
             "start_column": 9,
@@ -372,7 +372,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "test_another_public",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_another_public/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/minitest_tests.rb\\ --name\\ /Test\\\\\\#test_another_public/",
           {
             "start_line": 11,
             "start_column": 9,
@@ -468,7 +468,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "test_public_vcall",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_public_vcall/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/minitest_tests.rb\\ --name\\ /Test\\\\\\#test_public_vcall/",
           {
             "start_line": 17,
             "start_column": 2,
@@ -564,7 +564,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "test_with_q?",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /Test\\#test_with_q\\?/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/minitest_tests.rb\\ --name\\ /Test\\\\\\#test_with_q\\\\\\?/",
           {
             "start_line": 19,
             "start_column": 2,
@@ -662,7 +662,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "AnotherTest",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /AnotherTest/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/minitest_tests.rb\\ --name\\ /AnotherTest/",
           {
             "start_line": 24,
             "start_column": 0,
@@ -759,7 +759,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "test_public",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /AnotherTest\\#test_public/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/minitest_tests.rb\\ --name\\ /AnotherTest\\\\\\#test_public/",
           {
             "start_line": 25,
             "start_column": 2,
@@ -855,7 +855,7 @@
         "arguments": [
           "/fixtures/minitest_tests.rb",
           "test_public_2",
-          "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name /AnotherTest\\#test_public_2/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/minitest_tests.rb\\ --name\\ /AnotherTest\\\\\\#test_public_2/",
           {
             "start_line": 31,
             "start_column": 2,
@@ -871,7 +871,5 @@
       }
     }
   ],
-  "params": [
-
-  ]
+  "params": []
 }

--- a/test/expectations/code_lens/nested_minitest_tests.exp.json
+++ b/test/expectations/code_lens/nested_minitest_tests.exp.json
@@ -83,7 +83,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "ParentTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /ParentTest/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/nested_minitest_tests.rb\\ --name\\ /ParentTest/",
           {
             "start_line": 0,
             "start_column": 0,
@@ -180,7 +180,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "test_public",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /ParentTest\\#test_public/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/nested_minitest_tests.rb\\ --name\\ /ParentTest\\\\\\#test_public/",
           {
             "start_line": 1,
             "start_column": 2,
@@ -278,7 +278,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "FirstChildTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /FirstChildTest/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/nested_minitest_tests.rb\\ --name\\ /FirstChildTest/",
           {
             "start_line": 5,
             "start_column": 2,
@@ -375,7 +375,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "test_public",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /FirstChildTest\\#test_public/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/nested_minitest_tests.rb\\ --name\\ /FirstChildTest\\\\\\#test_public/",
           {
             "start_line": 6,
             "start_column": 4,
@@ -473,7 +473,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "SecondChildTest",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /SecondChildTest/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/nested_minitest_tests.rb\\ --name\\ /SecondChildTest/",
           {
             "start_line": 13,
             "start_column": 2,
@@ -570,7 +570,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "test_public",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /SecondChildTest\\#test_public/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/nested_minitest_tests.rb\\ --name\\ /SecondChildTest\\\\\\#test_public/",
           {
             "start_line": 14,
             "start_column": 4,
@@ -666,7 +666,7 @@
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
           "test_public_again",
-          "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name /ParentTest\\#test_public_again/",
+          "bundle\\ exec\\ ruby\\ -Itest\\ /fixtures/nested_minitest_tests.rb\\ --name\\ /ParentTest\\\\\\#test_public_again/",
           {
             "start_line": 19,
             "start_column": 2,
@@ -682,7 +682,5 @@
       }
     }
   ],
-  "params": [
-
-  ]
+  "params": []
 }


### PR DESCRIPTION
### Motivation

In Rails projects with engines, you need to cd into the engine in order to run a test, or else requires, etc. will not work.

### Implementation

This change detects when a file has `engines` in its path and has a Rails dependency and alters the command to cd in (and out, afterwards) of the engine. This allows running a test and sending the test to terminal. The special characters involved break debug, which is fixed in the second commit. The second commit escapes the command when passing to `rdbg`.

### Automated Tests

Tests added

### Manual Tests

I am able to run tests in an engine using VS Code
