### PR TITLE
Remove magic comment version handling for tests

### DIFF
--- a/test/expectations/document_symbol/def_endless.exp.json
+++ b/test/expectations/document_symbol/def_endless.exp.json
@@ -5,21 +5,21 @@
       "kind": 6,
       "range": {
         "start": {
-          "line": 2,
+          "line": 0,
           "character": 0
         },
         "end": {
-          "line": 2,
+          "line": 0,
           "character": 12
         }
       },
       "selectionRange": {
         "start": {
-          "line": 2,
+          "line": 0,
           "character": 4
         },
         "end": {
-          "line": 2,
+          "line": 0,
           "character": 7
         }
       },

--- a/test/expectations/expectations_test_runner.rb
+++ b/test/expectations/expectations_test_runner.rb
@@ -44,14 +44,7 @@ class ExpectationsTestRunner < Minitest::Test
           raise "multiple expectations for #{test_name}"
         end
 
-        required_ruby_version = ruby_requirement_magic_comment_version(path)
-        if required_ruby_version && RUBY_VERSION < required_ruby_version
-          class_eval(<<~RB, __FILE__, __LINE__ + 1)
-            def test_#{expectation_suffix}__#{test_name}
-              skip "Fixture requires Ruby v#{required_ruby_version} while currently running v#{RUBY_VERSION}"
-            end
-          RB
-        elsif expectation_path && File.file?(expectation_path)
+        if expectation_path && File.file?(expectation_path)
           class_eval(<<~RB, __FILE__, __LINE__ + 1)
             def test_#{expectation_suffix}__#{test_name}
               @_path = "#{path}"
@@ -90,15 +83,6 @@ class ExpectationsTestRunner < Minitest::Test
     # to test_fixtures_prism_test_prism_fixtures_unparser_corpus_semantic_and
     def uniq_name_from_path(path)
       path.gsub("/", "_").gsub('.txt', '')
-    end
-
-    def ruby_requirement_magic_comment_version(fixture_path)
-      File.read(fixture_path)
-        .lines
-        .first
-        &.match(/^#\s*required_ruby_version:\s*(?<version>\d+\.\d+(\.\d+)?)$/)
-        &.named_captures
-        &.fetch("version")
     end
   end
 

--- a/test/expectations/selection_ranges/def_endless.exp.json
+++ b/test/expectations/selection_ranges/def_endless.exp.json
@@ -1,7 +1,7 @@
 {
     "params": [
         {
-            "line": 2,
+            "line": 0,
             "character": 2
         }
     ],
@@ -9,33 +9,33 @@
         {
             "range": {
                 "start": {
-                    "line": 2,
+                    "line": 0,
                     "character": 0
                 },
                 "end": {
-                    "line": 2,
+                    "line": 0,
                     "character": 12
                 }
             },
             "parent": {
                 "range": {
                     "start": {
-                        "line": 2,
+                        "line": 0,
                         "character": 0
                     },
                     "end": {
-                        "line": 2,
+                        "line": 0,
                         "character": 12
                     }
                 },
                 "parent": {
                     "range": {
                         "start": {
-                            "line": 2,
+                            "line": 0,
                             "character": 0
                         },
                         "end": {
-                            "line": 2,
+                            "line": 0,
                             "character": 12
                         }
                     }

--- a/test/expectations/semantic_highlighting/def_endless.exp.json
+++ b/test/expectations/semantic_highlighting/def_endless.exp.json
@@ -1,7 +1,7 @@
 {
   "result": [
     {
-      "delta_line": 2,
+      "delta_line": 0,
       "delta_start_char": 4,
       "length": 3,
       "token_type": 13,

--- a/test/fixtures/def_endless.rb
+++ b/test/fixtures/def_endless.rb
@@ -1,3 +1,1 @@
-# required_ruby_version: 3.0
-
 def baz = 10


### PR DESCRIPTION
Since we longer test on Rubies older than 3.0, the `required_ruby_version` magic comment handling wasn't being used.

There might be some new syntax in future that would need a similar approach, but we can restore the code from the git history if that ever becomes necessary.