### PR TITLE
Extract `RubyLsp::TestHelper` for addons to use

### DIFF
--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -1,0 +1,42 @@
+# typed: strict
+# frozen_string_literal: true
+
+# NOTE: This module is intended to be used by addons for writing their own tests, so keep that in mind if changing.
+
+module RubyLsp
+  module TestHelper
+    extend T::Sig
+
+    sig do
+      type_parameters(:T)
+        .params(
+          source: T.nilable(String),
+          uri: URI::Generic,
+          block: T.proc.params(server: RubyLsp::Server, uri: URI::Generic).returns(T.type_parameter(:T)),
+        ).returns(T.type_parameter(:T))
+    end
+    def with_server(source = nil, uri = Kernel.URI("file:///fake.rb"), &block)
+      server = RubyLsp::Server.new(test_mode: true)
+      server.process_message(method: "initialized")
+
+      if source
+        server.process_message({
+          method: "textDocument/didOpen",
+          params: {
+            textDocument: {
+              uri: uri,
+              text: source,
+              version: 1,
+            },
+          },
+        })
+      end
+
+      index = server.index
+      index.index_single(RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source)
+      block.call(server, uri)
+    ensure
+      T.must(server).run_shutdown
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 $VERBOSE = nil unless ENV["VERBOSE"] || ENV["CI"]
 
 require_relative "../lib/ruby_lsp/internal"
+require_relative "../lib/ruby_lsp/test_helper"
 require_relative "../lib/rubocop/cop/ruby_lsp/use_language_server_aliases"
 require_relative "../lib/rubocop/cop/ruby_lsp/use_register_with_handler_method"
 
@@ -40,6 +41,7 @@ Minitest::Reporters.use!(minitest_reporter)
 module Minitest
   class Test
     extend T::Sig
+    include RubyLsp::TestHelper
 
     Minitest::Test.make_my_diffs_pretty!
 
@@ -48,37 +50,6 @@ module Minitest
     sig { void }
     def stub_no_typechecker
       RubyLsp::DependencyDetector.instance.stubs(:typechecker).returns(false)
-    end
-
-    sig do
-      type_parameters(:T)
-        .params(
-          source: T.nilable(String),
-          uri: URI::Generic,
-          block: T.proc.params(server: RubyLsp::Server, uri: URI::Generic).returns(T.type_parameter(:T)),
-        ).returns(T.type_parameter(:T))
-    end
-    def with_server(source = nil, uri = URI("file:///fake.rb"), &block)
-      server = RubyLsp::Server.new(test_mode: true)
-
-      if source
-        server.process_message({
-          method: "textDocument/didOpen",
-          params: {
-            textDocument: {
-              uri: uri,
-              text: source,
-              version: 1,
-            },
-          },
-        })
-      end
-
-      index = server.index
-      index.index_single(RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)), source)
-      block.call(server, uri)
-    ensure
-      T.must(server).run_shutdown
     end
 
     sig do


### PR DESCRIPTION
This will allow us to use `with_server` in addons, e.g. https://github.com/Shopify/ruby-lsp-rails/pull/301