### PR TITLE
Use activated environment by RVM

### DIFF
--- a/vscode/src/test/suite/ruby/rvm.test.ts
+++ b/vscode/src/test/suite/ruby/rvm.test.ts
@@ -34,6 +34,17 @@ suite("RVM", () => {
       ".to_json)",
     ].join("");
 
+    const installationPathStub = sinon
+      .stub(rvm, "findRvmInstallation")
+      .resolves(
+        vscode.Uri.joinPath(
+          vscode.Uri.file(os.homedir()),
+          ".rvm",
+          "bin",
+          "rvm-auto-ruby",
+        ),
+      );
+
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: JSON.stringify({
@@ -66,5 +77,6 @@ suite("RVM", () => {
     assert.ok(env.PATH!.includes("/home/user/.rvm/rubies/ruby-3.0.0/bin"));
 
     execStub.restore();
+    installationPathStub.restore();
   });
 });

--- a/vscode/src/test/suite/ruby/rvm.test.ts
+++ b/vscode/src/test/suite/ruby/rvm.test.ts
@@ -27,12 +27,8 @@ suite("RVM", () => {
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
     const rvm = new Rvm(workspaceFolder, outputChannel);
 
-    const activationScript = [
-      "STDERR.print(",
-      "{yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION,",
-      "home:Gem.user_dir,default:Gem.default_dir,ruby:RbConfig.ruby}",
-      ".to_json)",
-    ].join("");
+    const activationScript =
+      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
 
     const installationPathStub = sinon
       .stub(rvm, "findRvmInstallation")
@@ -48,11 +44,11 @@ suite("RVM", () => {
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: JSON.stringify({
+        env: {
+          ANY: "true",
+        },
         yjit: true,
         version: "3.0.0",
-        home: "/home/user/.rvm/gems/ruby/3.0.0",
-        default: "/usr/lib/ruby/gems/3.0.0",
-        ruby: "/home/user/.rvm/rubies/ruby-3.0.0/bin/ruby",
       }),
     });
 
@@ -67,14 +63,7 @@ suite("RVM", () => {
 
     assert.strictEqual(version, "3.0.0");
     assert.strictEqual(yjit, true);
-    assert.strictEqual(env.GEM_HOME, "/home/user/.rvm/gems/ruby/3.0.0");
-    assert.strictEqual(
-      env.GEM_PATH,
-      "/home/user/.rvm/gems/ruby/3.0.0:/usr/lib/ruby/gems/3.0.0",
-    );
-    assert.ok(env.PATH!.includes("/home/user/.rvm/gems/ruby/3.0.0/bin"));
-    assert.ok(env.PATH!.includes("/usr/lib/ruby/gems/3.0.0/bin"));
-    assert.ok(env.PATH!.includes("/home/user/.rvm/rubies/ruby-3.0.0/bin"));
+    assert.deepStrictEqual(env.ANY, "true");
 
     execStub.restore();
     installationPathStub.restore();


### PR DESCRIPTION
### Motivation

Closes #1863, closes #1866, closes #1858

There were two issues with our previous implementation of RVM activation:

1. For some reason, when I first tested, `rvm-auto-ruby` was not setting environment variables as expected. I must have done something wrong, because it does set variables properly. This is really important for RVM because it overrides `GEM_HOME` and `GEM_PATH`, which means we can't rely on Ruby's defaults
2. You can install RVM under `/usr/local/rvm` and not just `~/.rvm`

### Implementation

1. Added a method to search for the RVM installation, accounting for the other directory we missed
2. Switched the implementation to basically match what we do for Mise and Shadowenv. We just invoke RVM and let it set the environment

### Automated Tests

Changed the existing tests.