### PR TITLE
Pass global state via Addon#activate instead of listener creation methods

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -50,8 +50,8 @@ module RubyLsp
       end
 
       # Discovers and loads all addons. Returns the list of activated addons
-      sig { params(global_state: GlobalState, message_queue: Thread::Queue).returns(T::Array[Addon]) }
-      def load_addons(global_state, message_queue)
+      sig { params(global_state: GlobalState, outgoing_queue: Thread::Queue).returns(T::Array[Addon]) }
+      def load_addons(global_state, outgoing_queue)
         # Require all addons entry points, which should be placed under
         # `some_gem/lib/ruby_lsp/your_gem_name/addon.rb`
         Gem.find_files("ruby_lsp/**/addon.rb").each do |addon|
@@ -67,7 +67,7 @@ module RubyLsp
         # Activate each one of the discovered addons. If any problems occur in the addons, we don't want to
         # fail to boot the server
         addons.each do |addon|
-          addon.activate(global_state, message_queue)
+          addon.activate(global_state, outgoing_queue)
         rescue => e
           addon.add_error(e)
         end
@@ -105,8 +105,8 @@ module RubyLsp
 
     # Each addon should implement `MyAddon#activate` and use to perform any sort of initialization, such as
     # reading information into memory or even spawning a separate process
-    sig { abstract.params(global_state: GlobalState, message_queue: Thread::Queue).void }
-    def activate(global_state, message_queue); end
+    sig { abstract.params(global_state: GlobalState, outgoing_queue: Thread::Queue).void }
+    def activate(global_state, outgoing_queue); end
 
     # Each addon should implement `MyAddon#deactivate` and use to perform any clean up, like shutting down a
     # child process

--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -50,8 +50,8 @@ module RubyLsp
       end
 
       # Discovers and loads all addons. Returns the list of activated addons
-      sig { params(message_queue: Thread::Queue).returns(T::Array[Addon]) }
-      def load_addons(message_queue)
+      sig { params(global_state: GlobalState, message_queue: Thread::Queue).returns(T::Array[Addon]) }
+      def load_addons(global_state, message_queue)
         # Require all addons entry points, which should be placed under
         # `some_gem/lib/ruby_lsp/your_gem_name/addon.rb`
         Gem.find_files("ruby_lsp/**/addon.rb").each do |addon|
@@ -67,7 +67,7 @@ module RubyLsp
         # Activate each one of the discovered addons. If any problems occur in the addons, we don't want to
         # fail to boot the server
         addons.each do |addon|
-          addon.activate(message_queue)
+          addon.activate(global_state, message_queue)
         rescue => e
           addon.add_error(e)
         end
@@ -105,8 +105,8 @@ module RubyLsp
 
     # Each addon should implement `MyAddon#activate` and use to perform any sort of initialization, such as
     # reading information into memory or even spawning a separate process
-    sig { abstract.params(message_queue: Thread::Queue).void }
-    def activate(message_queue); end
+    sig { abstract.params(global_state: GlobalState, message_queue: Thread::Queue).void }
+    def activate(global_state, message_queue); end
 
     # Each addon should implement `MyAddon#deactivate` and use to perform any clean up, like shutting down a
     # child process
@@ -121,23 +121,21 @@ module RubyLsp
     sig do
       overridable.params(
         response_builder: ResponseBuilders::CollectionResponseBuilder[Interface::CodeLens],
-        global_state: GlobalState,
         uri: URI::Generic,
         dispatcher: Prism::Dispatcher,
       ).void
     end
-    def create_code_lens_listener(response_builder, global_state, uri, dispatcher); end
+    def create_code_lens_listener(response_builder, uri, dispatcher); end
 
     # Creates a new Hover listener. This method is invoked on every Hover request
     sig do
       overridable.params(
         response_builder: ResponseBuilders::Hover,
-        global_state: GlobalState,
         nesting: T::Array[String],
         dispatcher: Prism::Dispatcher,
       ).void
     end
-    def create_hover_listener(response_builder, global_state, nesting, dispatcher); end
+    def create_hover_listener(response_builder, nesting, dispatcher); end
 
     # Creates a new DocumentSymbol listener. This method is invoked on every DocumentSymbol request
     sig do
@@ -160,24 +158,22 @@ module RubyLsp
     sig do
       overridable.params(
         response_builder: ResponseBuilders::CollectionResponseBuilder[Interface::Location],
-        global_state: GlobalState,
         uri: URI::Generic,
         nesting: T::Array[String],
         dispatcher: Prism::Dispatcher,
       ).void
     end
-    def create_definition_listener(response_builder, global_state, uri, nesting, dispatcher); end
+    def create_definition_listener(response_builder, uri, nesting, dispatcher); end
 
     # Creates a new Completion listener. This method is invoked on every Completion request
     sig do
       overridable.params(
         response_builder: ResponseBuilders::CollectionResponseBuilder[Interface::CompletionItem],
-        global_state: GlobalState,
         nesting: T::Array[String],
         dispatcher: Prism::Dispatcher,
         uri: URI::Generic,
       ).void
     end
-    def create_completion_listener(response_builder, global_state, nesting, dispatcher, uri); end
+    def create_completion_listener(response_builder, nesting, dispatcher, uri); end
   end
 end

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -48,7 +48,7 @@ module RubyLsp
         Listeners::CodeLens.new(@response_builder, global_state, uri, dispatcher)
 
         Addon.addons.each do |addon|
-          addon.create_code_lens_listener(@response_builder, global_state, uri, dispatcher)
+          addon.create_code_lens_listener(@response_builder, uri, dispatcher)
         end
       end
 

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -78,7 +78,7 @@ module RubyLsp
         )
 
         Addon.addons.each do |addon|
-          addon.create_completion_listener(@response_builder, global_state, nesting, dispatcher, document.uri)
+          addon.create_completion_listener(@response_builder, nesting, dispatcher, document.uri)
         end
 
         return unless matched && parent

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -67,7 +67,7 @@ module RubyLsp
         )
 
         Addon.addons.each do |addon|
-          addon.create_definition_listener(@response_builder, global_state, document.uri, nesting, dispatcher)
+          addon.create_definition_listener(@response_builder, document.uri, nesting, dispatcher)
         end
 
         @target = T.let(target, T.nilable(Prism::Node))

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -64,7 +64,7 @@ module RubyLsp
         @response_builder = T.let(ResponseBuilders::Hover.new, ResponseBuilders::Hover)
         Listeners::Hover.new(@response_builder, global_state, uri, nesting, dispatcher, typechecker_enabled)
         Addon.addons.each do |addon|
-          addon.create_hover_listener(@response_builder, global_state, nesting, dispatcher)
+          addon.create_hover_listener(@response_builder, nesting, dispatcher)
         end
 
         @dispatcher = dispatcher

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -90,7 +90,7 @@ module RubyLsp
 
     sig { void }
     def load_addons
-      Addon.load_addons(@outgoing_queue)
+      Addon.load_addons(@global_state, @outgoing_queue)
       errored_addons = Addon.addons.select(&:error?)
 
       if errored_addons.any?

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -44,7 +44,6 @@ module RubyLsp
     ensure
       if load_addons
         RubyLsp::Addon.addons.each(&:deactivate)
-        RubyLsp::Addon.addon_classes.clear
         RubyLsp::Addon.addons.clear
       end
       T.must(server).run_shutdown

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -14,7 +14,7 @@ module RubyLsp
           super
         end
 
-        def activate(global_state, message_queue)
+        def activate(global_state, outgoing_queue)
           @activated = true
         end
 
@@ -24,14 +24,14 @@ module RubyLsp
       end
       @global_state = GlobalState.new
 
-      @message_queue = Thread::Queue.new
-      Addon.load_addons(@global_state, @message_queue)
+      @outgoing_queue = Thread::Queue.new
+      Addon.load_addons(@global_state, @outgoing_queue)
     end
 
     def teardown
       RubyLsp::Addon.addon_classes.clear
       RubyLsp::Addon.addons.clear
-      @message_queue.close
+      @outgoing_queue.close
     end
 
     def test_registering_an_addon_invokes_activate_on_initialized
@@ -60,7 +60,7 @@ module RubyLsp
 
     def test_load_addons_returns_errors
       Class.new(Addon) do
-        def activate(global_state, message_queue)
+        def activate(global_state, outgoing_queue)
           raise StandardError, "Failed to activate"
         end
 
@@ -83,7 +83,7 @@ module RubyLsp
 
     def test_automatically_identifies_file_watcher_addons
       klass = Class.new(::RubyLsp::Addon) do
-        def activate(global_state, message_queue); end
+        def activate(global_state, outgoing_queue); end
         def deactivate; end
 
         def workspace_did_change_watched_files(changes); end

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -14,7 +14,7 @@ module RubyLsp
           super
         end
 
-        def activate(message_queue)
+        def activate(global_state, message_queue)
           @activated = true
         end
 
@@ -22,9 +22,10 @@ module RubyLsp
           "My Addon"
         end
       end
+      @global_state = GlobalState.new
 
       @message_queue = Thread::Queue.new
-      Addon.load_addons(@message_queue)
+      Addon.load_addons(@global_state, @message_queue)
     end
 
     def teardown
@@ -59,7 +60,7 @@ module RubyLsp
 
     def test_load_addons_returns_errors
       Class.new(Addon) do
-        def activate(message_queue)
+        def activate(global_state, message_queue)
           raise StandardError, "Failed to activate"
         end
 
@@ -69,7 +70,7 @@ module RubyLsp
       end
 
       queue = Thread::Queue.new
-      Addon.load_addons(queue)
+      Addon.load_addons(GlobalState.new, queue)
       error_addon = T.must(Addon.addons.find(&:error?))
       queue.close
 
@@ -82,7 +83,7 @@ module RubyLsp
 
     def test_automatically_identifies_file_watcher_addons
       klass = Class.new(::RubyLsp::Addon) do
-        def activate(message_queue); end
+        def activate(global_state, message_queue); end
         def deactivate; end
 
         def workspace_did_change_watched_files(changes); end
@@ -90,7 +91,7 @@ module RubyLsp
 
       begin
         queue = Thread::Queue.new
-        Addon.load_addons(queue)
+        Addon.load_addons(GlobalState.new, queue)
         assert_equal(1, Addon.file_watcher_addons.length)
         assert_instance_of(klass, Addon.file_watcher_addons.first)
       ensure

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -156,7 +156,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
   def create_code_lens_addon
     Class.new(RubyLsp::Addon) do
-      def create_code_lens_listener(response_builder, global_state, uri, dispatcher)
+      def create_code_lens_listener(response_builder, uri, dispatcher)
         raise "uri can't be nil" unless uri
 
         klass = Class.new do
@@ -183,7 +183,8 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
         T.unsafe(klass).new(response_builder, uri, dispatcher)
       end
 
-      def activate(message_queue); end
+      def activate(global_state, message_queue)
+      end
 
       def deactivate; end
 

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -130,25 +130,29 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
       class Test < Minitest::Test; end
     RUBY
 
-    create_code_lens_addon
+    begin
+      create_code_lens_addon
 
-    with_server(source) do |server, uri|
-      server.process_message({
-        id: 1,
-        method: "textDocument/codeLens",
-        params: { textDocument: { uri: uri }, position: { line: 1, character: 2 } },
-      })
+      with_server(source) do |server, uri|
+        server.process_message({
+          id: 1,
+          method: "textDocument/codeLens",
+          params: { textDocument: { uri: uri }, position: { line: 1, character: 2 } },
+        })
 
-      result = server.pop_response
-      assert_instance_of(RubyLsp::Result, result)
+        result = server.pop_response
+        assert_instance_of(RubyLsp::Result, result)
 
-      response = result.response
+        response = result.response
 
-      assert_equal(response.size, 4)
-      assert_match("Run", response[0].command.title)
-      assert_match("Run In Terminal", response[1].command.title)
-      assert_match("Debug", response[2].command.title)
-      assert_match("Run Test", response[3].command.title)
+        assert_equal(response.size, 4)
+        assert_match("Run", response[0].command.title)
+        assert_match("Run In Terminal", response[1].command.title)
+        assert_match("Debug", response[2].command.title)
+        assert_match("Run Test", response[3].command.title)
+      ensure
+        RubyLsp::Addon.addon_classes.clear
+      end
     end
   end
 

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -187,7 +187,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
         T.unsafe(klass).new(response_builder, uri, dispatcher)
       end
 
-      def activate(global_state, message_queue)
+      def activate(global_state, outgoing_queue)
       end
 
       def deactivate; end

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -896,7 +896,7 @@ class CompletionTest < Minitest::Test
         T.unsafe(klass).new(response_builder, nesting, dispatcher, uri)
       end
 
-      def activate(global_state, message_queue); end
+      def activate(global_state, outgoing_queue); end
 
       def deactivate; end
 

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -867,11 +867,11 @@ class CompletionTest < Minitest::Test
 
   def create_completion_addon
     Class.new(RubyLsp::Addon) do
-      def create_completion_listener(response_builder, global_state, nesting, dispatcher, uri)
+      def create_completion_listener(response_builder, nesting, dispatcher, uri)
         klass = Class.new do
           include RubyLsp::Requests::Support::Common
 
-          def initialize(response_builder, global_state, _, dispatcher, uri)
+          def initialize(response_builder, _, dispatcher, uri)
             @uri = uri
             @response_builder = response_builder
             dispatcher.register(self, :on_constant_read_node_enter)
@@ -889,10 +889,10 @@ class CompletionTest < Minitest::Test
           end
         end
 
-        T.unsafe(klass).new(response_builder, global_state, nesting, dispatcher, uri)
+        T.unsafe(klass).new(response_builder, nesting, dispatcher, uri)
       end
 
-      def activate(message_queue); end
+      def activate(global_state, message_queue); end
 
       def deactivate; end
 

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -797,18 +797,22 @@ class CompletionTest < Minitest::Test
       R
     RUBY
 
-    create_completion_addon
+    begin
+      create_completion_addon
 
-    with_server(source) do |server, uri|
-      server.process_message(
-        id: 1,
-        method: "textDocument/completion",
-        params: { textDocument: { uri: uri }, position: { character: 1, line: 0 } },
-      )
-      response = server.pop_response.response
+      with_server(source) do |server, uri|
+        server.process_message(
+          id: 1,
+          method: "textDocument/completion",
+          params: { textDocument: { uri: uri }, position: { character: 1, line: 0 } },
+        )
+        response = server.pop_response.response
 
-      assert_equal(1, response.size)
-      assert_match("MyCompletion", response[0].label)
+        assert_equal(1, response.size)
+        assert_match("MyCompletion", response[0].label)
+      end
+    ensure
+      RubyLsp::Addon.addon_classes.clear
     end
   end
 

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -201,28 +201,32 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       RubyLsp
     RUBY
 
-    create_definition_addon
+    begin
+      create_definition_addon
 
-    with_server(source) do |server, uri|
-      server.global_state.index.index_single(
-        RubyIndexer::IndexablePath.new(
-          "#{Dir.pwd}/lib",
-          File.expand_path(
-            "../../test/fixtures/class_reference_target.rb",
-            __dir__,
+      with_server(source) do |server, uri|
+        server.global_state.index.index_single(
+          RubyIndexer::IndexablePath.new(
+            "#{Dir.pwd}/lib",
+            File.expand_path(
+              "../../test/fixtures/class_reference_target.rb",
+              __dir__,
+            ),
           ),
-        ),
-      )
-      server.process_message(
-        id: 1,
-        method: "textDocument/definition",
-        params: { textDocument: { uri: uri }, position: { character: 0, line: 0 } },
-      )
-      response = server.pop_response.response
+        )
+        server.process_message(
+          id: 1,
+          method: "textDocument/definition",
+          params: { textDocument: { uri: uri }, position: { character: 0, line: 0 } },
+        )
+        response = server.pop_response.response
 
-      assert_equal(2, response.size)
-      assert_match("class_reference_target.rb", response[0].uri)
-      assert_match("generated_by_addon.rb", response[1].uri)
+        assert_equal(2, response.size)
+        assert_match("class_reference_target.rb", response[0].uri)
+        assert_match("generated_by_addon.rb", response[1].uri)
+      end
+    ensure
+      RubyLsp::Addon.addon_classes.clear
     end
   end
 

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -344,9 +344,9 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
 
   def create_definition_addon
     Class.new(RubyLsp::Addon) do
-      def create_definition_listener(response_builder, uri, nesting, index, dispatcher)
+      def create_definition_listener(response_builder, uri, nesting, dispatcher)
         klass = Class.new do
-          def initialize(response_builder, uri, _, _, dispatcher)
+          def initialize(response_builder, uri, _, dispatcher)
             @uri = uri
             @response_builder = response_builder
             dispatcher.register(self, :on_constant_read_node_enter)
@@ -367,10 +367,10 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
           end
         end
 
-        T.unsafe(klass).new(response_builder, uri, nesting, index, dispatcher)
+        T.unsafe(klass).new(response_builder, uri, nesting, dispatcher)
       end
 
-      def activate(message_queue); end
+      def activate(global_state, message_queue); end
 
       def deactivate; end
 

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -374,7 +374,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
         T.unsafe(klass).new(response_builder, uri, nesting, dispatcher)
       end
 
-      def activate(global_state, message_queue); end
+      def activate(global_state, outgoing_queue); end
 
       def deactivate; end
 

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -66,7 +66,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
 
   def create_document_symbol_addon
     Class.new(RubyLsp::Addon) do
-      def activate(message_queue); end
+      def activate(global_state, message_queue); end
 
       def name
         "Document SymbolsAddon"

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -70,7 +70,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
 
   def create_document_symbol_addon
     Class.new(RubyLsp::Addon) do
-      def activate(global_state, message_queue); end
+      def activate(global_state, outgoing_queue); end
 
       def name
         "Document SymbolsAddon"

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -32,23 +32,27 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
       end
     RUBY
 
-    create_document_symbol_addon
-    with_server(source) do |server, uri|
-      server.process_message({
-        id: 1,
-        method: "textDocument/documentSymbol",
-        params: { textDocument: { uri: uri } },
-      })
-      result = server.pop_response
-      assert_instance_of(RubyLsp::Result, result)
+    begin
+      create_document_symbol_addon
+      with_server(source) do |server, uri|
+        server.process_message({
+          id: 1,
+          method: "textDocument/documentSymbol",
+          params: { textDocument: { uri: uri } },
+        })
+        result = server.pop_response
+        assert_instance_of(RubyLsp::Result, result)
 
-      response = result.response
+        response = result.response
 
-      assert_equal(1, response.count)
-      assert_equal("Foo", response.first.name)
+        assert_equal(1, response.count)
+        assert_equal("Foo", response.first.name)
 
-      test_symbol = response.first.children.first
-      assert_equal(LanguageServer::Protocol::Constant::SymbolKind::METHOD, test_symbol.kind)
+        test_symbol = response.first.children.first
+        assert_equal(LanguageServer::Protocol::Constant::SymbolKind::METHOD, test_symbol.kind)
+      end
+    ensure
+      RubyLsp::Addon.addon_classes.clear
     end
   end
 

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -254,26 +254,30 @@ class HoverExpectationsTest < ExpectationsTestRunner
       Post
     RUBY
 
-    create_hover_addon
+    begin
+      create_hover_addon
 
-    with_server(source) do |server, uri|
-      server.process_message(
-        id: 1,
-        method: "textDocument/hover",
-        params: { textDocument: { uri: uri }, position: { character: 0, line: 4 } },
-      )
+      with_server(source) do |server, uri|
+        server.process_message(
+          id: 1,
+          method: "textDocument/hover",
+          params: { textDocument: { uri: uri }, position: { character: 0, line: 4 } },
+        )
 
-      assert_match(<<~RESPONSE.strip, server.pop_response.response.contents.value)
-        Title
+        assert_match(<<~RESPONSE.strip, server.pop_response.response.contents.value)
+          Title
 
-        **Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4)
-        Links
+          **Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4)
+          Links
 
 
 
-        Hello
-        Documentation from middleware: Post
-      RESPONSE
+          Hello
+          Documentation from middleware: Post
+        RESPONSE
+      end
+    ensure
+      RubyLsp::Addon.addon_classes.clear
     end
   end
 

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -285,7 +285,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
   def create_hover_addon
     Class.new(RubyLsp::Addon) do
-      def activate(global_state, message_queue); end
+      def activate(global_state, outgoing_queue); end
 
       def name
         "HoverAddon"

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -281,7 +281,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
   def create_hover_addon
     Class.new(RubyLsp::Addon) do
-      def activate(message_queue); end
+      def activate(global_state, message_queue); end
 
       def name
         "HoverAddon"
@@ -289,7 +289,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
       def deactivate; end
 
-      def create_hover_listener(response_builder, nesting, index, dispatcher)
+      def create_hover_listener(response_builder, nesting, dispatcher)
         klass = Class.new do
           def initialize(response_builder, dispatcher)
             @response_builder = response_builder

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -37,36 +37,40 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
       end
     RUBY
 
-    create_semantic_highlighting_addon
+    begin
+      create_semantic_highlighting_addon
 
-    with_server(source) do |server, uri|
-      server.process_message({
-        id: 1,
-        method: "textDocument/semanticTokens/full",
-        params: { textDocument: { uri: uri } },
-      })
+      with_server(source) do |server, uri|
+        server.process_message({
+          id: 1,
+          method: "textDocument/semanticTokens/full",
+          params: { textDocument: { uri: uri } },
+        })
 
-      result = server.pop_response
-      assert_instance_of(RubyLsp::Result, result)
+        result = server.pop_response
+        assert_instance_of(RubyLsp::Result, result)
 
-      decoded_response = decode_tokens(result.response.data)
-      assert_equal(
-        { delta_line: 0, delta_start_char: 6, length: 4, token_type: 2, token_modifiers: 1 },
-        decoded_response[0],
-      )
-      assert_equal(
-        { delta_line: 0, delta_start_char: 0, length: 4, token_type: 0, token_modifiers: 0 },
-        decoded_response[1],
-      )
-      assert_equal(
-        { delta_line: 1, delta_start_char: 2, length: 13, token_type: 13, token_modifiers: 0 },
-        decoded_response[2],
-      )
-      # This is the token modified by the addon
-      assert_equal(
-        { delta_line: 1, delta_start_char: 2, length: 13, token_type: 15, token_modifiers: 1 },
-        decoded_response[3],
-      )
+        decoded_response = decode_tokens(result.response.data)
+        assert_equal(
+          { delta_line: 0, delta_start_char: 6, length: 4, token_type: 2, token_modifiers: 1 },
+          decoded_response[0],
+        )
+        assert_equal(
+          { delta_line: 0, delta_start_char: 0, length: 4, token_type: 0, token_modifiers: 0 },
+          decoded_response[1],
+        )
+        assert_equal(
+          { delta_line: 1, delta_start_char: 2, length: 13, token_type: 13, token_modifiers: 0 },
+          decoded_response[2],
+        )
+        # This is the token modified by the addon
+        assert_equal(
+          { delta_line: 1, delta_start_char: 2, length: 13, token_type: 15, token_modifiers: 1 },
+          decoded_response[3],
+        )
+      end
+    ensure
+      RubyLsp::Addon.addon_classes.clear
     end
   end
 

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -95,7 +95,7 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
         T.unsafe(klass).new(response_builder, dispatcher)
       end
 
-      def activate(message_queue); end
+      def activate(global_state, message_queue); end
 
       def deactivate; end
 

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -99,7 +99,7 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
         T.unsafe(klass).new(response_builder, dispatcher)
       end
 
-      def activate(global_state, message_queue); end
+      def activate(global_state, outgoing_queue); end
 
       def deactivate; end
 


### PR DESCRIPTION
### Motivation

This allows addons to access the global state at the addon-level as well, while reducing the number of parameters passed to the listener creation methods.

### Implementation

Add `global_state` parameter to `Addon.load_addons` and `Addon#activate`, adn remove it from listener creation methods.

When testing this against `ruby-lsp-rspec`, I noticed that addon classes shouldn't be cleared in the `with_server` helper as it leaves no addons to load in later tests. So I moved it out of the helper and call it separately after each addon tests is executed.

(`ruby-lsp-rspec` [PR](https://github.com/st0012/ruby-lsp-rspec/pull/25))

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
