### PR TITLE
Add Prism warnings in diagnostics

### DIFF
--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -63,18 +63,20 @@ module RubyLsp
       sig { returns(T::Array[Interface::Diagnostic]) }
       def syntax_warning_diagnostics
         @document.parse_result.warnings.map do |warning|
+          location = warning.location
+
           Interface::Diagnostic.new(
             source: "Prism",
             message: warning.message,
             severity: Constant::DiagnosticSeverity::WARNING,
             range: Interface::Range.new(
               start: Interface::Position.new(
-                line: warning.location.start_line - 1,
-                character: warning.location.start_column,
+                line: location.start_line - 1,
+                character: location.start_column,
               ),
               end: Interface::Position.new(
-                line: warning.location.end_line - 1,
-                character: warning.location.end_column,
+                line: location.end_line - 1,
+                character: location.end_column,
               ),
             ),
           )
@@ -84,15 +86,17 @@ module RubyLsp
       sig { returns(T::Array[Interface::Diagnostic]) }
       def syntax_error_diagnostics
         @document.parse_result.errors.map do |error|
+          location = error.location
+
           Interface::Diagnostic.new(
             range: Interface::Range.new(
               start: Interface::Position.new(
-                line: error.location.start_line - 1,
-                character: error.location.start_column,
+                line: location.start_line - 1,
+                character: location.start_column,
               ),
               end: Interface::Position.new(
-                line: error.location.end_line - 1,
-                character: error.location.end_column,
+                line: location.end_line - 1,
+                character: location.end_column,
               ),
             ),
             message: error.message,

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -42,16 +42,46 @@ module RubyLsp
 
       sig { override.returns(T.nilable(T.all(T::Array[Interface::Diagnostic], Object))) }
       def perform
-        # Running RuboCop is slow, so to avoid excessive runs we only do so if the file is syntactically valid
-        return syntax_error_diagnostics if @document.syntax_error?
-        return [] unless defined?(Support::RuboCopDiagnosticsRunner)
+        diagnostics = []
+        diagnostics.concat(syntax_error_diagnostics, syntax_warning_diagnostics)
 
-        Support::RuboCopDiagnosticsRunner.instance.run(@uri, @document).map!(&:to_lsp_diagnostic)
+        # Running RuboCop is slow, so to avoid excessive runs we only do so if the file is syntactically valid
+        return diagnostics if @document.syntax_error?
+
+        diagnostics.concat(
+          Support::RuboCopDiagnosticsRunner.instance.run(
+            @uri,
+            @document,
+          ).map!(&:to_lsp_diagnostic),
+        ) if defined?(Support::RuboCopDiagnosticsRunner)
+
+        diagnostics
       end
 
       private
 
-      sig { returns(T.nilable(T::Array[Interface::Diagnostic])) }
+      sig { returns(T::Array[Interface::Diagnostic]) }
+      def syntax_warning_diagnostics
+        @document.parse_result.warnings.map do |warning|
+          Interface::Diagnostic.new(
+            source: "Prism",
+            message: warning.message,
+            severity: Constant::DiagnosticSeverity::WARNING,
+            range: Interface::Range.new(
+              start: Interface::Position.new(
+                line: warning.location.start_line - 1,
+                character: warning.location.start_column,
+              ),
+              end: Interface::Position.new(
+                line: warning.location.end_line - 1,
+                character: warning.location.end_column,
+              ),
+            ),
+          )
+        end
+      end
+
+      sig { returns(T::Array[Interface::Diagnostic]) }
       def syntax_error_diagnostics
         @document.parse_result.errors.map do |error|
           Interface::Diagnostic.new(

--- a/test/expectations/diagnostics/syntax_diagnostics.exp.json
+++ b/test/expectations/diagnostics/syntax_diagnostics.exp.json
@@ -1,0 +1,110 @@
+{
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 0
+        },
+        "end": {
+          "line": 7,
+          "character": 0
+        }
+      },
+      "severity": 1,
+      "source": "Prism",
+      "message": "unexpected end of file, assuming it is closing the parent top level context"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 0
+        },
+        "end": {
+          "line": 7,
+          "character": 0
+        }
+      },
+      "severity": 1,
+      "source": "Prism",
+      "message": "expected an `end` to close the `def` statement"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 2
+        },
+        "end": {
+          "line": 0,
+          "character": 3
+        }
+      },
+      "severity": 2,
+      "source": "Prism",
+      "message": "ambiguous first argument; put parentheses or a space even after `+` operator"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 2
+        },
+        "end": {
+          "line": 1,
+          "character": 3
+        }
+      },
+      "severity": 2,
+      "source": "Prism",
+      "message": "ambiguous first argument; put parentheses or a space even after `-` operator"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 2
+        },
+        "end": {
+          "line": 2,
+          "character": 3
+        }
+      },
+      "severity": 2,
+      "source": "Prism",
+      "message": "ambiguous `*` has been interpreted as an argument prefix"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 2
+        },
+        "end": {
+          "line": 3,
+          "character": 3
+        }
+      },
+      "severity": 2,
+      "source": "Prism",
+      "message": "ambiguous `/`; wrap regexp in parentheses or add a space after `/` operator"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 7
+        },
+        "end": {
+          "line": 4,
+          "character": 10
+        }
+      },
+      "severity": 2,
+      "source": "Prism",
+      "message": "END in method; use at_exit"
+    }
+  ],
+  "params": []
+}

--- a/test/fixtures/syntax_diagnostics.rb
+++ b/test/fixtures/syntax_diagnostics.rb
@@ -1,0 +1,7 @@
+b +a
+b -a
+b *a
+b /a/
+def m; END{}; end
+
+def foo

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -22,7 +22,7 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
     assert_empty(stdout)
 
     # On Windows, RuboCop will complain that the file is missing a carriage return at the end. We need to ignore these
-    T.must(result).reject { |diagnostic| diagnostic.code == "Layout/EndOfLine" }
+    T.must(result).reject { |diagnostic| diagnostic.source == "RuboCop" && diagnostic.code == "Layout/EndOfLine" }
   end
 
   def assert_expectations(source, expected)
@@ -32,7 +32,7 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
     actual.each do |diagnostic|
       attributes = diagnostic.attributes
 
-      attributes[:data][:code_actions].each do |code_action|
+      attributes.fetch(:data, {}).fetch(:code_actions, []).each do |code_action|
         code_action_changes = code_action.attributes[:edit].attributes[:documentChanges]
         code_action_changes.each do |code_action_change|
           code_action_change
@@ -51,7 +51,7 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
     diagnostics.map do |diagnostic|
       LanguageServer::Protocol::Interface::Diagnostic.new(
         message: diagnostic["message"],
-        source: "RuboCop",
+        source: diagnostic["source"],
         code: diagnostic["code"],
         severity: diagnostic["severity"],
         code_description: diagnostic["codeDescription"],


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/1406

Add [Prism warnings](https://github.com/ruby/prism/blob/0727b5d9ca2a3b0d50a7a9781f8f4e7e939eb824/src/diagnostic.c#L305-L313) in diagnostics, actually we handle only errors.
 
### Implementation

Same as error, but based on [`parse_result.warnings`](https://github.com/ruby/prism/blob/f41ba6d7ecfc844535996e24525d4ea47c0a85db/rbi/prism/parse_result.rbi#L214-L232)

Some minor changes in `DiagnosticsExpectationsTest` because we are not handling only Rubocop diagnostics now.

### Automated Tests

Added fixtures and expectations.

### Manual Tests

You can open `test/fixtures/syntax_diagnostics.rb` and see errors and warning.

![image](https://github.com/Shopify/ruby-lsp/assets/38727166/6090a650-5c5e-46b1-8b01-7c71a60d2ad2)

![image](https://github.com/Shopify/ruby-lsp/assets/38727166/0aa8b57a-f4c1-43b5-8eae-758d5db60182)


