### PR TITLE
Update setup_bundler.rb

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -208,6 +208,9 @@ module RubyLsp
 
       command << " || bundle install) "
 
+       # Safely silence output
+      command << " /dev/null "
+
       # Redirect stdout to stderr to prevent going into an infinite loop. The extension might confuse stdout output with
       # responses
       command << "1>&2"


### PR DESCRIPTION
### Motivation

[https://github.com/Shopify/ruby-lsp/issues/1675](https://github.com/Shopify/ruby-lsp/issues/1675
)
### Implementation

You are using `1>&2` only. This type of redirection is more a tool for managing output rather than a way to silence it entirely. If your goal is to avoid seeing the output at all, redirecting to `/dev/null` (or to a file if you wish to review the output later) would be the correct approach.

### Automated Tests

minor change 
