### PR TITLE
handles one more #to_spec returning nil in RubyIndexer::Configuration

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -213,7 +213,7 @@ module RubyIndexer
 
           # If the transitive dependency is included as a transitive dependency of a gem outside of the development
           # group, skip it
-          next if others.any? { |d| d.to_spec && d.to_spec.dependencies.include?(transitive_dependency) }
+          next if others.any? { |d| d.to_spec&.dependencies&.include?(transitive_dependency) }
 
           excluded << transitive_dependency
         end


### PR DESCRIPTION
### Motivation

Apparently, there is a know issue when `#to_spec` returns `nil` (see #1141 and #1246).

While you are still investigating why exactly it happens, some precautions were made in order to run `ruby-lsp` with no crashes (see PRs [1242](https://github.com/Shopify/ruby-lsp/pull/1242) and [1159](https://github.com/Shopify/ruby-lsp/pull/1159)).

It seems there is one more `#to_spec #=> nil` that needs handling. This PR handles this case.

### Implementation

To make sure the fix would allow me to run `ruby-lsp` with no crashes, I implemented the fix locally by manually changing the `/lib/ruby_indexer/lib/ruby_indexer/configuration.rb` file on my setup.

It worked.

Reviewers, be aware. I'm also not sure why this happens nor possible side effects of this change.

### Manual Tests

Run `ruby-lsp` for gemfile (bundled with 2.5.3):

```Ruby
source 'https://rubygems.org'

git_source(:github) { |repo| "https://github.com/#{repo}.git" }

ruby '3.3.0'

gem 'rails', '~> 7.1.2'
gem 'validates_timeliness', '>= 6.0.1'
```

It crashes with:

```console
.../ruby-lsp-0.13.4/lib/ruby_indexer/lib/ruby_indexer/configuration.rb:216:in `block (3 levels) in initial_excluded_gems': undefined method `dependencies' for nil (NoMethodError)

            d.to_spec.dependencies.include?(transitive_dependency)
```
