### PR TITLE
Handle constant completion when typing path separator

### DIFF
--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -35,7 +35,7 @@ module RubyLsp
         def provider
           Interface::CompletionOptions.new(
             resolve_provider: true,
-            trigger_characters: ["/", "\"", "'"],
+            trigger_characters: ["/", "\"", "'", ":"],
             completion_item: {
               labelDetailsSupport: true,
             },


### PR DESCRIPTION
### Motivation

Start showing constant completion when the user types `::`.

The reason we didn't support it before is quite interesting. This code: `Foo::` is not a constant path. Ruby allows singleton methods to be invoked both with a dot and with the double colon, so that node is actually a method call with no message associated to it yet.

This is the reason why we didn't support the completion yet - because we don't have special handling for showing constant completion when we discover that partial method call node.

### Implementation

We haven't implemented singleton completion yet, so for now the implementation for this is actually simplified in a certain way. The correct behaviour is to display both constants and singleton methods when the user types `::`, because we can't know ahead of time what the user is trying to type.

For now, we just check if the operator is a `::` with a constant receiver and then we display matching constants for completion.

### Automated Tests

Added tests.

### Manual Tests

1. Start the LSP on this branch
2. Open a file and type `RubyLsp:`. Then stop typing and dismiss the completion dialogue that was opened when you first typed the `R` character (click ESC)
3. Now type the second colon and verify that the completion list is brought back