### PR TITLE
Upgrade to Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
 
       - name: Check if documentation is up to date
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["3.0", "3.1", "3.2", "head"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
         include:
           - ruby: "head"
             experimental: true

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.2
+          ruby-version: 3.3.0
           bundler-cache: true
           cache-version: 1
 

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: ruby-lsp
 type: ruby
 
 up:
-  - ruby: '3.2.2'
+  - ruby: '3.3.0'
   - bundler:
       gemfile: Gemfile
 


### PR DESCRIPTION
### Motivation

Start using Ruby 3.3 in development and CI.
