### PR TITLE
Implement Windows activation as a manager object

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -10,6 +10,7 @@ import { Shadowenv } from "./ruby/shadowenv";
 import { Chruby } from "./ruby/chruby";
 import { VersionManager } from "./ruby/versionManager";
 import { Mise } from "./ruby/mise";
+import { RubyInstaller } from "./ruby/rubyInstaller";
 
 export enum ManagerIdentifier {
   Asdf = "asdf",
@@ -19,6 +20,7 @@ export enum ManagerIdentifier {
   Rvm = "rvm",
   Shadowenv = "shadowenv",
   Mise = "mise",
+  RubyInstaller = "rubyInstaller",
   None = "none",
   Custom = "custom",
 }
@@ -115,6 +117,11 @@ export class Ruby implements RubyInterface {
         case ManagerIdentifier.Mise:
           await this.runActivation(
             new Mise(this.workspaceFolder, this.outputChannel),
+          );
+          break;
+        case ManagerIdentifier.RubyInstaller:
+          await this.runActivation(
+            new RubyInstaller(this.workspaceFolder, this.outputChannel),
           );
           break;
         case ManagerIdentifier.Custom:
@@ -288,6 +295,11 @@ export class Ruby implements RubyInterface {
       return;
     } catch (error: any) {
       // If the Mise binary doesn't exist, then continue checking
+    }
+
+    if (os.platform() === "win32") {
+      this.versionManager = ManagerIdentifier.RubyInstaller;
+      return;
     }
 
     // If we can't find a version manager, just return None

--- a/vscode/src/ruby/rubyInstaller.ts
+++ b/vscode/src/ruby/rubyInstaller.ts
@@ -1,0 +1,48 @@
+import os from "os";
+
+import * as vscode from "vscode";
+
+import { Chruby } from "./chruby";
+
+interface RubyVersion {
+  engine?: string;
+  version: string;
+}
+
+// Most version managers do not support Windows. One popular way of installing Ruby on Windows is via RubyInstaller,
+// which places the rubies in directories like C:\Ruby32-x64 (i.e.: Ruby{major}{minor}-{arch}). To automatically switch
+// Ruby versions on Windows, we use the same mechanism as Chruby to discover the Ruby version based on `.ruby-version`
+// files and then try to search the directories commonly used by RubyInstaller.
+//
+// If we can't find it there, then we throw an error and rely on the user to manually select where Ruby is installed.
+export class RubyInstaller extends Chruby {
+  // Returns the full URI to the Ruby executable
+  protected async findRubyUri(rubyVersion: RubyVersion): Promise<vscode.Uri> {
+    const [major, minor, _patch] = rubyVersion.version.split(".").map(Number);
+
+    const possibleInstallationUris = [
+      vscode.Uri.joinPath(
+        vscode.Uri.file("C:"),
+        `Ruby${major}${minor}-${os.arch()}`,
+      ),
+      vscode.Uri.joinPath(
+        vscode.Uri.file(os.homedir()),
+        `Ruby${major}${minor}-${os.arch()}`,
+      ),
+    ];
+
+    for (const installationUri of possibleInstallationUris) {
+      try {
+        await vscode.workspace.fs.stat(installationUri);
+        return vscode.Uri.joinPath(installationUri, "bin", "ruby");
+      } catch (_error: any) {
+        // Continue searching
+      }
+    }
+
+    throw new Error(
+      `Cannot find installation directory for Ruby version ${rubyVersion.version}.\
+         Searched in ${possibleInstallationUris.map((uri) => uri.fsPath).join(", ")}`,
+    );
+  }
+}

--- a/vscode/src/test/suite/ruby/rubyInstaller.test.ts
+++ b/vscode/src/test/suite/ruby/rubyInstaller.test.ts
@@ -1,0 +1,104 @@
+import fs from "fs";
+import assert from "assert";
+import path from "path";
+import os from "os";
+
+import { before, after } from "mocha";
+import * as vscode from "vscode";
+
+import { RubyInstaller } from "../../../ruby/rubyInstaller";
+import { WorkspaceChannel } from "../../../workspaceChannel";
+import { LOG_CHANNEL } from "../../../common";
+
+const RUBY_VERSION = "3.3.0";
+
+suite("RubyInstaller", () => {
+  if (os.platform() !== "win32") {
+    // eslint-disable-next-line no-console
+    console.log("This test can only run on Windows");
+    return;
+  }
+
+  let rootPath: string;
+  let workspacePath: string;
+  let workspaceFolder: vscode.WorkspaceFolder;
+  let outputChannel: WorkspaceChannel;
+
+  before(() => {
+    rootPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-"));
+
+    workspacePath = path.join(rootPath, "workspace");
+    fs.mkdirSync(workspacePath);
+
+    workspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    outputChannel = new WorkspaceChannel("fake", LOG_CHANNEL);
+  });
+
+  after(() => {
+    fs.rmSync(rootPath, { recursive: true, force: true });
+  });
+
+  test("Finds Ruby when under C:/RubyXY-arch", async () => {
+    const [major, minor, _patch] = RUBY_VERSION.split(".").map(Number);
+    fs.symlinkSync(
+      path.join(
+        "C:",
+        "hostedtoolcache",
+        "windows",
+        "Ruby",
+        RUBY_VERSION,
+        "x64",
+      ),
+      path.join("C:", `Ruby${major}${minor}-${os.arch()}`),
+    );
+
+    fs.writeFileSync(path.join(workspacePath, ".ruby-version"), RUBY_VERSION);
+
+    const windows = new RubyInstaller(workspaceFolder, outputChannel);
+    const { env, version, yjit } = await windows.activate();
+
+    assert.match(env.GEM_PATH!, /ruby\/3\.3\.0/);
+    assert.match(env.GEM_PATH!, /lib\/ruby\/gems\/3\.3\.0/);
+    assert.strictEqual(version, RUBY_VERSION);
+    assert.notStrictEqual(yjit, undefined);
+
+    fs.rmSync(path.join("C:", `Ruby${major}${minor}-${os.arch()}`), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  test("Finds Ruby when under C:/Users/Username/RubyXY-arch", async () => {
+    const [major, minor, _patch] = RUBY_VERSION.split(".").map(Number);
+    fs.symlinkSync(
+      path.join(
+        "C:",
+        "hostedtoolcache",
+        "windows",
+        "Ruby",
+        RUBY_VERSION,
+        "x64",
+      ),
+      path.join(os.homedir(), `Ruby${major}${minor}-${os.arch()}`),
+    );
+
+    fs.writeFileSync(path.join(workspacePath, ".ruby-version"), RUBY_VERSION);
+
+    const windows = new RubyInstaller(workspaceFolder, outputChannel);
+    const { env, version, yjit } = await windows.activate();
+
+    assert.match(env.GEM_PATH!, /ruby\/3\.3\.0/);
+    assert.match(env.GEM_PATH!, /lib\/ruby\/gems\/3\.3\.0/);
+    assert.strictEqual(version, RUBY_VERSION);
+    assert.notStrictEqual(yjit, undefined);
+
+    fs.rmSync(path.join(os.homedir(), `Ruby${major}${minor}-${os.arch()}`), {
+      recursive: true,
+      force: true,
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

Implement automatic Ruby environment activation for Windows as a manager object. 

### Implementation

The majority of version managers actually don't work on Windows. A popular option is `RubyInstaller`, which only install rubies, but doesn't allow switching versions.

The implementation basically uses all of the mechanisms from `chruby` to activate the environment on Windows, with the only difference being where we search for the installations. RubyInstaller places the rubies under `C:/Ruby33-x64` based on version and arch.

### Automated Tests

Added tests.