### PR TITLE
Support instance variables for definition, hover, completion and workspace symbols

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -242,7 +242,7 @@ module RubyIndexer
     sig { params(node: Prism::InstanceVariableWriteNode).void }
     def on_instance_variable_write_node_enter(node)
       name = node.name.to_s
-      return if name.length == 1
+      return if name == "@"
 
       @index << Entry::InstanceVariable.new(
         name,
@@ -256,7 +256,7 @@ module RubyIndexer
     sig { params(node: Prism::InstanceVariableAndWriteNode).void }
     def on_instance_variable_and_write_node_enter(node)
       name = node.name.to_s
-      return if name.length == 1
+      return if name == "@"
 
       @index << Entry::InstanceVariable.new(
         name,
@@ -270,7 +270,7 @@ module RubyIndexer
     sig { params(node: Prism::InstanceVariableOperatorWriteNode).void }
     def on_instance_variable_operator_write_node_enter(node)
       name = node.name.to_s
-      return if name.length == 1
+      return if name == "@"
 
       @index << Entry::InstanceVariable.new(
         name,
@@ -284,7 +284,7 @@ module RubyIndexer
     sig { params(node: Prism::InstanceVariableOrWriteNode).void }
     def on_instance_variable_or_write_node_enter(node)
       name = node.name.to_s
-      return if name.length == 1
+      return if name == "@"
 
       @index << Entry::InstanceVariable.new(
         name,
@@ -298,7 +298,7 @@ module RubyIndexer
     sig { params(node: Prism::InstanceVariableTargetNode).void }
     def on_instance_variable_target_node_enter(node)
       name = node.name.to_s
-      return if name.length == 1
+      return if name == "@"
 
       @index << Entry::InstanceVariable.new(
         name,

--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -45,6 +45,11 @@ module RubyIndexer
         :on_constant_or_write_node_enter,
         :on_constant_and_write_node_enter,
         :on_constant_operator_write_node_enter,
+        :on_instance_variable_write_node_enter,
+        :on_instance_variable_and_write_node_enter,
+        :on_instance_variable_operator_write_node_enter,
+        :on_instance_variable_or_write_node_enter,
+        :on_instance_variable_target_node_enter,
       )
     end
 
@@ -206,6 +211,7 @@ module RubyIndexer
       @inside_def = true
       method_name = node.name.to_s
       comments = collect_comments(node)
+
       case node.receiver
       when nil
         @index << Entry::InstanceMethod.new(
@@ -231,6 +237,76 @@ module RubyIndexer
     sig { params(node: Prism::DefNode).void }
     def on_def_node_leave(node)
       @inside_def = false
+    end
+
+    sig { params(node: Prism::InstanceVariableWriteNode).void }
+    def on_instance_variable_write_node_enter(node)
+      name = node.name.to_s
+      return if name.length == 1
+
+      @index << Entry::InstanceVariable.new(
+        name,
+        @file_path,
+        node.name_loc,
+        collect_comments(node),
+        @owner_stack.last,
+      )
+    end
+
+    sig { params(node: Prism::InstanceVariableAndWriteNode).void }
+    def on_instance_variable_and_write_node_enter(node)
+      name = node.name.to_s
+      return if name.length == 1
+
+      @index << Entry::InstanceVariable.new(
+        name,
+        @file_path,
+        node.name_loc,
+        collect_comments(node),
+        @owner_stack.last,
+      )
+    end
+
+    sig { params(node: Prism::InstanceVariableOperatorWriteNode).void }
+    def on_instance_variable_operator_write_node_enter(node)
+      name = node.name.to_s
+      return if name.length == 1
+
+      @index << Entry::InstanceVariable.new(
+        name,
+        @file_path,
+        node.name_loc,
+        collect_comments(node),
+        @owner_stack.last,
+      )
+    end
+
+    sig { params(node: Prism::InstanceVariableOrWriteNode).void }
+    def on_instance_variable_or_write_node_enter(node)
+      name = node.name.to_s
+      return if name.length == 1
+
+      @index << Entry::InstanceVariable.new(
+        name,
+        @file_path,
+        node.name_loc,
+        collect_comments(node),
+        @owner_stack.last,
+      )
+    end
+
+    sig { params(node: Prism::InstanceVariableTargetNode).void }
+    def on_instance_variable_target_node_enter(node)
+      name = node.name.to_s
+      return if name.length == 1
+
+      @index << Entry::InstanceVariable.new(
+        name,
+        @file_path,
+        node.location,
+        collect_comments(node),
+        @owner_stack.last,
+      )
     end
 
     private

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -380,5 +380,25 @@ module RubyIndexer
         @target = target
       end
     end
+
+    # Represents an instance variable e.g.: @a = 1
+    class InstanceVariable < Entry
+      sig { returns(T.nilable(Entry::Namespace)) }
+      attr_reader :owner
+
+      sig do
+        params(
+          name: String,
+          file_path: String,
+          location: T.any(Prism::Location, RubyIndexer::Location),
+          comments: T::Array[String],
+          owner: T.nilable(Entry::Namespace),
+        ).void
+      end
+      def initialize(name, file_path, location, comments, owner)
+        super(name, file_path, location, comments)
+        @owner = owner
+      end
+    end
   end
 end

--- a/lib/ruby_indexer/test/instance_variables_test.rb
+++ b/lib/ruby_indexer/test/instance_variables_test.rb
@@ -112,5 +112,20 @@ module RubyIndexer
 
       refute_entry("@")
     end
+
+    def test_class_instance_variables
+      index(<<~RUBY)
+        module Foo
+          class Bar
+            @a = 123
+          end
+        end
+      RUBY
+
+      assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:2-4:2-6")
+
+      entry = T.must(@index["@a"]&.first)
+      assert_equal("Foo::Bar", T.must(entry.owner).name)
+    end
   end
 end

--- a/lib/ruby_indexer/test/instance_variables_test.rb
+++ b/lib/ruby_indexer/test/instance_variables_test.rb
@@ -1,0 +1,116 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module RubyIndexer
+  class InstanceVariableTest < TestCase
+    def test_instance_variable_write
+      index(<<~RUBY)
+        module Foo
+          class Bar
+            def initialize
+              # Hello
+              @a = 1
+            end
+          end
+        end
+      RUBY
+
+      assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
+
+      entry = T.must(@index["@a"]&.first)
+      assert_equal("Foo::Bar", T.must(entry.owner).name)
+    end
+
+    def test_instance_variable_and_write
+      index(<<~RUBY)
+        module Foo
+          class Bar
+            def initialize
+              # Hello
+              @a &&= value
+            end
+          end
+        end
+      RUBY
+
+      assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
+
+      entry = T.must(@index["@a"]&.first)
+      assert_equal("Foo::Bar", T.must(entry.owner).name)
+    end
+
+    def test_instance_variable_operator_write
+      index(<<~RUBY)
+        module Foo
+          class Bar
+            def initialize
+              # Hello
+              @a += value
+            end
+          end
+        end
+      RUBY
+
+      assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
+
+      entry = T.must(@index["@a"]&.first)
+      assert_equal("Foo::Bar", T.must(entry.owner).name)
+    end
+
+    def test_instance_variable_or_write
+      index(<<~RUBY)
+        module Foo
+          class Bar
+            def initialize
+              # Hello
+              @a ||= value
+            end
+          end
+        end
+      RUBY
+
+      assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
+
+      entry = T.must(@index["@a"]&.first)
+      assert_equal("Foo::Bar", T.must(entry.owner).name)
+    end
+
+    def test_instance_variable_target
+      index(<<~RUBY)
+        module Foo
+          class Bar
+            def initialize
+              # Hello
+              @a, @b = [1, 2]
+            end
+          end
+        end
+      RUBY
+
+      assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
+      assert_entry("@b", Entry::InstanceVariable, "/fake/path/foo.rb:4-10:4-12")
+
+      entry = T.must(@index["@a"]&.first)
+      assert_equal("Foo::Bar", T.must(entry.owner).name)
+
+      entry = T.must(@index["@b"]&.first)
+      assert_equal("Foo::Bar", T.must(entry.owner).name)
+    end
+
+    def test_empty_name_instance_variables
+      index(<<~RUBY)
+        module Foo
+          class Bar
+            def initialize
+              @ = 123
+            end
+          end
+        end
+      RUBY
+
+      refute_entry("@")
+    end
+  end
+end

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -111,6 +111,36 @@ module RubyLsp
         end
       end
 
+      sig { params(node: Prism::InstanceVariableReadNode).void }
+      def on_instance_variable_read_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.location)
+      end
+
+      sig { params(node: Prism::InstanceVariableWriteNode).void }
+      def on_instance_variable_write_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.name_loc)
+      end
+
+      sig { params(node: Prism::InstanceVariableAndWriteNode).void }
+      def on_instance_variable_and_write_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.name_loc)
+      end
+
+      sig { params(node: Prism::InstanceVariableOperatorWriteNode).void }
+      def on_instance_variable_operator_write_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.name_loc)
+      end
+
+      sig { params(node: Prism::InstanceVariableOrWriteNode).void }
+      def on_instance_variable_or_write_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.name_loc)
+      end
+
+      sig { params(node: Prism::InstanceVariableTargetNode).void }
+      def on_instance_variable_target_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.location)
+      end
+
       private
 
       sig { params(name: String, range: Interface::Range).void }
@@ -157,36 +187,6 @@ module RubyLsp
             top_level_reference || top_level?(T.must(entries.first).name),
           )
         end
-      end
-
-      sig { params(node: Prism::InstanceVariableReadNode).void }
-      def on_instance_variable_read_node_enter(node)
-        handle_instance_variable_completion(node.name.to_s, node.location)
-      end
-
-      sig { params(node: Prism::InstanceVariableWriteNode).void }
-      def on_instance_variable_write_node_enter(node)
-        handle_instance_variable_completion(node.name.to_s, node.name_loc)
-      end
-
-      sig { params(node: Prism::InstanceVariableAndWriteNode).void }
-      def on_instance_variable_and_write_node_enter(node)
-        handle_instance_variable_completion(node.name.to_s, node.name_loc)
-      end
-
-      sig { params(node: Prism::InstanceVariableOperatorWriteNode).void }
-      def on_instance_variable_operator_write_node_enter(node)
-        handle_instance_variable_completion(node.name.to_s, node.name_loc)
-      end
-
-      sig { params(node: Prism::InstanceVariableOrWriteNode).void }
-      def on_instance_variable_or_write_node_enter(node)
-        handle_instance_variable_completion(node.name.to_s, node.name_loc)
-      end
-
-      sig { params(node: Prism::InstanceVariableTargetNode).void }
-      def on_instance_variable_target_node_enter(node)
-        handle_instance_variable_completion(node.name.to_s, node.location)
       end
 
       sig { params(name: String, location: Prism::Location).void }

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -30,6 +30,12 @@ module RubyLsp
           :on_constant_path_node_enter,
           :on_constant_read_node_enter,
           :on_call_node_enter,
+          :on_instance_variable_read_node_enter,
+          :on_instance_variable_write_node_enter,
+          :on_instance_variable_and_write_node_enter,
+          :on_instance_variable_operator_write_node_enter,
+          :on_instance_variable_or_write_node_enter,
+          :on_instance_variable_target_node_enter,
         )
       end
 
@@ -149,6 +155,61 @@ module RubyLsp
             range,
             entries,
             top_level_reference || top_level?(T.must(entries.first).name),
+          )
+        end
+      end
+
+      sig { params(node: Prism::InstanceVariableReadNode).void }
+      def on_instance_variable_read_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.location)
+      end
+
+      sig { params(node: Prism::InstanceVariableWriteNode).void }
+      def on_instance_variable_write_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.name_loc)
+      end
+
+      sig { params(node: Prism::InstanceVariableAndWriteNode).void }
+      def on_instance_variable_and_write_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.name_loc)
+      end
+
+      sig { params(node: Prism::InstanceVariableOperatorWriteNode).void }
+      def on_instance_variable_operator_write_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.name_loc)
+      end
+
+      sig { params(node: Prism::InstanceVariableOrWriteNode).void }
+      def on_instance_variable_or_write_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.name_loc)
+      end
+
+      sig { params(node: Prism::InstanceVariableTargetNode).void }
+      def on_instance_variable_target_node_enter(node)
+        handle_instance_variable_completion(node.name.to_s, node.location)
+      end
+
+      sig { params(name: String, location: Prism::Location).void }
+      def handle_instance_variable_completion(name, location)
+        entries = T.cast(@index.prefix_search(name).flatten, T::Array[RubyIndexer::Entry::InstanceVariable])
+        current_self = @nesting.join("::")
+
+        variables = entries.select { |e| current_self == e.owner&.name }
+        variables.uniq!(&:name)
+
+        variables.each do |entry|
+          variable_name = entry.name
+
+          @response_builder << Interface::CompletionItem.new(
+            label: variable_name,
+            text_edit: Interface::TextEdit.new(
+              range: range_from_location(location),
+              new_text: variable_name,
+            ),
+            kind: Constant::CompletionItemKind::FIELD,
+            data: {
+              owner_name: entry.owner&.name,
+            },
           )
         end
       end

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -13,6 +13,12 @@ module RubyLsp
           Prism::ConstantReadNode,
           Prism::ConstantWriteNode,
           Prism::ConstantPathNode,
+          Prism::InstanceVariableReadNode,
+          Prism::InstanceVariableAndWriteNode,
+          Prism::InstanceVariableOperatorWriteNode,
+          Prism::InstanceVariableOrWriteNode,
+          Prism::InstanceVariableTargetNode,
+          Prism::InstanceVariableWriteNode,
         ],
         T::Array[T.class_of(Prism::Node)],
       )
@@ -49,6 +55,12 @@ module RubyLsp
           :on_constant_write_node_enter,
           :on_constant_path_node_enter,
           :on_call_node_enter,
+          :on_instance_variable_read_node_enter,
+          :on_instance_variable_write_node_enter,
+          :on_instance_variable_and_write_node_enter,
+          :on_instance_variable_operator_write_node_enter,
+          :on_instance_variable_or_write_node_enter,
+          :on_instance_variable_target_node_enter,
         )
       end
 
@@ -101,7 +113,50 @@ module RubyLsp
         end
       end
 
+      sig { params(node: Prism::InstanceVariableReadNode).void }
+      def on_instance_variable_read_node_enter(node)
+        handle_instance_variable_hover(node.name.to_s)
+      end
+
+      sig { params(node: Prism::InstanceVariableWriteNode).void }
+      def on_instance_variable_write_node_enter(node)
+        handle_instance_variable_hover(node.name.to_s)
+      end
+
+      sig { params(node: Prism::InstanceVariableAndWriteNode).void }
+      def on_instance_variable_and_write_node_enter(node)
+        handle_instance_variable_hover(node.name.to_s)
+      end
+
+      sig { params(node: Prism::InstanceVariableOperatorWriteNode).void }
+      def on_instance_variable_operator_write_node_enter(node)
+        handle_instance_variable_hover(node.name.to_s)
+      end
+
+      sig { params(node: Prism::InstanceVariableOrWriteNode).void }
+      def on_instance_variable_or_write_node_enter(node)
+        handle_instance_variable_hover(node.name.to_s)
+      end
+
+      sig { params(node: Prism::InstanceVariableTargetNode).void }
+      def on_instance_variable_target_node_enter(node)
+        handle_instance_variable_hover(node.name.to_s)
+      end
+
       private
+
+      sig { params(name: String).void }
+      def handle_instance_variable_hover(name)
+        entries = T.cast(@index[name], T.nilable(T::Array[RubyIndexer::Entry::InstanceVariable]))
+        return unless entries
+
+        current_self = @nesting.join("::")
+        owned_variables = entries.select { |e| current_self == e.owner&.name }
+
+        categorized_markdown_from_index_entries(name, owned_variables).each do |category, content|
+          @response_builder.push(content, category: category)
+        end
+      end
 
       sig { params(name: String, location: Prism::Location).void }
       def generate_hover(name, location)

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -17,6 +17,7 @@ module RubyLsp
     # - Constants
     # - Require paths
     # - Methods invoked on self only
+    # - Instance variables
     #
     # # Example
     #

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -47,6 +47,15 @@ module RubyLsp
         label = @item[:label]
         entries = @index[label] || []
 
+        owner_name = @item.dig(:data, :owner_name)
+
+        if owner_name
+          entries = entries.select do |entry|
+            (entry.is_a?(RubyIndexer::Entry::Member) || entry.is_a?(RubyIndexer::Entry::InstanceVariable)) &&
+              entry.owner&.name == owner_name
+          end
+        end
+
         @item[:labelDetails] = Interface::CompletionItemLabelDetails.new(
           description: entries.take(MAX_DOCUMENTATION_ENTRIES).map(&:file_name).join(","),
         )

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -17,7 +17,8 @@ module RubyLsp
     # - Modules
     # - Constants
     # - Require paths
-    # - Methods invoked on self only
+    # - Methods invoked on self only and on receivers where the type is unknown
+    # - Instance variables
     #
     # # Example
     #

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -48,7 +48,18 @@ module RubyLsp
 
         target, parent, nesting = document.locate_node(
           position,
-          node_types: [Prism::CallNode, Prism::ConstantReadNode, Prism::ConstantPathNode, Prism::BlockArgumentNode],
+          node_types: [
+            Prism::CallNode,
+            Prism::ConstantReadNode,
+            Prism::ConstantPathNode,
+            Prism::BlockArgumentNode,
+            Prism::InstanceVariableReadNode,
+            Prism::InstanceVariableAndWriteNode,
+            Prism::InstanceVariableOperatorWriteNode,
+            Prism::InstanceVariableOrWriteNode,
+            Prism::InstanceVariableTargetNode,
+            Prism::InstanceVariableWriteNode,
+          ],
         )
 
         if target.is_a?(Prism::ConstantReadNode) && parent.is_a?(Prism::ConstantPathNode)

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -79,6 +79,8 @@ module RubyLsp
           entry.name == "initialize" ? Constant::SymbolKind::CONSTRUCTOR : Constant::SymbolKind::METHOD
         when RubyIndexer::Entry::Accessor
           Constant::SymbolKind::PROPERTY
+        when RubyIndexer::Entry::InstanceVariable
+          Constant::SymbolKind::FIELD
         end
       end
     end

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -62,7 +62,7 @@ class CompletionResolveTest < Minitest::Test
     with_server(source, stub_no_typechecker: true) do |server, _uri|
       existing_item = {
         label: "@a",
-        kind: 5,
+        kind: RubyLsp::Constant::CompletionItemKind::FIELD,
         data: { owner_name: "Foo" },
       }
 

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -486,6 +486,42 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_definition_for_instance_variables
+    source = <<~RUBY
+      class Foo
+        def initialize
+          @a = 1
+        end
+
+        def bar
+          @a
+        end
+
+        def baz
+          @a = 5
+        end
+      end
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 4, line: 6 } },
+      )
+      response = server.pop_response.response.first
+      assert_equal(2, response.range.start.line)
+
+      server.process_message(
+        id: 1,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 4, line: 10 } },
+      )
+      response = server.pop_response.response.first
+      assert_equal(2, response.range.start.line)
+    end
+  end
+
   private
 
   def create_definition_addon

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -311,6 +311,41 @@ class HoverExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_hover_instance_variables
+    source = <<~RUBY
+      class Foo
+        def initialize
+          # Hello
+          @a = 1
+        end
+
+        def bar
+          @a
+        end
+
+        def baz
+          @a = 5
+        end
+      end
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/hover",
+        params: { textDocument: { uri: uri }, position: { character: 4, line: 7 } },
+      )
+      assert_match("Hello", server.pop_response.response.contents.value)
+
+      server.process_message(
+        id: 1,
+        method: "textDocument/hover",
+        params: { textDocument: { uri: uri }, position: { character: 4, line: 11 } },
+      )
+      assert_match("Hello", server.pop_response.response.contents.value)
+    end
+  end
+
   private
 
   def create_hover_addon


### PR DESCRIPTION
### Motivation

This PR starts indexing instance variables, so that we can provide definition, hover, completion and workspace symbol in the LSP. Eventually, it will also allow us to provide rename and find references.

### Implementation

I split the work by commit to make it easier to review:

1. Start indexing all possible ways to declare an instance variable
2. Definition support
3. Hover support
4. Completion support
5. Workspace symbol support

### Automated Tests

Added tests.

### Manual Tests

1. Start the LSP on this branch
2. Verify you can jump to the declaration of an instance variable
3. Verify you see documentation for an instance variable on hover
4. Verify you get completion when typing `@`
5. Verify you can find instance variable declarations when searching using workspace symbol (CMD + T)