### PR TITLE
Prioritize rspec in test library detection

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -63,17 +63,17 @@ module RubyLsp
 
     sig { returns(String) }
     def detect_test_library
+      if direct_dependency?(/^rspec/)
+        "rspec"
       # A Rails app may have a dependency on minitest, but we would instead want to use the Rails test runner provided
       # by ruby-lsp-rails.
-      if direct_dependency?(/^rails$/)
+      elsif direct_dependency?(/^rails$/)
         "rails"
       # NOTE: Intentionally ends with $ to avoid mis-matching minitest-reporters, etc. in a Rails app.
       elsif direct_dependency?(/^minitest$/)
         "minitest"
       elsif direct_dependency?(/^test-unit/)
         "test-unit"
-      elsif direct_dependency?(/^rspec/)
-        "rspec"
       else
         "unknown"
       end

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -39,6 +39,12 @@ module RubyLsp
       assert_equal("rails", GlobalState.new.test_library)
     end
 
+    def test_detects_rspec_if_both_rails_and_rspec_are_present
+      stub_dependencies("rspec" => "1.2.3", "rails" => "1.2.3")
+
+      assert_equal("rspec", GlobalState.new.test_library)
+    end
+
     def test_direct_dependency_returns_false_outside_of_bundle
       File.expects(:file?).at_least_once.returns(false)
       stub_dependencies({})


### PR DESCRIPTION
### Motivation

If a project has both rspec and rails, the test library detection should prioritize rspec over rails.

### Implementation


### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
