### PR TITLE
Replace RubyIndexer::Collector with RubyIndexer::DeclarationListener

### DIFF
--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -47,9 +47,7 @@ index = RubyIndexer::Index.new
 indexables = RubyIndexer.configuration.indexables
 
 indexables.each_with_index do |indexable, i|
-  result = Prism.parse(File.read(indexable.full_path))
-  collector = RubyIndexer::Collector.new(index, result, indexable.full_path)
-  collector.collect(result.value)
+  index.index_single(indexable)
 rescue => e
   errors[indexable.full_path] = e
 ensure

--- a/exe/ruby-lsp-doctor
+++ b/exe/ruby-lsp-doctor
@@ -19,8 +19,5 @@ puts "Globbing for indexable files"
 
 RubyIndexer.configuration.indexables.each do |indexable|
   puts "indexing: #{indexable.full_path}"
-  content = File.read(indexable.full_path)
-  result = Prism.parse(content)
-  collector = RubyIndexer::Collector.new(index, result, indexable.full_path)
-  collector.collect(result.value)
+  index.index_single(indexable)
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -185,9 +185,11 @@ module RubyIndexer
     sig { params(indexable_path: IndexablePath, source: T.nilable(String)).void }
     def index_single(indexable_path, source = nil)
       content = source || File.read(indexable_path.full_path)
+      dispatcher = Prism::Dispatcher.new
+
       result = Prism.parse(content)
-      collector = Collector.new(self, result, indexable_path.full_path)
-      collector.collect(result.value)
+      DeclarationListener.new(self, dispatcher, result, indexable_path.full_path)
+      dispatcher.dispatch(result.value)
 
       require_path = indexable_path.require_path
       @require_paths_tree.insert(require_path, indexable_path) if require_path

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -5,7 +5,7 @@ require "yaml"
 require "did_you_mean"
 
 require "ruby_indexer/lib/ruby_indexer/indexable_path"
-require "ruby_indexer/lib/ruby_indexer/collector"
+require "ruby_indexer/lib/ruby_indexer/declaration_listener"
 require "ruby_indexer/lib/ruby_indexer/index"
 require "ruby_indexer/lib/ruby_indexer/entry"
 require "ruby_indexer/lib/ruby_indexer/configuration"

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -14,6 +14,15 @@ module RubyIndexer
       assert_entry("Foo", Entry::Class, "/fake/path/foo.rb:0-0:1-3")
     end
 
+    def test_conditional_class
+      index(<<~RUBY)
+        class Foo
+        end if condition
+      RUBY
+
+      assert_entry("Foo", Entry::Class, "/fake/path/foo.rb:0-0:1-3")
+    end
+
     def test_class_with_statements
       index(<<~RUBY)
         class Foo
@@ -67,6 +76,15 @@ module RubyIndexer
       index(<<~RUBY)
         module Foo
         end
+      RUBY
+
+      assert_entry("Foo", Entry::Module, "/fake/path/foo.rb:0-0:1-3")
+    end
+
+    def test_conditional_module
+      index(<<~RUBY)
+        module Foo
+        end if condition
       RUBY
 
       assert_entry("Foo", Entry::Module, "/fake/path/foo.rb:0-0:1-3")

--- a/lib/ruby_indexer/test/constant_test.rb
+++ b/lib/ruby_indexer/test/constant_test.rb
@@ -12,10 +12,13 @@ module RubyIndexer
         class ::Bar
           FOO = 2
         end
+
+        BAR = 3 if condition
       RUBY
 
       assert_entry("FOO", Entry::Constant, "/fake/path/foo.rb:0-0:0-7")
       assert_entry("Bar::FOO", Entry::Constant, "/fake/path/foo.rb:3-2:3-9")
+      assert_entry("BAR", Entry::Constant, "/fake/path/foo.rb:6-0:6-7")
     end
 
     def test_constant_or_writes

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -16,6 +16,17 @@ module RubyIndexer
       assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
     end
 
+    def test_conditional_method
+      index(<<~RUBY)
+        class Foo
+          def bar
+          end if condition
+        end
+      RUBY
+
+      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+    end
+
     def test_singleton_method_using_self_receiver
       index(<<~RUBY)
         class Foo


### PR DESCRIPTION
### Motivation

This rewrite will give us a few benefits:

- We can use the same pattern as we write request listeners, which will make maintenance easier.
- It will make some future indexing features easier to implement. With collector, we don't have access to a node's leave events, which makes features like capturing visibility hard to implement.
- Since `Prism::Dispatcher` visits all nodes in the AST, we can now
  collect nodes that are defined unconventionally, like behind conditionals
  or begin blocks, just by doing the switching.

Unfortunately, this change will make indexing slower. In Core, it increases the indexing time from ~32 seconds to ~41 seconds (~28%). But on the other hand, if in the future `Prism::Dispatcher` receives performance improvements, the indexer will benefit automatically from them too.

### Implementation

1. Created a new `RubyIndexer::DeclarationListener` class
2. Besides having to take in a `Prism::Dispatcher` and register the relevant events, `DeclarationListener` can reuse most methods from `Collector` with minor tweaks and renaming.
3. Replaced all `Collector` references with `DeclarationListener`.

### Automated Tests

I added a few simple tests for the newly supported cases.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
