### PR TITLE
Use ASDF home as the `ASDF_DIR`

### DIFF
--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -24,7 +24,7 @@ export class Asdf extends VersionManager {
       {
         cwd: this.bundleUri.fsPath,
         env: {
-          ASDF_DIR: path.dirname(asdfUri.fsPath),
+          ASDF_DIR: asdfDaraDirUri.fsPath,
           ASDF_DATA_DIR: asdfDaraDirUri.fsPath,
         },
       },


### PR DESCRIPTION
### Motivation

Apparently, even if you install ASDF through Homebrew, the expected `ASDF_DIR` is `~/.asdf` and not `/opt/homebrew/opt/asdf` (where the executable gets installed).

### Implementation

That path matches exactly what we use for the data dir, so I switched to use it on both variables.