### PR TITLE
Integrate builder pattern to refactor hover responses

### DIFF
--- a/ADDONS.md
+++ b/ADDONS.md
@@ -129,6 +129,7 @@ module RubyLsp
     end
 
     # All listeners have to inherit from ::RubyLsp::Listener
+    # NOTE: Listeners are currently being refactored, but this implementation embodies the current approach for most listeners.
     class Hover < ::RubyLsp::Listener
       extend T::Sig
       extend T::Generic

--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require_relative "response_builder"
+
 module RubyLsp
   # To register an addon, inherit from this class and implement both `name` and `activate`
   #
@@ -118,12 +120,13 @@ module RubyLsp
     # Creates a new Hover listener. This method is invoked on every Hover request
     sig do
       overridable.params(
+        response_builder: RubyLsp::HoverResponseBuilder,
         nesting: T::Array[String],
         index: RubyIndexer::Index,
         dispatcher: Prism::Dispatcher,
       ).returns(T.nilable(Listener[T.nilable(Interface::Hover)]))
     end
-    def create_hover_listener(nesting, index, dispatcher); end
+    def create_hover_listener(response_builder, nesting, index, dispatcher); end
 
     # Creates a new DocumentSymbol listener. This method is invoked on every DocumentSymbol request
     sig do

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "ruby_lsp/listeners/hover"
+require "ruby_lsp/response_builder"
 
 module RubyLsp
   module Requests
@@ -52,19 +53,16 @@ module RubyLsp
           target = parent
         end
 
-        @listeners = T.let([], T::Array[Listener[ResponseType]])
+        @listeners = T.let([], T::Array[Listener[HoverResponseBuilder]])
 
         # Don't need to instantiate any listeners if there's no target
         return unless target
 
         uri = document.uri
-        @listeners = T.let(
-          [Listeners::Hover.new(uri, nesting, index, dispatcher, typechecker_enabled)],
-          T::Array[Listener[ResponseType]],
-        )
+        @response_builder = T.let(HoverResponseBuilder.new, HoverResponseBuilder)
+        Listeners::Hover.new(@response_builder, uri, nesting, index, dispatcher, typechecker_enabled)
         Addon.addons.each do |addon|
-          addon_listener = addon.create_hover_listener(nesting, index, dispatcher)
-          @listeners << addon_listener if addon_listener
+          addon.create_hover_listener(@response_builder, nesting, index, dispatcher)
         end
 
         @target = T.let(target, Prism::Node)
@@ -74,18 +72,15 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       def perform
         @dispatcher.dispatch_once(@target)
-        responses = @listeners.map(&:response).compact
 
-        first_response, *other_responses = responses
+        return if @response_builder.empty?
 
-        return unless first_response
-
-        # TODO: other_responses should never be nil. Check Sorbet
-        T.must(other_responses).each do |other_response|
-          first_response.contents.value << "\n\n" << other_response.contents.value
-        end
-
-        first_response
+        Interface::Hover.new(
+          contents: Interface::MarkupContent.new(
+            kind: "markdown",
+            value: @response_builder.build_concatenated_response,
+          ),
+        )
       end
     end
   end

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -86,7 +86,7 @@ module RubyLsp
           params(
             title: String,
             entries: T.any(T::Array[RubyIndexer::Entry], RubyIndexer::Entry),
-          ).returns(Interface::MarkupContent)
+          ).returns(String)
         end
         def markdown_from_index_entries(title, entries)
           markdown_title = "```ruby\n#{title}\n```"
@@ -108,16 +108,13 @@ module RubyLsp
             content << "\n\n#{entry.comments.join("\n")}" unless entry.comments.empty?
           end
 
-          Interface::MarkupContent.new(
-            kind: "markdown",
-            value: <<~MARKDOWN.chomp,
-              #{markdown_title}
+          <<~MARKDOWN.chomp
+            #{markdown_title}
 
-              **Definitions**: #{definitions.join(" | ")}
+            **Definitions**: #{definitions.join(" | ")}
 
-              #{content}
-            MARKDOWN
-          )
+            #{content}
+          MARKDOWN
         end
       end
     end

--- a/lib/ruby_lsp/response_builder.rb
+++ b/lib/ruby_lsp/response_builder.rb
@@ -1,0 +1,50 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  class OperationNotPermitted < StandardError; end
+
+  class ResponseBuilder
+    extend T::Sig
+    extend T::Generic
+
+    Elem = type_member { { upper: Object } }
+
+    sig { void }
+    def initialize
+      @response = T.let([], T::Array[Elem])
+    end
+
+    sig { params(elem: Elem).void }
+    def <<(elem)
+      @response << elem
+    end
+
+    sig { returns(T.nilable(Elem)) }
+    def pop
+      @response.pop
+    end
+
+    sig { returns(T::Boolean) }
+    def empty?
+      @response.empty?
+    end
+  end
+
+  class HoverResponseBuilder < ResponseBuilder
+    extend T::Sig
+    extend T::Generic
+
+    Elem = type_member { { fixed: String } }
+
+    sig { returns(String) }
+    def build_concatenated_response
+      @response.join("\n\n")
+    end
+
+    sig { override.returns(T.nilable(Elem)) }
+    def pop
+      raise OperationNotPermitted, "Cannot pop from a HoverResponseBuilder"
+    end
+  end
+end

--- a/test/expectations/hover/documented_class.exp.json
+++ b/test/expectations/hover/documented_class.exp.json
@@ -9,16 +9,6 @@
         "contents": {
             "kind": "markdown",
             "value": "```ruby\nBar\n```\n\n**Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4) | [fake.rb](file:///fake.rb#L6,1-7,4)\n\n\n\nThis is the documentation for Bar\n\nThis is more documentation for Bar"
-        },
-        "range": {
-            "start": {
-                "line": 1,
-                "character": 6
-            },
-            "end": {
-                "line": 1,
-                "character": 9
-            }
         }
     }
 }

--- a/test/expectations/hover/documented_constant.exp.json
+++ b/test/expectations/hover/documented_constant.exp.json
@@ -9,16 +9,6 @@
         "contents": {
             "kind": "markdown",
             "value": "```ruby\nBAZ\n```\n\n**Definitions**: [fake.rb](file:///fake.rb#L2,1-2,10)\n\n\n\nThis is the documentation for Baz"
-        },
-        "range": {
-            "start": {
-                "line": 1,
-                "character": 0
-            },
-            "end": {
-                "line": 1,
-                "character": 3
-            }
         }
     }
 }

--- a/test/expectations/hover/documented_module.exp.json
+++ b/test/expectations/hover/documented_module.exp.json
@@ -9,16 +9,6 @@
         "contents": {
             "kind": "markdown",
             "value": "```ruby\nFoo\n```\n\n**Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4)\n\n\n\nThis is the documentation for Foo"
-        },
-        "range": {
-            "start": {
-                "line": 1,
-                "character": 7
-            },
-            "end": {
-                "line": 1,
-                "character": 10
-            }
         }
     }
 }

--- a/test/expectations/hover/documented_namespaced_class.exp.json
+++ b/test/expectations/hover/documented_namespaced_class.exp.json
@@ -9,16 +9,6 @@
         "contents": {
             "kind": "markdown",
             "value": "```ruby\nFoo::Bar\n```\n\n**Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4) | [fake.rb](file:///fake.rb#L6,1-7,4) | [fake.rb](file:///fake.rb#L11,3-12,6)\n\n\n\nThis is the documentation for Foo::Bar\n\nThis is more documentation for Foo::Bar\n\nThis is even more documentation for Foo::Bar"
-        },
-        "range": {
-            "start": {
-                "line": 1,
-                "character": 6
-            },
-            "end": {
-                "line": 1,
-                "character": 14
-            }
         }
     }
 }

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -261,26 +261,19 @@ class HoverExpectationsTest < ExpectationsTestRunner
         "HoverAddon"
       end
 
-      def create_hover_listener(nesting, index, dispatcher)
-        klass = Class.new(RubyLsp::Listener) do
-          attr_reader :_response
-
-          def initialize(dispatcher)
-            super
+      def create_hover_listener(response_builder, nesting, index, dispatcher)
+        klass = Class.new do
+          def initialize(response_builder, dispatcher)
+            @response_builder = response_builder
             dispatcher.register(self, :on_constant_read_node_enter)
           end
 
           def on_constant_read_node_enter(node)
-            T.bind(self, RubyLsp::Listener[T.untyped])
-            contents = RubyLsp::Interface::MarkupContent.new(
-              kind: "markdown",
-              value: "Hello from middleware: #{node.slice}",
-            )
-            @_response = RubyLsp::Interface::Hover.new(range: range_from_location(node.location), contents: contents)
+            @response_builder << "Hello from middleware: #{node.slice}"
           end
         end
 
-        klass.new(dispatcher)
+        klass.new(response_builder, dispatcher)
       end
     end
   end


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Hover response construction and manipulation can be delegated to a builder class to promote extensibility and encapsulation.

Eventually, we want to facilitate deterministic categorization for hover responses. As part of this, we should first encapsulate our responses into a `HoverResponseBuilder` class, which will then handle the ordering of content in the future.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The previous approach for hover responses had some suboptimal aspects:
1. Within `Requests::Hover`, the `perform` method was responsible for constructing the response in a convoluted way.
2. The listener was responsible for instantiating `Hover` objects.
3. We were always passing in the `range` when constructing a `Hover` response, but as per the [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#hover), we weren't using this range in a meaningful fashion.

The new approach ensures:
1. We abstract away response construction to a builder. When we add deterministic categorization for hover responses, this will ensure that we have a concrete separation of concerns.
2. We now only construct a `Hover` object at one time, within `Requests::Hover` instead of the listener. This optimizes runtime as it ensures we limit the construction of objects.
3. We can disregard the `range`.
4. There is a more general `ResponseBuilder` class that we can use to refactor responses for other areas of the LSP as well.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

In `hover_expectations_test.rb`, we don't want to modify the expectations themselves (as the contract persists), but we can change the initialization work done to facilitate the tests such that it now reflects our changes.

We can also updated our broader expectations to remove `range`, since we are now phasing this out. 

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

We're not adding/removing any functionality, but are simply laying the foundation for improvements later in the future. As a consequence, testing this involves ensuring that our hover functionality is unchanged. 

As we can see, the hover functionality persists:

![hover_functionality](https://github.com/Shopify/ruby-lsp/assets/43973636/dad82004-75b0-4477-8e0a-a0d6912ecd5b)

