### PR TITLE
Add RubyMine note

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -181,3 +181,7 @@ To configure the Ruby LSP using [LSP for Sublime Text](https://github.com/sublim
 ```
 
 Restart LSP or Sublime Text and `ruby-lsp` will automatically activate when opening ruby files.
+
+## RubyMine (not yet supported)
+
+Although there is overlap between the features provided by RubyMine and Ruby LSP, there may be benefits in using both together. RubyMine has a [LSP API](https://blog.jetbrains.com/ruby/2023/07/the-rubymine-2023-2-beta-updated-ai-assistant-lsp-api-for-plugin-developers-and-more/), so adding support would involve writing a plugin using Kotlin. The [rubymine-sorbet-lsp](https://github.com/simoleone/rubymine-sorbet-lsp) project may be a useful reference for this.


### PR DESCRIPTION
At RailsConf, some people were curious if the ruby-lsp-rails features could be used with RubyMine. I sat with a RubyMine user to see if there's was any built-in support for LSPs but it seems there isn't.