### PR TITLE
Avoid `require_relative` in `test_helper`

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,10 +17,10 @@ end
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 $VERBOSE = nil unless ENV["VERBOSE"] || ENV["CI"]
 
-require_relative "../lib/ruby_lsp/internal"
-require_relative "../lib/ruby_lsp/test_helper"
-require_relative "../lib/rubocop/cop/ruby_lsp/use_language_server_aliases"
-require_relative "../lib/rubocop/cop/ruby_lsp/use_register_with_handler_method"
+require "ruby_lsp/internal"
+require "ruby_lsp/test_helper"
+require "rubocop/cop/ruby_lsp/use_language_server_aliases"
+require "rubocop/cop/ruby_lsp/use_register_with_handler_method"
 
 require "minitest/autorun"
 require "minitest/reporters"


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby-lsp/issues/1834

(I recall reading some guidance that suggested to use `require_relative` for files within a gem, so as to more easily distinguish between internal/external things, but I don't think there's a strong convention).