### PR TITLE
Do not fail indexing on non-existing files

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -191,8 +191,9 @@ module RubyIndexer
 
       require_path = indexable_path.require_path
       @require_paths_tree.insert(require_path, indexable_path) if require_path
-    rescue Errno::EISDIR
-      # If `path` is a directory, just ignore it and continue indexing
+    rescue Errno::EISDIR, Errno::ENOENT
+      # If `path` is a directory, just ignore it and continue indexing. If the file doesn't exist, then we also ignore
+      # it
     end
 
     # Follows aliases in a namespace. The algorithm keeps checking if the name is an alias and then recursively follows

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -308,5 +308,10 @@ module RubyIndexer
 
       refute_empty(@index.instance_variable_get(:@entries))
     end
+
+    def test_index_single_does_not_fail_for_non_existing_file
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"))
+      assert_empty(@index.instance_variable_get(:@entries))
+    end
   end
 end


### PR DESCRIPTION
### Motivation

If someone does a `git pull` right after booting the LSP, there's a race condition between computing the files that have to be indexed and actually indexing them.

If you pull at the right moment, a file might be included in the list to be indexed, but not exist when we get to index it.

### Implementation

I think just preventing the indexing from stopping if the file is not there should be enough. For every file modification, we'll receive events to process from the editor, so as long as we don't fail indexing, we should end up with the correct state.

### Automated Tests

Added a test.