### PR TITLE
Prepend vscode for relative image references

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img alt="Ruby LSP logo" width="200" src="icon.png" />
-</p>
-
 # Ruby LSP
 
 The Ruby LSP is an implementation of the [language server protocol](https://microsoft.github.io/language-server-protocol/)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -490,7 +490,7 @@
   },
   "scripts": {
     "vscode:prepublish": "yarn run esbuild-base --minify",
-    "package": "vsce package --out vscode-ruby-lsp.vsix",
+    "package": "vsce package --out vscode-ruby-lsp.vsix --baseImagesUrl https://github.com/Shopify/ruby-lsp/raw/HEAD/vscode",
     "package_prerelease": "vsce package --pre-release --out vscode-ruby-lsp.vsix",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "compile": "tsc -p ./",


### PR DESCRIPTION
### Motivation

Closes #1594

For some reason, the packaging tool `vsce` needs the image references to be relative to the top level.

For example, the correct relative path from the README.md would would be `extras/ruby_lsp_demo.gif` since both are inside the `vscode` directory. But that doesn't work. It only works if the relative path is `vscode/extras/ruby_lsp_demo.gif`.

I think it might use the `repo` configuration in `package.json` to derive the full URL for the images and that must be why it needs the path from the top level.

Unfortunately, if we simply prepend `vscode` manually to all references, they will not display correctly on GitHub, only on the marketplace.

### Implementation

I did two things:
1. Removed the icon from the extension's README. The icon already shows up immediately above in the marketplace page, so we end up repeating the same logo twice
2. Added a step in publish to prepend `vscode` to all image references in the README using `sed`