### PR TITLE
Fix broken URL for Ruby version docs

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -197,8 +197,7 @@ export class Ruby implements RubyInterface {
     if (major < 3) {
       throw new Error(
         `The Ruby LSP requires Ruby 3.0 or newer to run. This project is using ${this.rubyVersion}. \
-        [See alternatives](https://github.com/Shopify/ruby-lsp/blob/main/vscode/README.md \
-        ?tab=readme-ov-file#ruby-version-requirement)`,
+        [See alternatives](https://github.com/Shopify/ruby-lsp/blob/main/vscode/README.md?#ruby-version-requirement)`,
       );
     }
 


### PR DESCRIPTION
### Motivation

Closes #1598

Because of the escaping the URL had a space in it, making it invalid and thus not rendering properly.

### Implementation

We don't really need the `tab` thing for the link to work, so I just removed that to fit everything into a single line.