### PR TITLE
Increase timeout for tests

### DIFF
--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -109,8 +109,10 @@ suite("Client", () => {
   let client: Client;
 
   before(async function () {
+    // 60000 should be plenty but we're seeing timeouts on Windows in CI
+
     // eslint-disable-next-line no-invalid-this
-    this.timeout(60000);
+    this.timeout(90000);
 
     // eslint-disable-next-line no-process-env
     if (process.env.CI) {


### PR DESCRIPTION
### Motivation

We're seeing timeouts on Windows in CI, e.g. https://github.com/Shopify/ruby-lsp/actions/runs/8789287667/job/24118685238