### PR TITLE
Remove unused assignment in ExpectationsTestRunner

### DIFF
--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -12,7 +12,6 @@ class ExpectationsTestRunner < Minitest::Test
       class_eval(<<~RB, __FILE__, __LINE__ + 1)
         module ExpectationsRunnerMethods
           def run_expectations(source)
-            params = @__params&.any? ? @__params : default_args
             document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
             dispatcher = Prism::Dispatcher.new
             request = #{handler_class}.new(dispatcher)

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -12,11 +12,7 @@ class ExpectationsTestRunner < Minitest::Test
       class_eval(<<~RB, __FILE__, __LINE__ + 1)
         module ExpectationsRunnerMethods
           def run_expectations(source)
-            document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
-            dispatcher = Prism::Dispatcher.new
-            request = #{handler_class}.new(dispatcher)
-            dispatcher.dispatch(document.tree)
-            request.perform
+            raise "This method should be implemented in the inherited class"
           end
 
           def assert_expectations(source, expected)


### PR DESCRIPTION
I noticed this in the warnings when running on CI (repeated 14 times).

`/Users/runner/work/ruby-lsp/ruby-lsp/test/expectations/expectations_test_runner.rb:15: warning: assigned but unused variable - params`
