### PR TITLE
Rename defined_in_gem? to not_in_dependencies?

### DIFF
--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -113,7 +113,7 @@ module RubyLsp
 
         location = target_method.location
         file_path = target_method.file_path
-        return if @typechecker_enabled && defined_in_gem?(file_path)
+        return if @typechecker_enabled && not_in_dependencies?(file_path)
 
         @_response = Interface::Location.new(
           uri: URI::Generic.from_path(path: file_path).to_s,
@@ -182,7 +182,7 @@ module RubyLsp
           # additional behavior on top of jumping to RBIs. Sorbet can already handle go to definition for all constants
           # in the project, even if the files are typed false
           file_path = entry.file_path
-          next if DependencyDetector.instance.typechecker && defined_in_gem?(file_path)
+          next if DependencyDetector.instance.typechecker && not_in_dependencies?(file_path)
 
           Interface::Location.new(
             uri: URI::Generic.from_path(path: file_path).to_s,

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -70,7 +70,7 @@ module RubyLsp
         end
 
         sig { params(file_path: String).returns(T.nilable(T::Boolean)) }
-        def defined_in_gem?(file_path)
+        def not_in_dependencies?(file_path)
           BUNDLE_PATH &&
             !file_path.start_with?(T.must(BUNDLE_PATH)) &&
             !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -34,7 +34,7 @@ module RubyLsp
           # If the project is using Sorbet, we let Sorbet handle symbols defined inside the project itself and RBIs, but
           # we still return entries defined in gems to allow developers to jump directly to the source
           file_path = entry.file_path
-          next if DependencyDetector.instance.typechecker && defined_in_gem?(file_path)
+          next if DependencyDetector.instance.typechecker && not_in_dependencies?(file_path)
 
           # We should never show private symbols when searching the entire workspace
           next if entry.visibility == :private


### PR DESCRIPTION
### Motivation


I noticed that this method's name was actually mentioning the opposite of its implementation. The method checks if a file path is not in dependencies.