### PR TITLE
Remove pattern from document selector

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -91,7 +91,6 @@ function collectClientOptions(
   configuration: vscode.WorkspaceConfiguration,
   workspaceFolder: vscode.WorkspaceFolder,
   outputChannel: WorkspaceChannel,
-  ruby: Ruby,
 ): LanguageClientOptions {
   const pullOn: "change" | "save" | "both" =
     configuration.get("pullDiagnosticsOn")!;
@@ -104,26 +103,8 @@ function collectClientOptions(
   const features: EnabledFeatures = configuration.get("enabledFeatures")!;
   const enabledFeatures = Object.keys(features).filter((key) => features[key]);
 
-  const documentSelector = [
-    {
-      language: "ruby",
-      pattern: path.join(workspaceFolder.uri.fsPath, "**", "*"),
-    },
-  ];
-
-  if (ruby.env.GEM_PATH) {
-    const parts = ruby.env.GEM_PATH.split(path.delimiter);
-
-    parts.forEach((gemPath) => {
-      documentSelector.push({
-        language: "ruby",
-        pattern: path.join(gemPath, "**", "*"),
-      });
-    });
-  }
-
   return {
-    documentSelector,
+    documentSelector: [{ language: "ruby" }],
     workspaceFolder,
     diagnosticCollectionName: LSP_NAME,
     outputChannel,
@@ -167,7 +148,6 @@ export default class Client extends LanguageClient implements ClientInterface {
         vscode.workspace.getConfiguration("rubyLsp"),
         workspaceFolder,
         outputChannel,
-        ruby,
       ),
     );
 


### PR DESCRIPTION
### Motivation

Closes #1349

In https://github.com/Shopify/vscode-ruby-lsp/pull/986, we ended up making a mistake using `path.join` for the document selector pattern. In Windows, that's going to result in `workspace\**\*` (using backslashes), which doesn't get recognized properly.

### Implementation

I took another look at it and there's no reason why we actually need the pattern. We want to handle all Ruby files, so we can just remove it.

This is the same that [Rust Analyzer does](https://github.com/rust-lang/rust-analyzer/blob/a2e274142f35d21fd28d28655f4af8e8531ab649/editors/code/src/client.ts#L82).

### Manual Tests

1. Start the extension on this branch
2. Open any file and try to go to the definition of a constant
3. Verify you can do that inside the workspace
4. Jump to the source code of a gem
5. Verify you can also go to definitions inside the gem's source code