### PR TITLE
Use Snapper generator for RDoc documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem "mocha", "~> 2.1"
   gem "psych", "~> 5.1", require: false
   gem "rake", "~> 13.1"
-  gem "rdoc", require: false
+  gem "rdoc", require: false, github: "Shopify/rdoc", branch: "create_snapper_generator"
   gem "rubocop-minitest", "~> 0.34.5", require: false
   gem "rubocop-rake", "~> 0.6.0", require: false
   gem "rubocop-shopify", "~> 2.14", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/Shopify/rdoc.git
+  revision: 360dd09cdd025278e3f8156ca895395325f54d7b
+  branch: create_snapper_generator
+  specs:
+    rdoc (6.6.2)
+      psych (>= 4.0.0)
+
 PATH
   remote: .
   specs:
@@ -45,8 +53,6 @@ GEM
     rbi (0.1.8)
       prism (>= 0.18.0, < 0.22)
       sorbet-runtime (>= 0.5.9204)
-    rdoc (6.6.2)
-      psych (>= 4.0.0)
     regexp_parser (2.9.0)
     reline (0.4.1)
       io-console (~> 0.5)
@@ -122,7 +128,7 @@ DEPENDENCIES
   mocha (~> 2.1)
   psych (~> 5.1)
   rake (~> 13.1)
-  rdoc
+  rdoc!
   rubocop (~> 1.60)
   rubocop-minitest (~> 0.34.5)
   rubocop-rake (~> 0.6.0)

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ RDoc::Task.new do |rdoc|
   rdoc.rdoc_files.include("*.md", "lib/**/*.rb")
   rdoc.rdoc_dir = "docs"
   rdoc.markup = "markdown"
+  rdoc.generator = "snapper"
   rdoc.options.push("--copy-files", "misc")
   rdoc.options.push("--copy-files", "LICENSE.txt")
 end


### PR DESCRIPTION
### Motivation

We need to polish the new Snapper RDoc theme before we can propose it more generally. Let's install RDoc from our source so that we can generate our docs using it and dogfood it. That will help us make incremental improvements.
