### PR TITLE
Provide constant type differentiation in semantic highlighting request

### DIFF
--- a/lib/ruby_lsp/listeners/semantic_highlighting.rb
+++ b/lib/ruby_lsp/listeners/semantic_highlighting.rb
@@ -34,6 +34,7 @@ module RubyLsp
           regexp: 20,
           operator: 21,
           decorator: 22,
+          constant: 23
         }.freeze,
         T::Hash[Symbol, Integer],
       )

--- a/lib/ruby_lsp/listeners/semantic_highlighting.rb
+++ b/lib/ruby_lsp/listeners/semantic_highlighting.rb
@@ -107,6 +107,7 @@ module RubyLsp
         @special_methods = T.let(nil, T.nilable(T::Array[String]))
         @current_scope = T.let(ParameterScope.new, ParameterScope)
         @index = index
+        @nesting = T.let([], T::Array[String])
         @inside_regex_capture = T.let(false, T::Boolean)
 
         dispatcher.register(
@@ -373,6 +374,7 @@ module RubyLsp
       def on_class_node_enter(node)
         return unless visible?(node, @range)
 
+        @nesting.push(node.name)
         add_token(node.constant_path.location, :class, [:declaration])
 
         superclass = node.superclass
@@ -383,6 +385,7 @@ module RubyLsp
       def on_module_node_enter(node)
         return unless visible?(node, @range)
 
+        @nesting.push(node.name)
         add_token(node.constant_path.location, :namespace, [:declaration])
       end
 

--- a/lib/ruby_lsp/listeners/semantic_highlighting.rb
+++ b/lib/ruby_lsp/listeners/semantic_highlighting.rb
@@ -92,14 +92,21 @@ module RubyLsp
       sig { override.returns(ResponseType) }
       attr_reader :_response
 
-      sig { params(dispatcher: Prism::Dispatcher, range: T.nilable(T::Range[Integer])).void }
-      def initialize(dispatcher, range: nil)
+      sig {
+        params(
+          dispatcher: Prism::Dispatcher,
+          index: RubyIndexer::Index,
+          range: T.nilable(T::Range[Integer])
+        ).void
+      }
+      def initialize(dispatcher, index, range: nil)
         super(dispatcher)
 
         @_response = T.let([], ResponseType)
         @range = range
         @special_methods = T.let(nil, T.nilable(T::Array[String]))
         @current_scope = T.let(ParameterScope.new, ParameterScope)
+        @index = index
         @inside_regex_capture = T.let(false, T::Boolean)
 
         dispatcher.register(

--- a/lib/ruby_lsp/listeners/semantic_highlighting.rb
+++ b/lib/ruby_lsp/listeners/semantic_highlighting.rb
@@ -114,12 +114,14 @@ module RubyLsp
           self,
           :on_call_node_enter,
           :on_class_node_enter,
+          :on_class_node_leave,
           :on_def_node_enter,
           :on_def_node_leave,
           :on_block_node_enter,
           :on_block_node_leave,
           :on_self_node_enter,
           :on_module_node_enter,
+          :on_module_node_leave,
           :on_local_variable_write_node_enter,
           :on_local_variable_read_node_enter,
           :on_block_parameter_node_enter,
@@ -381,12 +383,22 @@ module RubyLsp
         add_token(superclass.location, :class) if superclass
       end
 
+      sig { params(node: Prism::ClassNode).void }
+      def on_class_node_leave(node)
+        @nesting.pop
+      end
+
       sig { params(node: Prism::ModuleNode).void }
       def on_module_node_enter(node)
         return unless visible?(node, @range)
 
         @nesting.push(node.name)
         add_token(node.constant_path.location, :namespace, [:declaration])
+      end
+
+      sig { params(node: Prism::ClassNode).void }
+      def on_module_node_leave(node)
+        @nesting.pop
       end
 
       private

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -43,10 +43,16 @@ module RubyLsp
         end
       end
 
-      sig { params(dispatcher: Prism::Dispatcher, range: T.nilable(T::Range[Integer])).void }
-      def initialize(dispatcher, range: nil)
+      sig {
+        params(
+          dispatcher: Prism::Dispatcher,
+          index: RubyIndexer::Index,
+          range: T.nilable(T::Range[Integer])
+        ).void
+      }
+      def initialize(dispatcher, index, range: nil)
         super()
-        @listener = T.let(Listeners::SemanticHighlighting.new(dispatcher, range: range), Listener[ResponseType])
+        @listener = T.let(Listeners::SemanticHighlighting.new(dispatcher, index, range: range), Listener[ResponseType])
       end
 
       sig { override.returns(ResponseType) }


### PR DESCRIPTION
### Motivation

This is a new version of #1148 which closed when I tried to update my fork of the repo. Also making this a draft to gather feedback on my solution and give me time to do proper testing, since I use neovim and I'll probably need to figure some things out in that area.

Fixes #1128 (Potentially)

This PR aims to modify the `SemanticHighlighting` class so that it can properly determine what type of constant is being referenced in a given piece of code. The details and discussion can be found in the issue, but we want syntax highlighting to know that `Foo` in `Foo.new` below is referencing the class `Foo` and isn't just some other constant `Foo`, for example:

```ruby
class Foo
  THIS_IS_A_CONSTANT = 1

  def self.create_instance
    Foo.new
  end
end
```

### Implementation

Following @vinistock's recommendations, I made sure an instance of `RubyIndexer::Index` is given to the request and created a variable to keep track of nesting. Additionally subscribed to events needed to keep track of this nesting.

At the time of submission, the PR is incomplete, however. I wasn't able to figure out how to properly set up the index in the tests, so the lines where I call `index_single` are definitely something that needs fixing.

Finally, one thing discussed in the issue is that, even if this is implemented correctly, it might be too resource intensive, so if this gets finished, benchmarks will be required

### Automated Tests

Haven't added any new tests so far but only tried to modify the current test to reflect the needed changes.

### Manual Tests

The issue was opened referencing neovim, so I'm not sure if this affects VS Code. However the request doesn't have this specific capability so I think it's surely possible to replicate this by opening the example file provided in the issue.