### PR TITLE
Handle nested method calls in signature help without adjusting positions

### DIFF
--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -50,22 +50,12 @@ module RubyLsp
       end
       def initialize(document, index, position, context, dispatcher)
         super()
-        current_signature = context && context[:activeSignatureHelp]
         target, parent, nesting = document.locate_node(
-          { line: position[:line], character: position[:character] - 2 },
+          { line: position[:line], character: position[:character] },
           node_types: [Prism::CallNode],
         )
 
-        # If we're typing a nested method call (e.g.: `foo(bar)`), then we may end up locating `bar` as the target
-        # method call incorrectly. To correct that, we check if there's an active signature with the same name as the
-        # parent node and then replace the target
-        if current_signature && parent.is_a?(Prism::CallNode)
-          active_signature = current_signature[:activeSignature] || 0
-
-          if current_signature.dig(:signatures, active_signature, :label)&.start_with?(parent.message)
-            target = parent
-          end
-        end
+        target = adjust_for_nested_target(target, parent, position)
 
         @target = T.let(target, T.nilable(Prism::Node))
         @dispatcher = dispatcher
@@ -79,6 +69,53 @@ module RubyLsp
 
         @dispatcher.dispatch_once(@target)
         @response_builder.response
+      end
+
+      private
+
+      # Adjust the target of signature help in the case where we have nested method calls. This is necessary so that we
+      # select the right target in a situation like this:
+      #
+      # foo(another_method_call)
+      #
+      # In that case, we want to provide signature help for `foo` and not `another_method_call`.
+      sig do
+        params(
+          target: T.nilable(Prism::Node),
+          parent: T.nilable(Prism::Node),
+          position: T::Hash[Symbol, T.untyped],
+        ).returns(T.nilable(Prism::Node))
+      end
+      def adjust_for_nested_target(target, parent, position)
+        # If the parent node is not a method call, then make no adjustments
+        return target unless parent.is_a?(Prism::CallNode)
+        # If the parent is a method call, but the target isn't, then return the parent
+        return parent unless target.is_a?(Prism::CallNode)
+
+        # If both are method calls, we check the arguments of the inner method call. If there are no arguments, then
+        # we're providing signature help for the outer method call.
+        #
+        # If there are arguments, then we check if the arguments node covers the requested position. If it doesn't
+        # cover, then we're providing signature help for the outer method call.
+        arguments = target.arguments
+        arguments.nil? || !node_covers?(arguments, position) ? parent : target
+      end
+
+      sig { params(node: Prism::Node, position: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      def node_covers?(node, position)
+        location = node.location
+        start_line = location.start_line - 1
+        start_character = location.start_column
+        end_line = location.end_line - 1
+        end_character = location.end_column
+
+        start_covered = start_line < position[:line] ||
+          (start_line == position[:line] && start_character <= position[:character])
+
+        end_covered = end_line > position[:line] ||
+          (end_line == position[:line] && end_character >= position[:character])
+
+        start_covered && end_covered
       end
     end
   end


### PR DESCRIPTION
### Motivation

Related to https://github.com/Shopify/vscode-ruby-lsp/issues/1025 and https://github.com/Shopify/vscode-ruby-lsp/issues/1021

We've been able to determine that something in signature help is causing the LSP to get stuck and spike in CPU. I haven't been able to reproduce this myself, but looking at our code for signature help the only thing that could get us into that situation is the `locate_node` invocation.

If we try to find a position that doesn't exist, we may get stuck in [this loop](https://github.com/Shopify/ruby-lsp/blob/8c990dd9582bbf6262cf56669c87ae10cb2fb914/lib/ruby_lsp/document.rb#L207), which would explain the server getting stuck and spiking in CPU. I can't think of anything else that would get the server stuck.

This PR removes the position adjustment we had, so that we always use the position we get from the editor, to try to avoid this infinite loop issue.

### Implementation

The main issue to be solved is handling signature help for nested method calls properly. We need to understand for which method to display the help for.

Instead of relying on the position and the previous checks, I reworked the code to check for nested method invocations.

### Automated Tests

Added two new tests.