### PR TITLE
Support inherited methods in definition, hover and completion

### DIFF
--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -684,5 +684,29 @@ module RubyIndexer
 
       assert_equal(["A", "ALIAS"], @index.linearized_ancestors_of("A"))
     end
+
+    def test_resolving_an_inherited_method
+      index(<<~RUBY)
+        module Foo
+          def baz; end
+        end
+
+        class Bar
+          def qux; end
+        end
+
+        class Wow < Bar
+          include Foo
+        end
+      RUBY
+
+      entry = T.must(@index.resolve_method("baz", "Wow")&.first)
+      assert_equal("baz", entry.name)
+      assert_equal("Foo", T.must(entry.owner).name)
+
+      entry = T.must(@index.resolve_method("qux", "Wow")&.first)
+      assert_equal("qux", entry.name)
+      assert_equal("Bar", T.must(entry.owner).name)
+    end
   end
 end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -708,5 +708,30 @@ module RubyIndexer
       assert_equal("qux", entry.name)
       assert_equal("Bar", T.must(entry.owner).name)
     end
+
+    def test_resolving_an_inherited_method_lands_on_first_match
+      index(<<~RUBY)
+        module Foo
+          def qux; end
+        end
+
+        class Bar
+          def qux; end
+        end
+
+        class Wow < Bar
+          prepend Foo
+
+          def qux; end
+        end
+      RUBY
+
+      entries = T.must(@index.resolve_method("qux", "Wow"))
+      assert_equal(1, entries.length)
+
+      entry = T.must(entries.first)
+      assert_equal("qux", entry.name)
+      assert_equal("Foo", T.must(entry.owner).name)
+    end
   end
 end

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -265,9 +265,10 @@ module RubyLsp
         return unless receiver_entries
 
         receiver = T.must(receiver_entries.first)
+        ancestors = @index.linearized_ancestors_of(receiver.name)
 
         @index.prefix_search(name).each do |entries|
-          entry = entries.find { |e| e.is_a?(RubyIndexer::Entry::Member) && e.owner&.name == receiver.name }
+          entry = entries.find { |e| e.is_a?(RubyIndexer::Entry::Member) && ancestors.any?(e.owner&.name) }
           next unless entry
 
           @response_builder << build_method_completion(T.cast(entry, RubyIndexer::Entry::Member), node)

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -522,6 +522,47 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_definition_for_inherited_methods
+    source = <<~RUBY
+      module Foo
+        module First
+          def method1; end
+        end
+
+        class Bar
+          def method2; end
+        end
+
+        class Baz < Bar
+          include First
+
+          def method3
+            method1
+            method2
+          end
+        end
+      end
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 6, line: 13 } },
+      )
+      response = server.pop_response.response.first
+      assert_equal(2, response.range.start.line)
+
+      server.process_message(
+        id: 1,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 6, line: 14 } },
+      )
+      response = server.pop_response.response.first
+      assert_equal(6, response.range.start.line)
+    end
+  end
+
   private
 
   def create_definition_addon

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -346,6 +346,48 @@ class HoverExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_hovering_over_inherited_methods
+    source = <<~RUBY
+      module Foo
+        module First
+          # Method 1
+          def method1; end
+        end
+
+        class Bar
+          # Method 2
+          def method2; end
+        end
+
+        class Baz < Bar
+          include First
+
+          def method3
+            method1
+            method2
+          end
+        end
+      end
+    RUBY
+
+    # Going to definition on `argument` should not take you to the `foo` method definition
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/hover",
+        params: { textDocument: { uri: uri }, position: { character: 6, line: 15 } },
+      )
+      assert_match("Method 1", server.pop_response.response.contents.value)
+
+      server.process_message(
+        id: 1,
+        method: "textDocument/hover",
+        params: { textDocument: { uri: uri }, position: { character: 6, line: 16 } },
+      )
+      assert_match("Method 2", server.pop_response.response.contents.value)
+    end
+  end
+
   private
 
   def create_hover_addon


### PR DESCRIPTION
### Motivation

Step towards #899

Use the linearized ancestor information from #2024 to support inherited methods for definition, hover and completion.

### Implementation

1. Changed `resolve_method` to linearize ancestors lazily. Then we search ancestors in order and return the first methods we return, which ensures we jump to the right method
2. Adapted completion to consider all ancestors when filtering possible methods being invoked

### Automated Tests

Added tests.


https://github.com/Shopify/ruby-lsp/assets/18742907/ad6ff4e5-33b2-4f79-ac88-93f0846bbdf1
