### PR TITLE
Allow configuring extra chruby paths

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -253,6 +253,10 @@
             "miseExecutablePath": {
               "description": "The path to the Mise executable, if not installed in ~/.local/bin/mise",
               "type": "string"
+            },
+            "chrubyRubies": {
+              "description": "An array of extra directories to search for Ruby installations when using chruby. Equivalent to the RUBIES environment variable",
+              "type": "array"
             }
           },
           "default": {

--- a/vscode/src/test/suite/ruby/chruby.test.ts
+++ b/vscode/src/test/suite/ruby/chruby.test.ts
@@ -6,6 +6,7 @@ import os from "os";
 
 import { before, after } from "mocha";
 import * as vscode from "vscode";
+import sinon from "sinon";
 
 import { Chruby } from "../../../ruby/chruby";
 import { WorkspaceChannel } from "../../../workspaceChannel";
@@ -154,6 +155,29 @@ suite("Chruby", () => {
     const { env, version, yjit } = await chruby.activate();
 
     assert.match(env.PATH!, new RegExp(`/ruby-${RUBY_VERSION}/bin`));
+    assert.strictEqual(version, RUBY_VERSION);
+    assert.notStrictEqual(yjit, undefined);
+  });
+
+  test("Finds Ruby when extra RUBIES are configured", async () => {
+    fs.writeFileSync(path.join(workspacePath, ".ruby-version"), RUBY_VERSION);
+
+    const configStub = sinon
+      .stub(vscode.workspace, "getConfiguration")
+      .returns({
+        get: (name: string) =>
+          name === "rubyVersionManager.chrubyRubies"
+            ? [path.join(rootPath, "opt", "rubies")]
+            : "",
+      } as any);
+
+    const chruby = new Chruby(workspaceFolder, outputChannel);
+    configStub.restore();
+
+    const { env, version, yjit } = await chruby.activate();
+
+    assert.match(env.GEM_PATH!, new RegExp(`ruby/${VERSION_REGEX}`));
+    assert.match(env.GEM_PATH!, new RegExp(`lib/ruby/gems/${VERSION_REGEX}`));
     assert.strictEqual(version, RUBY_VERSION);
     assert.notStrictEqual(yjit, undefined);
   });


### PR DESCRIPTION
### Motivation

Addressed the first part of #1969

Chruby allows configuring extra directories to search for Ruby installations. We'll need to offer a similar setting to match the behaviour.

### Implementation

Added the setting and started pushing the configured URIs into the list of places to search for.

### Automated Tests

Added a test.