### PR TITLE
Randomly assign issues to contributors

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,0 +1,41 @@
+name: Auto assign
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto_assign:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout
+
+      - name: Randomly assign reviewers to community issues
+        uses: actions/github-script@v7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const devExpResponse = await github.rest.teams.listMembersInOrg({
+              org: "shopify",
+              team_slug: "ruby-dev-exp",
+            });
+            const members = devExpResponse.data.map((member) => member.login);
+            const issue = github.event.issue;
+
+            if (!members.includes(issue.user.login)) {
+              const dxResponse = await github.rest.teams.listMembersInOrg({
+                org: "shopify",
+                team_slug: "ruby-dx",
+              });
+              const reviewers = dxResponse.data.map((member) => member.login);
+              const assignee = reviewers[Math.floor(Math.random() * reviewers.length)];
+
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                assignees: [assignee]
+              });
+            }


### PR DESCRIPTION
### Motivation

The volume of issues from the community has been quite high. Let's spread the load on the team by assigning a random team member as primary contact on each issue.

### Implementation

The script does the following:

1. Lists all members of `ruby-dev-exp`
2. If the issue was created by a member of the team, nothing happens
3. Otherwise, list the members of `ruby-dx`
4. Randomize an item from the reviewers array
5. Assign the issue to the randomized person

I ended up not including pull requests because I realized that this action would not run automatically (because of the security feature to block running automation on PRs). Let's begin with issues only and we can decide if we want to add PRs later.