### PR TITLE
Turn off IRB integration on server launch

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -84,13 +84,10 @@ if options[:debug]
   end
 
   begin
-    original_stdout = $stdout
-    $stdout = $stderr
+    ENV.delete("RUBY_DEBUG_IRB_CONSOLE")
     require "debug/open_nonstop"
   rescue LoadError
     $stderr.puts("You need to install the debug gem to use the --debug flag")
-  ensure
-    $stdout = original_stdout
   end
 end
 


### PR DESCRIPTION
### Motivation

The previous approach of trying to avoid STDOUT prints from IRB doesn't work properly because it ends up swallowing the communication between the debugger and the editor - making it impossible to attach.

### Implementation

I started turning off the IRB integration (which is the thing printing to STDOUT) when we launch the server in debug mode instead.