### PR TITLE
Use owner stack to associate owners to methods

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -11,7 +11,6 @@ module RubyIndexer
     def initialize(index, dispatcher, parse_result, file_path)
       @index = index
       @file_path = file_path
-      @stack = T.let([], T::Array[String])
       @comments_by_line = T.let(
         parse_result.comments.to_h do |c|
           [c.location.start_line, c]
@@ -19,7 +18,13 @@ module RubyIndexer
         T::Hash[Integer, Prism::Comment],
       )
       @inside_def = T.let(false, T::Boolean)
-      @current_owner = T.let(nil, T.nilable(Entry::Namespace))
+
+      # The nesting stack we're currently inside. Used to determine the fully qualified name of constants, but only
+      # stored by unresolved aliases which need the original nesting to be lazily resolved
+      @stack = T.let([], T::Array[String])
+
+      # A stack of namespace entries that represent where we currently are. Used to properly assign methods to an owner
+      @owner_stack = T.let([], T::Array[Entry::Namespace])
 
       dispatcher.register(
         self,
@@ -57,20 +62,23 @@ module RubyIndexer
         superclass.slice
       end
 
-      @current_owner = Entry::Class.new(
+      entry = Entry::Class.new(
         fully_qualify_name(name),
         @file_path,
         node.location,
         comments,
         parent_class,
       )
-      @index << @current_owner
+
+      @owner_stack << entry
+      @index << entry
       @stack << name
     end
 
     sig { params(node: Prism::ClassNode).void }
     def on_class_node_leave(node)
       @stack.pop
+      @owner_stack.pop
     end
 
     sig { params(node: Prism::ModuleNode).void }
@@ -79,14 +87,17 @@ module RubyIndexer
       return unless /^[A-Z:]/.match?(name)
 
       comments = collect_comments(node)
-      @current_owner = Entry::Module.new(fully_qualify_name(name), @file_path, node.location, comments)
-      @index << @current_owner
+      entry = Entry::Module.new(fully_qualify_name(name), @file_path, node.location, comments)
+
+      @owner_stack << entry
+      @index << entry
       @stack << name
     end
 
     sig { params(node: Prism::ModuleNode).void }
     def on_module_node_leave(node)
       @stack.pop
+      @owner_stack.pop
     end
 
     sig { params(node: Prism::MultiWriteNode).void }
@@ -206,7 +217,7 @@ module RubyIndexer
           node.location,
           comments,
           node.parameters,
-          @current_owner,
+          @owner_stack.last,
         )
       when Prism::SelfNode
         @index << Entry::SingletonMethod.new(
@@ -215,7 +226,7 @@ module RubyIndexer
           node.location,
           comments,
           node.parameters,
-          @current_owner,
+          @owner_stack.last,
         )
       end
     end
@@ -346,15 +357,17 @@ module RubyIndexer
 
         next unless name && loc
 
-        @index << Entry::Accessor.new(name, @file_path, loc, comments, @current_owner) if reader
-        @index << Entry::Accessor.new("#{name}=", @file_path, loc, comments, @current_owner) if writer
+        @index << Entry::Accessor.new(name, @file_path, loc, comments, @owner_stack.last) if reader
+        @index << Entry::Accessor.new("#{name}=", @file_path, loc, comments, @owner_stack.last) if writer
       end
     end
 
     sig { params(node: Prism::CallNode, operation: Symbol).void }
     def handle_module_operation(node, operation)
       return if @inside_def
-      return unless @current_owner
+
+      owner = @owner_stack.last
+      return unless owner
 
       arguments = node.arguments&.arguments
       return unless arguments
@@ -368,7 +381,7 @@ module RubyIndexer
         # If a constant path reference is dynamic or missing parts, we can't
         # index it
       end
-      collection = operation == :included_modules ? @current_owner.included_modules : @current_owner.prepended_modules
+      collection = operation == :included_modules ? owner.included_modules : owner.prepended_modules
       collection.concat(names)
     end
   end

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -296,5 +296,28 @@ module RubyIndexer
 
       assert_no_entry("bar")
     end
+
+    def test_properly_tracks_multiple_levels_of_nesting
+      index(<<~RUBY)
+        module Foo
+          def first; end
+
+          module Bar
+            def second; end
+          end
+
+          def third; end
+        end
+      RUBY
+
+      entry = T.must(@index["first"]&.first)
+      assert_equal("Foo", T.must(entry.owner).name)
+
+      entry = T.must(@index["second"]&.first)
+      assert_equal("Foo::Bar", T.must(entry.owner).name)
+
+      entry = T.must(@index["third"]&.first)
+      assert_equal("Foo", T.must(entry.owner).name)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Closes #1338

Previous attempt #1264.

We cannot use a single owner value to keep track of method owners because there might be several levels of nesting. We need to use a stack.

On the original PR, the main source of discussion was that it was trying to get rid of `@stack` to have only an owner stack. Unfortunately, that would break aliases which need to remember the exact nesting in which they were found.

Thinking more about the problem, I think it should be fine to maintain two separate stacks. The only values that need to remember the exact nesting where they were discovered are unresolved aliases. Being forced to store the original nesting arrays on every namespace would be wasteful. Better to use two arrays and let them be garbage collected as soon as we're done.

### Implementation

Changed `@current_owner` to be an `@owner_stack` instead.

### Automated Tests

Added a test that reproduces the bug.