### PR TITLE
Show method parameters as completion details

### DIFF
--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -178,6 +178,7 @@ module RubyLsp
           text_edit: Interface::TextEdit.new(range: range_from_node(node), new_text: name),
           kind: Constant::CompletionItemKind::METHOD,
           label_details: Interface::CompletionItemLabelDetails.new(
+            detail: "(#{entry.parameters.map(&:decorated_name).join(", ")})",
             description: entry.file_name,
           ),
           documentation: markdown_from_index_entries(name, entry),

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -494,6 +494,7 @@ class CompletionTest < Minitest::Test
     assert_equal(["bar", "baz"], result.map(&:label))
     assert_equal(["bar", "baz"], result.map(&:filter_text))
     assert_equal(["bar", "baz"], result.map { |completion| completion.text_edit.new_text })
+    assert_equal(["(a, b)", "(c, d)"], result.map { |completion| completion.label_details.detail })
   end
 
   def test_completion_for_methods_named_with_uppercase_characters


### PR DESCRIPTION
### Motivation

We weren't showing method parameters as part of completion label details. I think it's nice to add them, so that you can see more of the signature as you're selecting items.

This is what it looks like. The addition is only the parameters within the parenthesis.

<img width="941" alt="image" src="https://github.com/Shopify/ruby-lsp/assets/18742907/91ef3d14-5dc2-4b2b-92b2-cb09ce1ada77">

### Implementation

Added the missing value using the parameter for the entry we're completing.

### Automated Tests

Added a test to verify we're presenting this.