### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,13 @@ updates:
     labels:
       - "dependencies"
       - "fixtures"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "Shopify/ruby-dev-exp"
+    labels:
+      - "chore"
+      - "dependencies"
+      - "gh-actions"


### PR DESCRIPTION
Saves us having to update manually, like in https://github.com/Shopify/ruby-lsp/pull/1520.