### PR TITLE
replaced occurrences of node.slice with node.full_name

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -44,6 +44,8 @@ module RubyLsp
         return if DependencyDetector.instance.typechecker
 
         name = constant_name(node)
+        return if name.nil?
+
         candidates = @index.prefix_search(name, @nesting)
         candidates.each do |entries|
           complete_name = T.must(entries.first).name
@@ -63,6 +65,7 @@ module RubyLsp
         return if DependencyDetector.instance.typechecker
 
         name = constant_name(node)
+        return if name.nil?
 
         top_level_reference = if name.start_with?("::")
           name = name.delete_prefix("::")

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -43,7 +43,7 @@ module RubyLsp
       def on_constant_read_node_enter(node)
         return if DependencyDetector.instance.typechecker
 
-        name = node.slice
+        name = constant_name(node)
         candidates = @index.prefix_search(name, @nesting)
         candidates.each do |entries|
           complete_name = T.must(entries.first).name
@@ -62,7 +62,7 @@ module RubyLsp
       def on_constant_path_node_enter(node)
         return if DependencyDetector.instance.typechecker
 
-        name = node.slice
+        name = constant_name(node)
 
         top_level_reference = if name.start_with?("::")
           name = name.delete_prefix("::")

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -45,12 +45,18 @@ module RubyLsp
 
       sig { params(node: Prism::ConstantPathNode).void }
       def on_constant_path_node_enter(node)
-        find_in_index(constant_name(node))
+        name = constant_name(node)
+        return if name.nil?
+
+        find_in_index(name)
       end
 
       sig { params(node: Prism::ConstantReadNode).void }
       def on_constant_read_node_enter(node)
-        find_in_index(constant_name(node))
+        name = constant_name(node)
+        return if name.nil?
+
+        find_in_index(name)
       end
 
       private

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -45,12 +45,12 @@ module RubyLsp
 
       sig { params(node: Prism::ConstantPathNode).void }
       def on_constant_path_node_enter(node)
-        find_in_index(node.slice)
+        find_in_index(constant_name(node))
       end
 
       sig { params(node: Prism::ConstantReadNode).void }
       def on_constant_read_node_enter(node)
-        find_in_index(node.slice)
+        find_in_index(constant_name(node))
       end
 
       private

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -55,7 +55,10 @@ module RubyLsp
       def on_constant_read_node_enter(node)
         return if @typechecker_enabled
 
-        generate_hover(constant_name(node), node.location)
+        name = constant_name(node)
+        return if name.nil?
+
+        generate_hover(name, node.location)
       end
 
       sig { params(node: Prism::ConstantWriteNode).void }
@@ -69,7 +72,10 @@ module RubyLsp
       def on_constant_path_node_enter(node)
         return if DependencyDetector.instance.typechecker
 
-        generate_hover(constant_name(node), node.location)
+        name = constant_name(node)
+        return if name.nil?
+
+        generate_hover(name, node.location)
       end
 
       sig { params(node: Prism::CallNode).void }

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -55,7 +55,7 @@ module RubyLsp
       def on_constant_read_node_enter(node)
         return if @typechecker_enabled
 
-        generate_hover(node.slice, node.location)
+        generate_hover(constant_name(node), node.location)
       end
 
       sig { params(node: Prism::ConstantWriteNode).void }
@@ -69,7 +69,7 @@ module RubyLsp
       def on_constant_path_node_enter(node)
         return if DependencyDetector.instance.typechecker
 
-        generate_hover(node.slice, node.location)
+        generate_hover(constant_name(node), node.location)
       end
 
       sig { params(node: Prism::CallNode).void }

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -117,7 +117,15 @@ module RubyLsp
           MARKDOWN
         end
 
-        sig { params(node: Prism::Node).returns(T.nilable(String)) }
+        sig do
+          params(
+            node: T.any(
+              Prism::ConstantPathNode,
+              Prism::ConstantReadNode,
+              Prism::ConstantPathTargetNode,
+            ),
+          ).returns(T.nilable(String))
+        end
         def constant_name(node)
           node.full_name
         rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -116,6 +116,13 @@ module RubyLsp
             #{content}
           MARKDOWN
         end
+
+        sig { params(node: Prism::Node).returns(T.nilable(String)) }
+        def constant_name(node)
+          node.full_name
+        rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError
+          nil
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/Shopify/ruby-lsp/issues/1130

replaced occurrences of node.slice with node.full_name
handled `Prism::ConstantPathNode::DynamicPartsInConstantPathError` with `full_name`

previously opened PR reference https://github.com/Shopify/ruby-lsp/pull/1131

was waiting on https://github.com/ruby/prism/pull/1742 to get merged.
