### PR TITLE
Remove YJIT setting

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -250,11 +250,6 @@
           "description": "A shell command to activate the right Ruby version or add a custom Ruby bin folder to the PATH. Only used if rubyVersionManager is set to 'custom'",
           "type": "string"
         },
-        "rubyLsp.yjit": {
-          "description": "Use YJIT to speed up the Ruby LSP server",
-          "type": "boolean",
-          "default": true
-        },
         "rubyLsp.formatter": {
           "description": "Which tool the Ruby LSP should use for formatting files",
           "type": "string",

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -12,7 +12,6 @@ export enum Command {
   Update = "rubyLsp.update",
   ToggleExperimentalFeatures = "rubyLsp.toggleExperimentalFeatures",
   ServerOptions = "rubyLsp.serverOptions",
-  ToggleYjit = "rubyLsp.toggleYjit",
   SelectVersionManager = "rubyLsp.selectRubyVersionManager",
   ToggleFeatures = "rubyLsp.toggleFeatures",
   FormatterHelp = "rubyLsp.formatterHelp",

--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -223,12 +223,7 @@ export class Ruby implements RubyInterface {
       this.yjitEnabled && (major > 3 || (major === 3 && minor >= 2));
 
     // Starting with Ruby 3.3 the server enables YJIT itself
-    const useYjit =
-      vscode.workspace.getConfiguration("rubyLsp").get("yjit") &&
-      major === 3 &&
-      minor === 2;
-
-    if (this.supportsYjit && useYjit) {
+    if (this.supportsYjit && major === 3 && minor === 2) {
       // RUBYOPT may be empty or it may contain bundler paths. In the second case, we must concat to avoid accidentally
       // removing the paths from the env variable
       if (this._env.RUBYOPT) {

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -253,17 +253,6 @@ export class RubyLsp {
             .update("enabledFeatures", features, true, true);
         }
       }),
-      vscode.commands.registerCommand(Command.ToggleYjit, () => {
-        const lspConfig = vscode.workspace.getConfiguration("rubyLsp");
-        const yjitEnabled = lspConfig.get("yjit");
-        lspConfig.update("yjit", !yjitEnabled, true, true);
-
-        const workspace = this.currentActiveWorkspace();
-
-        if (workspace) {
-          STATUS_EMITTER.fire(workspace);
-        }
-      }),
       vscode.commands.registerCommand(
         Command.ToggleExperimentalFeatures,
         async () => {

--- a/vscode/src/status.ts
+++ b/vscode/src/status.ts
@@ -129,39 +129,6 @@ export class ExperimentalFeaturesStatus extends StatusItem {
   refresh(_workspace: WorkspaceInterface): void {}
 }
 
-export class YjitStatus extends StatusItem {
-  constructor() {
-    super("yjit");
-
-    this.item.name = "YJIT";
-    this.item.text = "Fetching YJIT information";
-  }
-
-  refresh(workspace: WorkspaceInterface): void {
-    const useYjit: boolean | undefined = vscode.workspace
-      .getConfiguration("rubyLsp")
-      .get("yjit");
-
-    if (useYjit && workspace.ruby.supportsYjit) {
-      this.item.text = "YJIT enabled";
-
-      this.item.command = {
-        title: "Disable",
-        command: Command.ToggleYjit,
-      };
-    } else {
-      this.item.text = "YJIT disabled";
-
-      if (workspace.ruby.supportsYjit) {
-        this.item.command = {
-          title: "Enable",
-          command: Command.ToggleYjit,
-        };
-      }
-    }
-  }
-}
-
 export class FeaturesStatus extends StatusItem {
   constructor() {
     super("features");
@@ -219,7 +186,6 @@ export class StatusItems {
       new RubyVersionStatus(),
       new ServerStatus(),
       new ExperimentalFeaturesStatus(),
-      new YjitStatus(),
       new FeaturesStatus(),
       new FormatterStatus(),
     ];

--- a/vscode/src/telemetry.ts
+++ b/vscode/src/telemetry.ts
@@ -74,7 +74,6 @@ export class Telemetry {
     const promises: Promise<void>[] = [
       { namespace: "workbench", field: "colorTheme" },
       { namespace: "rubyLsp", field: "enableExperimentalFeatures" },
-      { namespace: "rubyLsp", field: "yjit" },
       { namespace: "rubyLsp", field: "rubyVersionManager" },
       { namespace: "rubyLsp", field: "formatter" },
     ].map(({ namespace, field }) => {

--- a/vscode/src/test/suite/status.test.ts
+++ b/vscode/src/test/suite/status.test.ts
@@ -9,7 +9,6 @@ import {
   RubyVersionStatus,
   ServerStatus,
   ExperimentalFeaturesStatus,
-  YjitStatus,
   StatusItem,
   FeaturesStatus,
   FormatterStatus,
@@ -145,70 +144,6 @@ suite("StatusItems", () => {
         status.item.command!.command,
         Command.ToggleExperimentalFeatures,
       );
-    });
-  });
-
-  suite("YjitStatus when Ruby supports it", () => {
-    beforeEach(() => {
-      ruby = { supportsYjit: true } as Ruby;
-      workspace = {
-        ruby,
-        lspClient: {
-          state: State.Running,
-          formatter: "none",
-          serverVersion: "1.0.0",
-          sendRequest: <T>() => Promise.resolve([] as T),
-        },
-        error: false,
-      };
-      status = new YjitStatus();
-      status.refresh(workspace);
-    });
-
-    test("Status is initialized with the right values", () => {
-      assert.strictEqual(status.item.text, "YJIT enabled");
-      assert.strictEqual(status.item.name, "YJIT");
-      assert.strictEqual(status.item.command?.title, "Disable");
-      assert.strictEqual(status.item.command.command, Command.ToggleYjit);
-    });
-
-    test("Refresh updates whether it's disabled or enabled", () => {
-      assert.strictEqual(status.item.text, "YJIT enabled");
-
-      workspace.ruby.supportsYjit = false;
-      status.refresh(workspace);
-      assert.strictEqual(status.item.text, "YJIT disabled");
-    });
-  });
-
-  suite("YjitStatus when Ruby does not support it", () => {
-    beforeEach(() => {
-      ruby = { supportsYjit: false } as Ruby;
-      workspace = {
-        ruby,
-        lspClient: {
-          state: State.Running,
-          formatter: "none",
-          serverVersion: "1.0.0",
-          sendRequest: <T>() => Promise.resolve([] as T),
-        },
-        error: false,
-      };
-      status = new YjitStatus();
-      status.refresh(workspace);
-    });
-
-    test("Refresh ignores YJIT configuration if Ruby doesn't support it", () => {
-      assert.strictEqual(status.item.text, "YJIT disabled");
-      assert.strictEqual(status.item.command, undefined);
-
-      const lspConfig = vscode.workspace.getConfiguration("rubyLsp");
-      lspConfig.update("yjit", true, true, true);
-      workspace.ruby.supportsYjit = false;
-      status.refresh(workspace);
-
-      assert.strictEqual(status.item.text, "YJIT disabled");
-      assert.strictEqual(status.item.command, undefined);
     });
   });
 

--- a/vscode/src/test/suite/telemetry.test.ts
+++ b/vscode/src/test/suite/telemetry.test.ts
@@ -99,7 +99,7 @@ suite("Telemetry", () => {
       .get("enabledFeatures")!;
 
     const expectedNumberOfEvents =
-      5 + Object.keys(featureConfigurations).length;
+      4 + Object.keys(featureConfigurations).length;
 
     assert.strictEqual(api.sentEvents.length, expectedNumberOfEvents);
 


### PR DESCRIPTION
### Motivation

Starting to migrate https://github.com/Shopify/vscode-ruby-lsp/pull/923 into this repo by parts.

We added the possibility to turn off YJIT (even when Ruby was compiled with support for it) just in case there was a major issue with YJIT that prevented people from using the LSP. It's been a long time and no one has ever reported any YJIT related issues that weren't fixed before Ruby releases, so keeping this setting doesn't add much value.

### Implementation

Removed the setting, the related status item and command.