### PR TITLE
Remove fixed debugger socket path from the executable

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -94,13 +94,6 @@ if options[:debug]
     exit 1
   end
 
-  sockets_dir = "/tmp/ruby-lsp-debug-sockets"
-  Dir.mkdir(sockets_dir) unless Dir.exist?(sockets_dir)
-  # ruby-debug-ENV["USER"] is an implicit naming pattern in ruby/debug
-  # if it's not present, rdbg will not find the socket
-  socket_identifier = "ruby-debug-#{ENV["USER"]}-#{File.basename(Dir.pwd)}.sock"
-  ENV["RUBY_DEBUG_SOCK_PATH"] = "#{sockets_dir}/#{socket_identifier}"
-
   begin
     require "debug/open_nonstop"
   rescue LoadError


### PR DESCRIPTION
After https://github.com/Shopify/vscode-ruby-lsp/pull/876, we don't specify the debugger socket path on the extension side anymore. So if we keep the fixed path in the executable, it will cause the debugger to fail to connect.
