### PR TITLE
Remove unused short_name method

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -60,11 +60,6 @@ module RubyIndexer
 
       abstract!
 
-      sig { returns(String) }
-      def short_name
-        T.must(@name.split("::").last)
-      end
-
       sig { returns(T::Array[String]) }
       def included_modules
         @included_modules ||= T.let([], T.nilable(T::Array[String]))


### PR DESCRIPTION
### Motivation

This method is not used anywhere.

### Implementation

Removed it.