### PR TITLE
Apply formatter selected in initialization options

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -21,7 +21,7 @@ module RubyLsp
     def initialize
       @workspace_uri = T.let(URI::Generic.from_path(path: Dir.pwd), URI::Generic)
 
-      @formatter = T.let(detect_formatter, String)
+      @formatter = T.let("auto", String)
       @test_library = T.let(detect_test_library, String)
       @typechecker = T.let(detect_typechecker, T::Boolean)
       @index = T.let(RubyIndexer::Index.new, RubyIndexer::Index)
@@ -42,6 +42,10 @@ module RubyLsp
     def apply_options(options)
       workspace_uri = options.dig(:workspaceFolders, 0, :uri)
       @workspace_uri = URI(workspace_uri) if workspace_uri
+
+      specified_formatter = options.dig(:initializationOptions, :formatter)
+      @formatter = specified_formatter if specified_formatter
+      @formatter = detect_formatter if @formatter == "auto"
     end
 
     sig { returns(String) }

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -129,8 +129,6 @@ module RubyLsp
 
       progress = options.dig(:capabilities, :window, :workDoneProgress)
       @store.supports_progress = progress.nil? ? true : progress
-      formatter = options.dig(:initializationOptions, :formatter) || "auto"
-
       configured_features = options.dig(:initializationOptions, :enabledFeatures)
       @store.experimental_features = options.dig(:initializationOptions, :experimentalFeaturesEnabled) || false
 
@@ -177,7 +175,7 @@ module RubyLsp
           document_link_provider: document_link_provider,
           folding_range_provider: folding_ranges_provider,
           semantic_tokens_provider: semantic_tokens_provider,
-          document_formatting_provider: enabled_features["formatting"] && formatter != "none",
+          document_formatting_provider: enabled_features["formatting"] && @global_state.formatter != "none",
           document_highlight_provider: enabled_features["documentHighlights"],
           code_action_provider: code_action_provider,
           document_on_type_formatting_provider: on_type_formatting_provider,

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -51,6 +51,18 @@ module RubyLsp
       refute(GlobalState.new.direct_dependency?(/^ruby-lsp/))
     end
 
+    def test_apply_option_selects_formatter
+      state = GlobalState.new
+      state.apply_options({ initializationOptions: { formatter: "syntax_tree" } })
+      assert_equal("syntax_tree", state.formatter)
+    end
+
+    def test_applying_auto_formatter_invokes_detection
+      state = GlobalState.new
+      state.apply_options({ initializationOptions: { formatter: "auto" } })
+      assert_equal("rubocop", state.formatter)
+    end
+
     private
 
     def stub_dependencies(dependencies)

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -141,7 +141,7 @@ class ServerTest < Minitest::Test
   end
 
   def test_server_info_includes_formatter
-    @server.global_state.expects(:formatter).returns("rubocop")
+    @server.global_state.expects(:formatter).twice.returns("rubocop")
     capture_subprocess_io do
       @server.process_message({
         id: 1,


### PR DESCRIPTION
### Motivation

Closes #1884

The global state refactor introduced a regression. We were eagerly detecting the formatter and then never taking into consideration initialization options coming from editors, which makes it impossible to use our `rubyLsp.formatter` option to select which formatter you want to use.

### Implementation

We can't detect the formatter eagerly, that can only happen if the formatter is set to `auto` **after** we already applied the user's configurations.

So we initialize it to `auto`, override it if something is coming from configurations and then only detect the formatter if after all that it is still set to `auto`.

### Automated Tests

Added a couple of new tests.