### PR TITLE
Move `supports_progress` to the global state

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -23,6 +23,9 @@ module RubyLsp
     sig { returns(T::Boolean) }
     attr_reader :supports_watching_files
 
+    sig { returns(T::Boolean) }
+    attr_reader :supports_progress
+
     sig { void }
     def initialize
       @workspace_uri = T.let(URI::Generic.from_path(path: Dir.pwd), URI::Generic)
@@ -34,6 +37,7 @@ module RubyLsp
       @index = T.let(RubyIndexer::Index.new, RubyIndexer::Index)
       @supported_formatters = T.let({}, T::Hash[String, Requests::Support::Formatter])
       @supports_watching_files = T.let(false, T::Boolean)
+      @supports_progress = T.let(false, T::Boolean)
     end
 
     sig { params(identifier: String, instance: Requests::Support::Formatter).void }
@@ -70,6 +74,8 @@ module RubyLsp
       if file_watching_caps&.dig(:dynamicRegistration) && file_watching_caps&.dig(:relativePatternSupport)
         @supports_watching_files = true
       end
+
+      @supports_progress = true if options.dig(:capabilities, :window, :workDoneProgress)
     end
 
     sig { returns(String) }

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -118,8 +118,6 @@ module RubyLsp
       client_name = options.dig(:clientInfo, :name)
       @store.client_name = client_name if client_name
 
-      progress = options.dig(:capabilities, :window, :workDoneProgress)
-      @store.supports_progress = progress.nil? ? true : progress
       configured_features = options.dig(:initializationOptions, :enabledFeatures)
       @store.experimental_features = options.dig(:initializationOptions, :experimentalFeaturesEnabled) || false
 
@@ -711,7 +709,7 @@ module RubyLsp
 
     sig { params(id: String, title: String, percentage: Integer).void }
     def begin_progress(id, title, percentage: 0)
-      return unless @store.supports_progress
+      return unless @global_state.supports_progress
 
       send_message(Request.new(
         id: @current_request_id,
@@ -735,7 +733,7 @@ module RubyLsp
 
     sig { params(id: String, percentage: Integer).void }
     def progress(id, percentage)
-      return unless @store.supports_progress
+      return unless @global_state.supports_progress
 
       send_message(
         Notification.new(
@@ -754,7 +752,7 @@ module RubyLsp
 
     sig { params(id: String).void }
     def end_progress(id)
-      return unless @store.supports_progress
+      return unless @global_state.supports_progress
 
       send_message(
         Notification.new(

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -6,9 +6,6 @@ module RubyLsp
     extend T::Sig
 
     sig { returns(T::Boolean) }
-    attr_accessor :supports_progress
-
-    sig { returns(T::Boolean) }
     attr_accessor :experimental_features
 
     sig { returns(T::Hash[Symbol, RequestConfig]) }
@@ -20,7 +17,6 @@ module RubyLsp
     sig { void }
     def initialize
       @state = T.let({}, T::Hash[String, Document])
-      @supports_progress = T.let(true, T::Boolean)
       @experimental_features = T.let(false, T::Boolean)
       @features_configuration = T.let(
         {

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -105,6 +105,24 @@ module RubyLsp
       refute(state.supports_watching_files)
     end
 
+    def test_progress_if_supported
+      state = GlobalState.new
+      state.apply_options({ capabilities: { window: { workDoneProgress: true } } })
+      assert(state.supports_progress)
+    end
+
+    def test_progress_if_not_supported
+      state = GlobalState.new
+      state.apply_options({ capabilities: { window: { workDoneProgress: false } } })
+      refute(state.supports_progress)
+    end
+
+    def test_progress_if_not_reported
+      state = GlobalState.new
+      state.apply_options({ capabilities: {} })
+      refute(state.supports_progress)
+    end
+
     private
 
     def stub_dependencies(dependencies)


### PR DESCRIPTION
### Motivation

Consolidate global state into the GlobalState object. It looks like the store was previously used like some sort of global state, it just holds this variable and doesn't reference it itself.

### Automated Tests

There were not tests for this, I added some basic ones. Not sending this property apparently equals support? That at least is how the current implementation handles that but I don't think that is correct:

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities
> A missing property should be interpreted as an absence of the capability.

I tweakted the implementation to adhere to the spec

### Manual Tests

Start the LSP with the VSCode extension and check for the index progress indicator
