### PR TITLE
Allow addons to define initialize

### DIFF
--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -7,7 +7,12 @@ module RubyLsp
   class AddonTest < Minitest::Test
     def setup
       @addon = Class.new(Addon) do
-        attr_reader :activated
+        attr_reader :activated, :field
+
+        def initialize
+          @field = 123
+          super
+        end
 
         def activate(message_queue)
           @activated = true
@@ -17,10 +22,15 @@ module RubyLsp
           "My Addon"
         end
       end
+
+      @message_queue = Thread::Queue.new
+      Addon.load_addons(@message_queue)
     end
 
     def teardown
-      Addon.addons.clear
+      RubyLsp::Addon.addon_classes.clear
+      RubyLsp::Addon.addons.clear
+      @message_queue.close
     end
 
     def test_registering_an_addon_invokes_activate_on_initialized
@@ -34,6 +44,10 @@ module RubyLsp
     end
 
     def test_addons_are_automatically_tracked
+      assert_equal(123, T.unsafe(Addon.addons.first).field)
+    end
+
+    def test_loading_addons_initializes_them
       assert(
         Addon.addons.any? { |addon| addon.is_a?(@addon) },
         "Expected addon to be automatically tracked",

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -114,6 +114,7 @@ class ExpectationsTestRunner < Minitest::Test
     message_queue = Thread::Queue.new
 
     send(addon_creation_method)
+    RubyLsp::Addon.load_addons(message_queue)
 
     store = RubyLsp::Store.new
     uri = URI::Generic.from_path(path: "/fake.rb")
@@ -127,6 +128,8 @@ class ExpectationsTestRunner < Minitest::Test
 
     yield(executor)
   ensure
+    RubyLsp::Addon.addons.each(&:deactivate)
+    RubyLsp::Addon.addon_classes.clear
     RubyLsp::Addon.addons.clear
     T.must(message_queue).close
   end

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -154,6 +154,12 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
         T.unsafe(klass).new(response_builder, uri, dispatcher)
       end
+
+      def activate(message_queue); end
+
+      def deactivate; end
+
+      def name; end
     end
   end
 

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -406,6 +406,12 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
 
         T.unsafe(klass).new(response_builder, uri, nesting, index, dispatcher)
       end
+
+      def activate(message_queue); end
+
+      def deactivate; end
+
+      def name; end
     end
   end
 end

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -43,6 +43,8 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
         "Document SymbolsAddon"
       end
 
+      def deactivate; end
+
       def create_document_symbol_listener(response_builder, dispatcher)
         klass = Class.new do
           include RubyLsp::Requests::Support::Common

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -311,6 +311,8 @@ class HoverExpectationsTest < ExpectationsTestRunner
         "HoverAddon"
       end
 
+      def deactivate; end
+
       def create_hover_listener(response_builder, nesting, index, dispatcher)
         klass = Class.new do
           def initialize(response_builder, dispatcher)

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -89,6 +89,12 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
 
         T.unsafe(klass).new(response_builder, dispatcher)
       end
+
+      def activate(message_queue); end
+
+      def deactivate; end
+
+      def name; end
     end
   end
 


### PR DESCRIPTION
### Motivation

I noticed that if an Addon defined an `initialize` method to keep some internal state, we were never invoking it. The reason is because we instantiated the addon classes too early during the `inherited` hook, before `initialize` was even defined.

### Implementation

Delegated creating the new instances to when we activate the addons, which then allows usage of the initialize method.

### Automated Tests

Fixed existing tests and added one showing that state set in `initialize` is present after activation.