### PR TITLE
Check if path exists before adding spec code lens

### DIFF
--- a/lib/ruby_lsp/listeners/code_lens.rb
+++ b/lib/ruby_lsp/listeners/code_lens.rb
@@ -264,12 +264,14 @@ module RubyLsp
 
         return unless name
 
-        add_test_code_lens(
-          node,
-          name: name,
-          command: generate_test_command(spec_name: name),
-          kind: kind,
-        )
+        if @path
+          add_test_code_lens(
+            node,
+            name: name,
+            command: generate_test_command(spec_name: name),
+            kind: kind,
+          )
+        end
       end
     end
   end

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -102,6 +102,25 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     assert_empty(response)
   end
 
+  def test_no_code_lens_for_unsaved_specs
+    source = <<~RUBY
+      describe FooTest < Minitest::Spec
+        it "does something"; end
+      end
+    RUBY
+    uri = URI::Generic.build(scheme: "untitled", opaque: "Untitled-1")
+
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+
+    dispatcher = Prism::Dispatcher.new
+    stub_test_library("minitest")
+    listener = RubyLsp::Requests::CodeLens.new(uri, dispatcher)
+    dispatcher.dispatch(document.tree)
+    response = listener.perform
+
+    assert_empty(response)
+  end
+
   def test_code_lens_addons
     source = <<~RUBY
       class Test < Minitest::Test; end


### PR DESCRIPTION
### Motivation

The `@path` will be `nil` for untitled files and we weren't checking before trying to add the code lens, which ultimately results in a `TypeError`.

### Implementation

Added the guard to prevent trying to add a code lens without a path.

### Automated Tests

Added a test that reproduces the issue.