### PR TITLE
Run `initialized` directly without pushing to queue

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -62,7 +62,7 @@ module RubyLsp
         # The following requests need to be executed in the main thread directly to avoid concurrency issues. Everything
         # else is pushed into the incoming queue
         case method
-        when "initialize", "textDocument/didOpen", "textDocument/didClose", "textDocument/didChange"
+        when "initialize", "initialized", "textDocument/didOpen", "textDocument/didClose", "textDocument/didChange"
           process_message(message)
         when "shutdown"
           $stderr.puts("Shutting down Ruby LSP...")


### PR DESCRIPTION
### Motivation

Closes #1922

Since addons now receive the global state on `activate`, we must ensure that it gets invoked before any features are processed. If we don't run `initialized` sequentially, we risk having threads switch and try to execute features that depend on the global state before we had a chance to pass that to the addons.

### Implementation

Started running `initialized` directly, without pushing the notification into the queue.