### PR TITLE
Implement ASDF as a manager object

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -15,6 +15,7 @@ import { Rbenv } from "./ruby/rbenv";
 import { Rvm } from "./ruby/rvm";
 import { None } from "./ruby/none";
 import { Custom } from "./ruby/custom";
+import { Asdf } from "./ruby/asdf";
 
 export enum ManagerIdentifier {
   Asdf = "asdf",
@@ -48,7 +49,6 @@ export class Ruby implements RubyInterface {
   private _error = false;
   private readonly context: vscode.ExtensionContext;
   private readonly customBundleGemfile?: string;
-  private readonly cwd: string;
   private readonly outputChannel: WorkspaceChannel;
 
   constructor(
@@ -71,10 +71,6 @@ export class Ruby implements RubyInterface {
             path.join(this.workspaceFolder.uri.fsPath, customBundleGemfile),
           );
     }
-
-    this.cwd = this.customBundleGemfile
-      ? path.dirname(this.customBundleGemfile)
-      : this.workspaceFolder.uri.fsPath;
   }
 
   get versionManager(): ManagerConfiguration {
@@ -117,7 +113,9 @@ export class Ruby implements RubyInterface {
     try {
       switch (this.versionManager.identifier) {
         case ManagerIdentifier.Asdf:
-          await this.activate("asdf exec ruby");
+          await this.runActivation(
+            new Asdf(this.workspaceFolder, this.outputChannel),
+          );
           break;
         case ManagerIdentifier.Chruby:
           await this.runActivation(
@@ -190,43 +188,6 @@ export class Ruby implements RubyInterface {
     this._env = env;
     this.rubyVersion = version;
     this.yjitEnabled = (yjit && major > 3) || (major === 3 && minor >= 2);
-  }
-
-  private async activate(ruby: string) {
-    let command = this.shell ? `${this.shell} -i -c '` : "";
-
-    // The Ruby activation script is intentionally written as an array that gets joined into a one liner because some
-    // terminals cannot handle line breaks. Do not switch this to a multiline string or that will break activation for
-    // those terminals
-    const script = [
-      "STDERR.printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, ",
-      "JSON.dump({ env: ENV.to_h, ruby_version: RUBY_VERSION, yjit: defined?(RubyVM::YJIT) }))",
-    ].join("");
-
-    command += `${ruby} -rjson -e "${script}"`;
-
-    if (this.shell) {
-      command += "'";
-    }
-
-    this.outputChannel.info(
-      `Trying to activate Ruby environment with command: ${command} inside directory: ${this.cwd}`,
-    );
-
-    const result = await asyncExec(command, { cwd: this.cwd });
-    const rubyInfoJson = /RUBY_ENV_ACTIVATE(.*)RUBY_ENV_ACTIVATE/.exec(
-      result.stderr,
-    )![1];
-
-    const rubyInfo = JSON.parse(rubyInfoJson);
-
-    this._env = rubyInfo.env;
-    this.rubyVersion = rubyInfo.ruby_version;
-
-    const [major, minor, _patch] = rubyInfo.ruby_version.split(".").map(Number);
-    this.yjitEnabled =
-      (rubyInfo.yjit === "constant" && major > 3) ||
-      (major === 3 && minor >= 2);
   }
 
   // Fetch information related to the Ruby version. This can only be invoked after activation, so that `rubyVersion` is

--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -1,0 +1,135 @@
+/* eslint-disable no-process-env */
+
+import path from "path";
+import os from "os";
+
+import * as vscode from "vscode";
+
+import { asyncExec } from "../common";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// A tool to manage multiple runtime versions with a single CLI tool
+//
+// Learn more: https://github.com/asdf-vm/asdf
+export class Asdf extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    const asdfUri = await this.findAsdfInstallation();
+    const asdfDaraDirUri = await this.findAsdfDataDir();
+    const activationScript =
+      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
+
+    const result = await asyncExec(
+      `. ${asdfUri.fsPath} && asdf exec ruby -W0 -rjson -e '${activationScript}'`,
+      {
+        cwd: this.bundleUri.fsPath,
+        env: {
+          ASDF_DIR: path.dirname(asdfUri.fsPath),
+          ASDF_DATA_DIR: asdfDaraDirUri.fsPath,
+        },
+      },
+    );
+
+    const parsedResult = JSON.parse(result.stderr);
+
+    // ASDF does not set GEM_HOME or GEM_PATH. It also does not add the gem bin directories to the PATH. Instead, it
+    // adds its shims directory to the PATH, where all gems have a shim that invokes the gem's executable with the right
+    // version
+    parsedResult.env.PATH = [
+      vscode.Uri.joinPath(asdfDaraDirUri, "shims").fsPath,
+      parsedResult.env.PATH,
+    ].join(path.delimiter);
+
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+    };
+  }
+
+  // Find the ASDF data directory. The default is for this to be in the same directories where we'd find the asdf.sh
+  // file, but that may not be the case for a Homebrew installation, in which case the we'd have
+  // `/opt/homebrew/opt/asdf/libexec/asdf.sh`, but the data directory might be `~/.asdf`
+  async findAsdfDataDir(): Promise<vscode.Uri> {
+    const possiblePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".asdf"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "asdf-vm"),
+      vscode.Uri.joinPath(
+        vscode.Uri.file("/"),
+        "opt",
+        "homebrew",
+        "opt",
+        "asdf",
+        "libexec",
+      ),
+      vscode.Uri.joinPath(
+        vscode.Uri.file("/"),
+        "usr",
+        "local",
+        "opt",
+        "asdf",
+        "libexec",
+      ),
+    ];
+
+    for (const possiblePath of possiblePaths) {
+      try {
+        await vscode.workspace.fs.stat(
+          vscode.Uri.joinPath(possiblePath, "shims"),
+        );
+        return possiblePath;
+      } catch (error: any) {
+        // Continue looking
+      }
+    }
+
+    throw new Error(
+      `Could not find ASDF data dir. Searched in ${possiblePaths.join(", ")}`,
+    );
+  }
+
+  // Only public for testing. Finds the ASDF installation URI based on what's advertised in the ASDF documentation
+  async findAsdfInstallation(): Promise<vscode.Uri> {
+    // Possible ASDF installation paths as described in https://asdf-vm.com/guide/getting-started.html#_3-install-asdf.
+    // In order, the methods of installation are:
+    // 1. Git
+    // 2. Pacman
+    // 3. Homebrew M series
+    // 4. Homebrew Intel series
+    const possiblePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".asdf", "asdf.sh"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "asdf-vm", "asdf.sh"),
+      vscode.Uri.joinPath(
+        vscode.Uri.file("/"),
+        "opt",
+        "homebrew",
+        "opt",
+        "asdf",
+        "libexec",
+        "asdf.sh",
+      ),
+      vscode.Uri.joinPath(
+        vscode.Uri.file("/"),
+        "usr",
+        "local",
+        "opt",
+        "asdf",
+        "libexec",
+        "asdf.sh",
+      ),
+    ];
+
+    for (const possiblePath of possiblePaths) {
+      try {
+        await vscode.workspace.fs.stat(possiblePath);
+        return possiblePath;
+      } catch (error: any) {
+        // Continue looking
+      }
+    }
+
+    throw new Error(
+      `Could not find ASDF installation. Searched in ${possiblePaths.join(", ")}`,
+    );
+  }
+}

--- a/vscode/src/test/suite/ruby/asdf.test.ts
+++ b/vscode/src/test/suite/ruby/asdf.test.ts
@@ -1,0 +1,72 @@
+import assert from "assert";
+import path from "path";
+import os from "os";
+
+import * as vscode from "vscode";
+import sinon from "sinon";
+
+import { Asdf } from "../../../ruby/asdf";
+import { WorkspaceChannel } from "../../../workspaceChannel";
+import * as common from "../../../common";
+
+suite("Asdf", () => {
+  if (os.platform() === "win32") {
+    // eslint-disable-next-line no-console
+    console.log("Skipping Asdf tests on Windows");
+    return;
+  }
+
+  test("Finds Ruby based on .tool-versions", async () => {
+    // eslint-disable-next-line no-process-env
+    const workspacePath = process.env.PWD!;
+    const workspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
+    const asdf = new Asdf(workspaceFolder, outputChannel);
+    const activationScript =
+      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
+
+    const execStub = sinon.stub(common, "asyncExec").resolves({
+      stdout: "",
+      stderr: JSON.stringify({
+        env: { ANY: "true" },
+        yjit: true,
+        version: "3.0.0",
+      }),
+    });
+
+    const findInstallationStub = sinon
+      .stub(asdf, "findAsdfInstallation")
+      .resolves(vscode.Uri.file(`${os.homedir()}/.asdf/asdf.sh`));
+    const findDataDirStub = sinon
+      .stub(asdf, "findAsdfDataDir")
+      .resolves(vscode.Uri.file(`${os.homedir()}/.asdf`));
+
+    const { env, version, yjit } = await asdf.activate();
+
+    assert.ok(
+      execStub.calledOnceWithExactly(
+        `. ${os.homedir()}/.asdf/asdf.sh && asdf exec ruby -W0 -rjson -e '${activationScript}'`,
+        {
+          cwd: workspacePath,
+          env: {
+            ASDF_DIR: `${os.homedir()}/.asdf`,
+            ASDF_DATA_DIR: `${os.homedir()}/.asdf`,
+          },
+        },
+      ),
+    );
+
+    assert.strictEqual(version, "3.0.0");
+    assert.strictEqual(yjit, true);
+    assert.ok(env.PATH!.includes(`${os.homedir()}/.asdf/shims`));
+    assert.strictEqual(env.ANY, "true");
+
+    execStub.restore();
+    findInstallationStub.restore();
+    findDataDirStub.restore();
+  });
+});


### PR DESCRIPTION
### Motivation

Migrate ASDF to the manager object implementation. This is the last version manager to migrate.

The only parts left of the Ruby activation restructuring is handling no version manager, custom Ruby activation and allowing manual selection of the Ruby installation.

### Implementation

ASDF activation is similar to Rbenv. The main difference is that the `asdf.sh` file is not an executable and can only be sourced to allow invoking `asdf`.

In addition to that, the [asdf documentation](https://asdf-vm.com/guide/getting-started.html#_3-install-asdf) lists a number of different installation alternatives, all of which end up with the `asdf.sh` script in a different file path. I listed all possible paths described in the docs and we search for the script in those paths.

Then we source the script and use `asdf exec ruby` to run the activation script in the context of the activated Ruby. Like Rbenv, ASDF doesn't set `GEM_HOME` or `GEM_PATH` so we need to do that ourselves.

I tested this manually on a Spin instance where I installed ASDF.

### Automated Tests

Added a test.

### Manual Tests

1. Start the extension on this branch
2. Open a project with a `.tools-version` file
3. Verify the Ruby LSP boots properly using the specified Ruby version