### PR TITLE
Add note about Ruby version for RDoc task

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.2 # `bundle exec rake rdoc` fails on 3.3.0
           bundler-cache: true
 
       - name: Configure git


### PR DESCRIPTION
Noticed when working on https://github.com/Shopify/ruby-lsp-rails/pull/292