### PR TITLE
Add support for hover and go to definition when typechecker enabled but typed: false

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -301,7 +301,7 @@ module RubyLsp
       target = parent if target.is_a?(Prism::ConstantReadNode) && parent.is_a?(Prism::ConstantPathNode)
 
       dispatcher = Prism::Dispatcher.new
-      base_listener = Requests::Definition.new(uri, nesting, @index, dispatcher)
+      base_listener = Requests::Definition.new(uri, nesting, @index, dispatcher, document.typechecker_enabled?)
       dispatcher.dispatch_once(target)
       base_listener.response
     end
@@ -327,7 +327,7 @@ module RubyLsp
 
       # Instantiate all listeners
       dispatcher = Prism::Dispatcher.new
-      hover = Requests::Hover.new(@index, nesting, dispatcher)
+      hover = Requests::Hover.new(@index, nesting, dispatcher, document.typechecker_enabled?)
 
       # Emit events for all listeners
       dispatcher.dispatch_once(target)

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -46,12 +46,14 @@ module RubyLsp
           index: RubyIndexer::Index,
           nesting: T::Array[String],
           dispatcher: Prism::Dispatcher,
+          typechecker_enabled: T::Boolean,
         ).void
       end
-      def initialize(index, nesting, dispatcher)
+      def initialize(index, nesting, dispatcher, typechecker_enabled)
         @index = index
         @nesting = nesting
         @_response = T.let(nil, ResponseType)
+        @typechecker_enabled = typechecker_enabled
 
         super(dispatcher)
         dispatcher.register(
@@ -106,7 +108,7 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode).void }
       def on_call_node_enter(node)
-        return if DependencyDetector.instance.typechecker
+        return if @typechecker_enabled
         return unless self_receiver?(node)
 
         message = node.message

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -71,7 +71,8 @@ module RubyLsp
 
         sig { params(file_path: String).returns(T.nilable(T::Boolean)) }
         def defined_in_gem?(file_path)
-          DependencyDetector.instance.typechecker && BUNDLE_PATH && !file_path.start_with?(T.must(BUNDLE_PATH)) &&
+          BUNDLE_PATH &&
+            !file_path.start_with?(T.must(BUNDLE_PATH)) &&
             !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])
         end
 

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -34,7 +34,7 @@ module RubyLsp
           # If the project is using Sorbet, we let Sorbet handle symbols defined inside the project itself and RBIs, but
           # we still return entries defined in gems to allow developers to jump directly to the source
           file_path = entry.file_path
-          next if defined_in_gem?(file_path)
+          next if DependencyDetector.instance.typechecker && defined_in_gem?(file_path)
 
           # We should never show private symbols when searching the entire workspace
           next if entry.visibility == :private

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -229,6 +229,8 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
 
     uri = URI("file:///folder/fake.rb")
     source = <<~RUBY
+      # typed: false
+
       class A
         def bar
           foo
@@ -246,10 +248,9 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source
     )
 
-    stub_no_typechecker
     response = executor.execute({
       method: "textDocument/definition",
-      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: { character: 4, line: 2 } },
+      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: { character: 4, line: 4 } },
     }).response
 
     assert_equal(uri.to_s, response.attributes[:uri])
@@ -263,6 +264,8 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
 
     uri = URI("file:///folder/fake.rb")
     source = <<~RUBY
+      # typed: false
+
       class A
         def bar
           self.foo
@@ -280,10 +283,9 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source
     )
 
-    stub_no_typechecker
     response = executor.execute({
       method: "textDocument/definition",
-      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: { character: 9, line: 2 } },
+      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: { character: 9, line: 4 } },
     }).response
 
     assert_equal(uri.to_s, response.attributes[:uri])
@@ -297,6 +299,8 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
 
     uri = URI("file:///folder/fake.rb")
     source = <<~RUBY
+      # typed: false
+
       class A
         def bar
           foo
@@ -312,10 +316,9 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source
     )
 
-    stub_no_typechecker
     response = executor.execute({
       method: "textDocument/definition",
-      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: { character: 4, line: 2 } },
+      params: { textDocument: { uri: "file:///folder/fake.rb" }, position: { character: 4, line: 4 } },
     }).response
 
     assert_nil(response)

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -67,6 +67,8 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
     uri = URI("file:///fake.rb")
     source = <<~RUBY
+      # typed: false
+
       class A
         # Hello from `foo`
         def foo; end
@@ -82,10 +84,9 @@ class HoverExpectationsTest < ExpectationsTestRunner
     index = executor.instance_variable_get(:@index)
     index.index_single(RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source)
 
-    stub_no_typechecker
     response = executor.execute({
       method: "textDocument/hover",
-      params: { textDocument: { uri: uri }, position: { character: 4, line: 5 } },
+      params: { textDocument: { uri: uri }, position: { character: 4, line: 7 } },
     }).response
 
     assert_match("Hello from `foo`", response.contents.value)
@@ -99,6 +100,8 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
     uri = URI("file:///fake.rb")
     source = <<~RUBY
+      # typed: false
+
       class A
         # Hello from `foo`
         def foo; end
@@ -114,10 +117,9 @@ class HoverExpectationsTest < ExpectationsTestRunner
     index = executor.instance_variable_get(:@index)
     index.index_single(RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source)
 
-    stub_no_typechecker
     response = executor.execute({
       method: "textDocument/hover",
-      params: { textDocument: { uri: uri }, position: { character: 9, line: 5 } },
+      params: { textDocument: { uri: uri }, position: { character: 9, line: 7 } },
     }).response
 
     assert_match("Hello from `foo`", response.contents.value)


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

This is a follow up to https://github.com/Shopify/ruby-lsp/pull/1245 by @SeanKG and I. 

We did another pair programming session today to continue that work to add hover and go to definition support for when the type checker is enabled but the file is `typed: false`. 

A lot of our files are currently `typed: false` but we still wanted to get the editor benefits of the Ruby LSP despite that.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The implementation was very similar to https://github.com/Shopify/ruby-lsp/pull/1245. We added an extra parameter to the `initialize` method in both `hover.rb` and `definition.rb` to store whether the type checker is enabled or not, and then we replaced existing instances of `DependencyDetector.instance.typechecker` with that newly provided instance variable `@typechecker_enabled`.

There is also a small refactor to `common.rb` included in these changes so that we could modify the code we needed to modify. We pulled out the call to `DependencyDetector.instance.typechecker` because it didn't relate to whether the caller was defined in a gem or not. So now the `defined_in_gem?` method looks like this
```ruby
def defined_in_gem?(file_path)
  BUNDLE_PATH &&
    !file_path.start_with?(T.must(BUNDLE_PATH)) &&
    !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])
end
```

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

We didn't add any new automated tests as part of this change. However we did update existing ones. 

The reasoning behind that was we thought the change in functionality was small enough this time that updating the existing tests would be ok. If this is not ok definitely let us know.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

Note as of 2:00pm on January 5th, 2024 this has not been manually tested yet. I will update when it has been.