### PR TITLE
Set error to false on workspace restart

### DIFF
--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -124,6 +124,8 @@ export class Workspace implements WorkspaceInterface {
         return;
       }
 
+      this.error = false;
+
       // If there's no client, then we can just start a new one
       if (!this.lspClient) {
         return this.start();


### PR DESCRIPTION
### Motivation

I noticed that when the LSP recovered during a restart, the status item was not being updated. It turns out it's because we were never resetting the `error` property, so it was always true after the initial error.

### Implementation

Starting setting the `error` to `false` when restarting the LSP.