### PR TITLE
Fix missing images on the documentation website

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Generate documentation
         run: bundle exec rake rdoc
 
+      - name: Copy README images to the docs folder
+        run: |
+          mkdir docs/vscode
+          cp vscode/icon.png docs/vscode/icon.png
+          cp -R vscode/extras docs/vscode/
+
       - name: Commit to gh-pages
         run: |
           git add docs -f

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Shopify/rdoc.git
-  revision: 360dd09cdd025278e3f8156ca895395325f54d7b
+  revision: dbabc13c8ceea0375bf01c6652ca3c5175230c5b
   branch: create_snapper_generator
   specs:
     rdoc (6.6.2)


### PR DESCRIPTION
### Motivation

Currently, the documentation site's images are all missing: 

<img width="50%" alt="Screenshot 2024-03-05 at 23 59 44" src="https://github.com/Shopify/ruby-lsp/assets/5079556/c5873682-bb7d-4d54-9f3e-38eb29f41db4">


### Implementation

It's caused by 2 reasons:

1. The README's image paths don't exist under the `/docs` directory.
2. The Snapper template has a CSP rule that blocks local images.

2 has been fixed via https://github.com/Shopify/rdoc/pull/15

This commit addresses 1 by copying the images that README uses to the `/docs` directory in the doc publishing workflow.

The upside of this approach is that it's simple and we don't need to change the README's image paths, nor move the images around.

The downside is that we still can't see the images locally. But I think it's a reasonable trade-off.


### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
