### PR TITLE
Allow ENV to override GlobalState#test_library

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -110,7 +110,9 @@ module RubyLsp
 
     sig { returns(String) }
     def detect_test_library
-      if direct_dependency?(/^rspec/)
+      if ENV.key?("RUBY_LSP_TEST_LIBRARY")
+        ENV["RUBY_LSP_TEST_LIBRARY"]
+      elsif direct_dependency?(/^rspec/)
         "rspec"
       # A Rails app may have a dependency on minitest, but we would instead want to use the Rails test runner provided
       # by ruby-lsp-rails. A Rails app doesn't need to depend on the rails gem itself, individual components like

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -47,6 +47,20 @@ module RubyLsp
       assert_equal("rspec", GlobalState.new.test_library)
     end
 
+    def test_detects_library_from_env_if_present
+      original_env = ENV.fetch("RUBY_LSP_TEST_LIBRARY", :not_present)
+      ENV["RUBY_LSP_TEST_LIBRARY"] = "minitest"
+      stub_dependencies("test-unit" => "1.2.3")
+      stub_dependencies("rspec" => "1.2.3")
+      assert_equal("minitest", GlobalState.new.test_library)
+    ensure
+      if original_env == :not_present
+        ENV.delete("RUBY_LSP_TEST_LIBRARY")
+      else
+        ENV["RUBY_LSP_TEST_LIBRARY"] = original_env
+      end
+    end
+
     def test_direct_dependency_returns_false_outside_of_bundle
       File.expects(:file?).at_least_once.returns(false)
       stub_dependencies({})


### PR DESCRIPTION
### Motivation

In our project we have a small amount of rspec tests and a large amount of minitest tests. The test library detection method prefers rspec over minitest and as a result, the testing code lenses don't work for the vast majority of our tests. 

Having multiple test frameworks in-use in a single project is certainly not standard. Ours is a monorepo-ish application born years ago, being converted from engines to packwerk, so it's got a sprinkling of various things in it. We're looking for some way to be able to override the test library detection to be able to force it to `"rails"`. 

   

### Implementation

Potential solutions I've dreamed up:

1. Create our own custom `Addon` that inherits from `RubyLsp::Rails::Addon` but removes this restriction: https://github.com/Shopify/ruby-lsp-rails/blob/8c0e73a2e938c5cda5e7ff20098d78d132f09853/lib/ruby_lsp/ruby_lsp_rails/addon.rb#L50
  - Pros: No upstream changes
  - Cons: Our little anemic Addon has to be committed and maintained over time

2. Same as (1) except we fork the RubyLsp::Rails repo and remove the line.

3. Allow an ENV var to specify the testing library
  - Pros: Small code change
  - Cons: one-off ENV var specification rather than being specified as part of a wider configuration system. (Not sure if this other open PR would be relevant here or if it's tackling a different sort of configuration? https://github.com/Shopify/ruby-lsp/pull/1434)

4. Add some way to hook into the loading of RubyLsp so that I can go wild with ~monkey-patching~ behavior modifications. Something like RubyLsp looks for `ruby-lsp_boot.rb` or something at the root dir and just `load`s it as part of its booting process. In my case, I could use it to prepend my own module to the library, but I could also see this as a way to make small Addons where creating a full gem seems like a lot. Sort of a use-at-your-own-risk escape hatch.

- Pros: Small code change. 
- Cons: Increased surface for issues to arise. Ie, how many new issues will be created in your repo because somebody checked in a broken boot file into their codebase. Those codebases descend into chaos and darkness (though perhaps a few reach enlightenment).  

5. I create `ruby-lsp_boot.rb` in my home directory that uses that uses the `const_defined` callback to modify `RubyLsp::GlobalState` as its loaded. Then I `export RUBYOPT="-r ${HOME}/ruby-lsp_boot"` to get my fingers into every single ruby process and I convince my coworkers to do the same.
- Pros: I bask in the glory of my rube-goldberg creation
- Cons: too many to list
 
 In this PR I've gone with option 4. Though I understand if this whole minitest/rspec living together is not a use-case you care to support.

### Automated Tests

I added the test. It's a bit annoying to mutate the ENV and put it back correctly. It's also not thread-safe. But it works.

### Manual Tests

Make a rails project that contains both rspec and minitest gems and tests. The test runners will be present for the rspec tests and not for the minitest tests. Then, `export RUBY_LSP_TEST_LIBRARY="minitest"` and reload the window. The opposite will now be true.

