### PR TITLE
Support RuboCop's LSP mode

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -13,6 +13,10 @@ rescue LoadError
   raise StandardError, "Incompatible RuboCop version. Ruby LSP requires >= 1.4.0"
 end
 
+if RuboCop.const_defined?(:LSP) # This condition will be removed when requiring RuboCop >= 1.61.
+  RuboCop::LSP.enable
+end
+
 module RubyLsp
   module Requests
     module Support


### PR DESCRIPTION
### Motivation

Resolves #1449.

This PR applies `RuboCop::LSP.enable`, which is the minimal API for RuboCop to handle in the context of LSP: https://docs.rubocop.org/rubocop/1.61/usage/lsp.html#language-server-development

### Implementation

Furthermore, `RuboCop::LSP.enable` method and `RuboCop::LSP` module were introduced in RuboCop 1.61.0. This PR ensures compatibility with existing versions of RuboCop dependencies. However, in older versions of RuboCop prior to 1.60, `AutoCorrect: contextual` behaves the same as `AutoCorrect: true`.
