### PR TITLE
Fix failing test on main for DocumentSymbol

### DIFF
--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -16,7 +16,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
 
     dispatcher = Prism::Dispatcher.new
-    listener = RubyLsp::Requests::DocumentSymbol.new(dispatcher)
+    listener = RubyLsp::Requests::DocumentSymbol.new(uri, dispatcher)
     dispatcher.dispatch(document.tree)
     response = listener.perform
 


### PR DESCRIPTION
Was failing due to the change in https://github.com/Shopify/ruby-lsp/pull/1444/files#diff-7059e8ce6c342ec9a646c2f293ce120c65bdb933d70c81da97471b21c6465bdaR100