### PR TITLE
Indexed prepended modules on namespaces

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/collector.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/collector.rb
@@ -154,6 +154,8 @@ module RubyIndexer
         handle_attribute(node, reader: true, writer: true)
       when :include
         handle_include(node)
+      when :prepend
+        handle_prepend(node)
       end
     end
 
@@ -355,6 +357,16 @@ module RubyIndexer
 
     sig { params(node: Prism::CallNode).void }
     def handle_include(node)
+      handle_module_operation(node, :included_modules)
+    end
+
+    sig { params(node: Prism::CallNode).void }
+    def handle_prepend(node)
+      handle_module_operation(node, :prepended_modules)
+    end
+
+    sig { params(node: Prism::CallNode, operation: Symbol).void }
+    def handle_module_operation(node, operation)
       return unless @current_owner
 
       arguments = node.arguments&.arguments
@@ -369,7 +381,8 @@ module RubyIndexer
         # If a constant path reference is dynamic or missing parts, we can't
         # index it
       end
-      @current_owner.included_modules.concat(names)
+      collection = operation == :included_modules ? @current_owner.included_modules : @current_owner.prepended_modules
+      collection.concat(names)
     end
   end
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -43,6 +43,9 @@ module RubyIndexer
       sig { returns(T::Array[String]) }
       attr_accessor :included_modules
 
+      sig { returns(T::Array[String]) }
+      attr_accessor :prepended_modules
+
       sig do
         params(
           name: String,
@@ -54,6 +57,7 @@ module RubyIndexer
       def initialize(name, file_path, location, comments)
         super(name, file_path, location, comments)
         @included_modules = T.let([], T::Array[String])
+        @prepended_modules = T.let([], T::Array[String])
       end
 
       sig { returns(String) }


### PR DESCRIPTION
### Motivation

Resolves fourth point of #1333 

This changes index prepended modules of all Namespaces, including `Class` and `Module` nodes.

### Implementation
1. Added prepended_modules property in the Namespace class.
2. Added a handler for the collector for the prepended modules and refactor to reuse the code that handle included modules.

### Automated Tests

Tests where added in `lib/ruby_indexer/test/classes_and_modules_test.rb` to cover different cases.

### Manual Tests

Test indexing the same repo and does not crash.
