### PR TITLE
Run initialize and document synchronization in main thread

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -59,9 +59,11 @@ module RubyLsp
           end
         end
 
-        # We need to process shutdown and exit from the main thread in order to close queues and wait for other threads
-        # to finish. Everything else is pushed into the incoming queue
+        # The following requests need to be executed in the main thread directly to avoid concurrency issues. Everything
+        # else is pushed into the incoming queue
         case method
+        when "initialize", "textDocument/didOpen", "textDocument/didClose", "textDocument/didChange"
+          process_message(message)
         when "shutdown"
           $stderr.puts("Shutting down Ruby LSP...")
 


### PR DESCRIPTION
### Motivation

Another attempt to fix #1897

Before the base server refactor, we used to always run initialize and document synchronization requests directly in the main thread without first pushing them into the work queue.

Based on the reports on the issue, it seems that even using a mutex we can still ourselves with concurrency, so I propose we go back to the original implementation and run these requests directly without pushing them to the queue.

### Implementation

Added the list of requests that must be executed immediately in base server.

### Automated Tests

This is hard to write an automated test for. In fact, I can't even reproduce the issue manually.