### PR TITLE
Return early when building dependencies view if no client

### DIFF
--- a/vscode/src/dependenciesTree.ts
+++ b/vscode/src/dependenciesTree.ts
@@ -144,11 +144,11 @@ export class DependenciesTree
   private async fetchDependencies(): Promise<BundlerTreeNode[]> {
     this.gemRootFolders = {};
 
-    if (!this.currentWorkspace) {
+    if (!this.currentWorkspace || !this.currentWorkspace.lspClient) {
       return [];
     }
 
-    const resp = (await this.currentWorkspace.lspClient?.sendRequest(
+    const resp = (await this.currentWorkspace.lspClient.sendRequest(
       "rubyLsp/workspace/dependencies",
       {},
     )) as [


### PR DESCRIPTION
### Motivation

If there's no instantiated LSP client, then trying to send a request will return `undefined` and the code will break when doing `resp.sort`.

### Implementation

Started returning early if there's no LSP client.