### PR TITLE
Use sorbet-static to determine if Sorbet is present

### DIFF
--- a/lib/ruby_lsp/requests/support/dependency_detector.rb
+++ b/lib/ruby_lsp/requests/support/dependency_detector.rb
@@ -63,7 +63,11 @@ module RubyLsp
     def detect_typechecker
       return false if ENV["RUBY_LSP_BYPASS_TYPECHECKER"]
 
-      direct_dependency?(/^sorbet/) || direct_dependency?(/^sorbet-static-and-runtime/)
+      Bundler.with_original_env do
+        Bundler.locked_gems.specs.any? { |spec| spec.name == "sorbet-static" }
+      end
+    rescue Bundler::GemfileNotFound
+      false
     end
 
     sig { returns(T::Array[String]) }


### PR DESCRIPTION
### Motivation

It should be safe to assume that if `sorbet-static` is in the dependencies, then the project is using Sorbet.

### Implementation

Started checking all dependencies instead of just direct ones.