### PR TITLE
Simplify magic comment regex

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -155,7 +155,7 @@ module RubyIndexer
 
     sig { returns(Regexp) }
     def magic_comment_regex
-      @magic_comment_regex ||= T.let(/^#\s*#{@excluded_magic_comments.join("|")}/, T.nilable(Regexp))
+      @magic_comment_regex ||= T.let(/#{@excluded_magic_comments.join("|")}/, T.nilable(Regexp))
     end
 
     private


### PR DESCRIPTION
### Motivation

We actually spend a considerable amount of time checking each comment to see if they are a magic comment to exclude from the documentation while indexing. Since we always run this regex against comments, we can simplify it to achieve better performance.

### Implementation

We don't need the `^#\s*` part of the regex. We know for a fact the line we're checking will be a comment, we just care if the magic comment is there.

This is x1.81 faster than the previous implementation on my machine.

### Automated Tests

Current tests should cover it.