### PR TITLE
Add Mise option to setting enum

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -242,6 +242,7 @@
             "rbenv",
             "rvm",
             "shadowenv",
+            "mise",
             "custom"
           ],
           "default": "auto"


### PR DESCRIPTION
### Motivation

In #1529, I forgot to add `mise` to the list of possible values in the setting 🤦.
