### PR TITLE
Specify in Readme that global rubocop command is not supported

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -429,4 +429,5 @@ vscode.commands.registerCommand(
 When `rubyLsp.formatter` is set to `auto`, Ruby LSP tries to determine which formatter to use.
 
 If the bundle has a **direct** dependency on a supported formatter, such as `rubocop` or `syntax_tree`, that will be used.
-Otherwise, formatting will be disabled and you will need add one to the bundle.
+Otherwise, formatting will be disabled and you will need add one to the bundle. Using globally installed formatters or
+linters is not supported, they must in your Gemfile or gemspec.


### PR DESCRIPTION
### Motivation

Since I was instructed to open a PR in this repo in https://github.com/Shopify/vscode-shopify-ruby/pull/595, doing so now. cc: @vinistock 

https://github.com/Shopify/vscode-shopify-ruby/issues/443

It's easier to glance over the line that says to add `rubocop` or `syntax_tree` gem in Gemfile. Adding a concrete code example makes it find the solution.

I've seen few people ask about this in support issues in the repo as well.

### Implementation

Just the readme update.

### Automated Tests

NA

### Manual Tests

NA
