### PR TITLE
Fix handle resolve multiple methods

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -237,20 +237,20 @@ module RubyIndexer
       real_parts.join("::")
     end
 
-    # Attempts to find a given method for a resolved fully qualified receiver name. Returns `nil` if the method does not
-    # exist on that receiver
-    sig { params(method_name: String, receiver_name: String).returns(T.nilable(Entry::Member)) }
+    # Attempts to find methods for a resolved fully qualified receiver name.
+    # Returns an empty array if the method does not exist on that receiver
+    sig { params(method_name: String, receiver_name: String).returns(T::Array[Entry::Member]) }
     def resolve_method(method_name, receiver_name)
       method_entries = self[method_name]
       owner_entries = self[receiver_name]
-      return unless owner_entries && method_entries
+      return [] unless owner_entries && method_entries
 
       owner_name = T.must(owner_entries.first).name
       T.cast(
-        method_entries.grep(Entry::Member).find do |entry|
+        method_entries.grep(Entry::Member).select do |entry|
           T.cast(entry, Entry::Member).owner&.name == owner_name
         end,
-        T.nilable(Entry::Member),
+        T::Array[Entry::Member],
       )
     end
 

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -92,10 +92,10 @@ module RubyLsp
         message = node.message
         return unless message
 
-        target_method = @index.resolve_method(message, @nesting.join("::"))
-        return unless target_method
+        methods = @index.resolve_method(message, @nesting.join("::"))
+        return if methods.none?
 
-        categorized_markdown_from_index_entries(message, target_method).each do |category, content|
+        categorized_markdown_from_index_entries(message, methods).each do |category, content|
           @response_builder.push(content, category: category)
         end
       end

--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -30,9 +30,10 @@ module RubyLsp
         message = node.message
         return unless message
 
-        target_method = @index.resolve_method(message, @nesting.join("::"))
-        return unless target_method
+        methods = @index.resolve_method(message, @nesting.join("::"))
+        return if methods.none?
 
+        target_method = T.must(methods.first)
         parameters = target_method.parameters
         name = target_method.name
 
@@ -59,7 +60,7 @@ module RubyLsp
               parameters: parameters.map { |param| Interface::ParameterInformation.new(label: param.name) },
               documentation: Interface::MarkupContent.new(
                 kind: "markdown",
-                value: markdown_from_index_entries("", target_method),
+                value: markdown_from_index_entries("", methods),
               ),
             ),
           ],


### PR DESCRIPTION
### Motivation

Closes: https://github.com/Shopify/ruby-lsp/issues/1343

### Implementation

When we invoke `resolve_method`, do not pick only the first match, bot return an array containing all matches.
- replace `find` by `select`
- return an empty array when nothing match (**feel free to challenge this point**, as the interface change)

Handle in all requests using this resolve following [advices](https://github.com/Shopify/ruby-lsp/issues/1343):
- merge documentation for hover
- push all `Location` for definition 
- merge documentation for signature help

**Question:** On `signature_help` request, we could propose multiple [signatures](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#signatureHelp), with for each [signature information](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#signatureInformation) the related documentation and parameters. I did a try, it changes the interface, to allow user changing signature with arrow. You can find an example for VS Code documentation [here](https://code.visualstudio.com/docs/languages/javascript#_signature-help). Do you think it can be better or bring some unwanted complexity? Idk how it's handled by other IDE.

### Automated Tests

Added tests in all request and indexer, again, if missed some useful cases, just say it 👍 

### Manual Tests

Given this code: 

```
# file 1
module Func
  def start
    something()
  end

  # Does something interesting
  def something(argument_name)
    puts argument_name
  end
end

# file 2
module Func
  # Does something interesting
  def something(argument_with_other_name)
    puts argument_with_other_name
  end
end
```

For hover on `something`: 
<img width="207" alt="image" src="https://github.com/Shopify/ruby-lsp/assets/38727166/917d6e0e-9437-47c6-8bd5-e420c530d3f4">

For go to definition on `something`:
<img width="1249" alt="image" src="https://github.com/Shopify/ruby-lsp/assets/38727166/637549a0-dad5-4635-adf3-802199d21ba9">

For signature_help on `something`:
<img width="394" alt="image" src="https://github.com/Shopify/ruby-lsp/assets/38727166/bc42fb59-95f9-47fc-a659-f56c2b2af0a5">

