### PR TITLE
Fix lazy document parsing and error reporting

### DIFF
--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -105,9 +105,11 @@ module RubyLsp
     def to_hash
       {
         id: @id,
-        code: @code,
-        message: @message,
-        data: @data,
+        error: {
+          code: @code,
+          message: @message,
+          data: @data,
+        },
       }
     end
   end


### PR DESCRIPTION
### Motivation

We identified two issues after the server refactor in main:

1. Error reporting was failing, because the response was not in the expected structure
2. Trying to open an untitled Ruby file was failing because we were trying to run lazy document parsing event on text synchronization notifications (which we didn't do before the refactor)

This PR fixes both.

### Implementation

We never want to parse documents on text synchronization notifications, so I excluded them by checking against `textDocument/did`, which all of the notifications use.

For the error, the issue was simply that the fields have to be nested inside the `error` key.

### Manual Tests

1. Start the LSP on this branch
2. Open a new untitled file
3. Switch the language mode to Ruby
4. Verify it does not fail because of lazy parsing

**Note**: I actually identified a bug in RuboCop while trying this out and you will see an `IndexError` when opening the empty file. RuboCop is trying to access some index in the source buffer which fails because the string is empty.