### PR TITLE
Refactor global usage of `Prism::Location` to minimize memory usage

### DIFF
--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -22,10 +22,9 @@ module RubyIndexer
       entry = entries.first
       assert_instance_of(type, entry, "Expected #{expected_name} to be a #{type}")
 
-      location = entry.location
       location_string =
-        "#{entry.file_path}:#{location.start_line - 1}-#{location.start_column}" \
-          ":#{location.end_line - 1}-#{location.end_column}"
+        "#{entry.file_path}:#{entry.start_line - 1}-#{entry.start_column}" \
+          ":#{entry.end_line - 1}-#{entry.end_column}"
 
       assert_equal(expected_location, location_string)
     end

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -73,15 +73,14 @@ module RubyLsp
         return unless methods
 
         methods.each do |target_method|
-          location = target_method.location
           file_path = target_method.file_path
           next if @typechecker_enabled && not_in_dependencies?(file_path)
 
           @response_builder << Interface::Location.new(
             uri: URI::Generic.from_path(path: file_path).to_s,
             range: Interface::Range.new(
-              start: Interface::Position.new(line: location.start_line - 1, character: location.start_column),
-              end: Interface::Position.new(line: location.end_line - 1, character: location.end_column),
+              start: Interface::Position.new(line: target_method.start_line - 1, character: target_method.start_column),
+              end: Interface::Position.new(line: target_method.end_line - 1, character: target_method.end_column),
             ),
           )
         end
@@ -140,7 +139,6 @@ module RubyLsp
         return if first_entry.visibility == :private && first_entry.name != "#{@nesting.join("::")}::#{value}"
 
         entries.each do |entry|
-          location = entry.location
           # If the project has Sorbet, then we only want to handle go to definition for constants defined in gems, as an
           # additional behavior on top of jumping to RBIs. Sorbet can already handle go to definition for all constants
           # in the project, even if the files are typed false
@@ -150,8 +148,8 @@ module RubyLsp
           @response_builder << Interface::Location.new(
             uri: URI::Generic.from_path(path: file_path).to_s,
             range: Interface::Range.new(
-              start: Interface::Position.new(line: location.start_line - 1, character: location.start_column),
-              end: Interface::Position.new(line: location.end_line - 1, character: location.end_column),
+              start: Interface::Position.new(line: entry.start_line - 1, character: entry.start_column),
+              end: Interface::Position.new(line: entry.end_line - 1, character: entry.end_column),
             ),
           )
         end

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -96,15 +96,13 @@ module RubyLsp
           entries = Array(entries)
           entries_to_format = max_entries ? entries.take(max_entries) : entries
           entries_to_format.each do |entry|
-            loc = entry.location
-
             # We always handle locations as zero based. However, for file links in Markdown we need them to be one
             # based, which is why instead of the usual subtraction of 1 to line numbers, we are actually adding 1 to
             # columns. The format for VS Code file URIs is
             # `file:///path/to/file.rb#Lstart_line,start_column-end_line,end_column`
             uri = URI::Generic.from_path(
               path: entry.file_path,
-              fragment: "L#{loc.start_line},#{loc.start_column + 1}-#{loc.end_line},#{loc.end_column + 1}",
+              fragment: "L#{entry.start_line},#{entry.start_column + 1}-#{entry.end_line},#{entry.end_column + 1}",
             )
 
             definitions << "[#{entry.file_name}](#{uri})"

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -42,7 +42,6 @@ module RubyLsp
           next if entry.visibility == :private
 
           kind = kind_for_entry(entry)
-          loc = entry.location
 
           # We use the namespace as the container name, but we also use the full name as the regular name. The reason we
           # do this is to allow people to search for fully qualified names (e.g.: `Foo::Bar`). If we only included the
@@ -56,8 +55,8 @@ module RubyLsp
             location: Interface::Location.new(
               uri: URI::Generic.from_path(path: file_path).to_s,
               range:  Interface::Range.new(
-                start: Interface::Position.new(line: loc.start_line - 1, character: loc.start_column),
-                end: Interface::Position.new(line: loc.end_line - 1, character: loc.end_column),
+                start: Interface::Position.new(line: entry.start_line - 1, character: entry.start_column),
+                end: Interface::Position.new(line: entry.end_line - 1, character: entry.end_column),
               ),
             ),
           )


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Currently, we store `Prism::Location` objects globally to keep track of certain location specifications for indexed entries.

These location specifications are the Start Line, End Line, Start Column, and End Column, all of which are integers.

However, `Prism::Location` objects themselves store a lot of information that we don't need to globally store. Consequently, we can refactor our usage of `Prism::Location` objects in indexed entries to only store what we need.

### Impact on Performance

Depending on the repository, memory usage of the indexer decreased as much as 21%, which is non-trivial, especially with larger repositories. 

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

All `RubyIndexer::Entry` objects can be changed to receive one of two arguments for its `location`:
1. A `Prism::Location` object
2. An array storing the Start Line, End Line, Start Column, and End Column

Regardless of which of the two arguments is received, we only persistently store the Start Line, End Line, Start Column, and End Column. It should be noted that the addition of Option 2 for arguments will make it much easier for us to cache indexed gems (#1009), as we will no longer have to create `Prism::Location` objects when deserializing the cache (we can directly send the integers).

This is a breaking change, as repositories like `ruby-lsp-rails` which directly access `RubyIndexer::Entry` objects can no longer expect `entry.location` to yield anything, they must directly call `entry.start_line` and so on.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

Automated tests have been updated to not rely on `entry.location`, but on `entry.start_line` ... instead. Apart from that, everything should operate as expected.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

Nothing specific here, we're just changing the layer at which we abstract away the `Prism::Location` object, so everything should function as normal. 