### PR TITLE
Set Bundler's UI level as early as possible

### DIFF
--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -7,13 +7,17 @@ yarp_require_paths = Gem.loaded_specs["yarp"]&.full_require_paths
 $LOAD_PATH.delete_if { |path| yarp_require_paths.include?(path) } if yarp_require_paths
 
 require "sorbet-runtime"
-require "prism"
-require "prism/visitor"
-require "language_server-protocol"
+
+# Set Bundler's UI level to silent as soon as possible to prevent any prints to STDOUT
 require "bundler"
+Bundler.ui.level = :silent
+
 require "uri"
 require "cgi"
 require "set"
+require "prism"
+require "prism/visitor"
+require "language_server-protocol"
 
 require "ruby-lsp"
 require "ruby_indexer/ruby_indexer"
@@ -29,5 +33,3 @@ require "ruby_lsp/ruby_document"
 require "ruby_lsp/store"
 require "ruby_lsp/addon"
 require "ruby_lsp/requests/support/rubocop_runner"
-
-Bundler.ui.level = :silent


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/vscode-ruby-lsp/issues/990

I believe the reason why some users are still seeing the prints from Bundler's debug logs because we call some Bundler APIs while loading classes. For example, [here](https://github.com/Shopify/ruby-lsp/blob/bc2223f6fdaadc6599f3d3e9e01379c62aa1b3f1/lib/ruby_lsp/utils.rb#L17).

Let's try to set the UI level to silent as early as possible so that nothing gets printed to STDOUT.

### Implementation

Moved the `level =` invocation as early as possible in the require.