### PR TITLE
Refactor hover request to adhere to builder pattern

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -118,12 +118,13 @@ module RubyLsp
     # Creates a new Hover listener. This method is invoked on every Hover request
     sig do
       overridable.params(
+        response_builder: ResponseBuilders::Hover,
         nesting: T::Array[String],
         index: RubyIndexer::Index,
         dispatcher: Prism::Dispatcher,
       ).returns(T.nilable(Listener[T.nilable(Interface::Hover)]))
     end
-    def create_hover_listener(nesting, index, dispatcher); end
+    def create_hover_listener(response_builder, nesting, index, dispatcher); end
 
     # Creates a new DocumentSymbol listener. This method is invoked on every DocumentSymbol request
     sig do

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -147,7 +147,10 @@ module RubyLsp
             detail: "(#{entry.parameters.map(&:decorated_name).join(", ")})",
             description: entry.file_name,
           ),
-          documentation: markdown_from_index_entries(name, entry),
+          documentation: Interface::MarkupContent.new(
+            kind: "markdown",
+            value: markdown_from_index_entries(name, entry),
+          ),
         )
       end
 
@@ -240,7 +243,10 @@ module RubyLsp
           label_details: Interface::CompletionItemLabelDetails.new(
             description: entries.map(&:file_name).join(","),
           ),
-          documentation: markdown_from_index_entries(real_name, entries),
+          documentation: Interface::MarkupContent.new(
+            kind: "markdown",
+            value: markdown_from_index_entries(real_name, entries),
+          ),
         )
       end
 

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -3,11 +3,9 @@
 
 module RubyLsp
   module Listeners
-    class Hover < Listener
+    class Hover
       extend T::Sig
-      extend T::Generic
-
-      ResponseType = type_member { { fixed: T.nilable(Interface::Hover) } }
+      include Requests::Support::Common
 
       ALLOWED_TARGETS = T.let(
         [
@@ -19,11 +17,9 @@ module RubyLsp
         T::Array[T.class_of(Prism::Node)],
       )
 
-      sig { override.returns(ResponseType) }
-      attr_reader :_response
-
       sig do
         params(
+          response_builder: ResponseBuilders::Hover,
           uri: URI::Generic,
           nesting: T::Array[String],
           index: RubyIndexer::Index,
@@ -31,14 +27,13 @@ module RubyLsp
           typechecker_enabled: T::Boolean,
         ).void
       end
-      def initialize(uri, nesting, index, dispatcher, typechecker_enabled)
+      def initialize(response_builder, uri, nesting, index, dispatcher, typechecker_enabled) # rubocop:disable Metrics/ParameterLists
+        @response_builder = response_builder
         @path = T.let(uri.to_standardized_path, T.nilable(String))
         @nesting = nesting
         @index = index
         @typechecker_enabled = typechecker_enabled
-        @_response = T.let(nil, ResponseType)
 
-        super(dispatcher)
         dispatcher.register(
           self,
           :on_constant_read_node_enter,
@@ -86,12 +81,7 @@ module RubyLsp
         target_method = @index.resolve_method(message, @nesting.join("::"))
         return unless target_method
 
-        location = target_method.location
-
-        @_response = Interface::Hover.new(
-          range: range_from_location(location),
-          contents: markdown_from_index_entries(message, target_method),
-        )
+        @response_builder << markdown_from_index_entries(message, target_method)
       end
 
       private
@@ -106,10 +96,7 @@ module RubyLsp
         first_entry = T.must(entries.first)
         return if first_entry.visibility == :private && first_entry.name != "#{@nesting.join("::")}::#{name}"
 
-        @_response = Interface::Hover.new(
-          range: range_from_location(location),
-          contents: markdown_from_index_entries(name, entries),
-        )
+        @response_builder << markdown_from_index_entries(name, entries)
       end
 
       sig { params(node: Prism::CallNode).void }
@@ -138,13 +125,7 @@ module RubyLsp
           #{info}
         MARKDOWN
 
-        @_response = Interface::Hover.new(
-          range: range_from_location(node.location),
-          contents: Interface::MarkupContent.new(
-            kind: Constant::MarkupKind::MARKDOWN,
-            value: markdown,
-          ),
-        )
+        @response_builder << markdown
       rescue Gem::MissingSpecError
         # Do nothing if the spec cannot be found
       end

--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -63,7 +63,10 @@ module RubyLsp
             Interface::SignatureInformation.new(
               label: label,
               parameters: parameters.map { |param| Interface::ParameterInformation.new(label: param.name) },
-              documentation: markdown_from_index_entries("", target_method),
+              documentation: Interface::MarkupContent.new(
+                kind: "markdown",
+                value: markdown_from_index_entries("", target_method),
+              ),
             ),
           ],
           active_parameter: active_parameter,

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -86,7 +86,7 @@ module RubyLsp
           params(
             title: String,
             entries: T.any(T::Array[RubyIndexer::Entry], RubyIndexer::Entry),
-          ).returns(Interface::MarkupContent)
+          ).returns(String)
         end
         def markdown_from_index_entries(title, entries)
           markdown_title = "```ruby\n#{title}\n```"
@@ -108,16 +108,13 @@ module RubyLsp
             content << "\n\n#{entry.comments.join("\n")}" unless entry.comments.empty?
           end
 
-          Interface::MarkupContent.new(
-            kind: "markdown",
-            value: <<~MARKDOWN.chomp,
-              #{markdown_title}
+          <<~MARKDOWN.chomp
+            #{markdown_title}
 
-              **Definitions**: #{definitions.join(" | ")}
+            **Definitions**: #{definitions.join(" | ")}
 
-              #{content}
-            MARKDOWN
-          )
+            #{content}
+          MARKDOWN
         end
       end
     end

--- a/lib/ruby_lsp/response_builders.rb
+++ b/lib/ruby_lsp/response_builders.rb
@@ -5,6 +5,7 @@ module RubyLsp
   module ResponseBuilders
     autoload :ResponseBuilder, "ruby_lsp/response_builders/response_builder"
     autoload :DocumentSymbol, "ruby_lsp/response_builders/document_symbol"
+    autoload :Hover, "ruby_lsp/response_builders/hover"
     autoload :SemanticHighlighting, "ruby_lsp/response_builders/semantic_highlighting"
   end
 end

--- a/lib/ruby_lsp/response_builders/hover.rb
+++ b/lib/ruby_lsp/response_builders/hover.rb
@@ -1,0 +1,39 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module ResponseBuilders
+    class Hover < ResponseBuilder
+      ResponseType = type_member { { fixed: String } }
+
+      extend T::Sig
+      extend T::Generic
+
+      sig { void }
+      def initialize
+        super
+        @stack = T.let(
+          [],
+          T::Array[String],
+        )
+      end
+
+      sig { params(hover_response: String).void }
+      def push(hover_response)
+        @stack << hover_response
+      end
+
+      alias_method(:<<, :push)
+
+      sig { returns(T::Boolean) }
+      def empty?
+        @stack.empty?
+      end
+
+      sig { override.returns(String) }
+      def response
+        @stack.join("\n\n")
+      end
+    end
+  end
+end

--- a/test/expectations/hover/documented_class.exp.json
+++ b/test/expectations/hover/documented_class.exp.json
@@ -9,16 +9,6 @@
         "contents": {
             "kind": "markdown",
             "value": "```ruby\nBar\n```\n\n**Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4) | [fake.rb](file:///fake.rb#L6,1-7,4)\n\n\n\nThis is the documentation for Bar\n\nThis is more documentation for Bar"
-        },
-        "range": {
-            "start": {
-                "line": 1,
-                "character": 6
-            },
-            "end": {
-                "line": 1,
-                "character": 9
-            }
         }
     }
 }

--- a/test/expectations/hover/documented_constant.exp.json
+++ b/test/expectations/hover/documented_constant.exp.json
@@ -9,16 +9,6 @@
         "contents": {
             "kind": "markdown",
             "value": "```ruby\nBAZ\n```\n\n**Definitions**: [fake.rb](file:///fake.rb#L2,1-2,10)\n\n\n\nThis is the documentation for Baz"
-        },
-        "range": {
-            "start": {
-                "line": 1,
-                "character": 0
-            },
-            "end": {
-                "line": 1,
-                "character": 3
-            }
         }
     }
 }

--- a/test/expectations/hover/documented_module.exp.json
+++ b/test/expectations/hover/documented_module.exp.json
@@ -9,16 +9,6 @@
         "contents": {
             "kind": "markdown",
             "value": "```ruby\nFoo\n```\n\n**Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4)\n\n\n\nThis is the documentation for Foo"
-        },
-        "range": {
-            "start": {
-                "line": 1,
-                "character": 7
-            },
-            "end": {
-                "line": 1,
-                "character": 10
-            }
         }
     }
 }

--- a/test/expectations/hover/documented_namespaced_class.exp.json
+++ b/test/expectations/hover/documented_namespaced_class.exp.json
@@ -9,16 +9,6 @@
         "contents": {
             "kind": "markdown",
             "value": "```ruby\nFoo::Bar\n```\n\n**Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4) | [fake.rb](file:///fake.rb#L6,1-7,4) | [fake.rb](file:///fake.rb#L11,3-12,6)\n\n\n\nThis is the documentation for Foo::Bar\n\nThis is more documentation for Foo::Bar\n\nThis is even more documentation for Foo::Bar"
-        },
-        "range": {
-            "start": {
-                "line": 1,
-                "character": 6
-            },
-            "end": {
-                "line": 1,
-                "character": 14
-            }
         }
     }
 }

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -261,26 +261,19 @@ class HoverExpectationsTest < ExpectationsTestRunner
         "HoverAddon"
       end
 
-      def create_hover_listener(nesting, index, dispatcher)
-        klass = Class.new(RubyLsp::Listener) do
-          attr_reader :_response
-
-          def initialize(dispatcher)
-            super
+      def create_hover_listener(response_builder, nesting, index, dispatcher)
+        klass = Class.new do
+          def initialize(response_builder, dispatcher)
+            @response_builder = response_builder
             dispatcher.register(self, :on_constant_read_node_enter)
           end
 
           def on_constant_read_node_enter(node)
-            T.bind(self, RubyLsp::Listener[T.untyped])
-            contents = RubyLsp::Interface::MarkupContent.new(
-              kind: "markdown",
-              value: "Hello from middleware: #{node.slice}",
-            )
-            @_response = RubyLsp::Interface::Hover.new(range: range_from_location(node.location), contents: contents)
+            @response_builder << "Hello from middleware: #{node.slice}"
           end
         end
 
-        klass.new(dispatcher)
+        klass.new(response_builder, dispatcher)
       end
     end
   end


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Hover response construction and manipulation can be delegated to a builder class to promote extensibility and encapsulation.

Eventually, we want to facilitate deterministic categorization for hover responses. As part of this, we should first encapsulate our responses.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The previous approach for hover responses had some suboptimal aspects:
1. Within `Requests::Hover`, the `perform` method was responsible for constructing the response in a convoluted way.
2. The listener was responsible for instantiating `Hover` objects.
3. We were always passing in the `range` when constructing a `Hover` response, but as per the [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#hover), we weren't using this range in a meaningful fashion.

The new approach ensures:
1. We abstract away response construction to a builder. When we add deterministic categorization for hover responses, this will ensure that we have a concrete separation of concerns.
2. We now only construct a `Hover` object at one time, within `Requests::Hover` instead of the listener. This optimizes runtime as it ensures we limit the construction of objects.
3. We can disregard the `range`.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

In `hover_expectations_test.rb`, we don't want to modify the expectations themselves (as the contract persists), but we can change the initialization work done to facilitate the tests such that it now reflects our changes.

We can also updated our broader expectations to remove `range`, since we are now phasing this out. 

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

We're not adding/removing any functionality, but are simply laying the foundation for improvements later in the future. As a consequence, testing this involves ensuring that our hover functionality is unchanged. 

As we can see, the hover functionality persists:

![hover_functionality](https://github.com/Shopify/ruby-lsp/assets/43973636/cbececa4-f97d-48ea-a525-2fb0ab831f6e)

