### PR TITLE
Enable bypassTypechcker by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,10 @@
   // Set this value to `verbose` to see the full JSON content of LSP requests and responses
   "ruby lsp.trace.server": "off",
   "[ruby]": {
-    "editor.defaultFormatter": "Shopify.ruby-lsp",
+    "editor.defaultFormatter": "Shopify.ruby-lsp"
   },
+  // So features like completion can still be displayed with Sorbet in the dependencies
+  "rubyLsp.bypassTypechecker": true,
   "search.exclude": {
     "**/test/fixtures/prism": true
   },
@@ -11,30 +13,20 @@
     {
       "languageId": "*",
       "locale": "en",
-      "dictionaries": [
-        "wordsEn"
-      ]
+      "dictionaries": ["wordsEn"]
     },
     {
       "languageId": "*",
       "locale": "en-US",
-      "dictionaries": [
-        "wordsEn"
-      ]
+      "dictionaries": ["wordsEn"]
     },
     {
       "languageId": "*",
-      "dictionaries": [
-        "companies",
-        "softwareTerms",
-        "misc"
-      ]
+      "dictionaries": ["companies", "softwareTerms", "misc"]
     },
     {
       "languageId": "ruby",
-      "dictionaries": [
-        "ruby"
-      ]
-    },
+      "dictionaries": ["ruby"]
+    }
   ]
 }


### PR DESCRIPTION
Because this project has Sorbet as a dependency, this setting is required for testing features like completion. And instead of asking every contributor to manually turn it on before testing, which could easily be missed, we can just turn it on by default.