### PR TITLE
Stop testing against Ruby head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
-        include:
-          - ruby: "head"
-            experimental: true
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ !!matrix.experimental }}
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
After talking to the team, including Kevin, it appears that nobody is checking the Ruby head test suite in this repo. So there's no benefit of having it with the cost of always red (tho non-blocking) builds.