### PR TITLE
Allow config to be passed into Indexer

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -43,14 +43,8 @@ module RubyIndexer
       )
     end
 
-    sig { void }
-    def load_config
-      return unless File.exist?(".index.yml")
-
-      config = YAML.parse_file(".index.yml")
-      return unless config
-
-      config_hash = config.to_ruby
+    sig { params(config_hash: T::Hash[String, String]).void }
+    def load_config(config_hash)
       validate_config!(config_hash)
       apply_config(config_hash)
     rescue Psych::SyntaxError => e

--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -43,14 +43,6 @@ module RubyIndexer
       )
     end
 
-    sig { params(config_hash: T::Hash[String, String]).void }
-    def load_config(config_hash)
-      validate_config!(config_hash)
-      apply_config(config_hash)
-    rescue Psych::SyntaxError => e
-      raise e, "Syntax error while loading .index.yml configuration: #{e.message}"
-    end
-
     sig { returns(T::Array[IndexablePath]) }
     def indexables
       excluded_gems = @excluded_gems - @included_gems
@@ -152,6 +144,17 @@ module RubyIndexer
       @magic_comment_regex ||= T.let(/^#\s*#{@excluded_magic_comments.join("|")}/, T.nilable(Regexp))
     end
 
+    sig { params(config: T::Hash[String, T.untyped]).void }
+    def apply_config(config)
+      validate_config!(config)
+
+      @excluded_gems.concat(config["excluded_gems"]) if config["excluded_gems"]
+      @included_gems.concat(config["included_gems"]) if config["included_gems"]
+      @excluded_patterns.concat(config["excluded_patterns"]) if config["excluded_patterns"]
+      @included_patterns.concat(config["included_patterns"]) if config["included_patterns"]
+      @excluded_magic_comments.concat(config["excluded_magic_comments"]) if config["excluded_magic_comments"]
+    end
+
     private
 
     sig { params(config: T::Hash[String, T.untyped]).void }
@@ -167,15 +170,6 @@ module RubyIndexer
       end
 
       raise ArgumentError, errors.join("\n") if errors.any?
-    end
-
-    sig { params(config: T::Hash[String, T.untyped]).void }
-    def apply_config(config)
-      @excluded_gems.concat(config["excluded_gems"]) if config["excluded_gems"]
-      @included_gems.concat(config["included_gems"]) if config["included_gems"]
-      @excluded_patterns.concat(config["excluded_patterns"]) if config["excluded_patterns"]
-      @included_patterns.concat(config["included_patterns"]) if config["included_patterns"]
-      @excluded_magic_comments.concat(config["excluded_magic_comments"]) if config["excluded_magic_comments"]
     end
 
     sig { returns(T::Array[String]) }

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -10,7 +10,7 @@ module RubyIndexer
     end
 
     def test_load_configuration_executes_configure_block
-      @config.load_config
+      @config.load_config({ "excluded_patterns" => ["**/test/fixtures/**/*.rb"] })
       indexables = @config.indexables
 
       assert(indexables.none? { |indexable| indexable.full_path.include?("test/fixtures") })
@@ -21,7 +21,7 @@ module RubyIndexer
     end
 
     def test_indexables_only_includes_gem_require_paths
-      @config.load_config
+      @config.load_config({})
       indexables = @config.indexables
 
       Bundler.locked_gems.specs.each do |lazy_spec|
@@ -35,7 +35,7 @@ module RubyIndexer
     end
 
     def test_indexables_does_not_include_default_gem_path_when_in_bundle
-      @config.load_config
+      @config.load_config({})
       indexables = @config.indexables
 
       assert(
@@ -44,7 +44,7 @@ module RubyIndexer
     end
 
     def test_indexables_includes_default_gems
-      @config.load_config
+      @config.load_config({})
       indexables = @config.indexables.map(&:full_path)
 
       assert_includes(indexables, "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb")
@@ -53,7 +53,7 @@ module RubyIndexer
     end
 
     def test_indexables_includes_project_files
-      @config.load_config
+      @config.load_config({})
       indexables = @config.indexables.map(&:full_path)
 
       Dir.glob("#{Dir.pwd}/lib/**/*.rb").each do |path|
@@ -66,7 +66,7 @@ module RubyIndexer
     def test_indexables_avoids_duplicates_if_bundle_path_is_inside_project
       Bundler.settings.set_global("path", "vendor/bundle")
       config = Configuration.new
-      config.load_config
+      config.load_config({})
 
       assert_includes(config.instance_variable_get(:@excluded_patterns), "#{Dir.pwd}/vendor/bundle/**/*.rb")
     ensure
@@ -74,7 +74,7 @@ module RubyIndexer
     end
 
     def test_indexables_does_not_include_gems_own_installed_files
-      @config.load_config
+      @config.load_config({})
       indexables = @config.indexables
 
       assert(
@@ -95,17 +95,15 @@ module RubyIndexer
     end
 
     def test_paths_are_unique
-      @config.load_config
+      @config.load_config({})
       indexables = @config.indexables
 
       assert_equal(indexables.uniq.length, indexables.length)
     end
 
     def test_configuration_raises_for_unknown_keys
-      Psych::Nodes::Document.any_instance.expects(:to_ruby).returns({ "unknown_config" => 123 })
-
       assert_raises(ArgumentError) do
-        @config.load_config
+        @config.load_config({ "unknown_config" => 123 })
       end
     end
 

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -21,7 +21,6 @@ module RubyIndexer
     end
 
     def test_indexables_only_includes_gem_require_paths
-      @config.apply_config({})
       indexables = @config.indexables
 
       Bundler.locked_gems.specs.each do |lazy_spec|
@@ -35,7 +34,6 @@ module RubyIndexer
     end
 
     def test_indexables_does_not_include_default_gem_path_when_in_bundle
-      @config.apply_config({})
       indexables = @config.indexables
 
       assert(
@@ -44,7 +42,6 @@ module RubyIndexer
     end
 
     def test_indexables_includes_default_gems
-      @config.apply_config({})
       indexables = @config.indexables.map(&:full_path)
 
       assert_includes(indexables, "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb")
@@ -53,7 +50,6 @@ module RubyIndexer
     end
 
     def test_indexables_includes_project_files
-      @config.apply_config({})
       indexables = @config.indexables.map(&:full_path)
 
       Dir.glob("#{Dir.pwd}/lib/**/*.rb").each do |path|
@@ -66,7 +62,6 @@ module RubyIndexer
     def test_indexables_avoids_duplicates_if_bundle_path_is_inside_project
       Bundler.settings.set_global("path", "vendor/bundle")
       config = Configuration.new
-      config.apply_config({})
 
       assert_includes(config.instance_variable_get(:@excluded_patterns), "#{Dir.pwd}/vendor/bundle/**/*.rb")
     ensure
@@ -74,7 +69,6 @@ module RubyIndexer
     end
 
     def test_indexables_does_not_include_gems_own_installed_files
-      @config.apply_config({})
       indexables = @config.indexables
 
       assert(
@@ -95,7 +89,6 @@ module RubyIndexer
     end
 
     def test_paths_are_unique
-      @config.apply_config({})
       indexables = @config.indexables
 
       assert_equal(indexables.uniq.length, indexables.length)

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -9,8 +9,8 @@ module RubyIndexer
       @config = Configuration.new
     end
 
-    def test_load_configuration_executes_configure_block
-      @config.load_config({ "excluded_patterns" => ["**/test/fixtures/**/*.rb"] })
+    def test_apply_configuration_executes_configure_block
+      @config.apply_config({ "excluded_patterns" => ["**/test/fixtures/**/*.rb"] })
       indexables = @config.indexables
 
       assert(indexables.none? { |indexable| indexable.full_path.include?("test/fixtures") })
@@ -21,7 +21,7 @@ module RubyIndexer
     end
 
     def test_indexables_only_includes_gem_require_paths
-      @config.load_config({})
+      @config.apply_config({})
       indexables = @config.indexables
 
       Bundler.locked_gems.specs.each do |lazy_spec|
@@ -35,7 +35,7 @@ module RubyIndexer
     end
 
     def test_indexables_does_not_include_default_gem_path_when_in_bundle
-      @config.load_config({})
+      @config.apply_config({})
       indexables = @config.indexables
 
       assert(
@@ -44,7 +44,7 @@ module RubyIndexer
     end
 
     def test_indexables_includes_default_gems
-      @config.load_config({})
+      @config.apply_config({})
       indexables = @config.indexables.map(&:full_path)
 
       assert_includes(indexables, "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb")
@@ -53,7 +53,7 @@ module RubyIndexer
     end
 
     def test_indexables_includes_project_files
-      @config.load_config({})
+      @config.apply_config({})
       indexables = @config.indexables.map(&:full_path)
 
       Dir.glob("#{Dir.pwd}/lib/**/*.rb").each do |path|
@@ -66,7 +66,7 @@ module RubyIndexer
     def test_indexables_avoids_duplicates_if_bundle_path_is_inside_project
       Bundler.settings.set_global("path", "vendor/bundle")
       config = Configuration.new
-      config.load_config({})
+      config.apply_config({})
 
       assert_includes(config.instance_variable_get(:@excluded_patterns), "#{Dir.pwd}/vendor/bundle/**/*.rb")
     ensure
@@ -74,7 +74,7 @@ module RubyIndexer
     end
 
     def test_indexables_does_not_include_gems_own_installed_files
-      @config.load_config({})
+      @config.apply_config({})
       indexables = @config.indexables
 
       assert(
@@ -95,7 +95,7 @@ module RubyIndexer
     end
 
     def test_paths_are_unique
-      @config.load_config({})
+      @config.apply_config({})
       indexables = @config.indexables
 
       assert_equal(indexables.uniq.length, indexables.length)
@@ -103,7 +103,7 @@ module RubyIndexer
 
     def test_configuration_raises_for_unknown_keys
       assert_raises(ArgumentError) do
-        @config.load_config({ "unknown_config" => 123 })
+        @config.apply_config({ "unknown_config" => 123 })
       end
     end
 

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -63,7 +63,7 @@ module RubyLsp
         indexing_config = {}
 
         # Need to use the workspace URI, otherwise, this will fail for people working on a project that is a symlink.
-        index_path = File.join(T.must(@store.workspace_uri.to_standardized_path), ".index.yml")
+        index_path = File.join(@store.workspace_uri.to_standardized_path, ".index.yml")
 
         if File.exist?(index_path)
           begin

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -255,7 +255,14 @@ module RubyLsp
     def perform_initial_indexing
       # The begin progress invocation happens during `initialize`, so that the notification is sent before we are
       # stuck indexing files
-      RubyIndexer.configuration.load_config
+
+      return unless File.exist?(".index.yml")
+
+      config = YAML.parse_file(".index.yml")
+      return unless config
+
+      config_hash = config.to_ruby
+      RubyIndexer.configuration.load_config(config_hash)
 
       Thread.new do
         begin

--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -62,7 +62,10 @@ module RubyLsp
 
         indexing_config = {}
 
-        if File.exist?(".index.yml")
+        # Need to use the workspace URI, otherwise, this will fail for people working on a project that is a symlink.
+        index_path = File.join(T.must(@store.workspace_uri.to_standardized_path), ".index.yml")
+
+        if File.exist?(index_path)
           begin
             indexing_config = YAML.parse_file(".index.yml").to_ruby
           rescue Psych::SyntaxError => e

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -34,6 +34,9 @@ class ExpectationsTestRunner < Minitest::Test
         include ExpectationsRunnerMethods
       RB
 
+      # The fixtures tests take some time to run, this allows us to skip them locally if desired
+      return if ENV["RUBY_LSP_SKIP_FIXTURES_TEST"]
+
       Dir.glob(TEST_RUBY_LSP_FIXTURES).each do |path|
         test_name = File.basename(path, ".rb")
 


### PR DESCRIPTION
### Motivation

We plan to rename `.index.yml` to `.ruby-lsp.yml` and use that for general configuration. As a first step, this PR refactors the indexer to accept a configuration hash, instead of reading the config file directly.

### Implementation

Pass the config as a hash.

### Automated Tests

Updated

### Manual Tests

Ensure the indexing runs successfully.
