### PR TITLE
Fix signature help for clients that don't support the context param

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -247,11 +247,11 @@ module RubyLsp
       params(
         uri: URI::Generic,
         position: T::Hash[Symbol, T.untyped],
-        context: T::Hash[Symbol, T.untyped],
+        context: T.nilable(T::Hash[Symbol, T.untyped]),
       ).returns(T.any(T.nilable(Interface::SignatureHelp), T::Hash[Symbol, T.untyped]))
     end
     def signature_help(uri, position, context)
-      current_signature = context[:activeSignatureHelp]
+      current_signature = context && context[:activeSignatureHelp]
       document = @store.get(uri)
       target, parent, nesting = document.locate_node(
         { line: position[:line], character: position[:character] - 2 },
@@ -270,7 +270,7 @@ module RubyLsp
       end
 
       dispatcher = Prism::Dispatcher.new
-      listener = Requests::SignatureHelp.new(context, nesting, @index, dispatcher)
+      listener = Requests::SignatureHelp.new(nesting, @index, dispatcher)
       dispatcher.dispatch_once(target)
       listener.response
     end

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -33,14 +33,12 @@ module RubyLsp
 
       sig do
         params(
-          context: T::Hash[Symbol, T.untyped],
           nesting: T::Array[String],
           index: RubyIndexer::Index,
           dispatcher: Prism::Dispatcher,
         ).void
       end
-      def initialize(context, nesting, index, dispatcher)
-        @context = context
+      def initialize(nesting, index, dispatcher)
         @nesting = nesting
         @index = index
         @_response = T.let(nil, ResponseType)


### PR DESCRIPTION
### Motivation

Closes #1284

Some clients don't support the `context` parameter and we were considering it never to be missing. We should test its presence so that we can avoid issues.

### Implementation

Started testing if `context` is available. I also noticed that we were passing `context` as an argument to the `SignatureHelp` request, but it was not used for anything, so I removed it. We can always add it back if needed.

### Automated Tests

Added a test to ensure we don't regress for clients that don't support context.