### PR TITLE
Add --time-index flag for timing index

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -18,6 +18,10 @@ parser = OptionParser.new do |opts|
     options[:debug] = true
   end
 
+  opts.on("--time-index", "Measure the time it takes to index the project") do
+    options[:time_index] = true
+  end
+
   opts.on(
     "--branch [BRANCH]",
     "Launch the Ruby LSP using the specified branch rather than the release version",
@@ -88,6 +92,16 @@ if options[:debug]
   ensure
     $stdout = original_stdout
   end
+end
+
+if options[:time_index]
+  require "benchmark"
+
+  index = RubyIndexer::Index.new
+
+  result = Benchmark.realtime { index.index_all }
+  puts "Ruby LSP v#{RubyLsp::VERSION}: Indexing took #{result.round(5)} seconds"
+  return
 end
 
 RubyLsp::Server.new.start


### PR DESCRIPTION
### Motivation

When working on indexing changes, we often care a lot about its performance impact. But currently there's no built-in utility for us to easily measure that.

### Implementation

Add a new `--time-index` flag to the `ruby-lsp` executable, which when applied will index the full project, print the result, and exit the process.

#### Example usage

1. Open a Ruby project
2. The VS Code extension should install Ruby LSP automatically. If not, run `gem install ruby-lsp` manually.
3. Run `ruby-lsp --time-index` and record the baseline result.
4. Update Gemfile to use the target version of Ruby LSP and run `bundle install`
5. Run `bundle exec ruby-lsp --time-index` and record the target result.
6. Compare the 2 results.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
