### PR TITLE
Fix newline on Gemfile dependency hover response

### DIFF
--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -134,6 +134,7 @@ module RubyLsp
 
         markdown = <<~MARKDOWN
           **#{spec.name}** (#{spec.version})
+
           #{info}
         MARKDOWN
 


### PR DESCRIPTION
### Motivation

https://github.com/Shopify/ruby-lsp/commit/31aa8ef8f38eb802728dc473ef2bb35aed4c3384 stripped a newline from the markdown output when hovering over a dependency in a Gemfile.

Not really opposed to the change in formatting but it does seem like an unintended regression.

Before:
<img width="874" alt="Screenshot 2024-01-12 at 12 15 35 PM" src="https://github.com/Shopify/ruby-lsp/assets/16616777/2452911c-c6d1-4076-b5f9-c9ca355da7cf">

After:
<img width="878" alt="Screenshot 2024-01-12 at 12 15 57 PM" src="https://github.com/Shopify/ruby-lsp/assets/16616777/f1583442-5bbb-4a0a-88d0-ed9d45234062">

### Implementation

Add back the newline.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
