### PR TITLE
docs: Recommend pull_diags.nvim instead of manual config for neovim

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -61,102 +61,10 @@ mason_lspconfig.setup_handlers {
 }
 ```
 
-### Neovim Limitations
+### Limitations
 
 Ruby LSP only supports pull diagnostics, and neovim versions prior to v0.10.0-dev-695+g58f948614 only support [publishDiagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics).
-Additional setup is required to enable diagnostics from Ruby LSP to appear in neovim.
-
-```lua
--- textDocument/diagnostic support until 0.10.0 is released
-_timers = {}
-local function setup_diagnostics(client, buffer)
-  if require("vim.lsp.diagnostic")._enable then
-    return
-  end
-
-  local diagnostic_handler = function()
-    local params = vim.lsp.util.make_text_document_params(buffer)
-    client.request("textDocument/diagnostic", { textDocument = params }, function(err, result)
-      if err then
-        local err_msg = string.format("diagnostics error - %s", vim.inspect(err))
-        vim.lsp.log.error(err_msg)
-      end
-      local diagnostic_items = {}
-      if result then
-        diagnostic_items = result.items
-      end
-      vim.lsp.diagnostic.on_publish_diagnostics(
-        nil,
-        vim.tbl_extend("keep", params, { diagnostics = diagnostic_items }),
-        { client_id = client.id }
-      )
-    end)
-  end
-
-  diagnostic_handler() -- to request diagnostics on buffer when first attaching
-
-  vim.api.nvim_buf_attach(buffer, false, {
-    on_lines = function()
-      if _timers[buffer] then
-        vim.fn.timer_stop(_timers[buffer])
-      end
-      _timers[buffer] = vim.fn.timer_start(200, diagnostic_handler)
-    end,
-    on_detach = function()
-      if _timers[buffer] then
-        vim.fn.timer_stop(_timers[buffer])
-      end
-    end,
-  })
-end
-
--- adds ShowRubyDeps command to show dependencies in the quickfix list.
--- add the `all` argument to show indirect dependencies as well
-local function add_ruby_deps_command(client, bufnr)
-    vim.api.nvim_buf_create_user_command(bufnr, "ShowRubyDeps",
-                                          function(opts)
-
-        local params = vim.lsp.util.make_text_document_params()
-
-        local showAll = opts.args == "all"
-
-        client.request("rubyLsp/workspace/dependencies", params,
-                        function(error, result)
-            if error then
-                print("Error showing deps: " .. error)
-                return
-            end
-
-            local qf_list = {}
-            for _, item in ipairs(result) do
-                if showAll or item.dependency then
-                    table.insert(qf_list, {
-                        text = string.format("%s (%s) - %s",
-                                              item.name,
-                                              item.version,
-                                              item.dependency),
-
-                        filename = item.path
-                    })
-                end
-            end
-
-            vim.fn.setqflist(qf_list)
-            vim.cmd('copen')
-        end, bufnr)
-    end, {nargs = "?", complete = function()
-        return {"all"}
-    end})
-end
-
-
-require("lspconfig").ruby_ls.setup({
-  on_attach = function(client, buffer)
-    setup_diagnostics(client, buffer)
-    add_ruby_deps_command(client, buffer)
-  end,
-})
-```
+[pull_diags.nvim](https://github.com/catlee/pull_diags.nvim) can be used to enable diagnostics from Ruby LSP to appear in neovim.
 
 ## Sublime Text LSP
 


### PR DESCRIPTION
When updating the ruby LSP name for neovim [here](https://github.com/Shopify/ruby-lsp/pull/1936), I noticed that there's a reference to `ruby_ls` in a large snippet for enabling pull diagnostics. This has been extracted to a [pull_diags.nvim](https://github.com/catlee/pull_diags.nvim) plugin, so I recommended that to make it more approachable. (cc @catlee)

I've extracted that commit from the PR, so that it can be discussed separately.