### PR TITLE
Disable warnings when running Ruby activation

### DIFF
--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -141,7 +141,7 @@ export class Chruby extends VersionManager {
     ].join(";");
 
     const result = await asyncExec(
-      `${rubyExecutableUri.fsPath} -rjson -e '${script}'`,
+      `${rubyExecutableUri.fsPath} -W0 -rjson -e '${script}'`,
       { cwd: this.bundleUri.fsPath },
     );
 

--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -32,7 +32,7 @@ export class Mise extends VersionManager {
 
     // The exec command in Mise is called `x`
     const result = await asyncExec(
-      `${miseUri.fsPath} x -- ruby -rjson -e '${activationScript}'`,
+      `${miseUri.fsPath} x -- ruby -W0 -rjson -e '${activationScript}'`,
       {
         cwd: this.bundleUri.fsPath,
       },

--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -27,7 +27,7 @@ export class Shadowenv extends VersionManager {
 
     try {
       const result = await asyncExec(
-        `shadowenv exec -- ruby -rjson -e '${activationScript}'`,
+        `shadowenv exec -- ruby -W0 -rjson -e '${activationScript}'`,
         {
           cwd: this.bundleUri.fsPath,
         },

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -43,7 +43,7 @@ suite("Mise", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `${os.homedir()}/.local/bin/mise x -- ruby -rjson -e '${activationScript}'`,
+        `${os.homedir()}/.local/bin/mise x -- ruby -W0 -rjson -e '${activationScript}'`,
         { cwd: workspacePath },
       ),
     );


### PR DESCRIPTION
### Motivation

We don't want warnings to be printed when running the Ruby script or else it will pollute `stderr` and mess up activation. Passing `-W0` should silence all warnings and prevent this from happening.
