### PR TITLE
Add Request class to standardise request interface

### DIFF
--- a/lib/ruby_lsp/check_docs.rb
+++ b/lib/ruby_lsp/check_docs.rb
@@ -56,7 +56,7 @@ module RubyLsp
         klass_name = klass.name
         next unless klass_name
 
-        klass if klass_name.match?(/RubyLsp::Requests::\w[^:]+$/) && !klass_name.include?("Support")
+        klass if klass.ancestors.include?(Request) && !klass == Request
       end
 
       missing_docs = T.let(Hash.new { |h, k| h[k] = [] }, T::Hash[String, T::Array[String]])

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -277,12 +277,12 @@ module RubyLsp
 
     sig { params(query: T.nilable(String)).returns(T::Array[Interface::WorkspaceSymbol]) }
     def workspace_symbol(query)
-      Requests::WorkspaceSymbol.new(query, @index).run
+      Requests::WorkspaceSymbol.new(query, @index).response
     end
 
     sig { params(uri: URI::Generic, range: T.nilable(T::Hash[Symbol, T.untyped])).returns({ ast: String }) }
     def show_syntax_tree(uri, range)
-      { ast: Requests::ShowSyntaxTree.new(@store.get(uri), range).run }
+      { ast: Requests::ShowSyntaxTree.new(@store.get(uri), range).response }
     end
 
     sig do
@@ -363,7 +363,7 @@ module RubyLsp
     end
     def selection_range(uri, positions)
       ranges = @store.cache_fetch(uri, "textDocument/selectionRange") do |document|
-        Requests::SelectionRanges.new(document).run
+        Requests::SelectionRanges.new(document).response
       end
 
       # Per the selection range request spec (https://microsoft.github.io/language-server-protocol/specification#textDocument_selectionRange),
@@ -390,7 +390,7 @@ module RubyLsp
       path = uri.to_standardized_path
       return unless path.nil? || path.start_with?(T.must(@store.workspace_uri.to_standardized_path))
 
-      Requests::Formatting.new(@store.get(uri), formatter: @store.formatter).run
+      Requests::Formatting.new(@store.get(uri), formatter: @store.formatter).response
     end
 
     sig do
@@ -401,7 +401,7 @@ module RubyLsp
       ).returns(T::Array[Interface::TextEdit])
     end
     def on_type_formatting(uri, position, character)
-      Requests::OnTypeFormatting.new(@store.get(uri), position, character).run
+      Requests::OnTypeFormatting.new(@store.get(uri), position, character).response
     end
 
     sig do
@@ -449,14 +449,14 @@ module RubyLsp
     def code_action(uri, range, context)
       document = @store.get(uri)
 
-      Requests::CodeActions.new(document, range, context).run
+      Requests::CodeActions.new(document, range, context).response
     end
 
     sig { params(params: T::Hash[Symbol, T.untyped]).returns(Interface::CodeAction) }
     def code_action_resolve(params)
       uri = URI(params.dig(:data, :uri))
       document = @store.get(uri)
-      result = Requests::CodeActionResolve.new(document, params).run
+      result = Requests::CodeActionResolve.new(document, params).response
 
       case result
       when Requests::CodeActionResolve::Error::EmptySelection
@@ -490,7 +490,7 @@ module RubyLsp
       return unless path.nil? || path.start_with?(T.must(@store.workspace_uri.to_standardized_path))
 
       response = @store.cache_fetch(uri, "textDocument/diagnostic") do |document|
-        Requests::Diagnostics.new(document).run
+        Requests::Diagnostics.new(document).response
       end
 
       Interface::FullDocumentDiagnosticReport.new(kind: "full", items: response) if response

--- a/lib/ruby_lsp/listener.rb
+++ b/lib/ruby_lsp/listener.rb
@@ -4,7 +4,7 @@
 module RubyLsp
   # Listener is an abstract class to be used by requests for listening to events emitted when visiting an AST using the
   # Prism::Dispatcher.
-  class Listener
+  class Listener < Requests::Request
     extend T::Sig
     extend T::Helpers
     extend T::Generic
@@ -16,10 +16,11 @@ module RubyLsp
 
     sig { params(dispatcher: Prism::Dispatcher).void }
     def initialize(dispatcher)
+      super()
       @dispatcher = dispatcher
     end
 
-    sig { returns(ResponseType) }
+    sig { override.returns(ResponseType) }
     def response
       _response
     end
@@ -61,7 +62,7 @@ module RubyLsp
       @external_listeners.each { |l| merge_response!(l) }
     end
 
-    sig { returns(ResponseType) }
+    sig { override.returns(ResponseType) }
     def response
       merge_external_listeners_responses! unless @response_merged
       super

--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -25,6 +25,7 @@ module RubyLsp
   # - [SignatureHelp](rdoc-ref:RubyLsp::Requests::SignatureHelp)
 
   module Requests
+    autoload :Request, "ruby_lsp/requests/request"
     autoload :DocumentSymbol, "ruby_lsp/requests/document_symbol"
     autoload :DocumentLink, "ruby_lsp/requests/document_link"
     autoload :Hover, "ruby_lsp/requests/hover"

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -21,7 +21,7 @@ module RubyLsp
     #
     # ```
     #
-    class CodeActionResolve
+    class CodeActionResolve < Request
       extend T::Sig
       NEW_VARIABLE_NAME = "new_variable"
 
@@ -36,12 +36,13 @@ module RubyLsp
 
       sig { params(document: Document, code_action: T::Hash[Symbol, T.untyped]).void }
       def initialize(document, code_action)
+        super()
         @document = document
         @code_action = code_action
       end
 
-      sig { returns(T.any(Interface::CodeAction, Error)) }
-      def run
+      sig { override.returns(T.any(Interface::CodeAction, Error)) }
+      def response
         return Error::EmptySelection if @document.source.empty?
 
         source_range = @code_action.dig(:data, :range)

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -16,7 +16,7 @@ module RubyLsp
     # puts "Hello" # --> code action: quick fix indentation
     # end
     # ```
-    class CodeActions
+    class CodeActions < Request
       extend T::Sig
 
       class << self
@@ -36,14 +36,15 @@ module RubyLsp
         ).void
       end
       def initialize(document, range, context)
+        super()
         @document = document
         @uri = T.let(document.uri, URI::Generic)
         @range = range
         @context = context
       end
 
-      sig { returns(T.nilable(T.all(T::Array[Interface::CodeAction], Object))) }
-      def run
+      sig { override.returns(T.nilable(T.all(T::Array[Interface::CodeAction], Object))) }
+      def response
         diagnostics = @context[:diagnostics]
 
         code_actions = diagnostics.flat_map do |diagnostic|

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -18,7 +18,7 @@ module RubyLsp
     # puts "Hello" # --> diagnostics: incorrect indentation
     # end
     # ```
-    class Diagnostics
+    class Diagnostics < Request
       extend T::Sig
 
       class << self
@@ -35,12 +35,13 @@ module RubyLsp
 
       sig { params(document: Document).void }
       def initialize(document)
+        super()
         @document = document
         @uri = T.let(document.uri, URI::Generic)
       end
 
-      sig { returns(T.nilable(T.all(T::Array[Interface::Diagnostic], Object))) }
-      def run
+      sig { override.returns(T.nilable(T.all(T::Array[Interface::Diagnostic], Object))) }
+      def response
         # Running RuboCop is slow, so to avoid excessive runs we only do so if the file is syntactically valid
         return syntax_error_diagnostics if @document.syntax_error?
         return unless defined?(Support::RuboCopDiagnosticsRunner)

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -25,7 +25,7 @@ module RubyLsp
     # puts "Hello" # --> formatting: fixes the indentation on save
     # end
     # ```
-    class Formatting
+    class Formatting < Request
       class Error < StandardError; end
       class InvalidFormatter < StandardError; end
 
@@ -55,13 +55,14 @@ module RubyLsp
 
       sig { params(document: Document, formatter: String).void }
       def initialize(document, formatter: "auto")
+        super()
         @document = document
         @uri = T.let(document.uri, URI::Generic)
         @formatter = formatter
       end
 
-      sig { returns(T.nilable(T.all(T::Array[Interface::TextEdit], Object))) }
-      def run
+      sig { override.returns(T.nilable(T.all(T::Array[Interface::TextEdit], Object))) }
+      def response
         return if @formatter == "none"
         return if @document.syntax_error?
 

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -15,7 +15,7 @@ module RubyLsp
     #   # <-- cursor ends up here
     # end # <-- end is automatically added
     # ```
-    class OnTypeFormatting
+    class OnTypeFormatting < Request
       extend T::Sig
 
       class << self
@@ -40,6 +40,7 @@ module RubyLsp
 
       sig { params(document: Document, position: T::Hash[Symbol, T.untyped], trigger_character: String).void }
       def initialize(document, position, trigger_character)
+        super()
         @document = document
         @lines = T.let(@document.source.lines, T::Array[String])
         line = @lines[[position[:line] - 1, 0].max]
@@ -51,8 +52,8 @@ module RubyLsp
         @trigger_character = trigger_character
       end
 
-      sig { returns(T.all(T::Array[Interface::TextEdit], Object)) }
-      def run
+      sig { override.returns(T.all(T::Array[Interface::TextEdit], Object)) }
+      def response
         case @trigger_character
         when "{"
           handle_curly_brace if @document.syntax_error?

--- a/lib/ruby_lsp/requests/request.rb
+++ b/lib/ruby_lsp/requests/request.rb
@@ -1,0 +1,17 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Requests
+    # :nodoc:
+    class Request
+      extend T::Sig
+      extend T::Generic
+
+      abstract!
+
+      sig { abstract.returns(T.anything) }
+      def response; end
+    end
+  end
+end

--- a/lib/ruby_lsp/requests/selection_ranges.rb
+++ b/lib/ruby_lsp/requests/selection_ranges.rb
@@ -20,18 +20,19 @@ module RubyLsp
     #   puts "Hello, world!" # --> Cursor is on this line
     # end
     # ```
-    class SelectionRanges
+    class SelectionRanges < Request
       extend T::Sig
       include Support::Common
       sig { params(document: Document).void }
       def initialize(document)
+        super()
         @document = document
         @ranges = T.let([], T::Array[Support::SelectionRange])
         @stack = T.let([], T::Array[Support::SelectionRange])
       end
 
-      sig { returns(T.all(T::Array[Support::SelectionRange], Object)) }
-      def run
+      sig { override.returns(T.all(T::Array[Support::SelectionRange], Object)) }
+      def response
         # [node, parent]
         queue = [[@document.tree, nil]]
 

--- a/lib/ruby_lsp/requests/show_syntax_tree.rb
+++ b/lib/ruby_lsp/requests/show_syntax_tree.rb
@@ -17,17 +17,18 @@ module RubyLsp
     # # (program (statements ((binary (int "1") + (int "1")))))
     # ```
     #
-    class ShowSyntaxTree
+    class ShowSyntaxTree < Request
       extend T::Sig
 
       sig { params(document: Document, range: T.nilable(T::Hash[Symbol, T.untyped])).void }
       def initialize(document, range)
+        super()
         @document = document
         @range = range
       end
 
-      sig { returns(String) }
-      def run
+      sig { override.returns(String) }
+      def response
         return ast_for_range if @range
 
         output_string = +""

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -18,18 +18,19 @@ module RubyLsp
     # end
     # ```
     #
-    class WorkspaceSymbol
+    class WorkspaceSymbol < Request
       extend T::Sig
       include Support::Common
 
       sig { params(query: T.nilable(String), index: RubyIndexer::Index).void }
       def initialize(query, index)
+        super()
         @query = query
         @index = index
       end
 
-      sig { returns(T::Array[Interface::WorkspaceSymbol]) }
-      def run
+      sig { override.returns(T::Array[Interface::WorkspaceSymbol]) }
+      def response
         @index.fuzzy_search(@query).filter_map do |entry|
           # If the project is using Sorbet, we let Sorbet handle symbols defined inside the project itself and RBIs, but
           # we still return entries defined in gems to allow developers to jump directly to the source

--- a/test/requests/code_action_resolve_expectations_test.rb
+++ b/test/requests/code_action_resolve_expectations_test.rb
@@ -11,7 +11,7 @@ class CodeActionResolveExpectationsTest < ExpectationsTestRunner
     params = @__params&.any? ? @__params : default_args
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
 
-    RubyLsp::Requests::CodeActionResolve.new(document, params).run
+    RubyLsp::Requests::CodeActionResolve.new(document, params).response
   end
 
   def assert_expectations(source, expected)

--- a/test/requests/code_actions_expectations_test.rb
+++ b/test/requests/code_actions_expectations_test.rb
@@ -17,7 +17,7 @@ class CodeActionsExpectationsTest < ExpectationsTestRunner
         document,
         params[:range],
         params[:context],
-      ).run
+      ).response
     end
 
     assert_empty(stdout)

--- a/test/requests/code_actions_formatting_test.rb
+++ b/test/requests/code_actions_formatting_test.rb
@@ -75,12 +75,12 @@ class CodeActionsFormattingTest < Minitest::Test
       encoding: LanguageServer::Protocol::Constant::PositionEncodingKind::UTF16,
     )
 
-    diagnostics = RubyLsp::Requests::Diagnostics.new(document).run
+    diagnostics = RubyLsp::Requests::Diagnostics.new(document).response
     diagnostic = T.must(T.must(diagnostics).find { |d| d.code == diagnostic_code })
     range = diagnostic.range.to_hash.transform_values(&:to_hash)
     result = RubyLsp::Requests::CodeActions.new(document, range, {
       diagnostics: [JSON.parse(T.must(diagnostic).to_json, symbolize_names: true)],
-    }).run
+    }).response
 
     # CodeActions#run returns Array<CodeAction, Hash>. We're interested in the
     # hashes here, so cast to untyped and only look at those.

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -9,12 +9,12 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    RubyLsp::Requests::Diagnostics.new(document).run
+    RubyLsp::Requests::Diagnostics.new(document).response
     result = T.let(nil, T.nilable(T::Array[RubyLsp::Interface::Diagnostic]))
 
     stdout, _ = capture_io do
       result = T.cast(
-        RubyLsp::Requests::Diagnostics.new(document).run,
+        RubyLsp::Requests::Diagnostics.new(document).response,
         T::Array[RubyLsp::Interface::Diagnostic],
       )
     end

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -12,7 +12,7 @@ class DiagnosticsTest < Minitest::Test
       uri: URI::Generic.from_path(path: fixture_path),
     )
 
-    result = RubyLsp::Requests::Diagnostics.new(document).run
+    result = RubyLsp::Requests::Diagnostics.new(document).response
     assert_empty(result)
   end
 
@@ -21,7 +21,7 @@ class DiagnosticsTest < Minitest::Test
       def foo
     RUBY
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(document).run)
+    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(document).response)
 
     assert_equal(2, diagnostics.length)
     assert_equal("expected an `end` to close the `def` statement", T.must(diagnostics.last).message)

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -9,7 +9,7 @@ class FormattingExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run&.first&.new_text
+    RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").response&.first&.new_text
   end
 
   def assert_expectations(source, expected)

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -36,7 +36,7 @@ class FormattingTest < Minitest::Test
 
   def test_does_not_format_with_formatter_is_none
     document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "none").run)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "none").response)
   end
 
   def test_syntax_tree_formatting_uses_options_from_streerc
@@ -72,7 +72,7 @@ class FormattingTest < Minitest::Test
   def test_syntax_tree_formatting_ignores_syntax_invalid_documents
     require "ruby_lsp/requests"
     document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "syntax_tree").run)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "syntax_tree").response)
   end
 
   def test_syntax_tree_formatting_returns_nil_if_file_matches_ignore_files_options_from_streerc
@@ -93,7 +93,7 @@ class FormattingTest < Minitest::Test
 
   def test_rubocop_formatting_ignores_syntax_invalid_documents
     document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").response)
   end
 
   def test_returns_nil_if_document_is_already_formatted
@@ -106,7 +106,7 @@ class FormattingTest < Minitest::Test
         end
       end
     RUBY
-    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").run)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").response)
   end
 
   def test_allows_specifying_formatter
@@ -150,7 +150,7 @@ class FormattingTest < Minitest::Test
 
   def formatted_document(formatter)
     require "ruby_lsp/requests"
-    RubyLsp::Requests::Formatting.new(@document, formatter: formatter).run&.first&.new_text
+    RubyLsp::Requests::Formatting.new(@document, formatter: formatter).response&.first&.new_text
   end
 
   def with_syntax_tree_config_file(contents)

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -16,7 +16,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
@@ -46,7 +46,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 11 }, "{").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 11 }, "{").response
     expected_edits = [
       {
         range: { start: { line: 0, character: 11 }, end: { line: 0, character: 11 } },
@@ -72,7 +72,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 12 }, "|").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 12 }, "|").response
     expected_edits = [
       {
         range: { start: { line: 0, character: 12 }, end: { line: 0, character: 12 } },
@@ -98,7 +98,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "|").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "|").response
     assert_empty(T.must(edits))
   end
 
@@ -121,7 +121,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 3,
     )
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 12 }, "|").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 12 }, "|").response
     expected_edits = [
       {
         range: { start: { line: 0, character: 12 }, end: { line: 0, character: 12 } },
@@ -144,7 +144,7 @@ class OnTypeFormattingTest < Minitest::Test
       version: 3,
     )
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 13 }, "|").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 13 }, "|").response
     expected_edits = [
       {
         range: { start: { line: 0, character: 13 }, end: { line: 0, character: 14 } },
@@ -177,7 +177,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 3,
     )
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 17 }, "|").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 17 }, "|").response
     expected_edits = [
       {
         range: { start: { line: 0, character: 17 }, end: { line: 0, character: 18 } },
@@ -203,7 +203,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 0, character: 14 }, end: { line: 0, character: 14 } },
@@ -225,7 +225,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 5 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 5 }, "\n").response
     assert_empty(edits)
   end
 
@@ -243,7 +243,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 0, character: 14 }, end: { line: 0, character: 14 } },
@@ -268,7 +268,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 7 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 7 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 0, character: 7 }, end: { line: 0, character: 7 } },
@@ -290,7 +290,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
@@ -321,7 +321,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "\n").response
     assert_empty(edits)
   end
 
@@ -337,7 +337,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
@@ -354,7 +354,7 @@ class OnTypeFormattingTest < Minitest::Test
 
   def test_auto_indent_after_end_keyword
     document = RubyLsp::RubyDocument.new(source: +"if foo\nbar\nend", version: 1, uri: URI("file:///fake.rb"))
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 2, character: 2 }, "d").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 2, character: 2 }, "d").response
 
     expected_edits = [
       {
@@ -372,13 +372,13 @@ class OnTypeFormattingTest < Minitest::Test
 
   def test_breaking_line_if_a_keyword_is_part_of_method_call
     document = RubyLsp::RubyDocument.new(source: +"  force({", version: 1, uri: URI("file:///fake.rb"))
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
     assert_empty(edits)
   end
 
   def test_breaking_line_if_a_keyword_in_a_subexpression
     document = RubyLsp::RubyDocument.new(source: +"  var = (if", version: 1, uri: URI("file:///fake.rb"))
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
@@ -408,7 +408,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
@@ -429,7 +429,7 @@ class OnTypeFormattingTest < Minitest::Test
   def test_completing_end_token_inside_parameters
     document = RubyLsp::RubyDocument.new(source: +"foo(proc do\n)", version: 1, uri: URI("file:///fake.rb"))
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
@@ -450,7 +450,7 @@ class OnTypeFormattingTest < Minitest::Test
   def test_completing_end_token_inside_brackets
     document = RubyLsp::RubyDocument.new(source: +"foo[proc do\n]", version: 1, uri: URI("file:///fake.rb"))
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").run
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").response
     expected_edits = [
       {
         range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },

--- a/test/requests/selection_ranges_expectations_test.rb
+++ b/test/requests/selection_ranges_expectations_test.rb
@@ -9,7 +9,7 @@ class SelectionRangesExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
-    actual = RubyLsp::Requests::SelectionRanges.new(document).run
+    actual = RubyLsp::Requests::SelectionRanges.new(document).response
     params = @__params&.any? ? @__params : default_args
 
     filtered = params.map { |position| actual.find { |range| range.cover?(position) } }

--- a/test/requests/workspace_symbol_test.rb
+++ b/test/requests/workspace_symbol_test.rb
@@ -17,15 +17,15 @@ class WorkspaceSymbolTest < Minitest::Test
       CONSTANT = 1
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo", @index).response.first
     assert_equal("Foo", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Bar", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Bar", @index).response.first
     assert_equal("Bar", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::NAMESPACE, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("CONST", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("CONST", @index).response.first
     assert_equal("CONSTANT", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CONSTANT, T.must(result).kind)
   end
@@ -38,15 +38,15 @@ class WorkspaceSymbolTest < Minitest::Test
       CONSTANT = 1
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Floo", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Floo", @index).response.first
     assert_equal("Foo", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Bear", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Bear", @index).response.first
     assert_equal("Bar", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::NAMESPACE, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("CONF", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("CONF", @index).response.first
     assert_equal("CONSTANT", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CONSTANT, T.must(result).kind)
   end
@@ -65,7 +65,7 @@ class WorkspaceSymbolTest < Minitest::Test
       class Foo; end
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo", @index).run
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo", @index).response
     assert_equal(1, result.length)
     assert_equal(URI::Generic.from_path(path: path).to_s, T.must(result.first).location.uri)
   end
@@ -77,7 +77,7 @@ class WorkspaceSymbolTest < Minitest::Test
       end
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo::Bar", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo::Bar", @index).response.first
     assert_equal("Foo::Bar", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
     assert_equal("Foo", T.must(result).container_name)
@@ -86,7 +86,7 @@ class WorkspaceSymbolTest < Minitest::Test
   def test_finds_default_gem_symbols
     @index.index_single(RubyIndexer::IndexablePath.new(nil, "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb"))
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Pathname", @index).run
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Pathname", @index).response
     refute_empty(result)
   end
 
@@ -98,7 +98,7 @@ class WorkspaceSymbolTest < Minitest::Test
       end
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo::CONSTANT", @index).run
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo::CONSTANT", @index).response
     assert_equal(1, result.length)
     assert_equal("Foo", T.must(result.first).name)
   end
@@ -113,15 +113,15 @@ class WorkspaceSymbolTest < Minitest::Test
       end
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("bar", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("bar", @index).response.first
     assert_equal("bar", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::METHOD, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("initialize", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("initialize", @index).response.first
     assert_equal("initialize", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CONSTRUCTOR, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("baz", @index).run.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("baz", @index).response.first
     assert_equal("baz", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::PROPERTY, T.must(result).kind)
   end


### PR DESCRIPTION
### Motivation

Instead of having some request classes implementing `run` method as interface, and other listener-based classes implementing `response` instead, we should standardise the interface to just `response`.

Since I made a similar change in #1247 as well, merging this first will also make it easier to review.

### Implementation

We can enforce the interface by making all request classes to inherit an abstract `Request` class.

Note: after doing a major refactor in #1247, the only commonality shared between all request classes is that they all implement a method to return the result. I don't think there's more that we could put into the `Request` class atm.

### Automated Tests

All existing tests should pass.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
