### PR TITLE
Fix semantic highlighting document selector

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -29,7 +29,7 @@ module RubyLsp
         sig { returns(Interface::SemanticTokensRegistrationOptions) }
         def provider
           Interface::SemanticTokensRegistrationOptions.new(
-            document_selector: { scheme: "file", language: "ruby" },
+            document_selector: [{ language: "ruby" }],
             legend: Interface::SemanticTokensLegend.new(
               token_types: ResponseBuilders::SemanticHighlighting::TOKEN_TYPES.keys,
               token_modifiers: ResponseBuilders::SemanticHighlighting::TOKEN_MODIFIERS.keys,


### PR DESCRIPTION
### Motivation

Closes #1857

We were returning the semantic highlighting document selector with an incorrect value. The registration options extend [text registration options](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentRegistrationOptions), which includes the [document selector](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSelector), which is an array of [document filters](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentFilter).

Instead of returning an array of filters, we were returning a single filter. I'm not sure why VS Code never complained about this, but it's definitely not correct.

### Implementation

I made the selector an array and also removed the `scheme`, since we want to be able to highlight `git` schemes too.