### PR TITLE
Remove path exists and use VS Code's file system

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -1,4 +1,3 @@
-import fs from "fs/promises";
 import { exec } from "child_process";
 import { promisify } from "util";
 
@@ -54,18 +53,6 @@ export const LSP_NAME = "Ruby LSP";
 export const LOG_CHANNEL = vscode.window.createOutputChannel(LSP_NAME, {
   log: true,
 });
-
-export async function pathExists(
-  path: string,
-  mode = fs.constants.R_OK,
-): Promise<boolean> {
-  try {
-    await fs.access(path, mode);
-    return true;
-  } catch (error: any) {
-    return false;
-  }
-}
 
 // Creates a debounced version of a function with the specified delay. If the function is invoked before the delay runs
 // out, then the previous invocation of the function gets cancelled and a new one is scheduled.

--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -4,7 +4,7 @@ import os from "os";
 
 import * as vscode from "vscode";
 
-import { asyncExec, pathExists, RubyInterface } from "./common";
+import { asyncExec, RubyInterface } from "./common";
 import { WorkspaceChannel } from "./workspaceChannel";
 import { Shadowenv } from "./ruby/shadowenv";
 import { Chruby } from "./ruby/chruby";
@@ -236,13 +236,14 @@ export class Ruby implements RubyInterface {
       return;
     }
 
-    if (!(await pathExists(this.customBundleGemfile))) {
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.file(this.customBundleGemfile));
+      this._env.BUNDLE_GEMFILE = this.customBundleGemfile;
+    } catch (error: any) {
       throw new Error(
         `The configured bundle gemfile ${this.customBundleGemfile} does not exist`,
       );
     }
-
-    this._env.BUNDLE_GEMFILE = this.customBundleGemfile;
   }
 
   private async discoverVersionManager() {


### PR DESCRIPTION
### Motivation

Another step towards https://github.com/Shopify/vscode-ruby-lsp/issues/1044. We're almost done.

This PR removes our `pathExists` helper, which used `fs` instead of VS Code's file system API under the hood.

### Implementation

Started using `vscode.workspace.fs.stat` to check if files exist.