### PR TITLE
Merge supportsYjit and yjitEnabled into a single property

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -25,7 +25,6 @@ export interface RubyInterface {
   error: boolean;
   versionManager?: string;
   rubyVersion?: string;
-  supportsYjit?: boolean;
 }
 
 export interface ClientInterface {

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -40,7 +40,7 @@ suite("Ruby environment activation", () => {
 
     assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
     assert.notStrictEqual(
-      ruby.supportsYjit,
+      ruby.yjitEnabled,
       undefined,
       "Expected YJIT support to be set to true or false",
     );


### PR DESCRIPTION
### Motivation

After https://github.com/Shopify/ruby-lsp/pull/1427, there's no longer a use for having two separate fields to indicate the state of YJIT. We can merge them into one instead.

### Implementation

The `yjitEnabled` property's intent is to signal that YJIT is going to be enabled. That means, the Ruby was compiled with YJIT support and we're using a version where it will be activated. On 3.2, the extension activates it through the `--yjit` flag. On 3.3 or up, the server activates YJIT on its own.