### PR TITLE
Deactivate addons automatically in `with_server`

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -108,6 +108,11 @@ module RubyLsp
       end
     end
 
+    sig { override.void }
+    def shutdown
+      Addon.addons.each(&:deactivate)
+    end
+
     private
 
     sig { params(message: T::Hash[Symbol, T.untyped]).void }
@@ -672,11 +677,6 @@ module RubyLsp
       end
 
       send_message(Result.new(id: message[:id], response: response))
-    end
-
-    sig { override.void }
-    def shutdown
-      Addon.addons.each(&:deactivate)
     end
 
     sig { params(config_hash: T::Hash[String, T.untyped]).void }

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -46,7 +46,7 @@ module RubyLsp
         RubyLsp::Addon.addons.each(&:deactivate)
         RubyLsp::Addon.addons.clear
       end
-      T.must(server).run_shutdown
+      T.must(server).shutdown
     end
   end
 end


### PR DESCRIPTION
### Motivation

Now that we load addons automatically by default, we need to ensure we call `shutdown` instead of `run_shutdown`, because that method deactivates addons.

Otherwise, in https://github.com/Shopify/ruby-lsp-rails/pull/301, each test will spawn a new runner client and nothing will ensure the addon gets properly deactivated.
