### PR TITLE
Make definition and hover more precise

### DIFF
--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -49,7 +49,13 @@ module RubyLsp
           node_types: [Prism::CallNode, Prism::ConstantReadNode, Prism::ConstantPathNode],
         )
 
-        target = parent if target.is_a?(Prism::ConstantReadNode) && parent.is_a?(Prism::ConstantPathNode)
+        if target.is_a?(Prism::ConstantReadNode) && parent.is_a?(Prism::ConstantPathNode)
+          target = determine_target(
+            target,
+            parent,
+            position,
+          )
+        end
 
         Listeners::Definition.new(@response_builder, document.uri, nesting, index, dispatcher, typechecker_enabled)
 

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -50,7 +50,11 @@ module RubyLsp
         if (Listeners::Hover::ALLOWED_TARGETS.include?(parent.class) &&
             !Listeners::Hover::ALLOWED_TARGETS.include?(@target.class)) ||
             (parent.is_a?(Prism::ConstantPathNode) && @target.is_a?(Prism::ConstantReadNode))
-          @target = parent
+          @target = determine_target(
+            T.must(@target),
+            T.must(parent),
+            position,
+          )
         end
 
         # Don't need to instantiate any listeners if there's no target

--- a/lib/ruby_lsp/requests/request.rb
+++ b/lib/ruby_lsp/requests/request.rb
@@ -12,6 +12,57 @@ module RubyLsp
 
       sig { abstract.returns(T.anything) }
       def perform; end
+
+      private
+
+      # Checks if a location covers a position
+      sig { params(location: Prism::Location, position: T.untyped).returns(T::Boolean) }
+      def cover?(location, position)
+        start_covered =
+          location.start_line - 1 < position[:line] ||
+          (
+            location.start_line - 1 == position[:line] &&
+              location.start_column <= position[:character]
+          )
+        end_covered =
+          location.end_line - 1 > position[:line] ||
+          (
+            location.end_line - 1 == position[:line] &&
+              location.end_column >= position[:character]
+          )
+        start_covered && end_covered
+      end
+
+      # Based on a constant node target, a constant path node parent and a position, this method will find the exact
+      # portion of the constant path that matches the requested position, for higher precision in hover and
+      # definition. For example:
+      #
+      # ```ruby
+      # Foo::Bar::Baz
+      #  #        ^ Going to definition here should go to Foo::Bar::Baz
+      #  #   ^ Going to definition here should go to Foo::Bar
+      # #^ Going to definition here should go to Foo
+      # ```
+      sig do
+        params(
+          target: Prism::Node,
+          parent: Prism::Node,
+          position: T::Hash[Symbol, Integer],
+        ).returns(Prism::Node)
+      end
+      def determine_target(target, parent, position)
+        return target unless parent.is_a?(Prism::ConstantPathNode)
+
+        target = T.let(parent, Prism::Node)
+        parent = T.let(T.cast(target, Prism::ConstantPathNode).parent, T.nilable(Prism::Node))
+
+        while parent && cover?(parent.location, position)
+          target = parent
+          parent = target.is_a?(Prism::ConstantPathNode) ? target.parent : nil
+        end
+
+        target
+      end
     end
   end
 end

--- a/test/expectations/hover/documented_namespaced_class.exp.json
+++ b/test/expectations/hover/documented_namespaced_class.exp.json
@@ -2,7 +2,7 @@
     "params": [
         {
             "line": 1,
-            "character": 6
+            "character": 11
         }
     ],
     "result": {


### PR DESCRIPTION
### Motivation

We were not being precise when matching a constant path to a requested position. For example, if you had this

```ruby
Foo::Bar::Baz
#    ^ Requested go to definition here
```
Then we should go to the definition of `Foo::Bar` and not `Foo::Bar::Baz`.

### Implementation

We need to keep checking until we find the most precise constant path that matches the position. I added a method we can reuse in hover and definition.

### Automated Tests

Added tests.

### Manual Tests

1. Start the LSP on this branch
2. Open any file that has constant paths
3. Try to go the definition of specific parts in the constant path
4. Verify you land in the right place