### PR TITLE
Add a basic RubyLSP dependencies custom request

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -223,15 +223,7 @@ module RubyLsp
       when "rubyLsp/textDocument/showSyntaxTree"
         show_syntax_tree(uri, request.dig(:params, :range))
       when "rubyLsp/workspace/dependencies"
-        dep_keys = Bundler.definition.locked_deps.keys.to_set
-        Bundler.definition.specs.map do |spec|
-          {
-            name: spec.name,
-            version: spec.version,
-            path: spec.full_gem_path,
-            dependency: dep_keys.include?(spec.name),
-          }
-        end
+        workspace_dependencies
       else
         VOID
       end
@@ -260,6 +252,22 @@ module RubyLsp
       end
 
       VOID
+    end
+
+    sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+    def workspace_dependencies
+      definition = Bundler.definition
+      dep_keys = definition.locked_deps.keys.to_set
+      definition.specs.map do |spec|
+        {
+          name: spec.name,
+          version: spec.version,
+          path: spec.full_gem_path,
+          dependency: dep_keys.include?(spec.name),
+        }
+      end
+    rescue Bundler::GemfileNotFound
+      []
     end
 
     sig { void }

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -222,6 +222,16 @@ module RubyLsp
         workspace_symbol(request.dig(:params, :query))
       when "rubyLsp/textDocument/showSyntaxTree"
         show_syntax_tree(uri, request.dig(:params, :range))
+      when "rubyLsp/workspace/dependencies"
+        dep_keys = Bundler.definition.locked_deps.keys.to_set
+        Bundler.definition.specs.map do |spec|
+          {
+            name: spec.name,
+            version: spec.version,
+            path: spec.full_gem_path,
+            dependency: dep_keys.include?(spec.name),
+          }
+        end
       else
         VOID
       end

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -364,6 +364,20 @@ class ExecutorTest < Minitest::Test
     assert_equal("Foo", @store.client_name)
   end
 
+  def test_workspace_dependencies
+    result = @executor.execute({
+      method: "rubyLsp/workspace/dependencies",
+      params: {},
+    })
+
+    result.response.each do |gem_info|
+      assert_instance_of(String, gem_info[:name])
+      assert_instance_of(Gem::Version, gem_info[:version])
+      assert_instance_of(String, gem_info[:path])
+      assert(gem_info[:dependency].is_a?(TrueClass) || gem_info[:dependency].is_a?(FalseClass))
+    end
+  end
+
   private
 
   def with_uninstalled_rubocop(&block)


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
In order to support the ["Dependencies" view in VSCode](https://github.com/Shopify/vscode-ruby-lsp/pull/1018), we need to add a custom request in Ruby LSP to gather and return a list of dependencies of the current project.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Discover all direct dependencies using `Bundler.definition.locked_deps` and then convert all of the specs in the `Bundler.definition` into a list of spec name, version, path and if the spec is a direct dependency or not. The last property is useful for either sorting the view based on direct dependency vs transitive dependency, and, in the future, will also allow us to show "Remove" buttons next to direct dependencies.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
No tests yet

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
Can't manually test it except for making the LSP request.