### PR TITLE
Set default CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
To avoid jobs running continuously if there's a problem, like [this](https://github.com/Shopify/ruby-lsp/actions/runs/8440035436/job/23116030503).

(I think the default is 24h).