### PR TITLE
Use `highlighted_area` for rubocop diagnostics

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -40,6 +40,9 @@ module RubyLsp
 
         sig { returns(Interface::Diagnostic) }
         def to_lsp_diagnostic
+          # highlighted_area contains the begin and end position of the first line
+          # This ensures that multiline offenses don't clutter the editor
+          highlighted = @offense.highlighted_area
           Interface::Diagnostic.new(
             message: message,
             source: "RuboCop",
@@ -49,11 +52,11 @@ module RubyLsp
             range: Interface::Range.new(
               start: Interface::Position.new(
                 line: @offense.line - 1,
-                character: @offense.column,
+                character: highlighted.begin_pos,
               ),
               end: Interface::Position.new(
-                line: @offense.last_line - 1,
-                character: @offense.last_column,
+                line: @offense.line - 1,
+                character: highlighted.end_pos,
               ),
             ),
             data: {

--- a/test/expectations/diagnostics/def_bad_formatting.exp.json
+++ b/test/expectations/diagnostics/def_bad_formatting.exp.json
@@ -170,7 +170,7 @@
           "character": 0
         },
         "end": {
-          "line": 2,
+          "line": 1,
           "character": 0
         }
       },
@@ -253,7 +253,7 @@
           "character": 0
         },
         "end": {
-          "line": 3,
+          "line": 2,
           "character": 0
         }
       },

--- a/test/expectations/diagnostics/multiline_offense.exp.json
+++ b/test/expectations/diagnostics/multiline_offense.exp.json
@@ -1,0 +1,57 @@
+{
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 0
+        },
+        "end": {
+          "line": 5,
+          "character": 23
+        }
+      },
+      "severity": 3,
+      "code": "Metrics/MethodLength",
+      "codeDescription": {
+        "href": "https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmethodlength"
+      },
+      "source": "RuboCop",
+      "message": "Metrics/MethodLength: Method has too many lines. [11/10]\n\nThis offense is not auto-correctable.\n",
+      "data": {
+        "correctable": false,
+        "code_actions": [
+          {
+            "title": "Disable Metrics/MethodLength for this line",
+            "kind": "quickfix",
+            "edit": {
+              "documentChanges": [
+                {
+                  "textDocument": {
+                    "uri": "file:///fake",
+                    "version": null
+                  },
+                  "edits": [
+                    {
+                      "range": {
+                        "start": {
+                          "line": 5,
+                          "character": 23
+                        },
+                        "end": {
+                          "line": 5,
+                          "character": 23
+                        }
+                      },
+                      "newText": " # rubocop:disable Metrics/MethodLength"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/multiline_offense.rb
+++ b/test/fixtures/multiline_offense.rb
@@ -1,0 +1,20 @@
+# typed: true
+# frozen_string_literal: true
+
+# rubocop:enable Metrics/MethodLength
+sig { void }
+def very_complex_method
+  if foo
+    do_something
+  else
+    do_something_else
+  end
+
+  if bar
+    do_the_same
+  else
+    do_something_different
+  end
+
+  baz
+end


### PR DESCRIPTION
### Motivation

Closes #1119

### Implementation

Like suggested, this uses `highlight_range` on the offense to only mark the first line of multiline offenses.
This method result is not memoized by rubocop. I don't know if this really matters but I've added the method result in a local variable.

### Automated Tests

Yes. Almost all current tests need no changes with this.

### Manual Tests

![image](https://github.com/Shopify/ruby-lsp/assets/14981592/9cf949b3-a361-435f-ab9e-70506f53e312)

The quick fix still adds the rubocop disable command at the right location.
