### PR TITLE
Use original Bundler environment to find workspace dependencies

### DIFF
--- a/lib/ruby_lsp/executor.rb
+++ b/lib/ruby_lsp/executor.rb
@@ -235,15 +235,17 @@ module RubyLsp
 
     sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
     def workspace_dependencies
-      definition = Bundler.definition
-      dep_keys = definition.locked_deps.keys.to_set
-      definition.specs.map do |spec|
-        {
-          name: spec.name,
-          version: spec.version,
-          path: spec.full_gem_path,
-          dependency: dep_keys.include?(spec.name),
-        }
+      Bundler.with_original_env do
+        definition = Bundler.definition
+        dep_keys = definition.locked_deps.keys.to_set
+        definition.specs.map do |spec|
+          {
+            name: spec.name,
+            version: spec.version,
+            path: spec.full_gem_path,
+            dependency: dep_keys.include?(spec.name),
+          }
+        end
       end
     rescue Bundler::GemfileNotFound
       []


### PR DESCRIPTION
### Motivation

We need to use `Bundler.with_original_env` when getting the gems for the dependencies view, otherwise we include things from the custom bundle, which are not a part of the application's dependencies.

### Implementation

Just wrapped the code in a call to `Bundler.with_original_env`.