### PR TITLE
Implement RVM as a manager object

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -12,6 +12,7 @@ import { VersionManager } from "./ruby/versionManager";
 import { Mise } from "./ruby/mise";
 import { RubyInstaller } from "./ruby/rubyInstaller";
 import { Rbenv } from "./ruby/rbenv";
+import { Rvm } from "./ruby/rvm";
 
 export enum ManagerIdentifier {
   Asdf = "asdf",
@@ -115,7 +116,9 @@ export class Ruby implements RubyInterface {
           );
           break;
         case ManagerIdentifier.Rvm:
-          await this.activate("rvm-auto-ruby");
+          await this.runActivation(
+            new Rvm(this.workspaceFolder, this.outputChannel),
+          );
           break;
         case ManagerIdentifier.Mise:
           await this.runActivation(

--- a/vscode/src/ruby/rvm.ts
+++ b/vscode/src/ruby/rvm.ts
@@ -1,0 +1,56 @@
+/* eslint-disable no-process-env */
+import os from "os";
+import path from "path";
+
+import { asyncExec } from "../common";
+
+import { ActivationResult, VersionManager } from "./versionManager";
+
+// Ruby enVironment Manager. It manages Ruby application environments and enables switching between them.
+// Learn more:
+// - https://github.com/rvm/rvm
+// - https://rvm.io
+export class Rvm extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    const activationScript = [
+      "STDERR.print(",
+      "{yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION,",
+      "home:Gem.user_dir,default:Gem.default_dir,ruby:RbConfig.ruby}",
+      ".to_json)",
+    ].join("");
+
+    const result = await asyncExec(
+      `${path.join(os.homedir(), ".rvm", "bin", "rvm-auto-ruby")} -W0 -rjson -e '${activationScript}'`,
+      {
+        cwd: this.bundleUri.fsPath,
+      },
+    );
+
+    const parsedResult = JSON.parse(result.stderr);
+
+    // Invoking `rvm-auto-ruby` doesn't actually inject anything into the environment, it just finds the right Ruby to
+    // execute. We need to build the environment from the variables we return in the activation script
+    const env = {
+      GEM_HOME: parsedResult.home,
+      GEM_PATH: `${parsedResult.home}${path.delimiter}${parsedResult.default}`,
+      PATH: [
+        path.join(parsedResult.home, "bin"),
+        path.join(parsedResult.default, "bin"),
+        path.dirname(parsedResult.ruby),
+        process.env.PATH,
+      ].join(path.delimiter),
+    };
+
+    const activatedKeys = Object.entries(env)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(" ");
+
+    this.outputChannel.info(`Activated Ruby environment: ${activatedKeys}`);
+
+    return {
+      env: { ...process.env, ...env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+    };
+  }
+}

--- a/vscode/src/test/suite/ruby/rvm.test.ts
+++ b/vscode/src/test/suite/ruby/rvm.test.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-process-env */
+import assert from "assert";
+import path from "path";
+import os from "os";
+
+import * as vscode from "vscode";
+import sinon from "sinon";
+
+import { Rvm } from "../../../ruby/rvm";
+import { WorkspaceChannel } from "../../../workspaceChannel";
+import * as common from "../../../common";
+
+suite("RVM", () => {
+  if (os.platform() === "win32") {
+    // eslint-disable-next-line no-console
+    console.log("Skipping RVM tests on Windows");
+    return;
+  }
+
+  test("Populates the gem env and path", async () => {
+    const workspacePath = process.env.PWD!;
+    const workspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
+    const rvm = new Rvm(workspaceFolder, outputChannel);
+
+    const activationScript = [
+      "STDERR.print(",
+      "{yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION,",
+      "home:Gem.user_dir,default:Gem.default_dir,ruby:RbConfig.ruby}",
+      ".to_json)",
+    ].join("");
+
+    const execStub = sinon.stub(common, "asyncExec").resolves({
+      stdout: "",
+      stderr: JSON.stringify({
+        yjit: true,
+        version: "3.0.0",
+        home: "/home/user/.rvm/gems/ruby/3.0.0",
+        default: "/usr/lib/ruby/gems/3.0.0",
+        ruby: "/home/user/.rvm/rubies/ruby-3.0.0/bin/ruby",
+      }),
+    });
+
+    const { env, version, yjit } = await rvm.activate();
+
+    assert.ok(
+      execStub.calledOnceWithExactly(
+        `${path.join(os.homedir(), ".rvm", "bin", "rvm-auto-ruby")} -W0 -rjson -e '${activationScript}'`,
+        { cwd: workspacePath },
+      ),
+    );
+
+    assert.strictEqual(version, "3.0.0");
+    assert.strictEqual(yjit, true);
+    assert.strictEqual(env.GEM_HOME, "/home/user/.rvm/gems/ruby/3.0.0");
+    assert.strictEqual(
+      env.GEM_PATH,
+      "/home/user/.rvm/gems/ruby/3.0.0:/usr/lib/ruby/gems/3.0.0",
+    );
+    assert.ok(env.PATH!.includes("/home/user/.rvm/gems/ruby/3.0.0/bin"));
+    assert.ok(env.PATH!.includes("/usr/lib/ruby/gems/3.0.0/bin"));
+    assert.ok(env.PATH!.includes("/home/user/.rvm/rubies/ruby-3.0.0/bin"));
+
+    execStub.restore();
+  });
+});


### PR DESCRIPTION
### Motivation

Implement RVM support as a manager object.

### Implementation

Similar to Mise, we execute RVM from the default installation path. However, RVM doesn't actually activate anything in the environment variables when we run the script. `ENV.to_h` is basically empty.

Because of that, we need to return the essential parts of the environment ourselves from the script, to get the right `GEM_HOME`, `GEM_PATH` and `PATH`.

### Automated Tests

Added a test.