### PR TITLE
Add authors in changelog automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,8 @@ jobs:
                   pullRequests.push({
                     title: pr.title,
                     url: pr.html_url,
-                    labels: pr.labels.map((label) => label.name)
+                    labels: pr.labels.map((label) => label.name),
+                    author: pr.user.login
                   });
                 }
               });
@@ -70,19 +71,19 @@ jobs:
             let content = `# ${{ github.ref_name }}\n`;
 
             if (breakingChanges.length > 0) {
-              content += `## 🚧 Breaking Changes\n\n${breakingChanges.map((pull) => `- ${pull.title} (${pull.url})`).join("\n")}\n\n`;
+              content += `## 🚧 Breaking Changes\n\n${breakingChanges.map((pull) => `- ${pull.title} (${pull.url}) by @${pull.author}`).join("\n")}\n\n`;
             }
 
             if (enhancements.length > 0) {
-              content += `## ✨ Enhancements\n\n${enhancements.map((pull) => `- ${pull.title} (${pull.url})`).join("\n")}\n\n`;
+              content += `## ✨ Enhancements\n\n${enhancements.map((pull) => `- ${pull.title} (${pull.url}) by @${pull.author}`).join("\n")}\n\n`;
             }
 
             if (bugFixes.length > 0) {
-              content += `## 🐛 Bug Fixes\n\n${bugFixes.map((pull) => `- ${pull.title} (${pull.url})`).join("\n")}\n\n`;
+              content += `## 🐛 Bug Fixes\n\n${bugFixes.map((pull) => `- ${pull.title} (${pull.url}) by @${pull.author}`).join("\n")}\n\n`;
             }
 
             if (otherChanges.length > 0) {
-              content += `## 📦 Other Changes\n\n${otherChanges.map((pull) => `- ${pull.title} (${pull.url})`).join("\n")}\n\n`;
+              content += `## 📦 Other Changes\n\n${otherChanges.map((pull) => `- ${pull.title} (${pull.url}) by @${pull.author}`).join("\n")}\n\n`;
             }
 
             const releaseResponse = await github.rest.repos.getReleaseByTag({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,8 @@ jobs:
                   pullRequests.push({
                     title: pr.title,
                     url: pr.html_url,
-                    labels: pr.labels.map((label) => label.name)
+                    labels: pr.labels.map((label) => label.name),
+                    author: pr.user.login
                   });
                 }
               });
@@ -61,19 +62,19 @@ jobs:
             let content = `# ${{ github.ref_name }}\n`;
 
             if (breakingChanges.length > 0) {
-              content += `## 🚧 Breaking Changes\n\n${breakingChanges.map((pull) => `- ${pull.title} (${pull.url})`).join("\n")}\n\n`;
+              content += `## 🚧 Breaking Changes\n\n${breakingChanges.map((pull) => `- ${pull.title} (${pull.url}) by @${pull.author}`).join("\n")}\n\n`;
             }
 
             if (enhancements.length > 0) {
-              content += `## ✨ Enhancements\n\n${enhancements.map((pull) => `- ${pull.title} (${pull.url})`).join("\n")}\n\n`;
+              content += `## ✨ Enhancements\n\n${enhancements.map((pull) => `- ${pull.title} (${pull.url}) by @${pull.author}`).join("\n")}\n\n`;
             }
 
             if (bugFixes.length > 0) {
-              content += `## 🐛 Bug Fixes\n\n${bugFixes.map((pull) => `- ${pull.title} (${pull.url})`).join("\n")}\n\n`;
+              content += `## 🐛 Bug Fixes\n\n${bugFixes.map((pull) => `- ${pull.title} (${pull.url}) by @${pull.author}`).join("\n")}\n\n`;
             }
 
             if (otherChanges.length > 0) {
-              content += `## 📦 Other Changes\n\n${otherChanges.map((pull) => `- ${pull.title} (${pull.url})`).join("\n")}\n\n`;
+              content += `## 📦 Other Changes\n\n${otherChanges.map((pull) => `- ${pull.title} (${pull.url}) by @${pull.author}`).join("\n")}\n\n`;
             }
 
             await github.rest.repos.createRelease({


### PR DESCRIPTION
### Motivation

In regular GitHub release automation, the notes show the authors of each PR ([example](https://github.com/Shopify/ruby-lsp/releases/tag/v0.14.3)). We forgot to add that when we created our monorepo release automation.

This PR just adds the authors to the entries.
