### PR TITLE
Handle self receiver and string arguments for attribute accessors in document symbol

### DIFF
--- a/lib/ruby_lsp/listeners/document_symbol.rb
+++ b/lib/ruby_lsp/listeners/document_symbol.rb
@@ -206,7 +206,8 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode).void }
       def handle_attr_accessor(node)
-        return unless node.receiver.nil?
+        receiver = node.receiver
+        return if receiver && !receiver.is_a?(Prism::SelfNode)
 
         arguments = node.arguments
         return unless arguments

--- a/lib/ruby_lsp/listeners/document_symbol.rb
+++ b/lib/ruby_lsp/listeners/document_symbol.rb
@@ -213,17 +213,27 @@ module RubyLsp
         return unless arguments
 
         arguments.arguments.each do |argument|
-          next unless argument.is_a?(Prism::SymbolNode)
+          if argument.is_a?(Prism::SymbolNode)
+            name = argument.value
+            next unless name
 
-          name = argument.value
-          next unless name
+            create_document_symbol(
+              name: name,
+              kind: Constant::SymbolKind::FIELD,
+              range_location: argument.location,
+              selection_range_location: T.must(argument.value_loc),
+            )
+          elsif argument.is_a?(Prism::StringNode)
+            name = argument.content
+            next if name.empty?
 
-          create_document_symbol(
-            name: name,
-            kind: Constant::SymbolKind::FIELD,
-            range_location: argument.location,
-            selection_range_location: T.must(argument.value_loc),
-          )
+            create_document_symbol(
+              name: name,
+              kind: Constant::SymbolKind::FIELD,
+              range_location: argument.location,
+              selection_range_location: argument.content_loc,
+            )
+          end
         end
       end
 

--- a/test/expectations/document_symbol/attr_accessor.exp.json
+++ b/test/expectations/document_symbol/attr_accessor.exp.json
@@ -30,6 +30,31 @@
       "kind": 8,
       "range": {
         "start": {
+          "line": 0,
+          "character": 16
+        },
+        "end": {
+          "line": 0,
+          "character": 19
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 0,
+          "character": 17
+        },
+        "end": {
+          "line": 0,
+          "character": 18
+        }
+      },
+      "children": []
+    },
+    {
+      "name": "c",
+      "kind": 8,
+      "range": {
+        "start": {
           "line": 1,
           "character": 12
         },
@@ -51,7 +76,7 @@
       "children": []
     },
     {
-      "name": "c",
+      "name": "d",
       "kind": 8,
       "range": {
         "start": {
@@ -60,7 +85,7 @@
         },
         "end": {
           "line": 1,
-          "character": 18
+          "character": 19
         }
       },
       "selectionRange": {
@@ -76,7 +101,7 @@
       "children": []
     },
     {
-      "name": "d",
+      "name": "e",
       "kind": 8,
       "range": {
         "start": {
@@ -96,6 +121,31 @@
         "end": {
           "line": 2,
           "character": 16
+        }
+      },
+      "children": []
+    },
+    {
+      "name": "f",
+      "kind": 8,
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 18
+        },
+        "end": {
+          "line": 2,
+          "character": 21
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 2,
+          "character": 19
+        },
+        "end": {
+          "line": 2,
+          "character": 20
         }
       },
       "children": []
@@ -130,6 +180,31 @@
       "kind": 8,
       "range": {
         "start": {
+          "line": 4,
+          "character": 21
+        },
+        "end": {
+          "line": 4,
+          "character": 24
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 4,
+          "character": 22
+        },
+        "end": {
+          "line": 4,
+          "character": 23
+        }
+      },
+      "children": []
+    },
+    {
+      "name": "c",
+      "kind": 8,
+      "range": {
+        "start": {
           "line": 5,
           "character": 17
         },
@@ -151,7 +226,7 @@
       "children": []
     },
     {
-      "name": "c",
+      "name": "d",
       "kind": 8,
       "range": {
         "start": {
@@ -160,7 +235,7 @@
         },
         "end": {
           "line": 5,
-          "character": 23
+          "character": 24
         }
       },
       "selectionRange": {
@@ -176,7 +251,7 @@
       "children": []
     },
     {
-      "name": "d",
+      "name": "e",
       "kind": 8,
       "range": {
         "start": {
@@ -196,6 +271,31 @@
         "end": {
           "line": 6,
           "character": 21
+        }
+      },
+      "children": []
+    },
+    {
+      "name": "f",
+      "kind": 8,
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 23
+        },
+        "end": {
+          "line": 6,
+          "character": 26
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 6,
+          "character": 24
+        },
+        "end": {
+          "line": 6,
+          "character": 25
         }
       },
       "children": []

--- a/test/expectations/document_symbol/attr_accessor.exp.json
+++ b/test/expectations/document_symbol/attr_accessor.exp.json
@@ -99,6 +99,106 @@
         }
       },
       "children": []
+    },
+    {
+      "name": "a",
+      "kind": 8,
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 17
+        },
+        "end": {
+          "line": 4,
+          "character": 19
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 4,
+          "character": 18
+        },
+        "end": {
+          "line": 4,
+          "character": 19
+        }
+      },
+      "children": []
+    },
+    {
+      "name": "b",
+      "kind": 8,
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 17
+        },
+        "end": {
+          "line": 5,
+          "character": 19
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 5,
+          "character": 18
+        },
+        "end": {
+          "line": 5,
+          "character": 19
+        }
+      },
+      "children": []
+    },
+    {
+      "name": "c",
+      "kind": 8,
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 21
+        },
+        "end": {
+          "line": 5,
+          "character": 23
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 5,
+          "character": 22
+        },
+        "end": {
+          "line": 5,
+          "character": 23
+        }
+      },
+      "children": []
+    },
+    {
+      "name": "d",
+      "kind": 8,
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 19
+        },
+        "end": {
+          "line": 6,
+          "character": 21
+        }
+      },
+      "selectionRange": {
+        "start": {
+          "line": 6,
+          "character": 20
+        },
+        "end": {
+          "line": 6,
+          "character": 21
+        }
+      },
+      "children": []
     }
   ]
 }

--- a/test/fixtures/attr_accessor.rb
+++ b/test/fixtures/attr_accessor.rb
@@ -1,3 +1,7 @@
 attr_reader :a
 attr_writer :b, :c
 attr_accessor :d
+
+self.attr_reader :a
+self.attr_writer :b, :c
+self.attr_accessor :d

--- a/test/fixtures/attr_accessor.rb
+++ b/test/fixtures/attr_accessor.rb
@@ -1,7 +1,7 @@
-attr_reader :a
-attr_writer :b, :c
-attr_accessor :d
+attr_reader :a, "b", some_variable
+attr_writer :c, "d", some_variable
+attr_accessor :e, "f", some_variable
 
-self.attr_reader :a
-self.attr_writer :b, :c
-self.attr_accessor :d
+self.attr_reader :a, "b", some_variable
+self.attr_writer :c, "d", some_variable
+self.attr_accessor :e, "f", some_variable


### PR DESCRIPTION
### Motivation
- Attribute accessors are currently not being handled in document symbol when the receiver is a `SelfNode` ([#1348 (Comment)](https://github.com/Shopify/ruby-lsp/pull/1348#discussion_r1479570964))
- String arguments passed to attribute accessors are also not being handled

### Implementation
Updated the `handle_attr_accessor` method to process the `CallNode` when receiver is a `SelfNode` and to process `StringNode` arguments.

### Automated Tests
I have added automated tests.

### Manual Tests
#### Current behavior
![attr_accessors_current](https://github.com/Shopify/ruby-lsp/assets/77708400/6aea2e0e-653d-4fc6-b143-e51e03dd3830)

#### New behavior
![attr_accessors_new](https://github.com/Shopify/ruby-lsp/assets/77708400/85e7b589-4e3e-4070-84b8-c9bf47babedb)
