### PR TITLE
Use translated Prism AST to run RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ require:
   - ./lib/rubocop/cop/ruby_lsp/use_register_with_handler_method
 
 AllCops:
+  ParserEngine: parser_prism
   NewCops: disable
   SuggestExtensions: false
   Include:

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -36,7 +36,7 @@ module RubyLsp
 
     sig { returns(Prism::ProgramNode) }
     def tree
-      @parse_result.value
+      T.unsafe(@parse_result.value).first
     end
 
     sig { returns(T::Array[Prism::Comment]) }
@@ -113,7 +113,7 @@ module RubyLsp
       ).returns([T.nilable(Prism::Node), T.nilable(Prism::Node), T::Array[String]])
     end
     def locate_node(position, node_types: [])
-      locate(@parse_result.value, create_scanner.find_char_position(position), node_types: node_types)
+      locate(T.unsafe(@parse_result.value).first, create_scanner.find_char_position(position), node_types: node_types)
     end
 
     sig do

--- a/lib/ruby_lsp/requests/support/rubocop_diagnostics_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostics_runner.rb
@@ -22,7 +22,7 @@ module RubyLsp
         def run(uri, document)
           filename = T.must(uri.to_standardized_path || uri.opaque)
           # Invoke RuboCop with just this file in `paths`
-          @runner.run(filename, document.source)
+          @runner.run(filename, document.source, document.parse_result)
 
           @runner.offenses.map do |offense|
             Support::RuboCopDiagnostic.new(document, offense, uri)

--- a/lib/ruby_lsp/requests/support/rubocop_formatting_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_formatting_runner.rb
@@ -25,7 +25,7 @@ module RubyLsp
           filename = T.must(uri.to_standardized_path || uri.opaque)
 
           # Invoke RuboCop with just this file in `paths`
-          @runner.run(filename, document.source)
+          @runner.run(filename, document.source, document.parse_result)
 
           @runner.formatted_source
         end

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -8,7 +8,7 @@ module RubyLsp
       return @parse_result unless @needs_parsing
 
       @needs_parsing = false
-      @parse_result = Prism.parse(@source)
+      @parse_result = Prism.parse_lex(@source)
     end
   end
 end

--- a/sorbet/rbi/shims/rubocop.rbi
+++ b/sorbet/rbi/shims/rubocop.rbi
@@ -1,0 +1,6 @@
+# typed: true
+
+class Prism::Translation::Parser33; end
+class Prism::Translation::Parser34; end
+Prism::Translation::Parser::VERSION_3_3 = T.unsafe(nil)
+Prism::Translation::Parser::VERSION_3_4 = T.unsafe(nil)


### PR DESCRIPTION
### Motivation

Use the Prism AST translator to reuse our existing AST to run RuboCop.

### Implementation

RuboCop doesn't have an API where we can simply ask "format this AST", so implementing this requires patching a handful of places so that we can pass the AST around.

The idea is that we instantiate the `ProcessedSource` ourselves and prevent the Prism translator from re-parsing the file if we already have an AST in hand.

### Questions

1. Is this the best way to pass the existing AST around? Could we be doing this in a more elegant way?
2. What do we need to do to prevent this from failing in older RuboCop versions that do not support Prism as a backend?

### Automated Tests

Will add tests.

### Manual Tests

1. Start the LSP on this branch
3. Verify that diagnostics and formatting is working properly