### PR TITLE
Use ruby as default engine when searching for chruby installation

### DIFF
--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -90,23 +90,29 @@ export class Chruby extends VersionManager {
 
   // Returns the full URI to the Ruby executable
   private async findRubyUri(rubyVersion: RubyVersion): Promise<vscode.Uri> {
-    const fullRubyName = rubyVersion.engine
-      ? `${rubyVersion.engine}-${rubyVersion.version}`
-      : rubyVersion.version;
+    // If an engine was specified in the .ruby-version file, we favor looking for that first and also try just the
+    // version number. If no engine was specified, we first try just the version number and then we try using `ruby` as
+    // the default engine
+    const possibleVersionNames = rubyVersion.engine
+      ? [`${rubyVersion.engine}-${rubyVersion.version}`, rubyVersion.version]
+      : [rubyVersion.version, `ruby-${rubyVersion.version}`];
 
     for (const uri of this.rubyInstallationUris) {
-      const installationUri = vscode.Uri.joinPath(uri, fullRubyName);
+      let installationUri: vscode.Uri;
 
-      try {
-        await vscode.workspace.fs.stat(installationUri);
-        return vscode.Uri.joinPath(installationUri, "bin", "ruby");
-      } catch (_error: any) {
-        continue;
+      for (const versionName of possibleVersionNames) {
+        try {
+          installationUri = vscode.Uri.joinPath(uri, versionName);
+          await vscode.workspace.fs.stat(installationUri);
+          return vscode.Uri.joinPath(installationUri, "bin", "ruby");
+        } catch (_error: any) {
+          // Continue to the next version name
+        }
       }
     }
 
     throw new Error(
-      `Cannot find installation directory for Ruby version ${fullRubyName}`,
+      `Cannot find installation directory for Ruby version ${possibleVersionNames.join(" or ")}`,
     );
   }
 

--- a/vscode/src/test/suite/ruby/chruby.test.ts
+++ b/vscode/src/test/suite/ruby/chruby.test.ts
@@ -133,4 +133,26 @@ suite("Chruby", () => {
     assert.strictEqual(version, RUBY_VERSION);
     assert.notStrictEqual(yjit, undefined);
   });
+
+  test("Considers Ruby as the default engine if missing", async () => {
+    const rubyHome = path.join(rootPath, "fakehome", ".rubies");
+    fs.mkdirSync(path.join(rubyHome, `ruby-${RUBY_VERSION}`, "bin"), {
+      recursive: true,
+    });
+
+    createRubySymlinks(
+      path.join(rubyHome, `ruby-${RUBY_VERSION}`, "bin", "ruby"),
+    );
+
+    fs.writeFileSync(path.join(rootPath, ".ruby-version"), RUBY_VERSION);
+
+    const chruby = new Chruby(workspaceFolder, outputChannel);
+    chruby.rubyInstallationUris = [vscode.Uri.file(rubyHome)];
+
+    const { env, version, yjit } = await chruby.activate();
+
+    assert.match(env.PATH!, /ruby-3\.3\.0\/bin/);
+    assert.strictEqual(version, RUBY_VERSION);
+    assert.notStrictEqual(yjit, undefined);
+  });
 });


### PR DESCRIPTION
### Motivation

Closes #1603

Chruby allows you to not specify the engine in `.ruby-version`, but have the engine in the installation directory. For example:

```
# Dir
~/.rubies/ruby-3.3.0

# .ruby-version
3.3.0
```

It also allows you to do the opposite. Use `ruby-3.3.0` in `.ruby-version`, have the directory be just `3.3.0`. We need to account for that when we search for the Ruby installation.

### Implementation

Started doing the following:
- If the engine was specifically defined, then we first search for the directory with the engine name and then we try just the version number. It's important we try with the specified engine first because the .ruby-version file could be defining a truffleruby or jruby version
- If the engine is not specified, then we first look for the version number and then search for `ruby-X.Y.Z` (considering ruby as the default engine)

### Automated Tests

Added a test that reproduces the issue.