### PR TITLE
Split constant and method entries

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/collector.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/collector.rb
@@ -206,7 +206,7 @@ module RubyIndexer
 
       # The private_constant method does not resolve the constant name. It always points to a constant that needs to
       # exist in the current namespace
-      entries = @index[fully_qualify_name(name)]
+      entries = @index.get_constant(fully_qualify_name(name))
       entries&.each { |entry| entry.visibility = :private }
     end
 

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -161,10 +161,10 @@ module RubyIndexer
         class Bar; end
       RUBY
 
-      foo_entry = @index["Foo"].first
+      foo_entry = @index.get_constant("Foo").first
       assert_equal("This is a Foo comment\nThis is another Foo comment", foo_entry.comments.join("\n"))
 
-      bar_entry = @index["Bar"].first
+      bar_entry = @index.get_constant("Bar").first
       assert_equal("This Bar comment has 1 line padding", bar_entry.comments.join("\n"))
     end
 
@@ -174,7 +174,7 @@ module RubyIndexer
         class Foo
         end
       RUBY
-      assert(@index["Foo"].first)
+      assert(@index.get_constant("Foo").first)
     end
 
     def test_comments_can_be_attached_to_a_namespaced_class
@@ -187,10 +187,10 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = @index["Foo"].first
+      foo_entry = @index.get_constant("Foo").first
       assert_equal("This is a Foo comment\nThis is another Foo comment", foo_entry.comments.join("\n"))
 
-      bar_entry = @index["Foo::Bar"].first
+      bar_entry = @index.get_constant("Foo::Bar").first
       assert_equal("This is a Bar comment", bar_entry.comments.join("\n"))
     end
 
@@ -203,10 +203,10 @@ module RubyIndexer
         class Foo; end
       RUBY
 
-      first_foo_entry = @index["Foo"][0]
+      first_foo_entry = @index.get_constant("Foo")[0]
       assert_equal("This is a Foo comment", first_foo_entry.comments.join("\n"))
 
-      second_foo_entry = @index["Foo"][1]
+      second_foo_entry = @index.get_constant("Foo")[1]
       assert_equal("This is another Foo comment", second_foo_entry.comments.join("\n"))
     end
 
@@ -219,10 +219,10 @@ module RubyIndexer
         class Bar; end
       RUBY
 
-      first_foo_entry = @index["Foo"][0]
+      first_foo_entry = @index.get_constant("Foo")[0]
       assert_equal("This is a Foo comment", first_foo_entry.comments.join("\n"))
 
-      second_foo_entry = @index["Bar"][0]
+      second_foo_entry = @index.get_constant("Bar")[0]
       assert_equal("This is a Bar comment", second_foo_entry.comments.join("\n"))
     end
 
@@ -239,13 +239,13 @@ module RubyIndexer
         end
       RUBY
 
-      b_const = @index["A::B"].first
+      b_const = @index.get_constant("A::B").first
       assert_equal(:private, b_const.visibility)
 
-      c_const = @index["A::C"].first
+      c_const = @index.get_constant("A::C").first
       assert_equal(:private, c_const.visibility)
 
-      d_const = @index["A::D"].first
+      d_const = @index.get_constant("A::D").first
       assert_equal(:public, d_const.visibility)
     end
 
@@ -269,16 +269,16 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo"].first)
+      foo = T.must(@index.get_constant("Foo").first)
       assert_equal("Bar", foo.parent_class)
 
-      baz = T.must(@index["Baz"].first)
+      baz = T.must(@index.get_constant("Baz").first)
       assert_nil(baz.parent_class)
 
-      qux = T.must(@index["Something::Qux"].first)
+      qux = T.must(@index.get_constant("Something::Qux").first)
       assert_equal("::Baz", qux.parent_class)
 
-      final_thing = T.must(@index["FinalThing"].first)
+      final_thing = T.must(@index.get_constant("FinalThing").first)
       assert_equal("Something::Baz", final_thing.parent_class)
     end
 
@@ -318,13 +318,13 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo"][0])
+      foo = T.must(@index.get_constant("Foo")[0])
       assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.included_modules)
 
-      qux = T.must(@index["Foo::Qux"][0])
+      qux = T.must(@index.get_constant("Foo::Qux")[0])
       assert_equal(["Corge", "Corge", "Baz"], qux.included_modules)
 
-      constant_path_references = T.must(@index["ConstantPathReferences"][0])
+      constant_path_references = T.must(@index.get_constant("ConstantPathReferences")[0])
       assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.included_modules)
     end
 
@@ -364,13 +364,13 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo"][0])
+      foo = T.must(@index.get_constant("Foo")[0])
       assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.prepended_modules)
 
-      qux = T.must(@index["Foo::Qux"][0])
+      qux = T.must(@index.get_constant("Foo::Qux")[0])
       assert_equal(["Corge", "Corge", "Baz"], qux.prepended_modules)
 
-      constant_path_references = T.must(@index["ConstantPathReferences"][0])
+      constant_path_references = T.must(@index.get_constant("ConstantPathReferences")[0])
       assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.prepended_modules)
     end
   end

--- a/lib/ruby_indexer/test/constant_test.rb
+++ b/lib/ruby_indexer/test/constant_test.rb
@@ -83,16 +83,16 @@ module RubyIndexer
         A::BAZ = 1
       RUBY
 
-      foo_comment = @index["FOO"].first.comments.join("\n")
+      foo_comment = @index.get_constant("FOO").first.comments.join("\n")
       assert_equal("FOO comment", foo_comment)
 
-      a_foo_comment = @index["A::FOO"].first.comments.join("\n")
+      a_foo_comment = @index.get_constant("A::FOO").first.comments.join("\n")
       assert_equal("A::FOO comment", a_foo_comment)
 
-      bar_comment = @index["BAR"].first.comments.join("\n")
+      bar_comment = @index.get_constant("BAR").first.comments.join("\n")
       assert_equal("::BAR comment", bar_comment)
 
-      a_baz_comment = @index["A::BAZ"].first.comments.join("\n")
+      a_baz_comment = @index.get_constant("A::BAZ").first.comments.join("\n")
       assert_equal("A::BAZ comment", a_baz_comment)
     end
 
@@ -118,13 +118,13 @@ module RubyIndexer
         end
       RUBY
 
-      b_const = @index["A::B"].first
+      b_const = @index.get_constant("A::B").first
       assert_equal(:private, b_const.visibility)
 
-      c_const = @index["A::C"].first
+      c_const = @index.get_constant("A::C").first
       assert_equal(:private, c_const.visibility)
 
-      d_const = @index["A::D"].first
+      d_const = @index.get_constant("A::D").first
       assert_equal(:public, d_const.visibility)
     end
 
@@ -151,13 +151,13 @@ module RubyIndexer
         end
       RUBY
 
-      a_const = @index["A::B::CONST_A"].first
+      a_const = @index.get_constant("A::B::CONST_A").first
       assert_equal(:private, a_const.visibility)
 
-      b_const = @index["A::B::CONST_B"].first
+      b_const = @index.get_constant("A::B::CONST_B").first
       assert_equal(:private, b_const.visibility)
 
-      c_const = @index["A::B::CONST_C"].first
+      c_const = @index.get_constant("A::B::CONST_C").first
       assert_equal(:private, c_const.visibility)
     end
 
@@ -175,10 +175,10 @@ module RubyIndexer
         A::B.private_constant(:CONST_B)
       RUBY
 
-      a_const = @index["A::B::CONST_A"].first
+      a_const = @index.get_constant("A::B::CONST_A").first
       assert_equal(:private, a_const.visibility)
 
-      b_const = @index["A::B::CONST_B"].first
+      b_const = @index.get_constant("A::B::CONST_B").first
       assert_equal(:private, b_const.visibility)
     end
 
@@ -196,12 +196,12 @@ module RubyIndexer
         SECOND = A::FIRST
       RUBY
 
-      unresolve_entry = @index["A::FIRST"].first
+      unresolve_entry = @index.get_constant("A::FIRST").first
       assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("B::C", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::FIRST", []).first
+      resolved_entry = @index.resolve_constant("A::FIRST", []).first
       assert_instance_of(Entry::Alias, resolved_entry)
       assert_equal("A::B::C", resolved_entry.target)
     end
@@ -222,25 +222,25 @@ module RubyIndexer
         end
       RUBY
 
-      unresolve_entry = @index["A::ALIAS"].first
+      unresolve_entry = @index.get_constant("A::ALIAS").first
       assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("B", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("ALIAS", ["A"]).first
+      resolved_entry = @index.resolve_constant("ALIAS", ["A"]).first
       assert_instance_of(Entry::Alias, resolved_entry)
       assert_equal("A::B", resolved_entry.target)
 
-      resolved_entry = @index.resolve("ALIAS::C", ["A"]).first
+      resolved_entry = @index.resolve_constant("ALIAS::C", ["A"]).first
       assert_instance_of(Entry::Module, resolved_entry)
       assert_equal("A::B::C", resolved_entry.name)
 
-      unresolve_entry = @index["Other::ONE_MORE"].first
+      unresolve_entry = @index.get_constant("Other::ONE_MORE").first
       assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
       assert_equal(["Other"], unresolve_entry.nesting)
       assert_equal("A::ALIAS", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("Other::ONE_MORE::C", []).first
+      resolved_entry = @index.resolve_constant("Other::ONE_MORE::C", []).first
       assert_instance_of(Entry::Module, resolved_entry)
     end
 
@@ -255,55 +255,55 @@ module RubyIndexer
       RUBY
 
       # B and C
-      unresolve_entry = @index["A::B"].first
+      unresolve_entry = @index.get_constant("A::B").first
       assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("C", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::B", []).first
+      resolved_entry = @index.resolve_constant("A::B", []).first
       assert_instance_of(Entry::Alias, resolved_entry)
       assert_equal("A::C", resolved_entry.target)
 
-      constant = @index["A::C"].first
+      constant = @index.get_constant("A::C").first
       assert_instance_of(Entry::Constant, constant)
 
       # D and E
-      unresolve_entry = @index["A::D"].first
+      unresolve_entry = @index.get_constant("A::D").first
       assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("E", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::D", []).first
+      resolved_entry = @index.resolve_constant("A::D", []).first
       assert_instance_of(Entry::Alias, resolved_entry)
       assert_equal("A::E", resolved_entry.target)
 
       # F and G::H
-      unresolve_entry = @index["A::F"].first
+      unresolve_entry = @index.get_constant("A::F").first
       assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("G::H", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::F", []).first
+      resolved_entry = @index.resolve_constant("A::F", []).first
       assert_instance_of(Entry::Alias, resolved_entry)
       assert_equal("A::G::H", resolved_entry.target)
 
       # I::J, K::L and M
-      unresolve_entry = @index["A::I::J"].first
+      unresolve_entry = @index.get_constant("A::I::J").first
       assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("K::L", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::I::J", []).first
+      resolved_entry = @index.resolve_constant("A::I::J", []).first
       assert_instance_of(Entry::Alias, resolved_entry)
       assert_equal("A::K::L", resolved_entry.target)
 
       # When we are resolving A::I::J, we invoke `resolve("K::L", ["A"])`, which recursively resolves A::K::L too.
       # Therefore, both A::I::J and A::K::L point to A::M by the end of the previous resolve invocation
-      resolved_entry = @index["A::K::L"].first
+      resolved_entry = @index.get_constant("A::K::L").first
       assert_instance_of(Entry::Alias, resolved_entry)
       assert_equal("A::M", resolved_entry.target)
 
-      constant = @index["A::M"].first
+      constant = @index.get_constant("A::M").first
       assert_instance_of(Entry::Constant, constant)
     end
 

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -47,7 +47,7 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       assert_equal(1, entry.parameters.length)
       parameter = entry.parameters.first
       assert_equal(:a, parameter.name)
@@ -63,7 +63,7 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       assert_equal(1, entry.parameters.length)
       parameter = entry.parameters.first
       assert_equal(:"(a, (b, ))", parameter.name)
@@ -79,7 +79,7 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       assert_equal(1, entry.parameters.length)
       parameter = entry.parameters.first
       assert_equal(:a, parameter.name)
@@ -95,7 +95,7 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       assert_equal(2, entry.parameters.length)
       a, b = entry.parameters
 
@@ -115,7 +115,7 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       assert_equal(2, entry.parameters.length)
       a, b = entry.parameters
 
@@ -140,7 +140,7 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       assert_equal(2, entry.parameters.length)
       a, b = entry.parameters
 
@@ -150,7 +150,7 @@ module RubyIndexer
       assert_equal(:b, b.name)
       assert_instance_of(Entry::RequiredParameter, b)
 
-      entry = T.must(@index["baz"].first)
+      entry = T.must(@index.get_method("baz").first)
       assert_equal(2, entry.parameters.length)
       a, b = entry.parameters
 
@@ -160,7 +160,7 @@ module RubyIndexer
       assert_equal(:b, b.name)
       assert_instance_of(Entry::RequiredParameter, b)
 
-      entry = T.must(@index["qux"].first)
+      entry = T.must(@index.get_method("qux").first)
       assert_equal(2, entry.parameters.length)
       _a, second = entry.parameters
 
@@ -177,7 +177,7 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       assert_equal(1, entry.parameters.length)
       param = entry.parameters.first
 
@@ -196,12 +196,12 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       param = entry.parameters.first
       assert_equal(:block, param.name)
       assert_instance_of(Entry::BlockParameter, param)
 
-      entry = T.must(@index["baz"].first)
+      entry = T.must(@index.get_method("baz").first)
       assert_equal(1, entry.parameters.length)
 
       param = entry.parameters.first
@@ -218,7 +218,7 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       assert_equal(2, entry.parameters.length)
       first, second = entry.parameters
 
@@ -238,7 +238,7 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       assert_empty(entry.parameters)
     end
 
@@ -250,7 +250,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = T.must(@index.get_method("bar").first)
       owner_name = T.must(entry.owner).name
 
       assert_equal("Foo", owner_name)
@@ -267,9 +267,9 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Accessor, "/fake/path/foo.rb:2-15:2-18")
-      assert_equal("Hello there", @index["bar"].first.comments.join("\n"))
+      assert_equal("Hello there", @index.get_method("bar").first.comments.join("\n"))
       assert_entry("other", Entry::Accessor, "/fake/path/foo.rb:2-21:2-26")
-      assert_equal("Hello there", @index["other"].first.comments.join("\n"))
+      assert_equal("Hello there", @index.get_method("other").first.comments.join("\n"))
       assert_entry("baz=", Entry::Accessor, "/fake/path/foo.rb:3-15:3-18")
       assert_entry("qux", Entry::Accessor, "/fake/path/foo.rb:4-17:4-20")
       assert_entry("qux=", Entry::Accessor, "/fake/path/foo.rb:4-17:4-20")

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -16,7 +16,7 @@ module RubyIndexer
     end
 
     def assert_entry(expected_name, type, expected_location)
-      entries = @index[expected_name]
+      entries = @index.get_constant(expected_name) || @index.get_method(expected_name)
       refute_empty(entries, "Expected #{expected_name} to be indexed")
 
       entry = entries.first
@@ -31,16 +31,18 @@ module RubyIndexer
     end
 
     def refute_entry(expected_name)
-      entries = @index[expected_name]
+      entries = @index.get_constant(expected_name) || @index.get_method(expected_name)
       assert_nil(entries, "Expected #{expected_name} to not be indexed")
     end
 
     def assert_no_entries
-      assert_empty(@index.instance_variable_get(:@entries), "Expected nothing to be indexed")
+      assert_empty(@index.instance_variable_get(:@constant_entries), "Expected nothing to be indexed")
+      assert_empty(@index.instance_variable_get(:@method_entries), "Expected nothing to be indexed")
     end
 
     def assert_no_entry(entry)
-      refute(@index.instance_variable_get(:@entries).key?(entry), "Expected '#{entry}' to not be indexed")
+      refute(@index.instance_variable_get(:@constant_entries).key?(entry), "Expected '#{entry}' to not be indexed")
+      refute(@index.instance_variable_get(:@method_entries).key?(entry), "Expected '#{entry}' to not be indexed")
     end
   end
 end

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -74,7 +74,7 @@ module RubyLsp
         else
           # If the method doesn't have a receiver, then we provide a few candidates to jump to
           # But we don't want to provide too many candidates, as it can be overwhelming
-          @index[message]&.take(MAX_NUMBER_OF_DEFINITION_CANDIDATES_WITHOUT_RECEIVER)
+          @index.get_method(message)&.take(MAX_NUMBER_OF_DEFINITION_CANDIDATES_WITHOUT_RECEIVER)
         end
 
         return unless methods
@@ -138,7 +138,7 @@ module RubyLsp
 
       sig { params(value: String).void }
       def find_in_index(value)
-        entries = @index.resolve(value, @nesting)
+        entries = @index.resolve_constant(value, @nesting)
         return unless entries
 
         # We should only allow jumping to the definition of private constants if the constant is defined in the same

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -105,7 +105,7 @@ module RubyLsp
 
       sig { params(name: String, location: Prism::Location).void }
       def generate_hover(name, location)
-        entries = @index.resolve(name, @nesting)
+        entries = @index.resolve_constant(name, @nesting)
         return unless entries
 
         # We should only show hover for private constants if the constant is defined in the same namespace as the

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -39,7 +39,14 @@ module RubyLsp
       sig { override.returns(Interface::CompletionItem) }
       def perform
         label = @item[:label]
-        entries = @index[label] || []
+        entries = case @item[:kind]
+        when Constant::CompletionItemKind::CLASS, Constant::CompletionItemKind::MODULE,
+          Constant::CompletionItemKind::CONSTANT
+          @index.get_constant(label) || []
+        else
+          @index.get_method(label) || []
+        end
+
         Interface::CompletionItem.new(
           label: label,
           label_details: Interface::CompletionItemLabelDetails.new(

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -19,6 +19,7 @@ class CompletionResolveTest < Minitest::Test
     with_server(source, stub_no_typechecker: true) do |server, _uri|
       server.process_message(id: 1, method: "completionItem/resolve", params: {
         label: "Foo",
+        kind: Constant::CompletionItemKind::CLASS,
       })
 
       result = server.pop_response.response
@@ -30,7 +31,7 @@ class CompletionResolveTest < Minitest::Test
         ),
         documentation: Interface::MarkupContent.new(
           kind: "markdown",
-          value: markdown_from_index_entries("Foo", T.must(server.global_state.index["Foo"])),
+          value: markdown_from_index_entries("Foo", T.must(server.global_state.index.get_constant("Foo"))),
         ),
       )
       assert_match(/This is a class that does things/, result.documentation.value)

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -167,7 +167,7 @@ class ServerTest < Minitest::Test
       assert_equal("$/progress", @server.pop_response.method)
 
       index = @server.global_state.index
-      refute_empty(index.instance_variable_get(:@entries))
+      refute_empty(index.instance_variable_get(:@constant_entries))
     end
   end
 


### PR DESCRIPTION
### Motivation

First step for #1950, which will unblock ancestor linearization

Currently, we are putting all types of entries in the same data structure, mixing constants and methods. This leads to the following issues:

1. Naming conflicts lead to weird scenarios. For example, the `Array` class and `Array()` method. We end up having different types of entries for the same name
2. We get worse typing on the index API. For example, in `resolve_method`, we need to apply a bunch of casts since we know that the returned entry will be a method
3. For #1950 to work properly, we will need to have constants split from methods

### Implementation

Created separate data structures for methods. We now have a separate hash and separate prefix tree for methods.

- I benchmarked this and noticed no difference in indexing speed or memory consumption
- While the APIs are now split (e.g.: `resolve_constant` and `resolve_method`), I do not think this impacts the DX of using the index. We always know if something is a method call or a constant reference, there would never be a scenario where we are in doubt about which API to invoke

### Automated Tests

Adapted our tests.