### PR TITLE
Avoid activating debugger in tests by default

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -33,3 +33,6 @@ commands:
       argument: file
       optional: args...
     run: bin/test
+
+env:
+  'RUBY_DEBUG_IRB_CONSOLE': '1'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,10 +25,14 @@ require "rubocop/cop/ruby_lsp/use_register_with_handler_method"
 require "minitest/autorun"
 require "minitest/reporters"
 require "tempfile"
-require "debug"
 require "mocha/minitest"
 
 SORBET_PATHS = T.let(Gem.loaded_specs["sorbet-runtime"].full_require_paths.freeze, T::Array[String])
+
+# Define breakpoint methods without actually activating the debugger
+require "debug/prelude"
+# Load the debugger configuration to skip Sorbet paths. But this still doesn't activate the debugger
+require "debug/config"
 DEBUGGER__::CONFIG[:skip_path] = Array(DEBUGGER__::CONFIG[:skip_path]) + SORBET_PATHS
 
 minitest_reporter = if ENV["SPEC_REPORTER"]


### PR DESCRIPTION
### Motivation

Always having debugger running could cause unnecessary (though likely small) slow down. It also makes tests prone to (rare) debugger related failures that we can do nothing about.

### Implementation

Instead of requiring `debug`, which activates the debugger right away, we require `debug/prelude` and `debug/config` instead.

I also added a env var to use IRB as the debugger's console by default.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
