### PR TITLE
[VSCode] Change the order of existence checks for Manager. Check 'asdf' last.

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -288,10 +288,10 @@ export class Ruby implements RubyInterface {
     }
 
     const managers = [
-      ManagerIdentifier.Asdf,
       ManagerIdentifier.Chruby,
       ManagerIdentifier.Rbenv,
       ManagerIdentifier.Rvm,
+      ManagerIdentifier.Asdf,
     ];
 
     for (const tool of managers) {


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
It seems many people use asdf for managing environments other than Ruby. Chruby, rbenv, and rvm are mutually exclusive, and it's unlikely for someone to use two of them simultaneously. However, it's possible to use one of them in combination with asdf. For example, using rbenv for Ruby and asdf for bun. In such cases, it would be preferable to detect rbenv first. Therefore, I thought it would be best to check the other three before asdf, leaving asdf to be checked last.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
I simply changed the order of checks.

### Automated Tests

I didn't think they were necessary, but please let me know if they are.
<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

On an environment with both asdf and rbenv installed, set `"rubyLsp.rubyVersionManager": "auto"` and check if rbenv is detected. That would be considered OK. Below are screenshots from testing in my environment.

| Before | After |
| --- | --- |
| <img width="1057" alt="image" src="https://github.com/Shopify/ruby-lsp/assets/537424/a69aded7-7a53-4a3f-9e6e-dc27384240e4"> | <img width="1417" alt="image" src="https://github.com/Shopify/ruby-lsp/assets/537424/33609910-e2c6-4883-8f36-7abc09737de4"> | 

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

---

If there's anything I might have overlooked or any initial documentation that I should review first, I would appreciate it if you could let me know.
