### PR TITLE
Enhance version manager config to accept more fields

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -85,7 +85,12 @@ by clicking `Change version manager` in the language status center or by changin
 // "rbenv"
 // "rvm"
 // "shadowenv"
-"rubyLsp.rubyVersionManager": "chruby"
+// "mise"
+{
+  "rubyLsp.rubyVersionManager": {
+    "identifier": "chruby",
+  },
+}
 ```
 
 To make sure that the Ruby LSP can find the version manager scripts, make sure that they are loaded in the shell's

--- a/vscode/VERSION_MANAGERS.md
+++ b/vscode/VERSION_MANAGERS.md
@@ -10,30 +10,20 @@ If you're using a different version manager that's not supported by this extensi
 executable into the PATH, you will probably need to define custom activation so that the extension can find the correct
 Ruby.
 
-For these cases, set `rubyLsp.rubyVersionManager` to `"custom"` and then set `rubyLsp.customRubyCommand` to a shell
-command that will activate the right Ruby version or add the Ruby `bin` folder to the `PATH`. Some examples:
+For these cases, set `rubyLsp.rubyVersionManager.identifier` to `"custom"` and then set `rubyLsp.customRubyCommand` to a
+shell command that will activate the right Ruby version or add the Ruby `bin` folder to the `PATH`. Some examples:
 
 ```jsonc
 {
   // Don't forget to set the manager to custom when using this option
-  "rubyLsp.rubyVersionManager": "custom",
+  "rubyLsp.rubyVersionManager": {
+    "identifier": "custom",
+  },
 
   // Using a different version manager than the ones included by default
   "rubyLsp.customRubyCommand": "my_custom_version_manager activate",
 
   // Adding a custom Ruby bin folder to the PATH
   "rubyLsp.customRubyCommand": "PATH=/path/to/ruby/bin:$PATH",
-}
-```
-
-### mise (formerly rtx)
-
-[mise](https://github.com/jdx/mise) is a Rust clone compatible with asdf. You can use it by adding the following
-snippet to your user configuration JSON
-
-```json
-{
-  "rubyLsp.rubyVersionManager": "custom",
-  "rubyLsp.customRubyCommand": "eval \"$(mise env -s zsh)\"" // Instructions for zsh, change for bash or fish
 }
 ```

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -232,20 +232,28 @@
           }
         },
         "rubyLsp.rubyVersionManager": {
-          "description": "The Ruby version manager to use",
-          "type": "string",
-          "enum": [
-            "asdf",
-            "auto",
-            "chruby",
-            "none",
-            "rbenv",
-            "rvm",
-            "shadowenv",
-            "mise",
-            "custom"
-          ],
-          "default": "auto"
+          "type": "object",
+          "properties": {
+            "identifier": {
+              "description": "The Ruby version manager to use",
+              "type": "string",
+              "enum": [
+                "asdf",
+                "auto",
+                "chruby",
+                "none",
+                "rbenv",
+                "rvm",
+                "shadowenv",
+                "mise",
+                "custom"
+              ],
+              "default": "auto"
+            }
+          },
+          "default": {
+            "identifier": "auto"
+          }
         },
         "rubyLsp.customRubyCommand": {
           "description": "A shell command to activate the right Ruby version or add a custom Ruby bin folder to the PATH. Only used if rubyVersionManager is set to 'custom'",

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -22,7 +22,7 @@ export enum Command {
 
 export interface RubyInterface {
   error: boolean;
-  versionManager?: string;
+  versionManager: { identifier: string };
   rubyVersion?: string;
 }
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -11,8 +11,42 @@ export async function activate(context: vscode.ExtensionContext) {
 
   extension = new RubyLsp(context);
   await extension.activate();
+
+  await migrateManagerConfigurations();
 }
 
 export async function deactivate(): Promise<void> {
   await extension.deactivate();
+}
+
+type InspectKeys =
+  | "globalValue"
+  | "workspaceValue"
+  | "workspaceFolderValue"
+  | "globalLanguageValue"
+  | "workspaceLanguageValue"
+  | "workspaceFolderLanguageValue";
+// Function to migrate the old version manager configuration to the new format. Remove this after a few months
+async function migrateManagerConfigurations() {
+  const configuration = vscode.workspace.getConfiguration("rubyLsp");
+  const currentManagerSettings =
+    configuration.inspect<string>("rubyVersionManager")!;
+  let identifier: string | undefined;
+
+  const targetMap: Record<InspectKeys, vscode.ConfigurationTarget> = {
+    globalValue: vscode.ConfigurationTarget.Global,
+    globalLanguageValue: vscode.ConfigurationTarget.Global,
+    workspaceFolderLanguageValue: vscode.ConfigurationTarget.WorkspaceFolder,
+    workspaceFolderValue: vscode.ConfigurationTarget.WorkspaceFolder,
+    workspaceLanguageValue: vscode.ConfigurationTarget.Workspace,
+    workspaceValue: vscode.ConfigurationTarget.Workspace,
+  };
+
+  for (const [key, target] of Object.entries(targetMap)) {
+    identifier = currentManagerSettings[key as InspectKeys];
+
+    if (identifier && typeof identifier === "string") {
+      await configuration.update("rubyVersionManager", { identifier }, target);
+    }
+  }
 }

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -5,7 +5,7 @@ import { Telemetry } from "./telemetry";
 import DocumentProvider from "./documentProvider";
 import { Workspace } from "./workspace";
 import { Command, STATUS_EMITTER } from "./common";
-import { ManagerIdentifier } from "./ruby";
+import { ManagerIdentifier, ManagerConfiguration } from "./ruby";
 import { StatusItems } from "./status";
 import { TestController } from "./testController";
 import { Debugger } from "./debugger";
@@ -286,16 +286,18 @@ export class RubyLsp {
         Command.SelectVersionManager,
         async () => {
           const configuration = vscode.workspace.getConfiguration("rubyLsp");
+          const managerConfig =
+            configuration.get<ManagerConfiguration>("rubyVersionManager")!;
           const options = Object.values(ManagerIdentifier);
-          const manager = await vscode.window.showQuickPick(options, {
-            placeHolder: `Current: ${configuration.get("rubyVersionManager")}`,
-          });
+          const manager = (await vscode.window.showQuickPick(options, {
+            placeHolder: `Current: ${managerConfig.identifier}`,
+          })) as ManagerIdentifier | undefined;
 
           if (manager !== undefined) {
+            managerConfig.identifier = manager;
             await configuration.update(
               "rubyVersionManager",
-              manager,
-              true,
+              managerConfig,
               true,
             );
           }

--- a/vscode/src/status.ts
+++ b/vscode/src/status.ts
@@ -49,7 +49,7 @@ export class RubyVersionStatus extends StatusItem {
       this.item.text = "Failed to activate Ruby";
       this.item.severity = vscode.LanguageStatusSeverity.Error;
     } else {
-      this.item.text = `Using Ruby ${workspace.ruby.rubyVersion} with ${workspace.ruby.versionManager}`;
+      this.item.text = `Using Ruby ${workspace.ruby.rubyVersion} with ${workspace.ruby.versionManager.identifier}`;
       this.item.severity = vscode.LanguageStatusSeverity.Information;
     }
   }

--- a/vscode/src/telemetry.ts
+++ b/vscode/src/telemetry.ts
@@ -74,7 +74,7 @@ export class Telemetry {
     const promises: Promise<void>[] = [
       { namespace: "workbench", field: "colorTheme" },
       { namespace: "rubyLsp", field: "enableExperimentalFeatures" },
-      { namespace: "rubyLsp", field: "rubyVersionManager" },
+      { namespace: "rubyLsp", field: "rubyVersionManager.identifier" },
       { namespace: "rubyLsp", field: "formatter" },
     ].map(({ namespace, field }) => {
       return this.sendEvent({

--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -116,7 +116,12 @@ suite("Client", () => {
     if (process.env.CI) {
       await vscode.workspace
         .getConfiguration("rubyLsp")
-        .update("rubyVersionManager", ManagerIdentifier.None, true, true);
+        .update(
+          "rubyVersionManager",
+          { identifier: ManagerIdentifier.None },
+          true,
+          true,
+        );
     }
     client = await launchClient(workspaceUri);
   });

--- a/vscode/src/test/suite/debugger.test.ts
+++ b/vscode/src/test/suite/debugger.test.ts
@@ -168,7 +168,7 @@ suite("Debugger", () => {
       .returns({
         get: (name: string) => {
           if (name === "rubyVersionManager") {
-            return manager;
+            return { identifier: manager };
           } else if (name === "bundleGemfile") {
             return "";
           } else if (name === "saveBeforeStart") {

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -29,7 +29,7 @@ suite("Ruby environment activation", () => {
       .returns({
         get: (name: string) => {
           if (name === "rubyVersionManager") {
-            return manager;
+            return { identifier: manager };
           } else if (name === "bundleGemfile") {
             return "";
           }
@@ -66,7 +66,7 @@ suite("Ruby environment activation", () => {
       .returns({
         get: (name: string) => {
           if (name === "rubyVersionManager") {
-            return manager;
+            return { identifier: manager };
           } else if (name === "bundleGemfile") {
             return "";
           }

--- a/vscode/src/test/suite/status.test.ts
+++ b/vscode/src/test/suite/status.test.ts
@@ -28,7 +28,10 @@ suite("StatusItems", () => {
 
   suite("RubyVersionStatus", () => {
     beforeEach(() => {
-      ruby = { rubyVersion: "3.2.0", versionManager: "shadowenv" } as Ruby;
+      ruby = {
+        rubyVersion: "3.2.0",
+        versionManager: { identifier: "shadowenv" },
+      } as Ruby;
       workspace = {
         ruby,
         lspClient: {


### PR DESCRIPTION
### Motivation

Step towards https://github.com/Shopify/ruby-lsp/issues/1822

Because each version manager has its own customizations, I believe we need to offer more settings to match the behaviour in the editor. We currently only allow setting the identifier of the manager, but that's not always enough (e.g.: see the issue).

### Implementation

The idea is to change the `versionManager` setting so that it becomes an object and then we nest the identifier inside of that object. After this goes in, then we'll be able to add extra configuration fields, like the version manager executable path.

All of the changes are solely to migrate `versionManager` from a string to an object that looks like `{ identifier: "chruby" }`.

The only other change is the automated migration in `extension.ts`, where we read all of the existing configuration values and update them automatically to match the new format. That code is temporary and can be removed after it has been there for a while.

### Automated Tests

Adapted our existing tests.

### Manual Tests

1. Start the extension on this branch
2. Open your JSON settings
3. Verify that your version manager setting was migrated to the new format
4. verify the server boots properly