### PR TITLE
Indexed included modules on namespaces

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/collector.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/collector.rb
@@ -152,6 +152,8 @@ module RubyIndexer
         handle_attribute(node, reader: false, writer: true)
       when :attr_accessor
         handle_attribute(node, reader: true, writer: true)
+      when :include
+        handle_include(node)
       end
     end
 
@@ -349,6 +351,25 @@ module RubyIndexer
         @index << Entry::Accessor.new(name, @file_path, loc, comments, @current_owner) if reader
         @index << Entry::Accessor.new("#{name}=", @file_path, loc, comments, @current_owner) if writer
       end
+    end
+
+    sig { params(node: Prism::CallNode).void }
+    def handle_include(node)
+      return unless @current_owner
+
+      arguments = node.arguments&.arguments
+      return unless arguments
+
+      names = arguments.filter_map do |node|
+        if node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
+          node.full_name
+        end
+      rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError
+        # TO DO: add MissingNodesInConstantPathError when released in Prism
+        # If a constant path reference is dynamic or missing parts, we can't
+        # index it
+      end
+      @current_owner.included_modules.concat(names)
     end
   end
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -40,6 +40,22 @@ module RubyIndexer
 
       abstract!
 
+      sig { returns(T::Array[String]) }
+      attr_accessor :included_modules
+
+      sig do
+        params(
+          name: String,
+          file_path: String,
+          location: Prism::Location,
+          comments: T::Array[String],
+        ).void
+      end
+      def initialize(name, file_path, location, comments)
+        super(name, file_path, location, comments)
+        @included_modules = T.let([], T::Array[String])
+      end
+
       sig { returns(String) }
       def short_name
         T.must(@name.split("::").last)


### PR DESCRIPTION
### Motivation

Resolves second point of #1333 

This changes index included modules of all Namespaces, including `Class` and `Module` nodes.

### Implementation

Each time a class or module is visited by the collector, we instantiate a new visitor that only visits its inmediate nodes (depth 1 of the tree), looking for `CallNode` that match the `include` method. The collector has an index of all the included modules to keep track of all the modules included for a singe entry. Then pass this values to the `Namespaces` nodes. Because its passed by reference and because it's a `Set` data structure, the modules are propagated and not repeated.

### Automated Tests

Tests where added in `lib/ruby_indexer/test/classes_and_modules_test.rb` to cover different cases.

### Manual Tests

Test indexing the same repo and does not crash.
