### PR TITLE
Avoid memoizing dependencies

### DIFF
--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -8,49 +8,51 @@ module RubyLsp
     def test_detects_no_test_library_when_there_are_no_dependencies
       stub_dependencies({})
 
-      assert_equal("unknown", GlobalState.new.test_library)
+      state = GlobalState.new
+      state.apply_options({})
+      assert_equal("unknown", state.test_library)
     end
 
     def test_detects_minitest
       stub_dependencies("minitest" => "1.2.3")
 
-      assert_equal("minitest", GlobalState.new.test_library)
+      state = GlobalState.new
+      state.apply_options({})
+      assert_equal("minitest", state.test_library)
     end
 
     def test_does_not_detect_minitest_related_gems_as_minitest
       stub_dependencies("minitest-reporters" => "1.2.3")
 
-      assert_equal("unknown", GlobalState.new.test_library)
+      state = GlobalState.new
+      state.apply_options({})
+      assert_equal("unknown", state.test_library)
     end
 
     def test_detects_test_unit
       stub_dependencies("test-unit" => "1.2.3")
 
-      assert_equal("test-unit", GlobalState.new.test_library)
-    end
-
-    def test_detects_dependencies_in_gemspecs
-      assert(GlobalState.new.direct_dependency?(/^prism$/))
+      state = GlobalState.new
+      state.apply_options({})
+      assert_equal("test-unit", state.test_library)
     end
 
     def test_detects_rails_if_minitest_is_present_and_bin_rails_exists
       stub_dependencies("minitest" => "1.2.3")
       File.expects(:exist?).with("#{Dir.pwd}/bin/rails").once.returns(true)
 
-      assert_equal("rails", GlobalState.new.test_library)
+      state = GlobalState.new
+      state.apply_options({})
+      assert_equal("rails", state.test_library)
     end
 
     def test_detects_rspec_if_both_rails_and_rspec_are_present
       stub_dependencies("rspec" => "1.2.3")
       File.expects(:exist?).never
 
-      assert_equal("rspec", GlobalState.new.test_library)
-    end
-
-    def test_direct_dependency_returns_false_outside_of_bundle
-      File.expects(:file?).at_least_once.returns(false)
-      stub_dependencies({})
-      refute(GlobalState.new.direct_dependency?(/^ruby-lsp/))
+      state = GlobalState.new
+      state.apply_options({})
+      assert_equal("rspec", state.test_library)
     end
 
     def test_apply_option_selects_formatter


### PR DESCRIPTION
### Motivation

I noticed that we were keeping the project's dependencies in memory forever, but we only need that during boot. Let's save some memory and allow the array to be garbage collected.

### Implementation

I turned the array into a local variable that gets used during `apply_options`.

### Automated Tests

Adapted our tests.