### PR TITLE
Ignore non-ruby files in file watcher

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -610,6 +610,7 @@ module RubyLsp
         uri = URI(change[:uri])
         file_path = uri.to_standardized_path
         next if file_path.nil? || File.directory?(file_path)
+        next unless file_path.end_with?(".rb")
 
         load_path_entry = $LOAD_PATH.find { |load_path| file_path.start_with?(load_path) }
         indexable = RubyIndexer::IndexablePath.new(load_path_entry, file_path)

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -474,6 +474,27 @@ class ServerTest < Minitest::Test
     assert_match(%r{ruby-lsp/lib/ruby_lsp/server\.rb:\d+:in `process_message'}, stderr)
   end
 
+  def test_changed_file_only_indexes_ruby
+    @server.global_state.index.expects(:index_single).once.with do |indexable|
+      indexable.full_path == "/foo.rb"
+    end
+    @server.process_message({
+      method: "workspace/didChangeWatchedFiles",
+      params: {
+        changes: [
+          {
+            uri: URI("file:///foo.rb"),
+            type: RubyLsp::Constant::FileChangeType::CREATED,
+          },
+          {
+            uri: URI("file:///.rubocop.yml"),
+            type: RubyLsp::Constant::FileChangeType::CREATED,
+          },
+        ],
+      },
+    })
+  end
+
   private
 
   def with_uninstalled_rubocop(&block)


### PR DESCRIPTION
### Motivation

Currently there is only a listener for ruby files but that might changein the future. Addons are also able to register additional file watcher events, config files as an example.

I do not think that having non-rb files being passed to the indexer has any disadvantage, it just won't be parsed down to anything meaningful. You can also just paste giberish into a file and call it `.rb`. Still, this guard enforces my expectations of what the filepath is actually supposed to look like.

### Implementation

Simply bail out if the file doesn't end with `.rb`.

### Automated Tests

Validate that an update event for `.rubocop.yml` doesn't end up going to the indexer.

### Manual Tests

Make some changes to a file and see that the index is still being updated.
