### PR TITLE
Update auto assign workflow to reflect team change

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -22,7 +22,6 @@ jobs:
               "dirceu",
               "paracycle",
               "vinistock",
-              "aryan-soni",
               "rafaelfranca",
               "Morriar",
               "st0012",
@@ -35,7 +34,6 @@ jobs:
               const dxReviewers = [
                 "andyw8",
                 "vinistock",
-                "aryan-soni",
                 "st0012",
               ];
               const assignee = dxReviewers[Math.floor(Math.random() * dxReviewers.length)];


### PR DESCRIPTION
I noticed that today's new issues were still assigned to Aryan, which can be avoided by updating the workflow.