### PR TITLE
Add ability to linearize ancestors

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -68,8 +68,10 @@ module RubyIndexer
         superclass.slice
       end
 
+      nesting = name.start_with?("::") ? [name.delete_prefix("::")] : @stack + [name.delete_prefix("::")]
+
       entry = Entry::Class.new(
-        fully_qualify_name(name),
+        nesting,
         @file_path,
         node.location,
         comments,
@@ -94,7 +96,9 @@ module RubyIndexer
       name = node.constant_path.location.slice
 
       comments = collect_comments(node)
-      entry = Entry::Module.new(fully_qualify_name(name), @file_path, node.location, comments)
+
+      nesting = name.start_with?("::") ? [name.delete_prefix("::")] : @stack + [name.delete_prefix("::")]
+      entry = Entry::Module.new(nesting, @file_path, node.location, comments)
 
       @owner_stack << entry
       @index << entry
@@ -205,10 +209,8 @@ module RubyIndexer
         handle_attribute(node, reader: false, writer: true)
       when :attr_accessor
         handle_attribute(node, reader: true, writer: true)
-      when :include
-        handle_module_operation(node, :included_modules)
-      when :prepend
-        handle_module_operation(node, :prepended_modules)
+      when :include, :prepend, :extend
+        handle_module_operation(node, message)
       when :public
         @visibility_stack.push(Entry::Visibility::PUBLIC)
       when :protected
@@ -481,14 +483,14 @@ module RubyIndexer
 
       names = arguments.filter_map do |node|
         if node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
-          node.full_name
+          [operation, node.full_name]
         end
       rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError,
              Prism::ConstantPathNode::MissingNodesInConstantPathError
         # Do nothing
       end
-      collection = operation == :included_modules ? owner.included_modules : owner.prepended_modules
-      collection.concat(names)
+
+      owner.modules.concat(names)
     end
 
     sig { returns(Entry::Visibility) }

--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -481,16 +481,21 @@ module RubyIndexer
       arguments = node.arguments&.arguments
       return unless arguments
 
-      names = arguments.filter_map do |node|
-        if node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
-          [operation, node.full_name]
+      arguments.each do |node|
+        next unless node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
+
+        case operation
+        when :include
+          owner.mixin_operations << Entry::Include.new(node.full_name)
+        when :prepend
+          owner.mixin_operations << Entry::Prepend.new(node.full_name)
+        when :extend
+          owner.mixin_operations << Entry::Extend.new(node.full_name)
         end
       rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError,
              Prism::ConstantPathNode::MissingNodesInConstantPathError
         # Do nothing
       end
-
-      owner.modules.concat(names)
     end
 
     sig { returns(Entry::Visibility) }

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -369,13 +369,13 @@ module RubyIndexer
       RUBY
 
       foo = T.must(@index["Foo"][0])
-      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.modules.flat_map(&:last))
+      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.mixin_operation_module_names)
 
       qux = T.must(@index["Foo::Qux"][0])
-      assert_equal(["Corge", "Corge", "Baz"], qux.modules.flat_map(&:last))
+      assert_equal(["Corge", "Corge", "Baz"], qux.mixin_operation_module_names)
 
       constant_path_references = T.must(@index["ConstantPathReferences"][0])
-      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.modules.flat_map(&:last))
+      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.mixin_operation_module_names)
     end
 
     def test_keeping_track_of_prepended_modules
@@ -415,13 +415,13 @@ module RubyIndexer
       RUBY
 
       foo = T.must(@index["Foo"][0])
-      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.modules.flat_map(&:last))
+      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.mixin_operation_module_names)
 
       qux = T.must(@index["Foo::Qux"][0])
-      assert_equal(["Corge", "Corge", "Baz"], qux.modules.flat_map(&:last))
+      assert_equal(["Corge", "Corge", "Baz"], qux.mixin_operation_module_names)
 
       constant_path_references = T.must(@index["ConstantPathReferences"][0])
-      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.modules.flat_map(&:last))
+      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.mixin_operation_module_names)
     end
 
     def test_keeping_track_of_extended_modules
@@ -461,13 +461,13 @@ module RubyIndexer
       RUBY
 
       foo = T.must(@index["Foo"][0])
-      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.modules.flat_map(&:last))
+      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.mixin_operation_module_names)
 
       qux = T.must(@index["Foo::Qux"][0])
-      assert_equal(["Corge", "Corge", "Baz"], qux.modules.flat_map(&:last))
+      assert_equal(["Corge", "Corge", "Baz"], qux.mixin_operation_module_names)
 
       constant_path_references = T.must(@index["ConstantPathReferences"][0])
-      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.modules.flat_map(&:last))
+      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.mixin_operation_module_names)
     end
   end
 end

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -369,13 +369,13 @@ module RubyIndexer
       RUBY
 
       foo = T.must(@index["Foo"][0])
-      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.included_modules)
+      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.modules.flat_map(&:last))
 
       qux = T.must(@index["Foo::Qux"][0])
-      assert_equal(["Corge", "Corge", "Baz"], qux.included_modules)
+      assert_equal(["Corge", "Corge", "Baz"], qux.modules.flat_map(&:last))
 
       constant_path_references = T.must(@index["ConstantPathReferences"][0])
-      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.included_modules)
+      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.modules.flat_map(&:last))
     end
 
     def test_keeping_track_of_prepended_modules
@@ -415,13 +415,59 @@ module RubyIndexer
       RUBY
 
       foo = T.must(@index["Foo"][0])
-      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.prepended_modules)
+      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.modules.flat_map(&:last))
 
       qux = T.must(@index["Foo::Qux"][0])
-      assert_equal(["Corge", "Corge", "Baz"], qux.prepended_modules)
+      assert_equal(["Corge", "Corge", "Baz"], qux.modules.flat_map(&:last))
 
       constant_path_references = T.must(@index["ConstantPathReferences"][0])
-      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.prepended_modules)
+      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.modules.flat_map(&:last))
+    end
+
+    def test_keeping_track_of_extended_modules
+      index(<<~RUBY)
+        class Foo
+          # valid syntaxes that we can index
+          extend A1
+          self.extend A2
+          extend A3, A4
+          self.extend A5, A6
+
+          # valid syntaxes that we cannot index because of their dynamic nature
+          extend some_variable_or_method_call
+          self.extend some_variable_or_method_call
+
+          def something
+            extend A7 # We should not index this because of this dynamic nature
+          end
+
+          # Valid inner class syntax definition with its own modules prepended
+          class Qux
+            extend Corge
+            self.extend Corge
+            extend Baz
+
+            extend some_variable_or_method_call
+          end
+        end
+
+        class ConstantPathReferences
+          extend Foo::Bar
+          self.extend Foo::Bar2
+
+          extend dynamic::Bar
+          extend Foo::
+        end
+      RUBY
+
+      foo = T.must(@index["Foo"][0])
+      assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.modules.flat_map(&:last))
+
+      qux = T.must(@index["Foo::Qux"][0])
+      assert_equal(["Corge", "Corge", "Baz"], qux.modules.flat_map(&:last))
+
+      constant_path_references = T.must(@index["ConstantPathReferences"][0])
+      assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.modules.flat_map(&:last))
     end
   end
 end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -669,5 +669,20 @@ module RubyIndexer
       assert_equal(["Foo"], @index.linearized_ancestors_of("Foo"))
       assert_equal(["Bar"], @index.linearized_ancestors_of("Bar"))
     end
+
+    def test_linearizing_circular_aliased_dependency
+      index(<<~RUBY)
+        module A
+        end
+
+        ALIAS = A
+
+        module A
+          include ALIAS
+        end
+      RUBY
+
+      assert_equal(["A", "ALIAS"], @index.linearized_ancestors_of("A"))
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Step towards https://github.com/Shopify/ruby-lsp/issues/1333

Add the ability to linearize ancestors for a given name.

### Implementation

1. Changed the way we remember included, prepend and extended modules. We were throwing everything in separate arrays, but in reality we need to remember the exact order between prepends and includes to ensure we linearize it the right way
2. Added the linearization algorithm

The algorithm works like this:

```ruby
class Foo < Bar
  include A
  prepend B
end
```

1. Start with the namespace itself `[Foo]`
2. Handle the include. We must linearize the ancestors of `A` and ensure we're removing any duplicate modules that have already been prepended or included
3. Then handle the prepend. We must linearize the ancestors of `B` and only remove duplicates if they are present in the prepended modules. It is allowed to have duplicates if the module was included

Looking at the tests will better clarify the edge cases.

### Automated Tests

Added a bunch of tests and tried to cover all corner cases I could think of. Please let me know if you can think of other cases.