### PR TITLE
Migrate manager config before activating

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -5,14 +5,14 @@ import { RubyLsp } from "./rubyLsp";
 let extension: RubyLsp;
 
 export async function activate(context: vscode.ExtensionContext) {
+  await migrateManagerConfigurations();
+
   if (!vscode.workspace.workspaceFolders) {
     return;
   }
 
   extension = new RubyLsp(context);
   await extension.activate();
-
-  await migrateManagerConfigurations();
 }
 
 export async function deactivate(): Promise<void> {


### PR DESCRIPTION
### Motivation

We need to migrate the version manager configuration to the new format before trying to activate the workspace or else it fails.

### Implementation

Just moved the function call up before we activate.