### PR TITLE
vscode/asdf: search the default XDG base data directory

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -79,3 +79,13 @@ export function debounce(fn: (...args: any[]) => Promise<void>, delay: number) {
     });
   };
 }
+
+/**
+ * Validates the existence of a path.
+ *
+ * @param uri the path of which to validate the existence
+ * @returns `true` if the path exists, throws an error otherwise
+ */
+export async function validatePath(uri: vscode.Uri): Promise<boolean> {
+  return vscode.workspace.fs.stat(uri).then(() => true);
+}

--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -51,8 +51,19 @@ export class Asdf extends VersionManager {
   // file, but that may not be the case for a Homebrew installation, in which case the we'd have
   // `/opt/homebrew/opt/asdf/libexec/asdf.sh`, but the data directory might be `~/.asdf`
   async findAsdfDataDir(): Promise<vscode.Uri> {
+    // In order, the data locations are:
+    // 1. Default
+    // 2. XDG Base Directory
+    // 3. Homebrew M series
+    // 4. Homebrew Intel series
     const possiblePaths = [
       vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".asdf"),
+      vscode.Uri.joinPath(
+        vscode.Uri.file(os.homedir()),
+        ".local",
+        "share",
+        "asdf",
+      ),
       vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "asdf-vm"),
       vscode.Uri.joinPath(
         vscode.Uri.file("/"),

--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -5,7 +5,7 @@ import os from "os";
 
 import * as vscode from "vscode";
 
-import { asyncExec } from "../common";
+import { asyncExec, validatePath } from "../common";
 
 import { VersionManager, ActivationResult } from "./versionManager";
 
@@ -85,9 +85,7 @@ export class Asdf extends VersionManager {
 
     for (const possiblePath of possiblePaths) {
       try {
-        await vscode.workspace.fs.stat(
-          vscode.Uri.joinPath(possiblePath, "shims"),
-        );
+        await validatePath(vscode.Uri.joinPath(possiblePath, "shims"));
         return possiblePath;
       } catch (error: any) {
         // Continue looking
@@ -132,7 +130,7 @@ export class Asdf extends VersionManager {
 
     for (const possiblePath of possiblePaths) {
       try {
-        await vscode.workspace.fs.stat(possiblePath);
+        await validatePath(possiblePath);
         return possiblePath;
       } catch (error: any) {
         // Continue looking

--- a/vscode/src/test/suite/ruby/asdf.test.ts
+++ b/vscode/src/test/suite/ruby/asdf.test.ts
@@ -73,18 +73,18 @@ suite("Asdf", () => {
 
   suite("findAsdfDataDir", () => {
     const subject = asdf.findAsdfDataDir.bind(asdf);
-    let statStub: sinon.SinonStub;
+    let validatePath: sinon.SinonStub;
 
     setup(() => {
-      statStub = sinon.stub(vscode.workspace.fs, "stat");
+      validatePath = sinon.stub(common, "validatePath");
     });
 
     teardown(() => {
-      statStub.restore();
+      validatePath.restore();
     });
 
     test("searches common asdf data directory", async () => {
-      statStub.rejects();
+      validatePath.rejects();
       await subject().catch(() => {});
 
       [
@@ -94,7 +94,7 @@ suite("Asdf", () => {
         "/opt/homebrew/opt/asdf/libexec",
       ].forEach((base) => {
         const shims = vscode.Uri.joinPath(vscode.Uri.file(base), "shims");
-        assert.ok(statStub.calledWith(shims));
+        assert.ok(validatePath.calledWith(shims));
       });
     });
   });


### PR DESCRIPTION
This updates the detection of the asdf data directory for setting the environment variable `ASDF_DATA_DIR` during activation.

Fixes #2023

### Motivation

Fixes #2023 

The XDG base directory specification is becoming more popular in outside of Linux. The default base data directory is `~/.local/share` where applications store their user data within a directory under the base: e.g. `~/.local/share/asdf`.

### Implementation

This update includes the XDG base data directory in the list when detecting the location for activation.

### Automated Tests

Yes.

### Manual Tests

1. Create the directory `~/.local/share/asdf/shims`
2. Start VS Code
3. Open Ruby file

