### PR TITLE
Discard method call target if position doesn't cover identifier

### DIFF
--- a/lib/ruby_lsp/requests/request.rb
+++ b/lib/ruby_lsp/requests/request.rb
@@ -65,6 +65,20 @@ module RubyLsp
 
         target
       end
+
+      # Checks if a given location covers the position requested
+      sig { params(location: T.nilable(Prism::Location), position: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      def covers_position?(location, position)
+        return false unless location
+
+        start_line = location.start_line - 1
+        end_line = location.end_line - 1
+        line = position[:line]
+        character = position[:character]
+
+        (start_line < line || (start_line == line && location.start_column <= character)) &&
+          (end_line > line || (end_line == line && location.end_column >= character))
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation

With the current experience, clicking to go to the definition of a method (or hovering) over any part of the `CallNode` will always succeed. This is not what we want, since people should be able to go to definition or hover separately for method arguments.

It also leads to incorrect behaviour. For example:

```ruby
[].each(&:foo)
#         ^ go to definition here is currently taking you to `each`, which is not correct
```

### Implementation

We still need to locate the method calls based on the entire node, but if we're processing a method call that has no special handling (i.e.: not requires), then we need to ensure that the position being clicked is covered by method's identifier.

Otherwise, it means the user is clicking on the arguments node or on the receiver (neither of which should take you to the method declaration).

### Automated Tests

Added tests demonstrating the behaviour.