### PR TITLE
Implement Shadowenv as a version manager object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,22 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.3.0"
+
+      - name: Download shadowenv
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+            pattern="shadowenv-x86_64-unknown-linux-gnu"
+          else
+            pattern="shadowenv-x86_64-apple-darwin"
+          fi
+
+          gh release download --pattern $pattern --repo=Shopify/shadowenv --output shadowenv
+          chmod +x shadowenv
+          sudo mv shadowenv /usr/local/bin/shadowenv
 
       - name: Run tests
         working-directory: ./vscode

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -477,6 +477,7 @@
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.6",
     "@types/node": "20.x",
+    "@types/sinon": "^17.0.3",
     "@types/vscode": "^1.68.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
@@ -491,6 +492,7 @@
     "ovsx": "^0.8.3",
     "prettier": "^3.2.5",
     "typescript": "^5.4.2",
+    "sinon": "^17.0.1",
     "vscode-oniguruma": "^2.0.1",
     "vscode-textmate": "^9.0.0"
   },

--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -1,0 +1,62 @@
+/* eslint-disable no-process-env */
+import * as vscode from "vscode";
+
+import { asyncExec } from "../common";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// Shadowenv is a tool that allows managing environment variables upon entering a directory. It allows users to manage
+// which Ruby version should be used for each project, in addition to other customizations such as GEM_HOME.
+//
+// Learn more: https://github.com/Shopify/shadowenv
+export class Shadowenv extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    try {
+      vscode.workspace.fs.stat(
+        vscode.Uri.joinPath(this.bundleUri, ".shadowenv.d"),
+      );
+    } catch (error: any) {
+      throw new Error(
+        "The Ruby LSP version manager is configured to be shadowenv, \
+        but no .shadowenv.d directory was found in the workspace",
+      );
+    }
+
+    const activationScript =
+      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
+
+    try {
+      const result = await asyncExec(
+        `shadowenv exec -- ruby -rjson -e '${activationScript}'`,
+        {
+          cwd: this.bundleUri.fsPath,
+        },
+      );
+
+      const parsedResult = JSON.parse(result.stderr);
+      return {
+        env: { ...process.env, ...parsedResult.env },
+        yjit: parsedResult.yjit,
+        version: parsedResult.version,
+      };
+    } catch (error: any) {
+      // If running `shadowev exec` fails, it's typically because the workspace has not been trusted yet. Here we offer
+      // to trust it and fail it the user decides to not the trust the workspace (since in that case, we are unable to
+      // activate the Ruby environment).
+      const answer = await vscode.window.showErrorMessage(
+        `Failed to run shadowenv exec. Is ${this.bundleUri.fsPath} trusted? Run 'shadowenv trust --help' to know more`,
+        "Trust workspace",
+        "Cancel",
+      );
+
+      if (answer === "Trust workspace") {
+        await asyncExec("shadowenv trust", { cwd: this.bundleUri.fsPath });
+        return this.activate();
+      }
+
+      throw new Error(
+        "Cannot activate Ruby environment in an untrusted workspace",
+      );
+    }
+  }
+}

--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -1,0 +1,45 @@
+import path from "path";
+
+import * as vscode from "vscode";
+
+import { WorkspaceChannel } from "../workspaceChannel";
+
+export interface ActivationResult {
+  env: NodeJS.ProcessEnv;
+  yjit: boolean;
+  version: string;
+}
+
+export abstract class VersionManager {
+  protected readonly outputChannel: WorkspaceChannel;
+  protected readonly workspaceFolder: vscode.WorkspaceFolder;
+  protected readonly bundleUri: vscode.Uri;
+  private readonly customBundleGemfile?: string;
+
+  constructor(
+    workspaceFolder: vscode.WorkspaceFolder,
+    outputChannel: WorkspaceChannel,
+  ) {
+    this.workspaceFolder = workspaceFolder;
+    this.outputChannel = outputChannel;
+    const customBundleGemfile: string = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get("bundleGemfile")!;
+
+    if (customBundleGemfile.length > 0) {
+      this.customBundleGemfile = path.isAbsolute(customBundleGemfile)
+        ? customBundleGemfile
+        : path.resolve(
+            path.join(this.workspaceFolder.uri.fsPath, customBundleGemfile),
+          );
+    }
+
+    this.bundleUri = this.customBundleGemfile
+      ? vscode.Uri.file(path.dirname(this.customBundleGemfile))
+      : workspaceFolder.uri;
+  }
+
+  // Activate the Ruby environment for the version manager, returning all of the necessary information to boot the
+  // language server
+  abstract activate(): Promise<ActivationResult>;
+}

--- a/vscode/src/test/suite/ruby/shadowenv.test.ts
+++ b/vscode/src/test/suite/ruby/shadowenv.test.ts
@@ -1,0 +1,218 @@
+/* eslint-disable no-process-env */
+import fs from "fs";
+import assert from "assert";
+import path from "path";
+import os from "os";
+
+import { beforeEach, afterEach } from "mocha";
+import * as vscode from "vscode";
+import sinon from "sinon";
+
+import { Shadowenv } from "../../../ruby/shadowenv";
+import { WorkspaceChannel } from "../../../workspaceChannel";
+import { LOG_CHANNEL, asyncExec } from "../../../common";
+
+const RUBY_VERSION = "3.3.0";
+
+suite("Shadowenv", () => {
+  if (os.platform() === "win32") {
+    // eslint-disable-next-line no-console
+    console.log("Skipping Shadowenv tests on Windows");
+    return;
+  }
+
+  let rootPath: string;
+  let workspacePath: string;
+  let workspaceFolder: vscode.WorkspaceFolder;
+  let outputChannel: WorkspaceChannel;
+  let bundleGemfileStub: sinon.SinonStub;
+  let rubyBinPath: string;
+
+  if (process.env.CI && os.platform() === "linux") {
+    rubyBinPath = path.join(
+      "/",
+      "opt",
+      "hostedtoolcache",
+      "Ruby",
+      RUBY_VERSION,
+      "x64",
+      "bin",
+    );
+  } else if (process.env.CI) {
+    rubyBinPath = path.join(
+      "/",
+      "Users",
+      "runner",
+      "hostedtoolcache",
+      "Ruby",
+      RUBY_VERSION,
+      "x64",
+      "bin",
+    );
+  } else {
+    rubyBinPath = path.join("/", "opt", "rubies", RUBY_VERSION, "bin");
+  }
+
+  assert.ok(
+    fs.existsSync(rubyBinPath),
+    `Ruby bin path does not exist ${rubyBinPath}`,
+  );
+
+  beforeEach(() => {
+    rootPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-chruby-"));
+    workspacePath = path.join(rootPath, "workspace");
+
+    fs.mkdirSync(workspacePath);
+    fs.mkdirSync(path.join(workspacePath, ".shadowenv.d"));
+
+    bundleGemfileStub = sinon
+      .stub(vscode.workspace, "getConfiguration")
+      .returns({ get: () => path.join(workspacePath, "Gemfile") } as any)!;
+
+    workspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    outputChannel = new WorkspaceChannel("fake", LOG_CHANNEL);
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootPath, { recursive: true, force: true });
+    bundleGemfileStub.restore();
+  });
+
+  test("Finds Ruby only binary path is appended to PATH", async () => {
+    await asyncExec("shadowenv trust", { cwd: workspacePath });
+
+    fs.writeFileSync(
+      path.join(workspacePath, ".shadowenv.d", "500_ruby.lisp"),
+      `(env/prepend-to-pathlist "PATH" "${rubyBinPath}")`,
+    );
+
+    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+    const { env, version, yjit } = await shadowenv.activate();
+
+    assert.match(env.PATH!, new RegExp(rubyBinPath));
+    assert.strictEqual(version, RUBY_VERSION);
+    assert.notStrictEqual(yjit, undefined);
+  });
+
+  test("Finds Ruby on a complete shadowenv configuration", async () => {
+    await asyncExec("shadowenv trust", { cwd: workspacePath });
+
+    fs.writeFileSync(
+      path.join(workspacePath, ".shadowenv.d", "500_ruby.lisp"),
+      `(provide "ruby" "${RUBY_VERSION}")
+      (when-let ((ruby-root (env/get "RUBY_ROOT")))
+      (env/remove-from-pathlist "PATH" (path-concat ruby-root "bin"))
+      (when-let ((gem-root (env/get "GEM_ROOT")))
+        (env/remove-from-pathlist "PATH" (path-concat gem-root "bin")))
+      (when-let ((gem-home (env/get "GEM_HOME")))
+        (env/remove-from-pathlist "PATH" (path-concat gem-home "bin"))))
+
+      (env/set "BUNDLE_PATH" ())
+      (env/set "GEM_PATH" ())
+      (env/set "GEM_HOME" ())
+      (env/set "RUBYOPT" ())
+      (env/set "RUBYLIB" ())
+
+      (env/set "RUBY_ROOT" "${path.dirname(rubyBinPath)}")
+      (env/prepend-to-pathlist "PATH" "${rubyBinPath}")
+      (env/set "RUBY_ENGINE" "ruby")
+      (env/set "RUBY_VERSION" "${RUBY_VERSION}")
+      (env/set "GEM_ROOT" "${path.dirname(rubyBinPath)}/lib/ruby/gems/${RUBY_VERSION}")
+      `,
+    );
+
+    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+    const { env, version, yjit } = await shadowenv.activate();
+
+    assert.match(env.PATH!, new RegExp(rubyBinPath));
+    assert.strictEqual(
+      env.GEM_ROOT,
+      `${path.dirname(rubyBinPath)}/lib/ruby/gems/${RUBY_VERSION}`,
+    );
+    assert.strictEqual(version, RUBY_VERSION);
+    assert.notStrictEqual(yjit, undefined);
+  });
+
+  test("Overrides GEM_HOME and GEM_PATH if necessary", async () => {
+    await asyncExec("shadowenv trust", { cwd: workspacePath });
+
+    fs.writeFileSync(
+      path.join(workspacePath, ".shadowenv.d", "500_ruby.lisp"),
+      `(env/set "RUBY_ENGINE" "ruby")
+       (env/set "RUBY_VERSION" "${RUBY_VERSION}")
+
+       (env/set "GEM_HOME" "/fake/.bundle/project/${RUBY_VERSION}")
+       (env/set "GEM_PATH" "/fake/.bundle/project/${RUBY_VERSION}:")
+       (env/prepend-to-pathlist "PATH" "/fake/.bundle/project/${RUBY_VERSION}/bin")
+       (env/prepend-to-pathlist "PATH" "${rubyBinPath}")`,
+    );
+
+    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+    const { env, version, yjit } = await shadowenv.activate();
+
+    assert.match(env.PATH!, new RegExp(rubyBinPath));
+    assert.strictEqual(env.GEM_HOME, `/fake/.bundle/project/${RUBY_VERSION}`);
+    assert.strictEqual(version, RUBY_VERSION);
+    assert.notStrictEqual(yjit, undefined);
+  });
+
+  test("Untrusted workspace offers to trust it", async () => {
+    fs.writeFileSync(
+      path.join(workspacePath, ".shadowenv.d", "500_ruby.lisp"),
+      `(env/set "RUBY_ENGINE" "ruby")
+       (env/set "RUBY_VERSION" "${RUBY_VERSION}")
+
+       (env/set "GEM_HOME" "/fake/.bundle/project/${RUBY_VERSION}")
+       (env/set "GEM_PATH" "/fake/.bundle/project/${RUBY_VERSION}:")
+       (env/prepend-to-pathlist "PATH" "/fake/.bundle/project/${RUBY_VERSION}/bin")
+       (env/prepend-to-pathlist "PATH" "${rubyBinPath}")`,
+    );
+
+    const stub = sinon
+      .stub(vscode.window, "showErrorMessage")
+      .resolves("Trust workspace" as any);
+
+    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+    const { env, version, yjit } = await shadowenv.activate();
+
+    assert.match(env.PATH!, new RegExp(rubyBinPath));
+    assert.strictEqual(env.GEM_HOME, `/fake/.bundle/project/${RUBY_VERSION}`);
+    assert.strictEqual(version, RUBY_VERSION);
+    assert.notStrictEqual(yjit, undefined);
+
+    assert.ok(stub.calledOnce);
+
+    stub.restore();
+  });
+
+  test("Deciding not to trust the workspace fails activation", async () => {
+    fs.writeFileSync(
+      path.join(workspacePath, ".shadowenv.d", "500_ruby.lisp"),
+      `(env/set "RUBY_ENGINE" "ruby")
+       (env/set "RUBY_VERSION" "${RUBY_VERSION}")
+
+       (env/set "GEM_HOME" "/fake/.bundle/project/${RUBY_VERSION}")
+       (env/set "GEM_PATH" "/fake/.bundle/project/${RUBY_VERSION}:")
+       (env/prepend-to-pathlist "PATH" "/fake/.bundle/project/${RUBY_VERSION}/bin")
+       (env/prepend-to-pathlist "PATH" "${rubyBinPath}")`,
+    );
+
+    const stub = sinon
+      .stub(vscode.window, "showErrorMessage")
+      .resolves("Cancel" as any);
+
+    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+
+    await assert.rejects(async () => {
+      await shadowenv.activate();
+    });
+
+    assert.ok(stub.calledOnce);
+
+    stub.restore();
+  });
+});

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -499,6 +499,41 @@
   resolved "https://registry.yarnpkg.com/@shopify/prettier-config/-/prettier-config-1.1.2.tgz#612f87c0cd1196e8b43c85425e587d0fa7f1172d"
   integrity sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==
 
+"@sinonjs/commons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
+  integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^11.2.2":
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz#50063cc3574f4a27bd8453180a04171c85cc9699"
+  integrity sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+
+"@sinonjs/samsam@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.0.tgz#0d488c91efb3fa1442e26abea81759dfc8b5ac60"
+  integrity sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
+  integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -543,6 +578,18 @@
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
+"@types/sinon@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-17.0.3.tgz#9aa7e62f0a323b9ead177ed23a36ea757141a5fa"
+  integrity sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "8.1.5"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz#5fd3592ff10c1e9695d377020c033116cc2889f2"
+  integrity sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==
 
 "@types/vscode@^1.68.0":
   version "1.86.0"
@@ -1357,6 +1404,11 @@ diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
+diff@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
+  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2648,6 +2700,11 @@ jszip@^3.10.1:
     readable-stream "~2.3.6"
     setimmediate "^1.0.5"
 
+just-extend@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-6.2.0.tgz#b816abfb3d67ee860482e7401564672558163947"
+  integrity sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==
+
 keytar@^7.7.0:
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/keytar/-/keytar-7.9.0.tgz#4c6225708f51b50cbf77c5aae81721964c2918cb"
@@ -2708,6 +2765,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -2892,6 +2954,17 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nise@^5.1.5:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.9.tgz#0cb73b5e4499d738231a473cd89bd8afbb618139"
+  integrity sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+    "@sinonjs/fake-timers" "^11.2.2"
+    "@sinonjs/text-encoding" "^0.7.2"
+    just-extend "^6.2.0"
+    path-to-regexp "^6.2.1"
 
 no-case@^3.0.4:
   version "3.0.4"
@@ -3146,6 +3219,11 @@ path-scurry@^1.10.1:
   dependencies:
     lru-cache "^9.1.1 || ^10.0.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-to-regexp@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
+  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -3536,6 +3614,18 @@ simple-get@^4.0.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+sinon@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-17.0.1.tgz#26b8ef719261bf8df43f925924cccc96748e407a"
+  integrity sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+    "@sinonjs/fake-timers" "^11.2.2"
+    "@sinonjs/samsam" "^8.0.0"
+    diff "^5.1.0"
+    nise "^5.1.5"
+    supports-color "^7.2.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -3667,7 +3757,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -3787,6 +3877,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-detect@4.0.8, type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
### Motivation

Migrate Shadowenv to the new version manager implementation approach, with its own dedicated class.

### Implementation

1. Added Sinon JS so that we can use stubs, mocks and spys. This makes testing much easier
2. Moved all Shadowenv activation logic inside its own dedicated class.
3. Started out simple with the parent class `VersionManager`, only requiring that subclasses implement the `activate` method

### Automated Tests

One of the main advantages of this new approach is exactly being able to test each version manager in detail. Added tests for all scenarios we cover.

Had to start downloading Shadowenv, so that we can run the tests using the real tool.

### Manual Tests

1. Start the extension on this branch
4. In the extension host window, open a project using Shadowenv
5. Verify that the Ruby LSP boots properly using the declared Ruby version
