### PR TITLE
Use special syntax to refer to GH action event data

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -29,9 +29,9 @@ jobs:
               "egiurleo",
               "KaanOzkan"
             ];
-            const issue = github.event.issue;
+            const author = "${{ github.event.issue.user.login }}";
 
-            if (!fullTeam.includes(issue.user.login)) {
+            if (!fullTeam.includes(author)) {
               const dxReviewers = [
                 "andyw8",
                 "vinistock",
@@ -43,7 +43,7 @@ jobs:
               await github.rest.issues.addAssignees({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issue.number,
+                issue_number: ${{ github.event.issue.number }},
                 assignees: [assignee]
               });
             }


### PR DESCRIPTION
### Motivation

There was another mistake in the auto assign action. `github.event.issue` exists, but not as a variable directly in the TypeScript. It's a special variable that has to be inserted with the `${{ }}` syntax.

### Implementation

Started using the syntax so that we can get the values properly pasted in the script.