### PR TITLE
Log invalid JSON environment

### DIFF
--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -30,7 +30,7 @@ export class Asdf extends VersionManager {
       },
     );
 
-    const parsedResult = JSON.parse(result.stderr);
+    const parsedResult = this.parseWithErrorHandling(result.stderr);
 
     // ASDF does not set GEM_HOME or GEM_PATH. It also does not add the gem bin directories to the PATH. Instead, it
     // adds its shims directory to the PATH, where all gems have a shim that invokes the gem's executable with the right

--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -145,6 +145,6 @@ export class Chruby extends VersionManager {
       { cwd: this.bundleUri.fsPath },
     );
 
-    return JSON.parse(result.stderr);
+    return this.parseWithErrorHandling(result.stderr);
   }
 }

--- a/vscode/src/ruby/custom.ts
+++ b/vscode/src/ruby/custom.ts
@@ -22,7 +22,7 @@ export class Custom extends VersionManager {
       },
     );
 
-    const parsedResult = JSON.parse(result.stderr);
+    const parsedResult = this.parseWithErrorHandling(result.stderr);
     return {
       env: { ...process.env, ...parsedResult.env },
       yjit: parsedResult.yjit,

--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -25,7 +25,7 @@ export class Mise extends VersionManager {
       },
     );
 
-    const parsedResult = JSON.parse(result.stderr);
+    const parsedResult = this.parseWithErrorHandling(result.stderr);
     return {
       env: { ...process.env, ...parsedResult.env },
       yjit: parsedResult.yjit,

--- a/vscode/src/ruby/none.ts
+++ b/vscode/src/ruby/none.ts
@@ -37,7 +37,7 @@ export class None extends VersionManager {
       },
     );
 
-    const parsedResult = JSON.parse(result.stderr);
+    const parsedResult = this.parseWithErrorHandling(result.stderr);
     return {
       env: { ...process.env, ...parsedResult.env },
       yjit: parsedResult.yjit,

--- a/vscode/src/ruby/rbenv.ts
+++ b/vscode/src/ruby/rbenv.ts
@@ -19,7 +19,7 @@ export class Rbenv extends VersionManager {
       },
     );
 
-    const parsedResult = JSON.parse(result.stderr);
+    const parsedResult = this.parseWithErrorHandling(result.stderr);
 
     return {
       env: { ...process.env, ...parsedResult.env },

--- a/vscode/src/ruby/rvm.ts
+++ b/vscode/src/ruby/rvm.ts
@@ -25,7 +25,7 @@ export class Rvm extends VersionManager {
       },
     );
 
-    const parsedResult = JSON.parse(result.stderr);
+    const parsedResult = this.parseWithErrorHandling(result.stderr);
     const activatedKeys = Object.entries(parsedResult.env)
       .map(([key, value]) => `${key}=${value}`)
       .join(" ");

--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -33,7 +33,7 @@ export class Shadowenv extends VersionManager {
         },
       );
 
-      const parsedResult = JSON.parse(result.stderr);
+      const parsedResult = this.parseWithErrorHandling(result.stderr);
       return {
         env: { ...process.env, ...parsedResult.env },
         yjit: parsedResult.yjit,

--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -42,4 +42,16 @@ export abstract class VersionManager {
   // Activate the Ruby environment for the version manager, returning all of the necessary information to boot the
   // language server
   abstract activate(): Promise<ActivationResult>;
+
+  protected parseWithErrorHandling(json: string) {
+    try {
+      return JSON.parse(json);
+    } catch (error: any) {
+      this.outputChannel.error(
+        `Tried parsing invalid JSON environment: ${json}`,
+      );
+
+      throw error;
+    }
+  }
 }

--- a/vscode/src/test/suite/ruby/rbenv.test.ts
+++ b/vscode/src/test/suite/ruby/rbenv.test.ts
@@ -53,4 +53,47 @@ suite("Rbenv", () => {
     assert.strictEqual(env.ANY, "true");
     execStub.restore();
   });
+
+  test("Reports invalid JSON environments", async () => {
+    // eslint-disable-next-line no-process-env
+    const workspacePath = process.env.PWD!;
+    const workspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
+    const rbenv = new Rbenv(workspaceFolder, outputChannel);
+
+    const activationScript =
+      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
+
+    const execStub = sinon.stub(common, "asyncExec").resolves({
+      stdout: "",
+      stderr: "not a json",
+    });
+
+    const errorStub = sinon.stub(outputChannel, "error");
+
+    await assert.rejects(
+      rbenv.activate(),
+      "SyntaxError: Unexpected token 'o', \"not a json\" is not valid JSON",
+    );
+
+    assert.ok(
+      execStub.calledOnceWithExactly(
+        `rbenv exec ruby -W0 -rjson -e '${activationScript}'`,
+        { cwd: workspacePath },
+      ),
+    );
+
+    assert.ok(
+      errorStub.calledOnceWithExactly(
+        "Tried parsing invalid JSON environment: not a json",
+      ),
+    );
+
+    execStub.restore();
+    errorStub.restore();
+  });
 });


### PR DESCRIPTION
### Motivation

When something goes wrong with a version manager and they produce an invalid environment JSON, it's hard to debug or understand what's going on. We should log what string we tried to parse so that we can more easily diagnose issues.

### Implementation

Created a `parseWithErrorHandling` helper in the `VersionManager` parent class, which tries to parse and logs the error if that fails. Then started using it in all version managers.

### Automated Tests

Added a test for `rbenv` only because the behaviour is the same on all other managers.