### PR TITLE
Apply indexing configuration to ruby-lsp-doctor

### DIFF
--- a/exe/ruby-lsp-doctor
+++ b/exe/ruby-lsp-doctor
@@ -5,8 +5,14 @@ $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "ruby_lsp/internal"
 
 if File.exist?(".index.yml")
-  RubyIndexer.configuration.apply_config(YAML.parse_file(".index.yml").to_ruby)
+  begin
+    config = YAML.parse_file(".index.yml").to_ruby
+  rescue => e
+    abort("Error parsing config: #{e.message}")
+  end
+  RubyIndexer.configuration.apply_config(config)
 end
+
 index = RubyIndexer::Index.new
 
 puts "Globbing for indexable files"


### PR DESCRIPTION
### Motivation

Due to the changes in https://github.com/Shopify/ruby-lsp/pull/1814, the `ruby-lsp-doctor` tool needs to have the configuration loaded.

### Implementation

Check if an `.index.yml` exists, and load configuration if so.

### Automated Tests

Since this is a troubleshooting tool, I think tests are not critical.

### Manual Tests

- Create a file "foo/bar.rb"
- Run the index and pipe through grep to confirm `foo/bar.rb` is listed
- Update `.index.yml` to exclude `"**/foo**"`
- Run the index and pipe through grep to confirm `foo/bar.rb` is no longer listed

Notes:
- This will need adjusted again for https://github.com/Shopify/ruby-lsp/pull/1434
- I think I found a separate problem relating to relative paths while testing this. I will look into and create an issue if needed.