### PR TITLE
Require the Sorbet version that started supporting `T.anything`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ruby-lsp (0.13.3)
       language_server-protocol (~> 3.17.0)
       prism (>= 0.19.0, < 0.20)
-      sorbet-runtime (>= 0.5.5685)
+      sorbet-runtime (>= 0.5.10782)
 
 GEM
   remote: https://rubygems.org/

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("language_server-protocol", "~> 3.17.0")
   s.add_dependency("prism", ">= 0.19.0", "< 0.20")
-  s.add_dependency("sorbet-runtime", ">= 0.5.5685")
+  s.add_dependency("sorbet-runtime", ">= 0.5.10782")
 
   s.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
### Motivation

Without this, projects using older Sorbet versions can hit `NoMethodError` when the `T.anything` signature is hit, as shown in #1300.

Closes #1300

### Implementation

Bump the version requirement of `sorbet-runtime` in `gemspec`.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
