### PR TITLE
Prevent debugger from printing to STDOUT

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -75,14 +75,18 @@ require "ruby_lsp/internal"
 
 if options[:debug]
   if ["x64-mingw-ucrt", "x64-mingw32"].include?(RUBY_PLATFORM)
-    puts "Debugging is not supported on Windows"
+    $stderr.puts "Debugging is not supported on Windows"
     exit 1
   end
 
   begin
+    original_stdout = $stdout
+    $stdout = $stderr
     require "debug/open_nonstop"
   rescue LoadError
-    warn("You need to install the debug gem to use the --debug flag")
+    $stderr.puts("You need to install the debug gem to use the --debug flag")
+  ensure
+    $stdout = original_stdout
   end
 end
 


### PR DESCRIPTION
### Motivation

The debugger and IRB sometimes print to stdout, which breaks the LSP communication with editors. We should prevent it from printing anything while we require the debugger.

### Implementation

Started redirecting stdout to stderr until we finish requiring the debugger.
