### PR TITLE
Handle alias and alias method in document symbol

### DIFF
--- a/lib/ruby_lsp/listeners/document_symbol.rb
+++ b/lib/ruby_lsp/listeners/document_symbol.rb
@@ -33,6 +33,7 @@ module RubyLsp
           :on_class_variable_write_node_enter,
           :on_singleton_class_node_enter,
           :on_singleton_class_node_leave,
+          :on_alias_method_node_enter,
         )
       end
 
@@ -188,6 +189,22 @@ module RubyLsp
           kind: Constant::SymbolKind::VARIABLE,
           range_location: node.name_loc,
           selection_range_location: node.name_loc,
+        )
+      end
+
+      sig { params(node: Prism::AliasMethodNode).void }
+      def on_alias_method_node_enter(node)
+        new_name_node = node.new_name
+        return unless new_name_node.is_a?(Prism::SymbolNode)
+
+        name = new_name_node.value
+        return unless name
+
+        create_document_symbol(
+          name: name,
+          kind: Constant::SymbolKind::METHOD,
+          range_location: new_name_node.location,
+          selection_range_location: T.must(new_name_node.value_loc),
         )
       end
 

--- a/test/expectations/document_symbol/alias.exp.json
+++ b/test/expectations/document_symbol/alias.exp.json
@@ -1,0 +1,54 @@
+{
+  "result": [
+    {
+      "name": "foo",
+      "kind": 6,
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 6
+        },
+        "end": {
+          "line": 0,
+          "character": 10
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 0,
+          "character": 7
+        },
+        "end": {
+          "line": 0,
+          "character": 10
+        }
+      },
+      "children": []
+    },
+    {
+      "name": "foo",
+      "kind": 6,
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 9
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 1,
+          "character": 6
+        },
+        "end": {
+          "line": 1,
+          "character": 9
+        }
+      },
+      "children": []
+    }
+  ]
+}

--- a/test/expectations/document_symbol/alias_method.exp.json
+++ b/test/expectations/document_symbol/alias_method.exp.json
@@ -1,0 +1,29 @@
+{
+  "result": [
+    {
+      "name": "foo",
+      "kind": 6,
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 13
+        },
+        "end": {
+          "line": 0,
+          "character": 17
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 0,
+          "character": 14
+        },
+        "end": {
+          "line": 0,
+          "character": 17
+        }
+      },
+      "children": []
+    }
+  ]
+}

--- a/test/fixtures/alias.rb
+++ b/test/fixtures/alias.rb
@@ -1,0 +1,2 @@
+alias :foo :bar
+alias foo bar

--- a/test/fixtures/alias_method.rb
+++ b/test/fixtures/alias_method.rb
@@ -1,0 +1,1 @@
+alias_method :foo, :bar


### PR DESCRIPTION
### Motivation
Closes https://github.com/Shopify/ruby-lsp/issues/1209

Method aliases are currently not being handled in document symbol.

### Implementation
- Modified the `on_call_node_enter` event handler to deal with `alias_method`
- Added a new handler for the `on_alias_method_node_enter` event

### Automated Tests

I have added automated tests.

### Manual Tests
These changes can be tested manually by using the `alias` keyword or the `alias_method` method.