### PR TITLE
Support symbol procs in definition

### DIFF
--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -47,7 +47,7 @@ module RubyLsp
 
         target, parent, nesting = document.locate_node(
           position,
-          node_types: [Prism::CallNode, Prism::ConstantReadNode, Prism::ConstantPathNode],
+          node_types: [Prism::CallNode, Prism::ConstantReadNode, Prism::ConstantPathNode, Prism::BlockArgumentNode],
         )
 
         if target.is_a?(Prism::ConstantReadNode) && parent.is_a?(Prism::ConstantPathNode)

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -407,6 +407,8 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     source = <<~RUBY
       class Foo
         def foo(&block); end
+
+        def argument; end
       end
 
       bar.foo(&:argument)
@@ -417,16 +419,16 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       server.process_message(
         id: 1,
         method: "textDocument/definition",
-        params: { textDocument: { uri: uri }, position: { character: 12, line: 4 } },
+        params: { textDocument: { uri: uri }, position: { character: 12, line: 6 } },
       )
-      assert_empty(server.pop_response.response)
+      assert_equal(3, server.pop_response.response.first.range.start.line)
 
       server.process_message(
         id: 1,
         method: "textDocument/definition",
-        params: { textDocument: { uri: uri }, position: { character: 4, line: 4 } },
+        params: { textDocument: { uri: uri }, position: { character: 4, line: 6 } },
       )
-      refute_empty(server.pop_response.response)
+      assert_equal(1, server.pop_response.response.first.range.start.line)
     end
   end
 


### PR DESCRIPTION
### Motivation

Allow jumping to the definition of method calls passed as symbol proc arguments (e.g.: `map(&:to_i)`).

### Implementation

1. Started accepting `Prism::BlockArgumentNode` as a possible target to locate
2. Started handling that node type in the definition listener
3. Made a small refactor to make the method definition helper more reusable

### Automated Tests

Changed the example from #1981 to assert the right positions.