### PR TITLE
Prevent the RuboCop runner from catching interrupts during tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,3 +54,14 @@ begin
 rescue LoadError
   # Tapioca (and thus Spoom) is not available on Windows
 end
+
+# The RuboCop runner catches interrupts to show a nicer exit message to users.
+# This prevents the Interrupt from reaching minitest to stop execution.
+module ReraiseInterrupt
+  def run(...)
+    super
+    raise Interrupt if aborting?
+  end
+end
+
+RubyLsp::Requests::Support::RuboCopRunner.include(ReraiseInterrupt)


### PR DESCRIPTION
### Motivation

Closes #1519. cc @andyw8 

### Implementation

Since RuboCop is catching Interrupts, reraise it when running tests to make it bubble up to minitest.
The RuboCop part of this is at https://github.com/rubocop/rubocop/blob/1973badb1ca23c4419e88977ee60dac8acd2bbe8/lib/rubocop/runner.rb#L67-L82

I made it test only since this seems to only come up when running tests but it could also be put at the end of https://github.com/Shopify/ruby-lsp/blob/main/lib/ruby_lsp/requests/support/rubocop_runner.rb#L94

Please let me know if that is the preferred route to take.

### Automated Tests

None, not necessary (or easily possible)

### Manual Tests

`DiagnosticsExpectationsTest` which makes use of the RuboCop runner is now properly interruptable.
