### PR TITLE
Remove Gemfile.lock for Ruby head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: "recursive"
-
+      - if: ${{ matrix.ruby == 'head' }}
+        run: "rm ${{ matrix.gemfile }}.lock"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This will prevent failures such as:

```
nokogiri-1.16.0-x86_64-darwin requires ruby version < 3.4.dev, >= 3.0, which is
incompatible with the current version, 3.4.0.dev
```