### PR TITLE
Add ubuntu RVM path to list of possible installations

### DIFF
--- a/vscode/src/ruby/rvm.ts
+++ b/vscode/src/ruby/rvm.ts
@@ -55,6 +55,14 @@ export class Rvm extends VersionManager {
         "bin",
         "rvm-auto-ruby",
       ),
+      vscode.Uri.joinPath(
+        vscode.Uri.file("/"),
+        "usr",
+        "share",
+        "rvm",
+        "bin",
+        "rvm-auto-ruby",
+      ),
     ];
 
     for (const uri of possiblePaths) {


### PR DESCRIPTION
### Motivation

In #1868, I forgot to add the path `/usr/share/rvm`, which is used by https://github.com/rvm/ubuntu_rvm.