### PR TITLE
Enable add-ons to extend completion

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -166,5 +166,17 @@ module RubyLsp
       ).void
     end
     def create_definition_listener(response_builder, uri, nesting, index, dispatcher); end
+
+    # Creates a new Completion listener. This method is invoked on every Completion request
+    sig do
+      overridable.params(
+        response_builder: ResponseBuilders::CollectionResponseBuilder[Interface::CompletionItem],
+        index: RubyIndexer::Index,
+        nesting: T::Array[String],
+        dispatcher: Prism::Dispatcher,
+        uri: URI::Generic,
+      ).void
+    end
+    def create_completion_listener(response_builder, index, nesting, dispatcher, uri); end
   end
 end

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -70,6 +70,10 @@ module RubyLsp
 
         Listeners::Completion.new(@response_builder, index, nesting, typechecker_enabled, dispatcher, document.uri)
 
+        Addon.addons.each do |addon|
+          addon.create_completion_listener(@response_builder, index, nesting, dispatcher, document.uri)
+        end
+
         return unless matched && parent
 
         @target = case matched

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -80,6 +80,44 @@ module Minitest
     ensure
       T.must(server).run_shutdown
     end
+
+    sig do
+      params(
+        addon_creation_method: Symbol,
+        source: String,
+        block: T.proc.params(server: RubyLsp::Server).void,
+      ).void
+    end
+    def test_addon(addon_creation_method, source:, &block)
+      message_queue = Thread::Queue.new
+      stub_no_typechecker
+
+      uri = URI::Generic.from_path(path: "/fake.rb")
+      server = RubyLsp::Server.new(test_mode: true)
+      server.process_message({
+        method: "textDocument/didOpen",
+        params: {
+          textDocument: {
+            uri: uri,
+            text: source,
+            version: 1,
+          },
+        },
+      })
+      index = server.index
+      index.index_single(RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source)
+
+      send(addon_creation_method)
+      RubyLsp::Addon.load_addons(message_queue)
+
+      block.call(server)
+    ensure
+      RubyLsp::Addon.addons.each(&:deactivate)
+      RubyLsp::Addon.addon_classes.clear
+      RubyLsp::Addon.addons.clear
+      T.must(server).run_shutdown
+      T.must(message_queue).close
+    end
   end
 end
 


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Exposes the completion feature to add-ons.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Created a factory method for the feature, and updated the request to ensure the appropriate add-on config is in place.  

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

Created a unit test to ensure add-ons can indeed contribute to this feature.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

You can test that the completion functionality itself hasn't been disrupted. You can also technically use this branch from an add-on like `ruby-lsp-rails` and leverage the completion feature there to test it, but this would require configuration similar to the other features there.