### PR TITLE
Categorize hover content

### DIFF
--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -89,7 +89,9 @@ module RubyLsp
         target_method = @index.resolve_method(message, @nesting.join("::"))
         return unless target_method
 
-        @response_builder << markdown_from_index_entries(message, target_method)
+        categorized_markdown_from_index_entries(message, target_method).each do |category, content|
+          @response_builder.push(content, category: category)
+        end
       end
 
       private
@@ -104,7 +106,9 @@ module RubyLsp
         first_entry = T.must(entries.first)
         return if first_entry.visibility == :private && first_entry.name != "#{@nesting.join("::")}::#{name}"
 
-        @response_builder << markdown_from_index_entries(name, entries)
+        categorized_markdown_from_index_entries(name, entries).each do |category, content|
+          @response_builder.push(content, category: category)
+        end
       end
 
       sig { params(node: Prism::CallNode).void }
@@ -131,13 +135,11 @@ module RubyLsp
           page.start_with?(*ALLOWED_REMOTE_PROVIDERS)
         end
 
-        markdown = <<~MARKDOWN
-          **#{spec.name}** (#{spec.version}) #{remote_url && " - [open remote](#{remote_url})"}
-
-          #{info}
-        MARKDOWN
-
-        @response_builder << markdown
+        @response_builder.push(
+          "**#{spec.name}** (#{spec.version}) #{remote_url && " - [open remote](#{remote_url})"}",
+          category: :title,
+        )
+        @response_builder.push(info, category: :documentation)
       rescue Gem::MissingSpecError
         # Do nothing if the spec cannot be found
       end

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -86,9 +86,9 @@ module RubyLsp
           params(
             title: String,
             entries: T.any(T::Array[RubyIndexer::Entry], RubyIndexer::Entry),
-          ).returns(String)
+          ).returns(T::Hash[Symbol, String])
         end
-        def markdown_from_index_entries(title, entries)
+        def categorized_markdown_from_index_entries(title, entries)
           markdown_title = "```ruby\n#{title}\n```"
           definitions = []
           content = +""
@@ -108,12 +108,28 @@ module RubyLsp
             content << "\n\n#{entry.comments.join("\n")}" unless entry.comments.empty?
           end
 
+          {
+            title: markdown_title,
+            links: "**Definitions**: #{definitions.join(" | ")}",
+            documentation: content,
+          }
+        end
+
+        sig do
+          params(
+            title: String,
+            entries: T.any(T::Array[RubyIndexer::Entry], RubyIndexer::Entry),
+          ).returns(String)
+        end
+        def markdown_from_index_entries(title, entries)
+          categorized_markdown = categorized_markdown_from_index_entries(title, entries)
+
           <<~MARKDOWN.chomp
-            #{markdown_title}
+            #{categorized_markdown[:title]}
 
-            **Definitions**: #{definitions.join(" | ")}
+            #{categorized_markdown[:links]}
 
-            #{content}
+            #{categorized_markdown[:documentation]}
           MARKDOWN
         end
       end

--- a/lib/ruby_lsp/response_builders/hover.rb
+++ b/lib/ruby_lsp/response_builders/hover.rb
@@ -12,27 +12,37 @@ module RubyLsp
       sig { void }
       def initialize
         super
-        @stack = T.let(
-          [],
-          T::Array[String],
+
+        @response = T.let(
+          {
+            title: +"",
+            links: +"",
+            documentation: +"",
+          },
+          T::Hash[Symbol, String],
         )
       end
 
-      sig { params(hover_response: String).void }
-      def push(hover_response)
-        @stack << hover_response
+      sig { params(content: String, category: Symbol).void }
+      def push(content, category:)
+        hover_content = @response[category]
+        if hover_content
+          hover_content << content + "\n"
+        end
       end
-
-      alias_method(:<<, :push)
 
       sig { returns(T::Boolean) }
       def empty?
-        @stack.empty?
+        @response.values.all?(&:empty?)
       end
 
-      sig { override.returns(String) }
+      sig { override.returns(ResponseType) }
       def response
-        @stack.join("\n\n")
+        result = T.must(@response[:title])
+        result << "\n" << @response[:links] if @response[:links]
+        result << "\n" << @response[:documentation] if @response[:documentation]
+
+        result.strip
       end
     end
   end

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -248,7 +248,17 @@ class HoverExpectationsTest < ExpectationsTestRunner
       })
 
       assert_nil(response.error, response.error&.full_message)
-      assert_match("Hello\n\nHello from middleware: Post", response.response.contents.value)
+      assert_match(<<~RESPONSE.strip, response.response.contents.value)
+        Title
+
+        **Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4)
+        Links
+
+
+
+        Hello
+        Documentation from middleware: Post
+      RESPONSE
     end
   end
 
@@ -270,7 +280,15 @@ class HoverExpectationsTest < ExpectationsTestRunner
           end
 
           def on_constant_read_node_enter(node)
-            @response_builder << "Hello from middleware: #{node.slice}"
+            @response_builder.push(
+              "Documentation from middleware: #{node.slice}", category: :documentation
+            )
+            @response_builder.push(
+              "Links", category: :links
+            )
+            @response_builder.push(
+              "Title", category: :title
+            )
           end
         end
 


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Enables hover content to be displayed deterministically, based on categories. Add-ons that add content to hovers can specify the category of the content, then the Ruby LSP can render the content in hovers in an order that semantically maps to the category specified.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Updated the response builder to require categorization, with 3 possible categories for hover content (title, links and documentation).

The response is now stored via a hash, instead of an array. The hash contains the categories as its keys, and the associated content as its values.

In `common.rb`, a helper method has been extracted to map each piece of content with its category. This helper is then used when pushing to the response builder.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

The `hover_expectations_test` has been updated based on these changes. Note that the expectation tests associated with metaprogramming that are used have not been updated, since our expectation of what we expect to be rendered is the same.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

The goal here is to ensure we aren't disrupting the hover behaviour. Below is an example of the hover functionality in its current state: 

![hover_before_changes](https://github.com/Shopify/ruby-lsp/assets/43973636/e06c3c88-3cac-4761-a124-c810e4f8ac92)

This is the hover functionality with the changes in this PR made:

![hover_after_change](https://github.com/Shopify/ruby-lsp/assets/43973636/dd720616-1929-4276-b74e-8a84e59715cc)

The hover remains unchanged. This is because the LSP categorizes everything as expected and has not modified the visual output of the hover itself.

