### PR TITLE
Fix troubleshooting container link

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -100,7 +100,7 @@ steps that led to the server getting stuck.
 
 ### Developing on containers
 
-See the [documentation](README.md#developing-on-containers).
+See the [documentation](vscode/README.md#developing-on-containers).
 
 ## Diagnosing the problem
 


### PR DESCRIPTION
### Motivation

We didn't update this link while moving to the monorepo. That section exists in the README for the VS Code extension, not the top level README.
