### PR TITLE
Allow configuring Mise executable path

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -249,6 +249,10 @@
                 "custom"
               ],
               "default": "auto"
+            },
+            "miseExecutablePath": {
+              "description": "The path to the Mise executable, if not installed in ~/.local/bin/mise",
+              "type": "string"
             }
           },
           "default": {

--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -34,15 +34,22 @@ export class Mise extends VersionManager {
   }
 
   async findMiseUri(): Promise<vscode.Uri> {
-    const miseUri = vscode.Uri.joinPath(
-      vscode.Uri.file(os.homedir()),
-      ".local",
-      "bin",
-      "mise",
+    const config = vscode.workspace.getConfiguration("rubyLsp");
+    const misePath = config.get<string | undefined>(
+      "rubyVersionManager.miseExecutablePath",
     );
+    const miseUri = misePath
+      ? vscode.Uri.file(misePath)
+      : vscode.Uri.joinPath(
+          vscode.Uri.file(os.homedir()),
+          ".local",
+          "bin",
+          "mise",
+        );
 
     try {
       await vscode.workspace.fs.stat(miseUri);
+      return miseUri;
     } catch (error: any) {
       // Couldn't find it
     }

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import path from "path";
 import os from "os";
+import fs from "fs";
 
 import * as vscode from "vscode";
 import sinon from "sinon";
@@ -64,5 +65,60 @@ suite("Mise", () => {
 
     execStub.restore();
     findStub.restore();
+  });
+
+  test("Allows configuring where Mise is installed", async () => {
+    const workspacePath = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ruby-lsp-test-"),
+    );
+    const workspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
+    const mise = new Mise(workspaceFolder, outputChannel);
+
+    const activationScript =
+      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
+
+    const execStub = sinon.stub(common, "asyncExec").resolves({
+      stdout: "",
+      stderr: JSON.stringify({
+        env: { ANY: "true" },
+        yjit: true,
+        version: "3.0.0",
+      }),
+    });
+    const misePath = path.join(workspacePath, "mise");
+    fs.writeFileSync(misePath, "fakeMiseBinary");
+
+    const configStub = sinon
+      .stub(vscode.workspace, "getConfiguration")
+      .returns({
+        get: (name: string) => {
+          if (name === "rubyVersionManager.miseExecutablePath") {
+            return misePath;
+          }
+          return "";
+        },
+      } as any);
+
+    const { env, version, yjit } = await mise.activate();
+
+    assert.ok(
+      execStub.calledOnceWithExactly(
+        `${misePath} x -- ruby -W0 -rjson -e '${activationScript}'`,
+        { cwd: workspacePath },
+      ),
+    );
+
+    assert.strictEqual(version, "3.0.0");
+    assert.strictEqual(yjit, true);
+    assert.deepStrictEqual(env.ANY, "true");
+
+    execStub.restore();
+    configStub.restore();
+    fs.rmSync(workspacePath, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
### Motivation

Closes #1822

Allow configuring the Mise executable path if it's not installed in the default location.

### Implementation

Added a new setting under version manager. If the value is set to something, we use that as the Mise path, otherwise we fallback to the default installation path.

### Automated Tests

Added a test to verify that we use the configured value to invoke Mise.