### PR TITLE
Execute more specific test names for minitest specs

### DIFF
--- a/test/expectations/code_lens/minitest_spec_halfwritten.exp.json
+++ b/test/expectations/code_lens/minitest_spec_halfwritten.exp.json
@@ -1,0 +1,595 @@
+{
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 0
+        },
+        "end": {
+          "line": 15,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "Foo",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo(#|::)/\"",
+          {
+            "start_line": 3,
+            "start_column": 0,
+            "end_line": 15,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": null,
+        "kind": "group",
+        "id": 1
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 0
+        },
+        "end": {
+          "line": 15,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "Foo",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo(#|::)/\"",
+          {
+            "start_line": 3,
+            "start_column": 0,
+            "end_line": 15,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": null,
+        "kind": "group",
+        "id": 1
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 0
+        },
+        "end": {
+          "line": 15,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "Foo",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo(#|::)/\"",
+          {
+            "start_line": 3,
+            "start_column": 0,
+            "end_line": 15,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": null,
+        "kind": "group",
+        "id": 1
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 2
+        },
+        "end": {
+          "line": 6,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "something",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo::something(#|::)/\"",
+          {
+            "start_line": 6,
+            "start_column": 2,
+            "end_line": 6,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 1,
+        "kind": "group",
+        "id": 2
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 2
+        },
+        "end": {
+          "line": 6,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "something",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo::something(#|::)/\"",
+          {
+            "start_line": 6,
+            "start_column": 2,
+            "end_line": 6,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 1,
+        "kind": "group",
+        "id": 2
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 2
+        },
+        "end": {
+          "line": 6,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "something",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo::something(#|::)/\"",
+          {
+            "start_line": 6,
+            "start_column": 2,
+            "end_line": 6,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 1,
+        "kind": "group",
+        "id": 2
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 2
+        },
+        "end": {
+          "line": 8,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "something",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo::something(#|::)/\"",
+          {
+            "start_line": 8,
+            "start_column": 2,
+            "end_line": 8,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 1,
+        "kind": "group",
+        "id": 3
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 2
+        },
+        "end": {
+          "line": 8,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "something",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo::something(#|::)/\"",
+          {
+            "start_line": 8,
+            "start_column": 2,
+            "end_line": 8,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 1,
+        "kind": "group",
+        "id": 3
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 8,
+          "character": 2
+        },
+        "end": {
+          "line": 8,
+          "character": 22
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "something",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo::something(#|::)/\"",
+          {
+            "start_line": 8,
+            "start_column": 2,
+            "end_line": 8,
+            "end_column": 22
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 1,
+        "kind": "group",
+        "id": 3
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 2
+        },
+        "end": {
+          "line": 10,
+          "character": 11
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "runs",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name /^Foo\\#test_.*_runs$/",
+          {
+            "start_line": 10,
+            "start_column": 2,
+            "end_line": 10,
+            "end_column": 11
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 1,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 2
+        },
+        "end": {
+          "line": 10,
+          "character": 11
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "runs",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name /^Foo\\#test_.*_runs$/",
+          {
+            "start_line": 10,
+            "start_column": 2,
+            "end_line": 10,
+            "end_column": 11
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 1,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 2
+        },
+        "end": {
+          "line": 10,
+          "character": 11
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "runs",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name /^Foo\\#test_.*_runs$/",
+          {
+            "start_line": 10,
+            "start_column": 2,
+            "end_line": 10,
+            "end_column": 11
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 1,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 2
+        },
+        "end": {
+          "line": 14,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "something_else",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo::something_else(#|::)/\"",
+          {
+            "start_line": 12,
+            "start_column": 2,
+            "end_line": 14,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 1,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 2
+        },
+        "end": {
+          "line": 14,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "something_else",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo::something_else(#|::)/\"",
+          {
+            "start_line": 12,
+            "start_column": 2,
+            "end_line": 14,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 1,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 12,
+          "character": 2
+        },
+        "end": {
+          "line": 14,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "something_else",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name \"/^Foo::something_else(#|::)/\"",
+          {
+            "start_line": 12,
+            "start_column": 2,
+            "end_line": 14,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 1,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 4
+        },
+        "end": {
+          "line": 13,
+          "character": 12
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "abc",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name /^Foo::something_else\\#test_.*_abc$/",
+          {
+            "start_line": 13,
+            "start_column": 4,
+            "end_line": 13,
+            "end_column": 12
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 4
+        },
+        "end": {
+          "line": 13,
+          "character": 12
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "abc",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name /^Foo::something_else\\#test_.*_abc$/",
+          {
+            "start_line": 13,
+            "start_column": 4,
+            "end_line": 13,
+            "end_column": 12
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 13,
+          "character": 4
+        },
+        "end": {
+          "line": 13,
+          "character": 12
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_halfwritten.rb",
+          "abc",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_halfwritten.rb --name /^Foo::something_else\\#test_.*_abc$/",
+          {
+            "start_line": 13,
+            "start_column": 4,
+            "end_line": 13,
+            "end_column": 12
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 4,
+        "kind": "example"
+      }
+    }
+  ],
+  "params": [
+
+  ]
+}

--- a/test/expectations/code_lens/minitest_spec_in_module.exp.json
+++ b/test/expectations/code_lens/minitest_spec_in_module.exp.json
@@ -1,0 +1,202 @@
+{
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 2
+        },
+        "end": {
+          "line": 8,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_in_module.rb",
+          "Bar",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_in_module.rb --name \"/^Foo::Bar(#|::)/\"",
+          {
+            "start_line": 6,
+            "start_column": 2,
+            "end_line": 8,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": null,
+        "kind": "group",
+        "id": 1
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 2
+        },
+        "end": {
+          "line": 8,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_in_module.rb",
+          "Bar",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_in_module.rb --name \"/^Foo::Bar(#|::)/\"",
+          {
+            "start_line": 6,
+            "start_column": 2,
+            "end_line": 8,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": null,
+        "kind": "group",
+        "id": 1
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 2
+        },
+        "end": {
+          "line": 8,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_in_module.rb",
+          "Bar",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_in_module.rb --name \"/^Foo::Bar(#|::)/\"",
+          {
+            "start_line": 6,
+            "start_column": 2,
+            "end_line": 8,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": null,
+        "kind": "group",
+        "id": 1
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 4
+        },
+        "end": {
+          "line": 7,
+          "character": 31
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_in_module.rb",
+          "it_class_constant_path",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_in_module.rb --name /^Foo::Bar\\#test_.*_it_class_constant_path$/",
+          {
+            "start_line": 7,
+            "start_column": 4,
+            "end_line": 7,
+            "end_column": 31
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 1,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 4
+        },
+        "end": {
+          "line": 7,
+          "character": 31
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_in_module.rb",
+          "it_class_constant_path",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_in_module.rb --name /^Foo::Bar\\#test_.*_it_class_constant_path$/",
+          {
+            "start_line": 7,
+            "start_column": 4,
+            "end_line": 7,
+            "end_column": 31
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 1,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 4
+        },
+        "end": {
+          "line": 7,
+          "character": 31
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_in_module.rb",
+          "it_class_constant_path",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_in_module.rb --name /^Foo::Bar\\#test_.*_it_class_constant_path$/",
+          {
+            "start_line": 7,
+            "start_column": 4,
+            "end_line": 7,
+            "end_column": 31
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 1,
+        "kind": "example"
+      }
+    }
+  ],
+  "params": [
+
+  ]
+}

--- a/test/expectations/code_lens/minitest_spec_interpolation.exp.json
+++ b/test/expectations/code_lens/minitest_spec_interpolation.exp.json
@@ -1,0 +1,883 @@
+{
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 0
+        },
+        "end": {
+          "line": 21,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "Foo",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo(#|::)/\"",
+          {
+            "start_line": 5,
+            "start_column": 0,
+            "end_line": 21,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": null,
+        "kind": "group",
+        "id": 1
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 0
+        },
+        "end": {
+          "line": 21,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "Foo",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo(#|::)/\"",
+          {
+            "start_line": 5,
+            "start_column": 0,
+            "end_line": 21,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": null,
+        "kind": "group",
+        "id": 1
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 0
+        },
+        "end": {
+          "line": 21,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "Foo",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo(#|::)/\"",
+          {
+            "start_line": 5,
+            "start_column": 0,
+            "end_line": 21,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": null,
+        "kind": "group",
+        "id": 1
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 2
+        },
+        "end": {
+          "line": 12,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "string_+dynamic_reference+",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo::string_.*(#|::)/\"",
+          {
+            "start_line": 6,
+            "start_column": 2,
+            "end_line": 12,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 1,
+        "kind": "group",
+        "id": 2
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 2
+        },
+        "end": {
+          "line": 12,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "string_+dynamic_reference+",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo::string_.*(#|::)/\"",
+          {
+            "start_line": 6,
+            "start_column": 2,
+            "end_line": 12,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 1,
+        "kind": "group",
+        "id": 2
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 6,
+          "character": 2
+        },
+        "end": {
+          "line": 12,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "string_+dynamic_reference+",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo::string_.*(#|::)/\"",
+          {
+            "start_line": 6,
+            "start_column": 2,
+            "end_line": 12,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 1,
+        "kind": "group",
+        "id": 2
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 4
+        },
+        "end": {
+          "line": 7,
+          "character": 23
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "does_something",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::string_.*\\#test_.*_does_something$/",
+          {
+            "start_line": 7,
+            "start_column": 4,
+            "end_line": 7,
+            "end_column": 23
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 2,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 4
+        },
+        "end": {
+          "line": 7,
+          "character": 23
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "does_something",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::string_.*\\#test_.*_does_something$/",
+          {
+            "start_line": 7,
+            "start_column": 4,
+            "end_line": 7,
+            "end_column": 23
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 2,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 4
+        },
+        "end": {
+          "line": 7,
+          "character": 23
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "does_something",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::string_.*\\#test_.*_does_something$/",
+          {
+            "start_line": 7,
+            "start_column": 4,
+            "end_line": 7,
+            "end_column": 23
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 2,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 4
+        },
+        "end": {
+          "line": 11,
+          "character": 7
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "normal_string",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo::string_.*::normal_string(#|::)/\"",
+          {
+            "start_line": 9,
+            "start_column": 4,
+            "end_line": 11,
+            "end_column": 7
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 2,
+        "kind": "group",
+        "id": 3
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 4
+        },
+        "end": {
+          "line": 11,
+          "character": 7
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "normal_string",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo::string_.*::normal_string(#|::)/\"",
+          {
+            "start_line": 9,
+            "start_column": 4,
+            "end_line": 11,
+            "end_column": 7
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 2,
+        "kind": "group",
+        "id": 3
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 4
+        },
+        "end": {
+          "line": 11,
+          "character": 7
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "normal_string",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo::string_.*::normal_string(#|::)/\"",
+          {
+            "start_line": 9,
+            "start_column": 4,
+            "end_line": 11,
+            "end_column": 7
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 2,
+        "kind": "group",
+        "id": 3
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 6
+        },
+        "end": {
+          "line": 10,
+          "character": 30
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "does_something_else",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::string_.*::normal_string\\#test_.*_does_something_else$/",
+          {
+            "start_line": 10,
+            "start_column": 6,
+            "end_line": 10,
+            "end_column": 30
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 3,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 6
+        },
+        "end": {
+          "line": 10,
+          "character": 30
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "does_something_else",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::string_.*::normal_string\\#test_.*_does_something_else$/",
+          {
+            "start_line": 10,
+            "start_column": 6,
+            "end_line": 10,
+            "end_column": 30
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 3,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 10,
+          "character": 6
+        },
+        "end": {
+          "line": 10,
+          "character": 30
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "does_something_else",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::string_.*::normal_string\\#test_.*_does_something_else$/",
+          {
+            "start_line": 10,
+            "start_column": 6,
+            "end_line": 10,
+            "end_column": 30
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 3,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 2
+        },
+        "end": {
+          "line": 18,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "+dynamic_reference+_double_string_+dynamic_reference+",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo::.*_double_string_.*(#|::)/\"",
+          {
+            "start_line": 14,
+            "start_column": 2,
+            "end_line": 18,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 1,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 2
+        },
+        "end": {
+          "line": 18,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "+dynamic_reference+_double_string_+dynamic_reference+",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo::.*_double_string_.*(#|::)/\"",
+          {
+            "start_line": 14,
+            "start_column": 2,
+            "end_line": 18,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 1,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 14,
+          "character": 2
+        },
+        "end": {
+          "line": 18,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "+dynamic_reference+_double_string_+dynamic_reference+",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name \"/^Foo::.*_double_string_.*(#|::)/\"",
+          {
+            "start_line": 14,
+            "start_column": 2,
+            "end_line": 18,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 1,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 4
+        },
+        "end": {
+          "line": 15,
+          "character": 13
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "runs",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::.*_double_string_.*\\#test_.*_runs$/",
+          {
+            "start_line": 15,
+            "start_column": 4,
+            "end_line": 15,
+            "end_column": 13
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 4
+        },
+        "end": {
+          "line": 15,
+          "character": 13
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "runs",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::.*_double_string_.*\\#test_.*_runs$/",
+          {
+            "start_line": 15,
+            "start_column": 4,
+            "end_line": 15,
+            "end_column": 13
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 15,
+          "character": 4
+        },
+        "end": {
+          "line": 15,
+          "character": 13
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "runs",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::.*_double_string_.*\\#test_.*_runs$/",
+          {
+            "start_line": 15,
+            "start_column": 4,
+            "end_line": 15,
+            "end_column": 13
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 4
+        },
+        "end": {
+          "line": 17,
+          "character": 21
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "runs_as_well",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::.*_double_string_.*\\#test_.*_runs_as_well$/",
+          {
+            "start_line": 17,
+            "start_column": 4,
+            "end_line": 17,
+            "end_column": 21
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 4
+        },
+        "end": {
+          "line": 17,
+          "character": 21
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "runs_as_well",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::.*_double_string_.*\\#test_.*_runs_as_well$/",
+          {
+            "start_line": 17,
+            "start_column": 4,
+            "end_line": 17,
+            "end_column": 21
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 17,
+          "character": 4
+        },
+        "end": {
+          "line": 17,
+          "character": 21
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "runs_as_well",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo::.*_double_string_.*\\#test_.*_runs_as_well$/",
+          {
+            "start_line": 17,
+            "start_column": 4,
+            "end_line": 17,
+            "end_column": 21
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 20,
+          "character": 2
+        },
+        "end": {
+          "line": 20,
+          "character": 19
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "it_level_one",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo\\#test_.*_it_level_one$/",
+          {
+            "start_line": 20,
+            "start_column": 2,
+            "end_line": 20,
+            "end_column": 19
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 1,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 20,
+          "character": 2
+        },
+        "end": {
+          "line": 20,
+          "character": 19
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "it_level_one",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo\\#test_.*_it_level_one$/",
+          {
+            "start_line": 20,
+            "start_column": 2,
+            "end_line": 20,
+            "end_column": 19
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 1,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 20,
+          "character": 2
+        },
+        "end": {
+          "line": 20,
+          "character": 19
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_interpolation.rb",
+          "it_level_one",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_interpolation.rb --name /^Foo\\#test_.*_it_level_one$/",
+          {
+            "start_line": 20,
+            "start_column": 2,
+            "end_line": 20,
+            "end_column": 19
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 1,
+        "kind": "example"
+      }
+    }
+  ],
+  "params": [
+
+  ]
+}

--- a/test/expectations/code_lens/minitest_spec_tests.exp.json
+++ b/test/expectations/code_lens/minitest_spec_tests.exp.json
@@ -17,7 +17,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -50,7 +50,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -83,7 +83,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -116,7 +116,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo\\#test_.*_it_level_one$/",
           {
             "start_line": 1,
             "start_column": 2,
@@ -148,7 +148,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo\\#test_.*_it_level_one$/",
           {
             "start_line": 1,
             "start_column": 2,
@@ -180,7 +180,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo\\#test_.*_it_level_one$/",
           {
             "start_line": 1,
             "start_column": 2,
@@ -212,7 +212,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
@@ -245,7 +245,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
@@ -278,7 +278,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
@@ -311,7 +311,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::nested\\#test_.*_it_nested$/",
           {
             "start_line": 4,
             "start_column": 4,
@@ -343,7 +343,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::nested\\#test_.*_it_nested$/",
           {
             "start_line": 4,
             "start_column": 4,
@@ -375,7 +375,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::nested\\#test_.*_it_nested$/",
           {
             "start_line": 4,
             "start_column": 4,
@@ -407,7 +407,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
@@ -440,7 +440,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
@@ -473,7 +473,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
@@ -506,7 +506,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::nested::deep_nested\\#test_.*_it_deep_nested$/",
           {
             "start_line": 7,
             "start_column": 6,
@@ -538,7 +538,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::nested::deep_nested\\#test_.*_it_deep_nested$/",
           {
             "start_line": 7,
             "start_column": 6,
@@ -570,7 +570,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::nested::deep_nested\\#test_.*_it_deep_nested$/",
           {
             "start_line": 7,
             "start_column": 6,
@@ -602,7 +602,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::nested\\#test_.*_it_nested_again$/",
           {
             "start_line": 10,
             "start_column": 4,
@@ -634,7 +634,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::nested\\#test_.*_it_nested_again$/",
           {
             "start_line": 10,
             "start_column": 4,
@@ -666,7 +666,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::nested\\#test_.*_it_nested_again$/",
           {
             "start_line": 10,
             "start_column": 4,
@@ -698,7 +698,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo\\#test_.*_it_level_one_again$/",
           {
             "start_line": 13,
             "start_column": 2,
@@ -730,7 +730,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo\\#test_.*_it_level_one_again$/",
           {
             "start_line": 13,
             "start_column": 2,
@@ -762,7 +762,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo\\#test_.*_it_level_one_again$/",
           {
             "start_line": 13,
             "start_column": 2,
@@ -794,7 +794,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo::Bar",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo::Bar/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
           {
             "start_line": 16,
             "start_column": 0,
@@ -827,7 +827,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo::Bar",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo::Bar/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
           {
             "start_line": 16,
             "start_column": 0,
@@ -860,7 +860,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo::Bar",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo::Bar/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
           {
             "start_line": 16,
             "start_column": 0,
@@ -893,7 +893,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_class_constant_path",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_class_constant_path/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::Bar\\#test_.*_it_class_constant_path$/",
           {
             "start_line": 17,
             "start_column": 2,
@@ -925,7 +925,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_class_constant_path",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_class_constant_path/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::Bar\\#test_.*_it_class_constant_path$/",
           {
             "start_line": 17,
             "start_column": 2,
@@ -957,7 +957,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_class_constant_path",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_class_constant_path/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /^Foo::Bar\\#test_.*_it_class_constant_path$/",
           {
             "start_line": 17,
             "start_column": 2,

--- a/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
+++ b/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
@@ -17,7 +17,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "Test",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::Test(#|::)/\"",
           {
             "start_line": 9,
             "start_column": 2,
@@ -50,7 +50,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "Test",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::Test(#|::)/\"",
           {
             "start_line": 9,
             "start_column": 2,
@@ -83,7 +83,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "Test",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::Test(#|::)/\"",
           {
             "start_line": 9,
             "start_column": 2,
@@ -116,7 +116,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_something",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test\\#test_something$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::Test\\#test_something$/",
           {
             "start_line": 10,
             "start_column": 4,
@@ -148,7 +148,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_something",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test\\#test_something$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::Test\\#test_something$/",
           {
             "start_line": 10,
             "start_column": 4,
@@ -180,7 +180,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_something",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test\\#test_something$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::Test\\#test_something$/",
           {
             "start_line": 10,
             "start_column": 4,
@@ -212,7 +212,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_something_else",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test\\#test_something_else$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::Test\\#test_something_else$/",
           {
             "start_line": 12,
             "start_column": 4,
@@ -244,7 +244,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_something_else",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test\\#test_something_else$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::Test\\#test_something_else$/",
           {
             "start_line": 12,
             "start_column": 4,
@@ -276,7 +276,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_something_else",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test\\#test_something_else$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::Test\\#test_something_else$/",
           {
             "start_line": 12,
             "start_column": 4,
@@ -308,7 +308,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "NestedTest",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::Test::NestedTest(#|::)/\"",
           {
             "start_line": 14,
             "start_column": 4,
@@ -341,7 +341,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "NestedTest",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::Test::NestedTest(#|::)/\"",
           {
             "start_line": 14,
             "start_column": 4,
@@ -374,7 +374,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "NestedTest",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::Test::NestedTest(#|::)/\"",
           {
             "start_line": 14,
             "start_column": 4,
@@ -407,7 +407,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest\\#test_nested$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::Test::NestedTest\\#test_nested$/",
           {
             "start_line": 15,
             "start_column": 6,
@@ -439,7 +439,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest\\#test_nested$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::Test::NestedTest\\#test_nested$/",
           {
             "start_line": 15,
             "start_column": 6,
@@ -471,7 +471,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest\\#test_nested$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::Test::NestedTest\\#test_nested$/",
           {
             "start_line": 15,
             "start_column": 6,
@@ -493,7 +493,7 @@
           "character": 2
         },
         "end": {
-          "line": 23,
+          "line": 29,
           "character": 5
         }
       },
@@ -503,11 +503,11 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "SomeOtherTest",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::SomeOtherTest(#|::)/\"",
           {
             "start_line": 19,
             "start_column": 2,
-            "end_line": 23,
+            "end_line": 29,
             "end_column": 5
           }
         ]
@@ -526,7 +526,7 @@
           "character": 2
         },
         "end": {
-          "line": 23,
+          "line": 29,
           "character": 5
         }
       },
@@ -536,11 +536,11 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "SomeOtherTest",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::SomeOtherTest(#|::)/\"",
           {
             "start_line": 19,
             "start_column": 2,
-            "end_line": 23,
+            "end_line": 29,
             "end_column": 5
           }
         ]
@@ -559,7 +559,7 @@
           "character": 2
         },
         "end": {
-          "line": 23,
+          "line": 29,
           "character": 5
         }
       },
@@ -569,11 +569,11 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "SomeOtherTest",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::SomeOtherTest(#|::)/\"",
           {
             "start_line": 19,
             "start_column": 2,
-            "end_line": 23,
+            "end_line": 29,
             "end_column": 5
           }
         ]
@@ -602,7 +602,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_stuff",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest\\#test_stuff$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::SomeOtherTest\\#test_stuff$/",
           {
             "start_line": 20,
             "start_column": 4,
@@ -634,7 +634,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_stuff",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest\\#test_stuff$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::SomeOtherTest\\#test_stuff$/",
           {
             "start_line": 20,
             "start_column": 4,
@@ -666,7 +666,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_stuff",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest\\#test_stuff$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::SomeOtherTest\\#test_stuff$/",
           {
             "start_line": 20,
             "start_column": 4,
@@ -698,7 +698,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_other_stuff",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest\\#test_other_stuff$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::SomeOtherTest\\#test_other_stuff$/",
           {
             "start_line": 22,
             "start_column": 4,
@@ -730,7 +730,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_other_stuff",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest\\#test_other_stuff$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::SomeOtherTest\\#test_other_stuff$/",
           {
             "start_line": 22,
             "start_column": 4,
@@ -762,7 +762,7 @@
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
           "test_other_stuff",
-          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest\\#test_other_stuff$/",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::SomeOtherTest\\#test_other_stuff$/",
           {
             "start_line": 22,
             "start_column": 4,
@@ -774,6 +774,201 @@
       "data": {
         "type": "debug",
         "group_id": 3,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 25,
+          "character": 6
+        },
+        "end": {
+          "line": 27,
+          "character": 9
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "OtherDynamicTest",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::SomeOtherTest::.*::OtherDynamicTest(#|::)/\"",
+          {
+            "start_line": 25,
+            "start_column": 6,
+            "end_line": 27,
+            "end_column": 9
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 3,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 25,
+          "character": 6
+        },
+        "end": {
+          "line": 27,
+          "character": 9
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "OtherDynamicTest",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::SomeOtherTest::.*::OtherDynamicTest(#|::)/\"",
+          {
+            "start_line": 25,
+            "start_column": 6,
+            "end_line": 27,
+            "end_column": 9
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 3,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 25,
+          "character": 6
+        },
+        "end": {
+          "line": 27,
+          "character": 9
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "OtherDynamicTest",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/^.*::SomeOtherTest::.*::OtherDynamicTest(#|::)/\"",
+          {
+            "start_line": 25,
+            "start_column": 6,
+            "end_line": 27,
+            "end_column": 9
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 3,
+        "kind": "group",
+        "id": 4
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 26,
+          "character": 8
+        },
+        "end": {
+          "line": 26,
+          "character": 26
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "test_more",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::SomeOtherTest::.*::OtherDynamicTest\\#test_more$/",
+          {
+            "start_line": 26,
+            "start_column": 8,
+            "end_line": 26,
+            "end_column": 26
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 26,
+          "character": 8
+        },
+        "end": {
+          "line": 26,
+          "character": 26
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "test_more",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::SomeOtherTest::.*::OtherDynamicTest\\#test_more$/",
+          {
+            "start_line": 26,
+            "start_column": 8,
+            "end_line": 26,
+            "end_column": 26
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 4,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 26,
+          "character": 8
+        },
+        "end": {
+          "line": 26,
+          "character": 26
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "test_more",
+          "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /^.*::SomeOtherTest::.*::OtherDynamicTest\\#test_more$/",
+          {
+            "start_line": 26,
+            "start_column": 8,
+            "end_line": 26,
+            "end_column": 26
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 4,
         "kind": "example"
       }
     }

--- a/test/fixtures/minitest_spec_halfwritten.rb
+++ b/test/fixtures/minitest_spec_halfwritten.rb
@@ -1,0 +1,16 @@
+module Foo
+end
+
+describe Foo do
+  it
+
+  describe "something"
+
+  describe "something"
+
+  it "runs"
+
+  describe "something_else" do
+    it "abc"
+  end
+end

--- a/test/fixtures/minitest_spec_in_module.rb
+++ b/test/fixtures/minitest_spec_in_module.rb
@@ -1,0 +1,10 @@
+module Foo
+  module Bar
+  end
+end
+
+module Foo
+  describe Bar do
+    it 'it_class_constant_path'
+  end
+end

--- a/test/fixtures/minitest_spec_interpolation.rb
+++ b/test/fixtures/minitest_spec_interpolation.rb
@@ -1,0 +1,22 @@
+interpolation = "interpolation"
+
+module Foo
+end
+
+describe Foo do
+  describe "string_#{interpolation}" do
+    it "does_something"
+
+    describe "normal_string" do
+      it "does_something_else"
+    end
+  end
+
+  describe "#{interpolation}_double_string_#{interpolation}" do
+    it "runs"
+
+    it "runs_as_well"
+  end
+
+  it "it_level_one"
+end

--- a/test/fixtures/minitest_with_dynamic_constant_path.rb
+++ b/test/fixtures/minitest_with_dynamic_constant_path.rb
@@ -21,5 +21,11 @@ module foo::Baz
     def test_stuff; end
 
     def test_other_stuff; end
+
+    module nested::Dynamic
+      class OtherDynamicTest < Minitest::Test
+        def test_more; end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation

This will close #1605, do most of what is actually possible for #1604 and adress https://github.com/Shopify/ruby-lsp/pull/1606#issuecomment-1995274763

### Implementation

Use the group stack for spec as well. This removes most of the distinction these two previously had.

`minitest_spec_halfwritten` simulates a user typing new specs. It mostly tests that the group ids being sent to vscode are well formed so something like in #1605 doesn't happen. It shows codelenses for everything which isn't entirely correct, but I think that's better than it shifting around during typing.

I changed the reference marker into something that won't be escaped by shellescape. It needs to happen at the end, and when modified that doesn't work out.

Spec test names will look like this: `test_.*_my_test`, where `.*` is the 0001 part. Having the actual numbers there would require keeping track of how many `it`s a `describe` block has encountered and might also just not be possible if there's something that defines tests outside of `it` because the numbers would then always be off.

### Automated Tests

Added something for the variations I could come up with.

### Manual Tests

Tested code lenses for the modified/added expections execute the correct tests.
