### PR TITLE
Fix the discovered version manager logging as `[object Object]`

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -110,7 +110,7 @@ export class Ruby implements RubyInterface {
     if (this.versionManager.identifier === ManagerIdentifier.Auto) {
       await this.discoverVersionManager();
       this.outputChannel.info(
-        `Discovered version manager ${this.versionManager}`,
+        `Discovered version manager ${this.versionManager.identifier}`,
       );
     }
 


### PR DESCRIPTION
### Motivation

This was missed in #1831

### Automated Tests

Logs aren't tested at the moment.

### Manual Tests

Just boot up and check the logs