### PR TITLE
Allow request ids to be strings

### DIFF
--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -75,7 +75,7 @@ module RubyLsp
   class Request < Message
     extend T::Sig
 
-    sig { params(id: Integer, method: String, params: Object).void }
+    sig { params(id: T.any(Integer, String), method: String, params: Object).void }
     def initialize(id:, method:, params:)
       @id = id
       super(method: method, params: params)


### PR DESCRIPTION


### Motivation

The LSP spec allows this: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#requestMessage

Addons that want to sent requests must provide an id but since the counter is internal to the server that is not easily possible at the moment.

See the conversation starting at https://github.com/Shopify/ruby-lsp-rails/issues/326#issuecomment-2050336058 for more context
