### PR TITLE
Centralize Ruby Version to `.ruby-version`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
           bundler-cache: true
 
       - name: Check if documentation is up to date
@@ -86,8 +85,6 @@ jobs:
       # We need some Ruby installed for the environment activation tests
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3.0"
 
       - name: Download shadowenv
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'

--- a/.github/workflows/lsp_check.yml
+++ b/.github/workflows/lsp_check.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Run ruby-lsp-check

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.0
           bundler-cache: true
           cache-version: 1
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,6 @@ require:
 AllCops:
   NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: 3.0
   Include:
     - "sorbet/rbi/shims/**/*.rbi"
   Exclude:


### PR DESCRIPTION
## What are you trying to accomplish?
The `.ruby-version` file is the ecosystem standard for defining a Ruby version.  This PR adds the `.ruby-version` file, ensures a `required_ruby_version` is set, and removes all other references to Ruby in this repository, aligning it with the standard.
## What should reviewers focus on?
> [!IMPORTANT] 
> Please verify the following before merging:

Verify that the changes in the PR meets the following requirements or adjust manually to make it compliant:
  - [x] `.ruby-version` file is present with the correct Ruby version defined
  - [x] A `required_ruby_version` in your gemspec is set
  - [x] There is no Ruby version/requirement referenced in the `Gemfile` (no lines with `ruby  <some-version>`)
  - [x] A `Gemfile.lock` is built with the defined Ruby version
  - [x] The version of Rubocop installed is 1.61.0 or greater
  - [x] There is no `TargetRubyVersion` defined  in `rubocop.yml` 
  - [ ] There is no Ruby argument  present in  `ruby/setup-ruby` Github Actions that do **not**  run on a Ruby matrix (no lines with `ruby-version: “x.x”`)

Please merge this PR if it looks good, this PR will be merged if there isn't any activity after 4 weeks.

