### PR TITLE
Always print error backtraces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,3 @@ Sorbet/StrictSigil:
     - "lib/ruby_indexer/test/**/*.rb"
     - "lib/ruby-lsp.rb"
     - "lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb"
-
-Style/StderrPuts:
-  Enabled: true

--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -48,8 +48,7 @@ module RubyLsp
         Gem.find_files("ruby_lsp/**/addon.rb").each do |addon|
           require File.expand_path(addon)
         rescue => e
-          warn(e.message)
-          warn(e.backtrace.to_s) # rubocop:disable Lint/RedundantStringCoercion
+          $stderr.puts(e.full_message)
         end
 
         # Activate each one of the discovered addons. If any problems occur in the addons, we don't want to

--- a/lib/ruby_lsp/check_docs.rb
+++ b/lib/ruby_lsp/check_docs.rb
@@ -115,7 +115,7 @@ module RubyLsp
       end
 
       if missing_docs.any?
-        warn(<<~WARN)
+        $stderr.puts(<<~WARN)
           The following requests are missing documentation:
 
           #{missing_docs.map { |k, v| "#{k}\n\n#{v.join("\n")}" }.join("\n\n")}

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -25,7 +25,7 @@ module RubyLsp
       begin
         response = run(request)
       rescue StandardError, LoadError => e
-        warn(e.message)
+        $stderr.puts(e.full_message)
         error = e
       end
 
@@ -55,7 +55,7 @@ module RubyLsp
             ),
           )
 
-          warn(errored_addons.map(&:backtraces).join("\n\n"))
+          $stderr.puts(errored_addons.map(&:backtraces).join("\n\n"))
         end
 
         RubyVM::YJIT.enable if defined? RubyVM::YJIT.enable
@@ -63,7 +63,7 @@ module RubyLsp
         perform_initial_indexing
         check_formatter_is_available
 
-        warn("Ruby LSP is ready")
+        $stderr.puts("Ruby LSP is ready")
         VOID
       when "textDocument/didOpen"
         text_document_did_open(

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -58,7 +58,7 @@ module RubyLsp
 
     sig { void }
     def start
-      warn("Starting Ruby LSP v#{VERSION}...")
+      $stderr.puts("Starting Ruby LSP v#{VERSION}...")
 
       # Requests that have to be executed sequentially or in the main process are implemented here. All other requests
       # fall under the else branch which just pushes requests to the queue
@@ -73,7 +73,7 @@ module RubyLsp
         when "$/setTrace"
           VOID
         when "shutdown"
-          warn("Shutting down Ruby LSP...")
+          $stderr.puts("Shutting down Ruby LSP...")
 
           @message_queue.close
           # Close the queue so that we can no longer receive items
@@ -92,7 +92,7 @@ module RubyLsp
           # We return zero if shutdown has already been received or one otherwise as per the recommendation in the spec
           # https://microsoft.github.io/language-server-protocol/specification/#exit
           status = @store.empty? ? 0 : 1
-          warn("Shutdown complete with status #{status}")
+          $stderr.puts("Shutdown complete with status #{status}")
           exit(status)
         else
           # Default case: push the request to the queue to be executed by the worker

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -59,7 +59,9 @@ module RubyLsp
 
       # Do not setup a custom bundle if both `ruby-lsp` and `debug` are already in the Gemfile
       if @dependencies["ruby-lsp"] && @dependencies["debug"]
-        warn("Ruby LSP> Skipping custom bundle setup since both `ruby-lsp` and `debug` are already in #{@gemfile}")
+        $stderr.puts(
+          "Ruby LSP> Skipping custom bundle setup since both `ruby-lsp` and `debug` are already in #{@gemfile}",
+        )
 
         # If the user decided to add the `ruby-lsp` and `debug` to their Gemfile after having already run the Ruby LSP,
         # then we need to remove the `.ruby-lsp` folder, otherwise we will run `bundle install` for the top level and
@@ -76,7 +78,7 @@ module RubyLsp
       write_custom_gemfile
 
       unless @gemfile&.exist? && @lockfile&.exist?
-        warn("Ruby LSP> Skipping lockfile copies because there's no top level bundle")
+        $stderr.puts("Ruby LSP> Skipping lockfile copies because there's no top level bundle")
         return run_bundle_install(@custom_gemfile)
       end
 
@@ -84,7 +86,9 @@ module RubyLsp
       current_lockfile_hash = Digest::SHA256.hexdigest(lockfile_contents)
 
       if @custom_lockfile.exist? && @lockfile_hash_path.exist? && @lockfile_hash_path.read == current_lockfile_hash
-        warn("Ruby LSP> Skipping custom bundle setup since #{@custom_lockfile} already exists and is up to date")
+        $stderr.puts(
+          "Ruby LSP> Skipping custom bundle setup since #{@custom_lockfile} already exists and is up to date",
+        )
         return run_bundle_install(@custom_gemfile)
       end
 
@@ -209,8 +213,8 @@ module RubyLsp
       command << "1>&2"
 
       # Add bundle update
-      warn("Ruby LSP> Running bundle install for the custom bundle. This may take a while...")
-      warn("Ruby LSP> Command: #{command}")
+      $stderr.puts("Ruby LSP> Running bundle install for the custom bundle. This may take a while...")
+      $stderr.puts("Ruby LSP> Command: #{command}")
       system(env, command)
       [bundle_gemfile.to_s, expanded_path, env["BUNDLE_APP_CONFIG"]]
     end

--- a/test/executor_test.rb
+++ b/test/executor_test.rb
@@ -365,6 +365,20 @@ class ExecutorTest < Minitest::Test
     end
   end
 
+  def test_backtrace_is_printed_to_stderr_on_exceptions
+    @executor.expects(:run).raises(StandardError, "boom")
+
+    _stdout, stderr = capture_io do
+      @executor.execute({
+        method: "rubyLsp/workspace/dependencies",
+        params: {},
+      })
+    end
+
+    assert_match(/boom/, stderr)
+    assert_match(%r{ruby-lsp/lib/ruby_lsp/executor\.rb:\d+:in `execute'}, stderr)
+  end
+
   private
 
   def with_uninstalled_rubocop(&block)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -46,7 +46,7 @@ class IntegrationTest < Minitest::Test
 
     if @wait_thr.value != 0
       # If the process didn't exit cleanly, print the stderr
-      warn(@stderr.read)
+      $stderr.puts(@stderr.read)
     end
 
     # Make sure IOs are closed


### PR DESCRIPTION
### Motivation

If an error occurs in the server, it's difficult for users to report it. We should always print the backtrace information so that we can more easily diagnose errors.

### Implementation

Started warning the backtrace.

I also removed the `$VERBOSE = nil` from our tests. I understand the idea to remove noise from tests, since most of the warnings come from RuboCop and not us, but we need to be able to assert things against stderr, which is the only pipe we can print to. If verbose is off, the unit test I added can't pass.

### Automated Tests

Added a test to ensure the backtrace is present.