### PR TITLE
Add support for method aliases when indexing

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -469,5 +469,33 @@ module RubyIndexer
         @owner = owner
       end
     end
+
+    class UnresolvedMethodAlias < Entry
+      extend T::Sig
+
+      sig { returns(String) }
+      attr_reader :new_name, :old_name
+
+      sig { returns(T.nilable(Entry::Namespace)) }
+      attr_reader :owner
+
+      sig do
+        params(
+          new_name: String,
+          old_name: String,
+          owner: T.nilable(Entry::Namespace),
+          file_path: String,
+          location: Prism::Location,
+          comments: T::Array[String],
+        ).void
+      end
+      def initialize(new_name, old_name, owner, file_path, location, comments) # rubocop:disable Metrics/ParameterLists
+        super(new_name, file_path, location, comments)
+
+        @new_name = new_name
+        @old_name = old_name
+        @owner = owner
+      end
+    end
   end
 end

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -17,6 +17,7 @@ module RubyIndexer
 
     def assert_entry(expected_name, type, expected_location, visibility: nil)
       entries = @index[expected_name]
+      refute_nil(entries, "Expected #{expected_name} to be indexed")
       refute_empty(entries, "Expected #{expected_name} to be indexed")
 
       entry = entries.first


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

first step for https://github.com/Shopify/ruby-lsp/issues/1940

We need to keep track of aliases but they cannot be resolved until we know if the old method is inherited. Blocked on resolving aliases until https://github.com/Shopify/ruby-lsp/issues/1333 is complete.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Created new class for UnresolvedMethodAlias and started handling AliasNode and AliasMethod

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
Added test in method_test