### PR TITLE
Add MissingNodesInConstantPathError to collector include handler

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/collector.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/collector.rb
@@ -364,8 +364,7 @@ module RubyIndexer
         if node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
           node.full_name
         end
-      rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError
-        # TO DO: add MissingNodesInConstantPathError when released in Prism
+      rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError, MissingNodesInConstantPathError
         # If a constant path reference is dynamic or missing parts, we can't
         # index it
       end


### PR DESCRIPTION
### Motivation

In #1383 there was left a TO DO to put the `MissingNodesInConstantPathError` because Prism was not in version 0.24.0 and does not included the class yet.

### Implementation

Now that Prism new version has the class implemented the class was added to the rescue in the handle include of the collector.
