### PR TITLE
Revert incorrect changes from #1818

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"


### PR DESCRIPTION
1. `test/test_helper.rb`'s typed flag doesn't need to be changed.
2. The prism fixture submodule wasn't updated even after a rebase, which caused a downgrade after the PR's merged. This PR updates it again.