### PR TITLE
Avoid setting GEM_HOME and GEM_PATH for rbenv

### DIFF
--- a/vscode/src/ruby/rbenv.ts
+++ b/vscode/src/ruby/rbenv.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-process-env */
 
-import path from "path";
-
 import { asyncExec } from "../common";
 
 import { VersionManager, ActivationResult } from "./versionManager";
@@ -11,11 +9,8 @@ import { VersionManager, ActivationResult } from "./versionManager";
 // Learn more: https://github.com/rbenv/rbenv
 export class Rbenv extends VersionManager {
   async activate(): Promise<ActivationResult> {
-    const activationScript = [
-      "STDERR.print(",
-      "{env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION,home:Gem.user_dir,default:Gem.default_dir}",
-      ".to_json)",
-    ].join("");
+    const activationScript =
+      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
 
     const result = await asyncExec(
       `rbenv exec ruby -W0 -rjson -e '${activationScript}'`,
@@ -25,17 +20,6 @@ export class Rbenv extends VersionManager {
     );
 
     const parsedResult = JSON.parse(result.stderr);
-
-    // The addition of GEM_HOME, GEM_PATH and putting the bin directories into the PATH happens through Rbenv's shell
-    // hooks. Since we want to avoid spawning shells due to integration issues, we need to insert these variables
-    // ourselves, so that gem executables can be properly found
-    parsedResult.env.GEM_HOME = parsedResult.home;
-    parsedResult.env.GEM_PATH = `${parsedResult.home}${path.delimiter}${parsedResult.default}`;
-    parsedResult.env.PATH = [
-      path.join(parsedResult.home, "bin"),
-      path.join(parsedResult.default, "bin"),
-      parsedResult.env.PATH,
-    ].join(path.delimiter);
 
     return {
       env: { ...process.env, ...parsedResult.env },

--- a/vscode/src/test/suite/ruby/rbenv.test.ts
+++ b/vscode/src/test/suite/ruby/rbenv.test.ts
@@ -27,11 +27,8 @@ suite("Rbenv", () => {
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
     const rbenv = new Rbenv(workspaceFolder, outputChannel);
 
-    const activationScript = [
-      "STDERR.print(",
-      "{env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION,home:Gem.user_dir,default:Gem.default_dir}",
-      ".to_json)",
-    ].join("");
+    const activationScript =
+      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
@@ -39,8 +36,6 @@ suite("Rbenv", () => {
         env: { ANY: "true" },
         yjit: true,
         version: "3.0.0",
-        home: "/home/user/.gem/ruby/3.0.0",
-        default: "/usr/lib/ruby/gems/3.0.0",
       }),
     });
 
@@ -55,15 +50,7 @@ suite("Rbenv", () => {
 
     assert.strictEqual(version, "3.0.0");
     assert.strictEqual(yjit, true);
-    assert.strictEqual(env.GEM_HOME, "/home/user/.gem/ruby/3.0.0");
-    assert.strictEqual(
-      env.GEM_PATH,
-      "/home/user/.gem/ruby/3.0.0:/usr/lib/ruby/gems/3.0.0",
-    );
-    assert.ok(env.PATH!.includes("/home/user/.gem/ruby/3.0.0/bin"));
-    assert.ok(env.PATH!.includes("/usr/lib/ruby/gems/3.0.0/bin"));
     assert.strictEqual(env.ANY, "true");
-
     execStub.restore();
   });
 });


### PR DESCRIPTION
### Motivation

Closes #1947

Rbenv doesn't actually modify the GEM_HOME or GEM_PATH. It also doesn't add gem binary directories into the PATH. It follows a similar approach to ASDF by adding its `shims` directory into the PATH.

### Implementation

We can rely on the `env.PATH` returned by the activation script directly, without setting anything manually. That should be enough to find the gem executables.

### Automated Tests

Adapted our tests.