### PR TITLE
Allow config to be passed into Indexer

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -43,20 +43,6 @@ module RubyIndexer
       )
     end
 
-    sig { void }
-    def load_config
-      return unless File.exist?(".index.yml")
-
-      config = YAML.parse_file(".index.yml")
-      return unless config
-
-      config_hash = config.to_ruby
-      validate_config!(config_hash)
-      apply_config(config_hash)
-    rescue Psych::SyntaxError => e
-      raise e, "Syntax error while loading .index.yml configuration: #{e.message}"
-    end
-
     sig { returns(T::Array[IndexablePath]) }
     def indexables
       excluded_gems = @excluded_gems - @included_gems
@@ -158,6 +144,17 @@ module RubyIndexer
       @magic_comment_regex ||= T.let(/^#\s*#{@excluded_magic_comments.join("|")}/, T.nilable(Regexp))
     end
 
+    sig { params(config: T::Hash[String, T.untyped]).void }
+    def apply_config(config)
+      validate_config!(config)
+
+      @excluded_gems.concat(config["excluded_gems"]) if config["excluded_gems"]
+      @included_gems.concat(config["included_gems"]) if config["included_gems"]
+      @excluded_patterns.concat(config["excluded_patterns"]) if config["excluded_patterns"]
+      @included_patterns.concat(config["included_patterns"]) if config["included_patterns"]
+      @excluded_magic_comments.concat(config["excluded_magic_comments"]) if config["excluded_magic_comments"]
+    end
+
     private
 
     sig { params(config: T::Hash[String, T.untyped]).void }
@@ -173,15 +170,6 @@ module RubyIndexer
       end
 
       raise ArgumentError, errors.join("\n") if errors.any?
-    end
-
-    sig { params(config: T::Hash[String, T.untyped]).void }
-    def apply_config(config)
-      @excluded_gems.concat(config["excluded_gems"]) if config["excluded_gems"]
-      @included_gems.concat(config["included_gems"]) if config["included_gems"]
-      @excluded_patterns.concat(config["excluded_patterns"]) if config["excluded_patterns"]
-      @included_patterns.concat(config["included_patterns"]) if config["included_patterns"]
-      @excluded_magic_comments.concat(config["excluded_magic_comments"]) if config["excluded_magic_comments"]
     end
 
     sig { returns(T::Array[String]) }

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -10,7 +10,7 @@ module RubyIndexer
     end
 
     def test_load_configuration_executes_configure_block
-      @config.load_config
+      @config.apply_config({ "excluded_patterns" => ["**/test/fixtures/**/*.rb"] })
       indexables = @config.indexables
 
       assert(indexables.none? { |indexable| indexable.full_path.include?("test/fixtures") })
@@ -21,7 +21,6 @@ module RubyIndexer
     end
 
     def test_indexables_only_includes_gem_require_paths
-      @config.load_config
       indexables = @config.indexables
 
       Bundler.locked_gems.specs.each do |lazy_spec|
@@ -35,7 +34,6 @@ module RubyIndexer
     end
 
     def test_indexables_does_not_include_default_gem_path_when_in_bundle
-      @config.load_config
       indexables = @config.indexables
 
       assert(
@@ -44,7 +42,6 @@ module RubyIndexer
     end
 
     def test_indexables_includes_default_gems
-      @config.load_config
       indexables = @config.indexables.map(&:full_path)
 
       assert_includes(indexables, "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb")
@@ -53,7 +50,6 @@ module RubyIndexer
     end
 
     def test_indexables_includes_project_files
-      @config.load_config
       indexables = @config.indexables.map(&:full_path)
 
       Dir.glob("#{Dir.pwd}/lib/**/*.rb").each do |path|
@@ -66,7 +62,6 @@ module RubyIndexer
     def test_indexables_avoids_duplicates_if_bundle_path_is_inside_project
       Bundler.settings.set_global("path", "vendor/bundle")
       config = Configuration.new
-      config.load_config
 
       assert_includes(config.instance_variable_get(:@excluded_patterns), "#{Dir.pwd}/vendor/bundle/**/*.rb")
     ensure
@@ -74,7 +69,6 @@ module RubyIndexer
     end
 
     def test_indexables_does_not_include_gems_own_installed_files
-      @config.load_config
       indexables = @config.indexables
 
       assert(
@@ -95,17 +89,14 @@ module RubyIndexer
     end
 
     def test_paths_are_unique
-      @config.load_config
       indexables = @config.indexables
 
       assert_equal(indexables.uniq.length, indexables.length)
     end
 
     def test_configuration_raises_for_unknown_keys
-      Psych::Nodes::Document.any_instance.expects(:to_ruby).returns({ "unknown_config" => 123 })
-
       assert_raises(ArgumentError) do
-        @config.load_config
+        @config.apply_config({ "unknown_config" => 123 })
       end
     end
 

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -243,7 +243,7 @@ module RubyLsp
 
       if File.exist?(index_path)
         begin
-          indexing_config = YAML.parse_file(".index.yml").to_ruby
+          indexing_config = YAML.parse_file(index_path).to_ruby
         rescue Psych::SyntaxError => e
           message = "Syntax error while loading .index.yml configuration: #{e.message}"
           send_message(

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -236,7 +236,29 @@ module RubyLsp
 
       RubyVM::YJIT.enable if defined?(RubyVM::YJIT.enable)
 
-      perform_initial_indexing
+      indexing_config = {}
+
+      # Need to use the workspace URI, otherwise, this will fail for people working on a project that is a symlink.
+      index_path = File.join(@store.workspace_uri.to_standardized_path, ".index.yml")
+
+      if File.exist?(index_path)
+        begin
+          indexing_config = YAML.parse_file(".index.yml").to_ruby
+        rescue Psych::SyntaxError => e
+          message = "Syntax error while loading .index.yml configuration: #{e.message}"
+          send_message(
+            Notification.new(
+              method: "window/showMessage",
+              params: Interface::ShowMessageParams.new(
+                type: Constant::MessageType::WARNING,
+                message: message,
+              ),
+            ),
+          )
+        end
+      end
+
+      perform_initial_indexing(indexing_config)
       check_formatter_is_available
     end
 
@@ -639,11 +661,11 @@ module RubyLsp
       Addon.addons.each(&:deactivate)
     end
 
-    sig { void }
-    def perform_initial_indexing
+    sig { params(config_hash: T::Hash[String, T.untyped]).void }
+    def perform_initial_indexing(config_hash)
       # The begin progress invocation happens during `initialize`, so that the notification is sent before we are
       # stuck indexing files
-      RubyIndexer.configuration.load_config
+      RubyIndexer.configuration.apply_config(config_hash)
 
       Thread.new do
         begin

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -245,7 +245,7 @@ module RubyLsp
         begin
           indexing_config = YAML.parse_file(index_path).to_ruby
         rescue Psych::SyntaxError => e
-          message = "Syntax error while loading #{index_path} configuration: #{e.message}"
+          message = "Syntax error while loading configuration: #{e.message}"
           send_message(
             Notification.new(
               method: "window/showMessage",

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -245,7 +245,7 @@ module RubyLsp
         begin
           indexing_config = YAML.parse_file(index_path).to_ruby
         rescue Psych::SyntaxError => e
-          message = "Syntax error while loading .index.yml configuration: #{e.message}"
+          message = "Syntax error while loading #{index_path} configuration: #{e.message}"
           send_message(
             Notification.new(
               method: "window/showMessage",

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -332,9 +332,8 @@ class ServerTest < Minitest::Test
     @server.process_message({ method: "initialized" })
     notification = @server.pop_response
     assert_equal("window/showMessage", notification.method)
-    assert_equal(
-      "Syntax error while loading .index.yml configuration: (.index.yml): did not find expected node content " \
-        "while parsing a block node at line 1 column 1",
+    assert_match(
+      /Syntax error while loading configuration/,
       T.cast(notification.params, RubyLsp::Interface::ShowMessageParams).message,
     )
   ensure


### PR DESCRIPTION
(New version of https://github.com/Shopify/ruby-lsp/pull/1436)

### Motivation

We plan to rename `.index.yml` to `.ruby-lsp.yml` and use that for general configuration. As a first step, this PR refactors the indexer to accept a configuration hash, instead of reading the config file directly.

### Implementation

Pass the config as a hash.

### Automated Tests

Updated

### Manual Tests

* Open this branch
* Ensure indexing is working (e.g. the Jump to Definition works for constants)
* Edit `.index.yml` to make it invalid syntax and restart the LSP
* Ensure an error message is showing but otherwise everything works (e.g. formatting)
* Delete `.index.yml` and restart the LSP
* Ensure indexing completes successfully (e.g. the Jump to Definition works for constants)
