### PR TITLE
Implement Mise as a manager object

### DIFF
--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-process-env */
+import os from "os";
+
+import * as vscode from "vscode";
+
+import { asyncExec } from "../common";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// Mise (mise en place) is a manager for dev tools, environment variables and tasks
+//
+// Learn more: https://github.com/jdx/mise
+export class Mise extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    const miseUri = vscode.Uri.joinPath(
+      vscode.Uri.file(os.homedir()),
+      ".local",
+      "bin",
+      "mise",
+    );
+
+    try {
+      vscode.workspace.fs.stat(miseUri);
+    } catch (error: any) {
+      throw new Error(
+        `The Ruby LSP version manager is configured to be Mise, but ${miseUri.fsPath} does not exist`,
+      );
+    }
+
+    const activationScript =
+      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
+
+    // The exec command in Mise is called `x`
+    const result = await asyncExec(
+      `${miseUri.fsPath} x -- ruby -rjson -e '${activationScript}'`,
+      {
+        cwd: this.bundleUri.fsPath,
+      },
+    );
+
+    const parsedResult = JSON.parse(result.stderr);
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+    };
+  }
+}

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -1,0 +1,57 @@
+import assert from "assert";
+import path from "path";
+import os from "os";
+
+import * as vscode from "vscode";
+import sinon from "sinon";
+
+import { Mise } from "../../../ruby/mise";
+import { WorkspaceChannel } from "../../../workspaceChannel";
+import * as common from "../../../common";
+
+suite("Mise", () => {
+  if (os.platform() === "win32") {
+    // eslint-disable-next-line no-console
+    console.log("Skipping Mise tests on Windows");
+    return;
+  }
+
+  test("Finds Ruby only binary path is appended to PATH", async () => {
+    // eslint-disable-next-line no-process-env
+    const workspacePath = process.env.PWD!;
+    const workspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
+    const mise = new Mise(workspaceFolder, outputChannel);
+
+    const activationScript =
+      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
+
+    const execStub = sinon.stub(common, "asyncExec").resolves({
+      stdout: "",
+      stderr: JSON.stringify({
+        env: { ANY: "true" },
+        yjit: true,
+        version: "3.0.0",
+      }),
+    });
+
+    const { env, version, yjit } = await mise.activate();
+
+    assert.ok(
+      execStub.calledOnceWithExactly(
+        `${os.homedir()}/.local/bin/mise x -- ruby -rjson -e '${activationScript}'`,
+        { cwd: workspacePath },
+      ),
+    );
+
+    assert.strictEqual(version, "3.0.0");
+    assert.strictEqual(yjit, true);
+    assert.deepStrictEqual(env.ANY, "true");
+
+    execStub.restore();
+  });
+});


### PR DESCRIPTION
### Motivation

Implement Mise activation as a manager object.

### Implementation

Quite similar to Shadowenv, we use the executable to run a Ruby script with the environment activated.

According to the Mise docs, the standard installation location is `~/.local/bin/mise` and you have to use alternative methods to get it installed elsewhere. Because of this, I think it's fine to begin only supporting the default installation path.

Like most version managers, Mise does not support Windows.

### Automated Tests

Added a test just to verify we invoke the command with the expected arguments. I'm going to vote for not installing Mise in CI.

### Manual Tests

1. Start the extension in development mode on this branch
2. In the extension host window, open a project using Mise to manage the Ruby version
3. Verify that the Ruby LSP was booted using the right Ruby version by clicking the language status item (the `{}` button) right next to the language mode (where it says `Ruby` in the bottom right corner of the editor)