### PR TITLE
Move encoding into global state

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -20,13 +20,13 @@ module RubyLsp
     sig { returns(URI::Generic) }
     attr_reader :uri
 
-    sig { returns(String) }
+    sig { returns(Encoding) }
     attr_reader :encoding
 
-    sig { params(source: String, version: Integer, uri: URI::Generic, encoding: String).void }
-    def initialize(source:, version:, uri:, encoding: Constant::PositionEncodingKind::UTF8)
+    sig { params(source: String, version: Integer, uri: URI::Generic, encoding: Encoding).void }
+    def initialize(source:, version:, uri:, encoding: Encoding::UTF_8)
       @cache = T.let({}, T::Hash[String, T.untyped])
-      @encoding = T.let(encoding, String)
+      @encoding = T.let(encoding, Encoding)
       @source = T.let(source, String)
       @version = T.let(version, Integer)
       @uri = T.let(uri, URI::Generic)
@@ -187,7 +187,7 @@ module RubyLsp
       # After character 0xFFFF, UTF-16 considers characters to have length 2 and we have to account for that
       SURROGATE_PAIR_START = T.let(0xFFFF, Integer)
 
-      sig { params(source: String, encoding: String).void }
+      sig { params(source: String, encoding: Encoding).void }
       def initialize(source, encoding)
         @current_line = T.let(0, Integer)
         @pos = T.let(0, Integer)
@@ -209,7 +209,7 @@ module RubyLsp
         # need to adjust for surrogate pairs
         requested_position = @pos + position[:character]
 
-        if @encoding == Constant::PositionEncodingKind::UTF16
+        if @encoding == Encoding::UTF_16LE
           requested_position -= utf_16_character_position_correction(@pos, requested_position)
         end
 

--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -163,7 +163,7 @@ module RubyLsp
 
         sig { params(line: String).returns(Integer) }
         def length_of_line(line)
-          if @document.encoding == Constant::PositionEncodingKind::UTF16
+          if @document.encoding == Encoding::UTF_16LE
             line_length = 0
             line.codepoints.each do |codepoint|
               line_length += 1

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -5,9 +5,6 @@ module RubyLsp
   class Store
     extend T::Sig
 
-    sig { returns(String) }
-    attr_accessor :encoding
-
     sig { returns(T::Boolean) }
     attr_accessor :supports_progress
 
@@ -23,7 +20,6 @@ module RubyLsp
     sig { void }
     def initialize
       @state = T.let({}, T::Hash[String, Document])
-      @encoding = T.let(Constant::PositionEncodingKind::UTF8, String)
       @supports_progress = T.let(true, T::Boolean)
       @experimental_features = T.let(false, T::Boolean)
       @features_configuration = T.let(
@@ -49,9 +45,9 @@ module RubyLsp
       T.must(@state[uri.to_s])
     end
 
-    sig { params(uri: URI::Generic, source: String, version: Integer).void }
-    def set(uri:, source:, version:)
-      document = RubyDocument.new(source: source, version: version, uri: uri, encoding: @encoding)
+    sig { params(uri: URI::Generic, source: String, version: Integer, encoding: Encoding).void }
+    def set(uri:, source:, version:, encoding: Encoding::UTF_8)
+      document = RubyDocument.new(source: source, version: version, uri: uri, encoding: encoding)
       @state[uri.to_s] = document
     end
 

--- a/test/requests/code_actions_formatting_test.rb
+++ b/test/requests/code_actions_formatting_test.rb
@@ -72,7 +72,7 @@ class CodeActionsFormattingTest < Minitest::Test
       source: source.dup,
       version: 1,
       uri: URI::Generic.from_path(path: __FILE__),
-      encoding: LanguageServer::Protocol::Constant::PositionEncodingKind::UTF16,
+      encoding: Encoding::UTF_16LE,
     )
 
     global_state = RubyLsp::GlobalState.new

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -320,11 +320,17 @@ class RubyDocumentTest < Minitest::Test
   end
 
   def test_document_handle_4_byte_unicode_characters
-    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo.rb"), encoding: "utf-16")
+    source = +<<~RUBY
       class Foo
         a = "👋"
       end
     RUBY
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.rb"),
+      encoding: Encoding::UTF_16LE,
+    )
 
     document.push_edits(
       [


### PR DESCRIPTION
### Motivation

First step for #1251

Move the editor's selected encoding to the global state, so that we can start using it in requests to get the code unit locations.

### Implementation

Removed encoding from store and moved it to global state.