### PR TITLE
Rename Request#response to Request#perform

### DIFF
--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -42,7 +42,7 @@ module RubyLsp
       end
 
       sig { override.returns(T.any(Interface::CodeAction, Error)) }
-      def response
+      def perform
         return Error::EmptySelection if @document.source.empty?
 
         source_range = @code_action.dig(:data, :range)

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -44,7 +44,7 @@ module RubyLsp
       end
 
       sig { override.returns(T.nilable(T.all(T::Array[Interface::CodeAction], Object))) }
-      def response
+      def perform
         diagnostics = @context[:diagnostics]
 
         code_actions = diagnostics.flat_map do |diagnostic|

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -60,7 +60,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         @listeners.flat_map(&:response)
       end
     end

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -100,7 +100,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         return [] unless @target
 
         @dispatcher.dispatch_once(@target)

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -62,7 +62,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         @dispatcher.dispatch_once(@target)
         result = []
 

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -41,7 +41,7 @@ module RubyLsp
       end
 
       sig { override.returns(T.nilable(T.all(T::Array[Interface::Diagnostic], Object))) }
-      def response
+      def perform
         # Running RuboCop is slow, so to avoid excessive runs we only do so if the file is syntactically valid
         return syntax_error_diagnostics if @document.syntax_error?
         return [] unless defined?(Support::RuboCopDiagnosticsRunner)

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -43,7 +43,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         @listener.response
       end
     end

--- a/lib/ruby_lsp/requests/document_link.rb
+++ b/lib/ruby_lsp/requests/document_link.rb
@@ -46,7 +46,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         @listener.response
       end
     end

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -63,7 +63,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         @listeners.flat_map(&:response).compact
       end
     end

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -39,7 +39,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         @listener.response
       end
     end

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -62,7 +62,7 @@ module RubyLsp
       end
 
       sig { override.returns(T.nilable(T.all(T::Array[Interface::TextEdit], Object))) }
-      def response
+      def perform
         return if @formatter == "none"
         return if @document.syntax_error?
 

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -72,7 +72,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         @dispatcher.dispatch_once(@target)
         responses = @listeners.map(&:response).compact
 

--- a/lib/ruby_lsp/requests/inlay_hints.rb
+++ b/lib/ruby_lsp/requests/inlay_hints.rb
@@ -72,7 +72,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         @listener.response
       end
     end

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -53,7 +53,7 @@ module RubyLsp
       end
 
       sig { override.returns(T.all(T::Array[Interface::TextEdit], Object)) }
-      def response
+      def perform
         case @trigger_character
         when "{"
           handle_curly_brace if @document.syntax_error?

--- a/lib/ruby_lsp/requests/request.rb
+++ b/lib/ruby_lsp/requests/request.rb
@@ -11,7 +11,7 @@ module RubyLsp
       abstract!
 
       sig { abstract.returns(T.anything) }
-      def response; end
+      def perform; end
     end
   end
 end

--- a/lib/ruby_lsp/requests/selection_ranges.rb
+++ b/lib/ruby_lsp/requests/selection_ranges.rb
@@ -32,7 +32,7 @@ module RubyLsp
       end
 
       sig { override.returns(T.all(T::Array[Support::SelectionRange], Object)) }
-      def response
+      def perform
         # [node, parent]
         queue = [[@document.tree, nil]]
 

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -50,7 +50,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         @listener.response
       end
     end

--- a/lib/ruby_lsp/requests/show_syntax_tree.rb
+++ b/lib/ruby_lsp/requests/show_syntax_tree.rb
@@ -28,7 +28,7 @@ module RubyLsp
       end
 
       sig { override.returns(String) }
-      def response
+      def perform
         return ast_for_range if @range
 
         output_string = +""

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -76,7 +76,7 @@ module RubyLsp
       end
 
       sig { override.returns(ResponseType) }
-      def response
+      def perform
         return unless @target
 
         @dispatcher.dispatch_once(@target)

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -30,7 +30,7 @@ module RubyLsp
       end
 
       sig { override.returns(T::Array[Interface::WorkspaceSymbol]) }
-      def response
+      def perform
         @index.fuzzy_search(@query).filter_map do |entry|
           # If the project is using Sorbet, we let Sorbet handle symbols defined inside the project itself and RBIs, but
           # we still return entries defined in gems to allow developers to jump directly to the source

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -15,9 +15,9 @@ class ExpectationsTestRunner < Minitest::Test
             params = @__params&.any? ? @__params : default_args
             document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
             dispatcher = Prism::Dispatcher.new
-            listener = #{handler_class}.new(dispatcher)
+            request = #{handler_class}.new(dispatcher)
             dispatcher.dispatch(document.tree)
-            listener.response
+            request.perform
           end
 
           def assert_expectations(source, expected)

--- a/test/requests/code_action_resolve_expectations_test.rb
+++ b/test/requests/code_action_resolve_expectations_test.rb
@@ -11,7 +11,7 @@ class CodeActionResolveExpectationsTest < ExpectationsTestRunner
     params = @__params&.any? ? @__params : default_args
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
 
-    RubyLsp::Requests::CodeActionResolve.new(document, params).response
+    RubyLsp::Requests::CodeActionResolve.new(document, params).perform
   end
 
   def assert_expectations(source, expected)

--- a/test/requests/code_actions_expectations_test.rb
+++ b/test/requests/code_actions_expectations_test.rb
@@ -17,7 +17,7 @@ class CodeActionsExpectationsTest < ExpectationsTestRunner
         document,
         params[:range],
         params[:context],
-      ).response
+      ).perform
     end
 
     assert_empty(stdout)

--- a/test/requests/code_actions_formatting_test.rb
+++ b/test/requests/code_actions_formatting_test.rb
@@ -75,12 +75,12 @@ class CodeActionsFormattingTest < Minitest::Test
       encoding: LanguageServer::Protocol::Constant::PositionEncodingKind::UTF16,
     )
 
-    diagnostics = RubyLsp::Requests::Diagnostics.new(document).response
+    diagnostics = RubyLsp::Requests::Diagnostics.new(document).perform
     diagnostic = T.must(T.must(diagnostics).find { |d| d.code == diagnostic_code })
     range = diagnostic.range.to_hash.transform_values(&:to_hash)
     result = RubyLsp::Requests::CodeActions.new(document, range, {
       diagnostics: [JSON.parse(T.must(diagnostic).to_json, symbolize_names: true)],
-    }).response
+    }).perform
 
     # CodeActions#run returns Array<CodeAction, Hash>. We're interested in the
     # hashes here, so cast to untyped and only look at those.

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -15,7 +15,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     stub_test_library("minitest")
     listener = RubyLsp::Requests::CodeLens.new(uri, default_lenses_configuration, dispatcher)
     dispatcher.dispatch(document.tree)
-    listener.response
+    listener.perform
   end
 
   def test_command_generation_for_test_unit
@@ -32,7 +32,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::CodeLens.new(uri, default_lenses_configuration, dispatcher)
     dispatcher.dispatch(document.tree)
-    response = listener.response
+    response = listener.perform
 
     assert_equal(6, response.size)
 
@@ -59,7 +59,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     stub_test_library("unknown")
     listener = RubyLsp::Requests::CodeLens.new(uri, default_lenses_configuration, dispatcher)
     dispatcher.dispatch(document.tree)
-    response = listener.response
+    response = listener.perform
 
     assert_empty(response)
   end
@@ -78,7 +78,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     stub_test_library("rspec")
     listener = RubyLsp::Requests::CodeLens.new(uri, default_lenses_configuration, dispatcher)
     dispatcher.dispatch(document.tree)
-    response = listener.response
+    response = listener.perform
 
     assert_empty(response)
   end
@@ -97,7 +97,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     stub_test_library("minitest")
     listener = RubyLsp::Requests::CodeLens.new(uri, default_lenses_configuration, dispatcher)
     dispatcher.dispatch(document.tree)
-    response = listener.response
+    response = listener.perform
 
     assert_empty(response)
   end
@@ -112,7 +112,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     lenses_configuration = RubyLsp::RequestConfig.new({ gemfileLinks: false })
     listener = RubyLsp::Requests::CodeLens.new(uri, lenses_configuration, dispatcher)
     dispatcher.dispatch(document.tree)
-    response = listener.response
+    response = listener.perform
     assert_empty(response)
   end
 

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -9,12 +9,12 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    RubyLsp::Requests::Diagnostics.new(document).response
+    RubyLsp::Requests::Diagnostics.new(document).perform
     result = T.let(nil, T.nilable(T::Array[RubyLsp::Interface::Diagnostic]))
 
     stdout, _ = capture_io do
       result = T.cast(
-        RubyLsp::Requests::Diagnostics.new(document).response,
+        RubyLsp::Requests::Diagnostics.new(document).perform,
         T::Array[RubyLsp::Interface::Diagnostic],
       )
     end

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -12,7 +12,7 @@ class DiagnosticsTest < Minitest::Test
       uri: URI::Generic.from_path(path: fixture_path),
     )
 
-    result = RubyLsp::Requests::Diagnostics.new(document).response
+    result = RubyLsp::Requests::Diagnostics.new(document).perform
     assert_empty(result)
   end
 
@@ -21,7 +21,7 @@ class DiagnosticsTest < Minitest::Test
       def foo
     RUBY
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(document).response)
+    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(document).perform)
 
     assert_equal(2, diagnostics.length)
     assert_equal("expected an `end` to close the `def` statement", T.must(diagnostics.last).message)
@@ -39,7 +39,7 @@ class DiagnosticsTest < Minitest::Test
     klass = RubyLsp::Requests::Support::RuboCopDiagnosticsRunner
     RubyLsp::Requests::Support.send(:remove_const, :RuboCopDiagnosticsRunner)
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(document).response)
+    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(document).perform)
 
     assert_empty(diagnostics)
   ensure
@@ -54,7 +54,7 @@ class DiagnosticsTest < Minitest::Test
       end
     RUBY
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(document).response)
+    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(document).perform)
 
     refute_empty(diagnostics)
   end

--- a/test/requests/document_highlight_expectations_test.rb
+++ b/test/requests/document_highlight_expectations_test.rb
@@ -15,7 +15,7 @@ class DocumentHighlightExpectationsTest < ExpectationsTestRunner
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::DocumentHighlight.new(document, params.first, dispatcher)
     dispatcher.dispatch(document.tree)
-    listener.response
+    listener.perform
   end
 
   def default_args

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -27,7 +27,7 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::DocumentLink.new(uri, document.comments, dispatcher)
     dispatcher.dispatch(document.tree)
-    listener.response
+    listener.perform
   end
 
   private

--- a/test/requests/folding_ranges_expectations_test.rb
+++ b/test/requests/folding_ranges_expectations_test.rb
@@ -14,6 +14,6 @@ class FoldingRangesExpectationsTest < ExpectationsTestRunner
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::FoldingRanges.new(document.parse_result.comments, dispatcher)
     dispatcher.dispatch(document.tree)
-    listener.response
+    listener.perform
   end
 end

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -9,7 +9,7 @@ class FormattingExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").response&.first&.new_text
+    RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").perform&.first&.new_text
   end
 
   def assert_expectations(source, expected)

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -36,7 +36,7 @@ class FormattingTest < Minitest::Test
 
   def test_does_not_format_with_formatter_is_none
     document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "none").response)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "none").perform)
   end
 
   def test_syntax_tree_formatting_uses_options_from_streerc
@@ -72,7 +72,7 @@ class FormattingTest < Minitest::Test
   def test_syntax_tree_formatting_ignores_syntax_invalid_documents
     require "ruby_lsp/requests"
     document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "syntax_tree").response)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "syntax_tree").perform)
   end
 
   def test_syntax_tree_formatting_returns_nil_if_file_matches_ignore_files_options_from_streerc
@@ -93,7 +93,7 @@ class FormattingTest < Minitest::Test
 
   def test_rubocop_formatting_ignores_syntax_invalid_documents
     document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").response)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").perform)
   end
 
   def test_returns_nil_if_document_is_already_formatted
@@ -106,7 +106,7 @@ class FormattingTest < Minitest::Test
         end
       end
     RUBY
-    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").response)
+    assert_nil(RubyLsp::Requests::Formatting.new(document, formatter: "rubocop").perform)
   end
 
   def test_allows_specifying_formatter
@@ -150,7 +150,7 @@ class FormattingTest < Minitest::Test
 
   def formatted_document(formatter)
     require "ruby_lsp/requests"
-    RubyLsp::Requests::Formatting.new(@document, formatter: formatter).response&.first&.new_text
+    RubyLsp::Requests::Formatting.new(@document, formatter: formatter).perform&.first&.new_text
   end
 
   def with_syntax_tree_config_file(contents)

--- a/test/requests/inlay_hints_expectations_test.rb
+++ b/test/requests/inlay_hints_expectations_test.rb
@@ -16,7 +16,7 @@ class InlayHintsExpectationsTest < ExpectationsTestRunner
     hints_configuration = RubyLsp::RequestConfig.new({ implicitRescue: true, implicitHashValue: true })
     request = RubyLsp::Requests::InlayHints.new(document, params.first, hints_configuration, dispatcher)
     dispatcher.dispatch(document.tree)
-    request.response
+    request.perform
   end
 
   def default_args
@@ -33,7 +33,7 @@ class InlayHintsExpectationsTest < ExpectationsTestRunner
     hints_configuration = RubyLsp::RequestConfig.new({ implicitRescue: true, implicitHashValue: false })
     request = RubyLsp::Requests::InlayHints.new(document, default_args.first, hints_configuration, dispatcher)
     dispatcher.dispatch(document.tree)
-    request.response
+    request.perform
   end
 
   def test_skip_implicit_rescue
@@ -48,6 +48,6 @@ class InlayHintsExpectationsTest < ExpectationsTestRunner
     hints_configuration = RubyLsp::RequestConfig.new({ implicitRescue: false, implicitHashValue: true })
     request = RubyLsp::Requests::InlayHints.new(document, default_args.first, hints_configuration, dispatcher)
     dispatcher.dispatch(document.tree)
-    assert_empty(request.response)
+    assert_empty(request.perform)
   end
 end

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -16,7 +16,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
@@ -46,7 +46,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 11 }, "{").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 11 }, "{").perform
     expected_edits = [
       {
         range: { start: { line: 0, character: 11 }, end: { line: 0, character: 11 } },
@@ -72,7 +72,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 12 }, "|").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 12 }, "|").perform
     expected_edits = [
       {
         range: { start: { line: 0, character: 12 }, end: { line: 0, character: 12 } },
@@ -98,7 +98,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "|").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "|").perform
     assert_empty(T.must(edits))
   end
 
@@ -121,7 +121,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 3,
     )
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 12 }, "|").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 12 }, "|").perform
     expected_edits = [
       {
         range: { start: { line: 0, character: 12 }, end: { line: 0, character: 12 } },
@@ -144,7 +144,7 @@ class OnTypeFormattingTest < Minitest::Test
       version: 3,
     )
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 13 }, "|").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 13 }, "|").perform
     expected_edits = [
       {
         range: { start: { line: 0, character: 13 }, end: { line: 0, character: 14 } },
@@ -177,7 +177,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 3,
     )
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 17 }, "|").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 17 }, "|").perform
     expected_edits = [
       {
         range: { start: { line: 0, character: 17 }, end: { line: 0, character: 18 } },
@@ -203,7 +203,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 0, character: 14 }, end: { line: 0, character: 14 } },
@@ -225,7 +225,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 5 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 5 }, "\n").perform
     assert_empty(edits)
   end
 
@@ -243,7 +243,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 14 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 0, character: 14 }, end: { line: 0, character: 14 } },
@@ -268,7 +268,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 7 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 7 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 0, character: 7 }, end: { line: 0, character: 7 } },
@@ -290,7 +290,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
@@ -321,7 +321,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 0, character: 2 }, "\n").perform
     assert_empty(edits)
   end
 
@@ -337,7 +337,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
@@ -354,7 +354,7 @@ class OnTypeFormattingTest < Minitest::Test
 
   def test_auto_indent_after_end_keyword
     document = RubyLsp::RubyDocument.new(source: +"if foo\nbar\nend", version: 1, uri: URI("file:///fake.rb"))
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 2, character: 2 }, "d").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 2, character: 2 }, "d").perform
 
     expected_edits = [
       {
@@ -372,13 +372,13 @@ class OnTypeFormattingTest < Minitest::Test
 
   def test_breaking_line_if_a_keyword_is_part_of_method_call
     document = RubyLsp::RubyDocument.new(source: +"  force({", version: 1, uri: URI("file:///fake.rb"))
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").perform
     assert_empty(edits)
   end
 
   def test_breaking_line_if_a_keyword_in_a_subexpression
     document = RubyLsp::RubyDocument.new(source: +"  var = (if", version: 1, uri: URI("file:///fake.rb"))
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
@@ -408,7 +408,7 @@ class OnTypeFormattingTest < Minitest::Test
     )
     document.parse
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 2 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
@@ -429,7 +429,7 @@ class OnTypeFormattingTest < Minitest::Test
   def test_completing_end_token_inside_parameters
     document = RubyLsp::RubyDocument.new(source: +"foo(proc do\n)", version: 1, uri: URI("file:///fake.rb"))
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
@@ -450,7 +450,7 @@ class OnTypeFormattingTest < Minitest::Test
   def test_completing_end_token_inside_brackets
     document = RubyLsp::RubyDocument.new(source: +"foo[proc do\n]", version: 1, uri: URI("file:///fake.rb"))
 
-    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").response
+    edits = RubyLsp::Requests::OnTypeFormatting.new(document, { line: 1, character: 0 }, "\n").perform
     expected_edits = [
       {
         range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },

--- a/test/requests/selection_ranges_expectations_test.rb
+++ b/test/requests/selection_ranges_expectations_test.rb
@@ -9,7 +9,7 @@ class SelectionRangesExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
-    actual = RubyLsp::Requests::SelectionRanges.new(document).response
+    actual = RubyLsp::Requests::SelectionRanges.new(document).perform
     params = @__params&.any? ? @__params : default_args
 
     filtered = params.map { |position| actual.find { |range| range.cover?(position) } }

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -21,7 +21,7 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
     listener = RubyLsp::Requests::SemanticHighlighting.new(dispatcher, range: processed_range)
 
     dispatcher.dispatch(document.tree)
-    RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode(listener.response)
+    RubyLsp::Requests::Support::SemanticTokenEncoder.new.encode(listener.perform)
   end
 
   def assert_expectations(source, expected)

--- a/test/requests/workspace_symbol_test.rb
+++ b/test/requests/workspace_symbol_test.rb
@@ -17,15 +17,15 @@ class WorkspaceSymbolTest < Minitest::Test
       CONSTANT = 1
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo", @index).perform.first
     assert_equal("Foo", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Bar", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Bar", @index).perform.first
     assert_equal("Bar", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::NAMESPACE, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("CONST", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("CONST", @index).perform.first
     assert_equal("CONSTANT", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CONSTANT, T.must(result).kind)
   end
@@ -38,15 +38,15 @@ class WorkspaceSymbolTest < Minitest::Test
       CONSTANT = 1
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Floo", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Floo", @index).perform.first
     assert_equal("Foo", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Bear", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Bear", @index).perform.first
     assert_equal("Bar", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::NAMESPACE, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("CONF", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("CONF", @index).perform.first
     assert_equal("CONSTANT", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CONSTANT, T.must(result).kind)
   end
@@ -65,7 +65,7 @@ class WorkspaceSymbolTest < Minitest::Test
       class Foo; end
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo", @index).response
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo", @index).perform
     assert_equal(1, result.length)
     assert_equal(URI::Generic.from_path(path: path).to_s, T.must(result.first).location.uri)
   end
@@ -77,7 +77,7 @@ class WorkspaceSymbolTest < Minitest::Test
       end
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo::Bar", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo::Bar", @index).perform.first
     assert_equal("Foo::Bar", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
     assert_equal("Foo", T.must(result).container_name)
@@ -86,7 +86,7 @@ class WorkspaceSymbolTest < Minitest::Test
   def test_finds_default_gem_symbols
     @index.index_single(RubyIndexer::IndexablePath.new(nil, "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb"))
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Pathname", @index).response
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Pathname", @index).perform
     refute_empty(result)
   end
 
@@ -98,7 +98,7 @@ class WorkspaceSymbolTest < Minitest::Test
       end
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo::CONSTANT", @index).response
+    result = RubyLsp::Requests::WorkspaceSymbol.new("Foo::CONSTANT", @index).perform
     assert_equal(1, result.length)
     assert_equal("Foo", T.must(result.first).name)
   end
@@ -113,15 +113,15 @@ class WorkspaceSymbolTest < Minitest::Test
       end
     RUBY
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("bar", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("bar", @index).perform.first
     assert_equal("bar", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::METHOD, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("initialize", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("initialize", @index).perform.first
     assert_equal("initialize", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::CONSTRUCTOR, T.must(result).kind)
 
-    result = RubyLsp::Requests::WorkspaceSymbol.new("baz", @index).response.first
+    result = RubyLsp::Requests::WorkspaceSymbol.new("baz", @index).perform.first
     assert_equal("baz", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::PROPERTY, T.must(result).kind)
   end


### PR DESCRIPTION
### Motivation

As @vinistock pointed out [here](https://github.com/Shopify/ruby-lsp/pull/1247#discussion_r1447637861), using `#response` seems to imply that the request was already completed before it's called. In ruby-lsp's case, many requests are used in this pattern:

```rb
FooRequest.new(args).response
```

In this context, it feels like the computation is done in `FooRequest#initialize` and `#response` is just a getter, which is a bit misleading.

So this PR renames `#response` to `#perform` to make it more clear.

### Implementation

Renames relevant interfaces and callers.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
