### PR TITLE
Add output to ruby-lsp-doctor before indexing starts

### DIFF
--- a/exe/ruby-lsp-doctor
+++ b/exe/ruby-lsp-doctor
@@ -6,6 +6,8 @@ require "ruby_lsp/internal"
 
 index = RubyIndexer::Index.new
 
+puts "Globbing for indexable files"
+
 RubyIndexer.configuration.indexables.each do |indexable|
   puts "indexing: #{indexable.full_path}"
   content = File.read(indexable.full_path)


### PR DESCRIPTION
### Motivation
This can be helpful if glob pattern accidentally checks a huge amount of files/folders. Without this there would be no output until globbing has finished which could take quite long, depending on folder structure and hardware.

This situation can happen if developing with the ActiveStorage disk service. Closes https://github.com/Shopify/vscode-ruby-lsp/issues/1035

### Implementation

This could probably be made more verbose but just adding this is quite easy and maybe enough already. This ensures that ruby-lsp-doctor gives some feedback in case this Dir.glob takes an unreasonable amount of time. https://github.com/Shopify/ruby-lsp/blob/af05685a7af05307db88d21155c832159e6abb56/lib/ruby_indexer/lib/ruby_indexer/configuration.rb#L72-L73

### Automated Tests

The script seems only to be tested to execute without errors. I haven't found tests going into more detail than that.

### Manual Tests

The added line does indeed become part of the output.
