### PR TITLE
Make module tracking lazy

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -60,29 +60,19 @@ module RubyIndexer
 
       abstract!
 
-      sig { returns(T::Array[String]) }
-      attr_accessor :included_modules
-
-      sig { returns(T::Array[String]) }
-      attr_accessor :prepended_modules
-
-      sig do
-        params(
-          name: String,
-          file_path: String,
-          location: T.any(Prism::Location, RubyIndexer::Location),
-          comments: T::Array[String],
-        ).void
-      end
-      def initialize(name, file_path, location, comments)
-        super(name, file_path, location, comments)
-        @included_modules = T.let([], T::Array[String])
-        @prepended_modules = T.let([], T::Array[String])
-      end
-
       sig { returns(String) }
       def short_name
         T.must(@name.split("::").last)
+      end
+
+      sig { returns(T::Array[String]) }
+      def included_modules
+        @included_modules ||= T.let([], T.nilable(T::Array[String]))
+      end
+
+      sig { returns(T::Array[String]) }
+      def prepended_modules
+        @prepended_modules ||= T.let([], T.nilable(T::Array[String]))
       end
     end
 


### PR DESCRIPTION
### Motivation

This is a small optimization to how we're tracking included and prepended modules. There's no need to eagerly create the arrays to store them, since there might be many modules that don't include or prepend anything.

### Implementation

Made the modules initialization lazy, so that the arrays are only created if we actually found an include or prepend.