### PR TITLE
Fix no code lenses for minitest specs with constant paths

### DIFF
--- a/lib/ruby_lsp/listeners/code_lens.rb
+++ b/lib/ruby_lsp/listeners/code_lens.rb
@@ -258,8 +258,8 @@ module RubyLsp
         name = case first_argument
         when Prism::StringNode
           first_argument.content
-        when Prism::ConstantReadNode
-          first_argument.full_name
+        when Prism::ConstantReadNode, Prism::ConstantPathNode
+          constant_name(first_argument)
         end
 
         return unless name

--- a/test/expectations/code_lens/minitest_spec_tests.exp.json
+++ b/test/expectations/code_lens/minitest_spec_tests.exp.json
@@ -776,7 +776,204 @@
         "group_id": 1,
         "kind": "example"
       }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 16,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "Foo::Bar",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo::Bar/",
+          {
+            "start_line": 16,
+            "start_column": 0,
+            "end_line": 18,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": null,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 16,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "Foo::Bar",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo::Bar/",
+          {
+            "start_line": 16,
+            "start_column": 0,
+            "end_line": 18,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": null,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 16,
+          "character": 0
+        },
+        "end": {
+          "line": 18,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "Foo::Bar",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo::Bar/",
+          {
+            "start_line": 16,
+            "start_column": 0,
+            "end_line": 18,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": null,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 2
+        },
+        "end": {
+          "line": 17,
+          "character": 29
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "it_class_constant_path",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_class_constant_path/",
+          {
+            "start_line": 17,
+            "start_column": 2,
+            "end_line": 17,
+            "end_column": 29
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 2
+        },
+        "end": {
+          "line": 17,
+          "character": 29
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "it_class_constant_path",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_class_constant_path/",
+          {
+            "start_line": 17,
+            "start_column": 2,
+            "end_line": 17,
+            "end_column": 29
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 2
+        },
+        "end": {
+          "line": 17,
+          "character": 29
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "it_class_constant_path",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_class_constant_path/",
+          {
+            "start_line": 17,
+            "start_column": 2,
+            "end_line": 17,
+            "end_column": 29
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 4,
+        "kind": "example"
+      }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/fixtures/minitest_spec_tests.rb
+++ b/test/fixtures/minitest_spec_tests.rb
@@ -13,3 +13,7 @@ describe Foo do
 
   it "it_level_one_again"
 end
+
+describe Foo::Bar do
+  it 'it_class_constant_path'
+end


### PR DESCRIPTION
### Motivation

A `describe` with a class path did not show any code lenses. This fixes that.

### Implementation

Add the `ConstantPathNode` as a case to be handled and extract the path with the `constant_name` helper to handle/guard against dynamic paths.

### Automated Tests

Yes

### Manual Tests

See the modified expectation file, its code lenses result in the correct command being executed.
