### PR TITLE
Add rubyLsp/workspace/dependencies support to Neovim config

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -74,9 +74,50 @@ local function setup_diagnostics(client, buffer)
   })
 end
 
+-- adds ShowRubyDeps command to show dependencies in the quickfix list.
+-- add the `all` argument to show indirect dependencies as well
+local function add_ruby_deps_command(client, bufnr)
+    vim.api.nvim_buf_create_user_command(bufnr, "ShowRubyDeps",
+                                          function(opts)
+
+        local params = vim.lsp.util.make_text_document_params()
+
+        local showAll = opts.args == "all"
+
+        client.request("rubyLsp/workspace/dependencies", params,
+                        function(error, result)
+            if error then
+                print("Error showing deps: " .. error)
+                return
+            end
+
+            local qf_list = {}
+            for _, item in ipairs(result) do
+                if showAll or item.dependency then
+                    table.insert(qf_list, {
+                        text = string.format("%s (%s) - %s",
+                                              item.name,
+                                              item.version,
+                                              item.dependency),
+
+                        filename = item.path
+                    })
+                end
+            end
+
+            vim.fn.setqflist(qf_list)
+            vim.cmd('copen')
+        end, bufnr)
+    end, {nargs = "?", complete = function()
+        return {"all"}
+    end})
+end
+
+
 require("lspconfig").ruby_ls.setup({
   on_attach = function(client, buffer)
     setup_diagnostics(client, buffer)
+    add_ruby_deps_command(client, buffer)
   end,
 })
 ```


### PR DESCRIPTION
### Motivation

`rubyLsp/workspace/dependencies` is a custom method currently supported only in the VS Code plugin. It feels valuable to provide default instructions to make this available to other editors as well. This PR adds Neovim support.

https://github.com/Shopify/ruby-lsp/pull/1346

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This is modified from code I wrote in https://youtu.be/8_u0Fvtq_ew


I'm adding a function that piggy-backs in the `on_attach` to add this custom command.

This sends things to the quickfix menu which allows easy navigation between dependencies using `:cprev`, `:cnext` etc.

### Automated Tests

N/A

### Manual Tests

I've tested against Neovim 0.9.0 (released Apr 7, 2023) and 0.10.0 nightly. It may work on the 0.8.X line, but I haven't tested there.

- Using 0.9.0 or greater, open a ruby file in a project with dependencies supported by `rubyLsp/workspace/dependencies`.
- Type `:ShowRubyDeps` and hit enter.
  - You will see only direct dependencies
  - You can navigate between them using the quickfix as usual (`:cnext`, `:cprev`, etc.)
- Type `:ShowRubyDeps all` (also available as `:ShowRubyDeps` then hitting tab) then hit enter.
  - You will see direct _and_ indireect dependencies
  - You can navigate between them using the quickfix as usual (`:cnext`, `:cprev`, etc.)
