### PR TITLE
Avoid redirecting gem list output to stderr

### DIFF
--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -187,13 +187,13 @@ export class Workspace implements WorkspaceInterface {
       "rubyLsp.lastGemUpdate",
     );
 
-    const { stderr } = await asyncExec("gem list ruby-lsp 1>&2", {
+    const { stdout } = await asyncExec("gem list ruby-lsp", {
       cwd: this.workspaceFolder.uri.fsPath,
       env: this.ruby.env,
     });
 
     // If the gem is not yet installed, install it
-    if (!stderr.includes("ruby-lsp")) {
+    if (!stdout.includes("ruby-lsp")) {
       await asyncExec("gem install ruby-lsp", {
         cwd: this.workspaceFolder.uri.fsPath,
         env: this.ruby.env,


### PR DESCRIPTION
### Motivation

Closes #1902

I double checked the [Node documentation](https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback) for exec and it appears that the output is always buffered without impact the parent's stdout pipes. I don't think it's actually necessary to redirect the output to stderr.

### Implementation

Removed the redirection of the pipes.