### PR TITLE
Implement Rbenv activation as a manager object

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -11,6 +11,7 @@ import { Chruby } from "./ruby/chruby";
 import { VersionManager } from "./ruby/versionManager";
 import { Mise } from "./ruby/mise";
 import { RubyInstaller } from "./ruby/rubyInstaller";
+import { Rbenv } from "./ruby/rbenv";
 
 export enum ManagerIdentifier {
   Asdf = "asdf",
@@ -109,7 +110,9 @@ export class Ruby implements RubyInterface {
           );
           break;
         case ManagerIdentifier.Rbenv:
-          await this.activate("rbenv exec ruby");
+          await this.runActivation(
+            new Rbenv(this.workspaceFolder, this.outputChannel),
+          );
           break;
         case ManagerIdentifier.Rvm:
           await this.activate("rvm-auto-ruby");

--- a/vscode/src/ruby/rbenv.ts
+++ b/vscode/src/ruby/rbenv.ts
@@ -1,0 +1,46 @@
+/* eslint-disable no-process-env */
+
+import path from "path";
+
+import { asyncExec } from "../common";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// Seamlessly manage your app’s Ruby environment with rbenv.
+//
+// Learn more: https://github.com/rbenv/rbenv
+export class Rbenv extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    const activationScript = [
+      "STDERR.print(",
+      "{env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION,home:Gem.user_dir,default:Gem.default_dir}",
+      ".to_json)",
+    ].join("");
+
+    const result = await asyncExec(
+      `rbenv exec ruby -W0 -rjson -e '${activationScript}'`,
+      {
+        cwd: this.bundleUri.fsPath,
+      },
+    );
+
+    const parsedResult = JSON.parse(result.stderr);
+
+    // The addition of GEM_HOME, GEM_PATH and putting the bin directories into the PATH happens through Rbenv's shell
+    // hooks. Since we want to avoid spawning shells due to integration issues, we need to insert these variables
+    // ourselves, so that gem executables can be properly found
+    parsedResult.env.GEM_HOME = parsedResult.home;
+    parsedResult.env.GEM_PATH = `${parsedResult.home}${path.delimiter}${parsedResult.default}`;
+    parsedResult.env.PATH = [
+      path.join(parsedResult.home, "bin"),
+      path.join(parsedResult.default, "bin"),
+      parsedResult.env.PATH,
+    ].join(path.delimiter);
+
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+    };
+  }
+}

--- a/vscode/src/test/suite/ruby/rbenv.test.ts
+++ b/vscode/src/test/suite/ruby/rbenv.test.ts
@@ -1,0 +1,69 @@
+import assert from "assert";
+import path from "path";
+import os from "os";
+
+import * as vscode from "vscode";
+import sinon from "sinon";
+
+import { Rbenv } from "../../../ruby/rbenv";
+import { WorkspaceChannel } from "../../../workspaceChannel";
+import * as common from "../../../common";
+
+suite("Rbenv", () => {
+  if (os.platform() === "win32") {
+    // eslint-disable-next-line no-console
+    console.log("Skipping Rbenv tests on Windows");
+    return;
+  }
+
+  test("Finds Ruby based on .ruby-version", async () => {
+    // eslint-disable-next-line no-process-env
+    const workspacePath = process.env.PWD!;
+    const workspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
+    const rbenv = new Rbenv(workspaceFolder, outputChannel);
+
+    const activationScript = [
+      "STDERR.print(",
+      "{env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION,home:Gem.user_dir,default:Gem.default_dir}",
+      ".to_json)",
+    ].join("");
+
+    const execStub = sinon.stub(common, "asyncExec").resolves({
+      stdout: "",
+      stderr: JSON.stringify({
+        env: { ANY: "true" },
+        yjit: true,
+        version: "3.0.0",
+        home: "/home/user/.gem/ruby/3.0.0",
+        default: "/usr/lib/ruby/gems/3.0.0",
+      }),
+    });
+
+    const { env, version, yjit } = await rbenv.activate();
+
+    assert.ok(
+      execStub.calledOnceWithExactly(
+        `rbenv exec ruby -W0 -rjson -e '${activationScript}'`,
+        { cwd: workspacePath },
+      ),
+    );
+
+    assert.strictEqual(version, "3.0.0");
+    assert.strictEqual(yjit, true);
+    assert.strictEqual(env.GEM_HOME, "/home/user/.gem/ruby/3.0.0");
+    assert.strictEqual(
+      env.GEM_PATH,
+      "/home/user/.gem/ruby/3.0.0:/usr/lib/ruby/gems/3.0.0",
+    );
+    assert.ok(env.PATH!.includes("/home/user/.gem/ruby/3.0.0/bin"));
+    assert.ok(env.PATH!.includes("/usr/lib/ruby/gems/3.0.0/bin"));
+    assert.strictEqual(env.ANY, "true");
+
+    execStub.restore();
+  });
+});


### PR DESCRIPTION
### Motivation

Implement `rbenv` as a version manager object and decouple it from the shell. With this, we are only missing `asdf` and `rvm` to fully stabilize the new Ruby environment activation and ship `v0.7.0`.

### Implementation

As mentioned in [rbenv's README](https://github.com/rbenv/rbenv?tab=readme-ov-file#how-it-works), the executable is injected into the PATH during installation time. This is great because it means we can invoke it directly without having to know where exactly it is installed.

The implementation is almost identical to Mise or Shadowenv, where we just run a Ruby activation script using the manager's exec command.

There's only one gotcha. I created a Spin instance to test this end to end and apparently when we invoke `rbenv` directly without the shell integrations, it does not set `GEM_HOME`, `GEM_PATH` or insert the directories for gem executables into the `PATH`. Which means, the extension becomes unable to find the `ruby-lsp` executable since the directory where it exists is not a part of the `PATH`.

To account for this, we print the gem directories from the activation script and manually merge them into the environment.

### Automated Tests

Added a test verifying the functionality.

### Manual Tests

1. Start the extension on this branch
2. Open any Ruby project configured with rbenv
3. Verify that the Ruby LSP launches properly using the Ruby version declared by the project (or the global one)