### PR TITLE
Support go to definition for unknown receiver calls

### DIFF
--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -7,6 +7,8 @@ module RubyLsp
       extend T::Sig
       include Requests::Support::Common
 
+      MAX_NUMBER_OF_DEFINITION_CANDIDATES_WITHOUT_RECEIVER = 10
+
       sig do
         params(
           response_builder: ResponseBuilders::CollectionResponseBuilder[Interface::Location],
@@ -64,12 +66,17 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode).void }
       def handle_method_definition(node)
-        return unless self_receiver?(node)
-
         message = node.message
         return unless message
 
-        methods = @index.resolve_method(message, @nesting.join("::"))
+        methods = if self_receiver?(node)
+          @index.resolve_method(message, @nesting.join("::"))
+        else
+          # If the method doesn't have a receiver, then we provide a few candidates to jump to
+          # But we don't want to provide too many candidates, as it can be overwhelming
+          @index[message]&.take(MAX_NUMBER_OF_DEFINITION_CANDIDATES_WITHOUT_RECEIVER)
+        end
+
         return unless methods
 
         methods.each do |target_method|

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -344,6 +344,65 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_definitions_are_listed_for_method_with_unknown_receiver
+    source = <<~RUBY
+      # typed: false
+
+      class A
+        def foo; end
+      end
+
+      class B
+        def foo; end
+      end
+
+      obj.foo
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 4, line: 10 } },
+      )
+      response = server.pop_response.response
+
+      assert_equal(2, response.size)
+
+      range = response[0].attributes[:range].attributes
+      range_hash = { start: range[:start].to_hash, end: range[:end].to_hash }
+      assert_equal({ start: { line: 3, character: 2 }, end: { line: 3, character: 14 } }, range_hash)
+
+      range = response[1].attributes[:range].attributes
+      range_hash = { start: range[:start].to_hash, end: range[:end].to_hash }
+      assert_equal({ start: { line: 7, character: 2 }, end: { line: 7, character: 14 } }, range_hash)
+    end
+  end
+
+  def test_definitions_for_unknown_receiver_is_capped
+    source = +"# typed: false\n"
+
+    13.times do |i|
+      source << <<~RUBY
+        class Class#{i + 1}
+          def foo; end
+        end
+      RUBY
+    end
+    source << "\nobj.foo"
+
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 4, line: 41 } },
+      )
+      response = server.pop_response.response
+
+      assert_equal(10, response.size)
+    end
+  end
+
   private
 
   def create_definition_addon


### PR DESCRIPTION
### Motivation

Instead of providing no candidates for possible definitions on unknown receiver calls, we now provide 10 candidates (the exact number is subject to change in the future).

This will allow the user to navigate to the definition of more methods without overwhelming them with too many candidates in some cases.

### Implementation

When we can't derive the receiver of the target method, instead of return early we get 10 methods of the same name from the index.

### Automated Tests

A new test case was added for this new feature.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
