### PR TITLE
Handle constant paths with missing parts

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -373,10 +373,9 @@ module RubyIndexer
         if node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
           node.full_name
         end
-      rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError
-        # TO DO: add MissingNodesInConstantPathError when released in Prism
-        # If a constant path reference is dynamic or missing parts, we can't
-        # index it
+      rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError,
+             Prism::ConstantPathNode::MissingNodesInConstantPathError
+        # Do nothing
       end
       collection = operation == :included_modules ? owner.included_modules : owner.prepended_modules
       collection.concat(names)

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -155,7 +155,8 @@ module RubyLsp
         end
         def constant_name(node)
           node.full_name
-        rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError
+        rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError,
+               Prism::ConstantPathNode::MissingNodesInConstantPathError
           nil
         end
 


### PR DESCRIPTION
### Motivation

Closes #2050

Prism added a new error for `full_name` in the case where parts of the constant path are missing. We need to handle that error, otherwise the code breaks.

### Implementation

All we have to do is rescue that extra error.