### PR TITLE
Mention that bundleGemfile is not intended for multiroot workspaces

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -289,7 +289,7 @@
           "default": null
         },
         "rubyLsp.bundleGemfile": {
-          "description": "Relative or absolute path to the Gemfile to use for bundling the Ruby LSP server. Only necessary when using a separate Gemfile for the Ruby LSP",
+          "description": "Relative or absolute path to the Gemfile to use for bundling the Ruby LSP server. Do not use this if you're working on a monorepo or your project's Gemfile is in a subdirectory (look into multiroot workspaces instead). Only necessary when using a separate Gemfile for the Ruby LSP",
           "type": "string",
           "default": ""
         },


### PR DESCRIPTION
### Motivation

Explicitly mention that the `bundleGemfile` option is not intended for multi-root workspaces, but rather for users that have an independent Gemfile for their tooling separate from their project's bundle.
