### PR TITLE
Remove `Singleton` from formatters

### DIFF
--- a/ADDONS.md
+++ b/ADDONS.md
@@ -222,15 +222,13 @@ class MyFormatterRubyLspAddon < RubyLsp::Addon
   def activate(global_state, message_queue)
     # The first argument is an identifier users can pick to select this formatter. To use this formatter, users must
     # have rubyLsp.formatter configured to "my_formatter"
-    # The second argument is a singleton instance that implements the `FormatterRunner` interface (see below)
-    global_state.register_formatter("my_formatter", MyFormatterRunner.instance)
+    # The second argument is a class instance that implements the `FormatterRunner` interface (see below)
+    global_state.register_formatter("my_formatter", MyFormatterRunner.new)
   end
 end
 
 # Custom formatter
 class MyFormatter
-  # Make it a singleton class
-  include Singleton
   # If using Sorbet to develop the addon, then include this interface to make sure the class is properly implemented
   include RubyLsp::Requests::Support::Formatter
 

--- a/lib/ruby_lsp/requests/support/rubocop_formatter.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_formatter.rb
@@ -3,15 +3,12 @@
 
 return unless defined?(RubyLsp::Requests::Support::RuboCopRunner)
 
-require "singleton"
-
 module RubyLsp
   module Requests
     module Support
       class RuboCopFormatter
         extend T::Sig
         include Formatter
-        include Singleton
 
         sig { void }
         def initialize

--- a/lib/ruby_lsp/requests/support/syntax_tree_formatter.rb
+++ b/lib/ruby_lsp/requests/support/syntax_tree_formatter.rb
@@ -8,15 +8,12 @@ rescue LoadError
   return
 end
 
-require "singleton"
-
 module RubyLsp
   module Requests
     module Support
       # :nodoc:
       class SyntaxTreeFormatter
         extend T::Sig
-        include Singleton
         include Support::Formatter
 
         sig { void }

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -248,10 +248,10 @@ module RubyLsp
       end
 
       if defined?(Requests::Support::RuboCopFormatter)
-        @global_state.register_formatter("rubocop", Requests::Support::RuboCopFormatter.instance)
+        @global_state.register_formatter("rubocop", Requests::Support::RuboCopFormatter.new)
       end
       if defined?(Requests::Support::SyntaxTreeFormatter)
-        @global_state.register_formatter("syntax_tree", Requests::Support::SyntaxTreeFormatter.instance)
+        @global_state.register_formatter("syntax_tree", Requests::Support::SyntaxTreeFormatter.new)
       end
 
       perform_initial_indexing(indexing_config)

--- a/test/requests/code_actions_formatting_test.rb
+++ b/test/requests/code_actions_formatting_test.rb
@@ -79,7 +79,7 @@ class CodeActionsFormattingTest < Minitest::Test
     global_state.formatter = "rubocop"
     global_state.register_formatter(
       "rubocop",
-      RubyLsp::Requests::Support::RuboCopFormatter.instance,
+      RubyLsp::Requests::Support::RuboCopFormatter.new,
     )
 
     diagnostics = RubyLsp::Requests::Diagnostics.new(global_state, document).perform

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -14,7 +14,7 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
     global_state.formatter = "rubocop"
     global_state.register_formatter(
       "rubocop",
-      RubyLsp::Requests::Support::RuboCopFormatter.instance,
+      RubyLsp::Requests::Support::RuboCopFormatter.new,
     )
 
     stdout, _ = capture_io do

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -9,7 +9,7 @@ class DiagnosticsTest < Minitest::Test
     @global_state.formatter = "rubocop"
     @global_state.register_formatter(
       "rubocop",
-      RubyLsp::Requests::Support::RuboCopFormatter.instance,
+      RubyLsp::Requests::Support::RuboCopFormatter.new,
     )
   end
 
@@ -78,7 +78,6 @@ class DiagnosticsTest < Minitest::Test
     RUBY
 
     formatter_class = Class.new do
-      include Singleton
       include RubyLsp::Requests::Support::Formatter
 
       def run_diagnostic(uri, document)
@@ -96,7 +95,7 @@ class DiagnosticsTest < Minitest::Test
       end
     end
 
-    @global_state.register_formatter("my-custom-formatter", T.unsafe(formatter_class).instance)
+    @global_state.register_formatter("my-custom-formatter", T.unsafe(formatter_class).new)
     @global_state.formatter = "my-custom-formatter"
 
     diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(@global_state, document).perform)

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -12,7 +12,7 @@ class FormattingExpectationsTest < ExpectationsTestRunner
     global_state.formatter = "rubocop"
     global_state.register_formatter(
       "rubocop",
-      RubyLsp::Requests::Support::RuboCopFormatter.instance,
+      RubyLsp::Requests::Support::RuboCopFormatter.new,
     )
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
     RubyLsp::Requests::Formatting.new(global_state, document).perform&.first&.new_text

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -9,11 +9,11 @@ class FormattingTest < Minitest::Test
     @global_state.formatter = "rubocop"
     @global_state.register_formatter(
       "rubocop",
-      RubyLsp::Requests::Support::RuboCopFormatter.instance,
+      RubyLsp::Requests::Support::RuboCopFormatter.new,
     )
     @global_state.register_formatter(
       "syntax_tree",
-      RubyLsp::Requests::Support::SyntaxTreeFormatter.instance,
+      RubyLsp::Requests::Support::SyntaxTreeFormatter.new,
     )
     @document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI::Generic.from_path(path: __FILE__))
       class Foo
@@ -141,9 +141,7 @@ class FormattingTest < Minitest::Test
   end
 
   def test_using_a_custom_formatter
-    require "singleton"
     formatter_class = Class.new do
-      include Singleton
       include RubyLsp::Requests::Support::Formatter
 
       def run_formatting(uri, document)
@@ -151,7 +149,7 @@ class FormattingTest < Minitest::Test
       end
     end
 
-    @global_state.register_formatter("my-custom-formatter", T.unsafe(formatter_class).instance)
+    @global_state.register_formatter("my-custom-formatter", T.unsafe(formatter_class).new)
     assert_includes(formatted_document("my-custom-formatter"), "# formatter by my-custom-formatter")
   end
 
@@ -181,10 +179,9 @@ class FormattingTest < Minitest::Test
   def clear_syntax_tree_runner_singleton_instance
     return unless defined?(RubyLsp::Requests::Support::SyntaxTreeFormatter)
 
-    Singleton.__init__(RubyLsp::Requests::Support::SyntaxTreeFormatter)
     @global_state.register_formatter(
       "syntax_tree",
-      RubyLsp::Requests::Support::SyntaxTreeFormatter.instance,
+      RubyLsp::Requests::Support::SyntaxTreeFormatter.new,
     )
   end
 end


### PR DESCRIPTION
### Motivation

This will make it trivial to reload the rubocop config for #1457 without doing an awkward `Singleton.__init__`.
With `GlobalState` being a thing now, I don't see the need for a singleton anymore but open to hearing something else. 

### Implementation

Just use `new` everywhere. This exposed an issue with the `unload_rubocop_runner` function. `RuboCopFormatter` isn't defined if `RuboCopRunner` isn't defined, so both need to be removed for `test_shows_error_if_formatter_set_to_rubocop_but_rubocop_not_available` to properly work

### Automated Tests

Existing ones

### Manual Tests

Do some formatting, I guess.
