### PR TITLE
Add support for completionItem/resolve

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -284,13 +284,6 @@ module RubyLsp
             new_text: insertion_text,
           ),
           kind: kind,
-          label_details: Interface::CompletionItemLabelDetails.new(
-            description: entries.map(&:file_name).join(","),
-          ),
-          documentation: Interface::MarkupContent.new(
-            kind: "markdown",
-            value: markdown_from_index_entries(real_name, entries),
-          ),
         )
       end
 

--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -18,6 +18,7 @@ module RubyLsp
   # - [DocumentHighlight](rdoc-ref:RubyLsp::Requests::DocumentHighlight)
   # - [InlayHint](rdoc-ref:RubyLsp::Requests::InlayHints)
   # - [Completion](rdoc-ref:RubyLsp::Requests::Completion)
+  # - [CompletionResolve](rdoc-ref:RubyLsp::Requests::CompletionResolve)
   # - [CodeLens](rdoc-ref:RubyLsp::Requests::CodeLens)
   # - [Definition](rdoc-ref:RubyLsp::Requests::Definition)
   # - [ShowSyntaxTree](rdoc-ref:RubyLsp::Requests::ShowSyntaxTree)

--- a/lib/ruby_lsp/requests.rb
+++ b/lib/ruby_lsp/requests.rb
@@ -40,6 +40,7 @@ module RubyLsp
     autoload :DocumentHighlight, "ruby_lsp/requests/document_highlight"
     autoload :InlayHints, "ruby_lsp/requests/inlay_hints"
     autoload :Completion, "ruby_lsp/requests/completion"
+    autoload :CompletionResolve, "ruby_lsp/requests/completion_resolve"
     autoload :CodeLens, "ruby_lsp/requests/code_lens"
     autoload :Definition, "ruby_lsp/requests/definition"
     autoload :ShowSyntaxTree, "ruby_lsp/requests/show_syntax_tree"

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -33,7 +33,7 @@ module RubyLsp
         sig { returns(Interface::CompletionOptions) }
         def provider
           Interface::CompletionOptions.new(
-            resolve_provider: false,
+            resolve_provider: true,
             trigger_characters: ["/", "\"", "'"],
             completion_item: {
               labelDetailsSupport: true,

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -1,0 +1,36 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Requests
+    class CompletionResolve < Request
+      extend T::Sig
+      include Requests::Support::Common
+
+      MAX_DOCUMENTATION_ENTRIES = 10
+
+      sig { params(index: RubyIndexer::Index, item: T::Hash[Symbol, T.untyped]).void }
+      def initialize(index, item)
+        super()
+        @index = index
+        @item = item
+      end
+
+      sig { override.returns(Interface::CompletionItem) }
+      def perform
+        label = @item[:label]
+        entries = @index[label] || []
+        Interface::CompletionItem.new(
+          label: label,
+          label_details: Interface::CompletionItemLabelDetails.new(
+            description: entries.take(MAX_DOCUMENTATION_ENTRIES).map(&:file_name).join(","),
+          ),
+          documentation: Interface::MarkupContent.new(
+            kind: "markdown",
+            value: markdown_from_index_entries(label, entries, MAX_DOCUMENTATION_ENTRIES),
+          ),
+        )
+      end
+    end
+  end
+end

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -3,10 +3,22 @@
 
 module RubyLsp
   module Requests
+    # The [completionItem/resolve](https://microsoft.github.io/language-server-protocol/specification#completionItem_resolve)
+    # request provides additional information about the currently selected completion. Specifically, the `labelDetails`
+    # and `documentation` fields are provided, which are omitted from the completion items returned by
+    # `textDocument/completion`.
+    #
+    # The `labelDetails` field lists the files where the completion item is defined, and the `documentation` field
+    # includes any available documentation for those definitions.
+    #
+    # At most 10 definitions are included, to ensure low latency during request processing and rendering the completion
+    # item.
     class CompletionResolve < Request
       extend T::Sig
       include Requests::Support::Common
 
+      # set a limit on the number of documentation entries returned, to avoid rendering performance issues
+      # https://github.com/Shopify/ruby-lsp/pull/1798
       MAX_DOCUMENTATION_ENTRIES = 10
 
       sig { params(index: RubyIndexer::Index, item: T::Hash[Symbol, T.untyped]).void }

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -62,6 +62,8 @@ module RubyLsp
         text_document_diagnostic(message)
       when "textDocument/completion"
         text_document_completion(message)
+      when "completionItem/resolve"
+        text_document_completion_item_resolve(message)
       when "textDocument/signatureHelp"
         text_document_signature_help(message)
       when "textDocument/definition"
@@ -521,6 +523,14 @@ module RubyLsp
           ).perform,
         ),
       )
+    end
+
+    sig { params(message: T::Hash[Symbol, T.untyped]).void }
+    def text_document_completion_item_resolve(message)
+      send_message(Result.new(
+        id: message[:id],
+        response: Requests::CompletionResolve.new(@index, message[:params]).perform,
+      ))
     end
 
     sig { params(message: T::Hash[Symbol, T.untyped]).void }

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -1,0 +1,39 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CompletionResolveTest < Minitest::Test
+  include RubyLsp::Requests::Support::Common
+
+  Interface = LanguageServer::Protocol::Interface
+  Constant = LanguageServer::Protocol::Constant
+
+  def test_completion_resolve_for_constant
+    stub_no_typechecker
+    source = +<<~RUBY
+      class Foo
+      end
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(id: 1, method: "completionItem/resolve", params: {
+        label: "Foo",
+      })
+
+      result = server.pop_response.response
+
+      expected = Interface::CompletionItem.new(
+        label: "Foo",
+        label_details: Interface::CompletionItemLabelDetails.new(
+          description: "fake.rb",
+        ),
+        documentation: Interface::MarkupContent.new(
+          kind: "markdown",
+          value: markdown_from_index_entries("Foo", T.must(server.index["Foo"])),
+        ),
+      )
+      assert_equal(expected.to_json, result.to_json)
+    end
+  end
+end

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -12,6 +12,7 @@ class CompletionResolveTest < Minitest::Test
   def test_completion_resolve_for_constant
     stub_no_typechecker
     source = +<<~RUBY
+      # This is a class that does things
       class Foo
       end
     RUBY
@@ -33,6 +34,7 @@ class CompletionResolveTest < Minitest::Test
           value: markdown_from_index_entries("Foo", T.must(server.index["Foo"])),
         ),
       )
+      assert_match(/This is a class that does things/, result.documentation.value)
       assert_equal(expected.to_json, result.to_json)
     end
   end


### PR DESCRIPTION
This dramatically improves editor performance in certain situations by
omitting details and documentation from completion results. Instead, the
documentation and details are provided when the client resolves the
selected completion item.

Note that the number of entries considered when generating documentation
still needs to be limited, otherwise doing so can take multiple seconds
even during a single resolve request for a constant defined in thousands
of files.

As discussed here: https://ruby-dx.slack.com/archives/C050D17S6FP/p1710172892803489?thread_ts=1709595169.163439&cid=C050D17S6FP

Closes #1398 
