### PR TITLE
Add `RUBY_LSP_BACKTRACE` option for debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           cache-version: 1
 
       - name: Run tests
-        run: bundle exec rake
+        run: RUBY_LSP_BACKTRACE=1 bundle exec rake
 
       - name: Run index troubleshooting tool
         run: bundle exec ruby-lsp-doctor

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -25,8 +25,12 @@ module RubyLsp
       begin
         response = run(request)
       rescue StandardError, LoadError => e
-        warn(e.message)
-        error = e
+        if ENV["RUBY_LSP_BACKTRACE"]
+          raise
+        else
+          warn(e.message)
+          error = e
+        end
       end
 
       Result.new(response: response, error: error)


### PR DESCRIPTION
### Motivation

While working on an addon, I was encountering a Sorbet type error. Since `TypeError` inherits from `StandardError`, it was being rescued, meaning I couldn't see the full backtrace.

### Implementation

I've added an option to run with `RUBY_LSP_BACKTRACE`. (I originally considered just `BACKTRACE` but didn't want to risk clashing with other tooling).

Interestingly, this has caught a existing failure in the tests that was failing silently. (I can look into the fix for that).

### Automated Tests

Update to always run with `RUBY_LSP_BACKTRACE` in CI, since it can help to catch issues.

### Manual Tests

n/a
