### PR TITLE
No-op Sorbet type assertions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ Sorbet/TrueSigil:
     - "test/**/*.rb"
     - "lib/ruby_indexer/test/**/*.rb"
     - "lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb"
+    - "lib/ruby_lsp/disable_sorbet.rb"
   Exclude:
     - "**/*.rake"
     - "lib/**/*.rb"
@@ -54,3 +55,4 @@ Sorbet/StrictSigil:
     - "lib/ruby_indexer/test/**/*.rb"
     - "lib/ruby-lsp.rb"
     - "lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb"
+    - "lib/ruby_lsp/disable_sorbet.rb"

--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -69,6 +69,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
 end
 
 require "sorbet-runtime"
+require "ruby_lsp/disable_sorbet"
 
 begin
   T::Configuration.default_checked_level = :never

--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -4,6 +4,7 @@
 # This executable checks if all automatic LSP requests run successfully on every Ruby file under the current directory
 
 require "sorbet-runtime"
+require "ruby_lsp/disable_sorbet"
 
 begin
   T::Configuration.default_checked_level = :never

--- a/lib/ruby_lsp/disable_sorbet.rb
+++ b/lib/ruby_lsp/disable_sorbet.rb
@@ -1,0 +1,66 @@
+# typed: true
+# frozen_string_literal: true
+
+module RubyLsp
+  # No-op all inline type assertions defined in T
+  module InlineTypeAssertions
+    def cast(value, type, checked: true)
+      value
+    end
+
+    def let(value, type, checked: true)
+      value
+    end
+
+    def must(arg)
+      arg
+    end
+
+    def absurd(value)
+      value
+    end
+
+    def bind(value, type, checked: true)
+      value
+    end
+
+    def assert_type!(value, type, checked: true)
+      value
+    end
+
+    def any(type_a, type_b, *types)
+      T::Types::Union.new([type_a, type_b, *types])
+    end
+
+    def nilable(type)
+      T::Types::Union.new([type, T::Utils::Nilable::NIL_TYPE])
+    end
+
+    T.singleton_class.prepend(self)
+  end
+
+  # No-op generic type variable syntax
+  module TypeVariableSyntax
+    def type_member(variance = :invariant, fixed: nil, lower: T.untyped, upper: BasicObject, &block)
+      block = TypeVariableSyntax.build_bounds_block(fixed, lower, upper) if block.nil?
+      super(variance, &block)
+    end
+
+    def type_template(variance = :invariant, fixed: nil, lower: T.untyped, upper: BasicObject, &block)
+      block = TypeVariableSyntax.build_bounds_block(fixed, lower, upper) if block.nil?
+      super(variance, &block)
+    end
+
+    class << self
+      def build_bounds_block(fixed, lower, upper)
+        bounds = {}
+        bounds[:fixed] = fixed unless fixed.nil?
+        bounds[:lower] = lower unless lower == T.untyped
+        bounds[:upper] = upper unless upper == BasicObject
+        -> { bounds }
+      end
+    end
+
+    T::Generic.prepend(self)
+  end
+end

--- a/sorbet/rbi/shims/sorbet.rbi
+++ b/sorbet/rbi/shims/sorbet.rbi
@@ -1,0 +1,3 @@
+# typed: true
+
+T::Utils::Nilable::NIL_TYPE = T.unsafe(nil)


### PR DESCRIPTION
### Motivation

We should no-op the Sorbet type assertions so that we don't pay the performance price of runtime type checks when running the LSP.

### Implementation

Added two modules to patch as much as we can from the Sorbet runtime and reduce the overhead from runtime type checks.