### PR TITLE
Feat: Add Extract Method to CodeAction

### DIFF
--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -19,6 +19,9 @@ module RubyLsp
     class CodeActions < Request
       extend T::Sig
 
+      VARIABLE_REFACTOR_CODE_ACTION_TITLE = "Refactor: Extract Variable"
+      METHOD_REFACTOR_CODE_ACTION_TITLE = "Refactor: Extract Method"
+
       class << self
         extend T::Sig
 
@@ -52,7 +55,10 @@ module RubyLsp
         end
 
         # Only add refactor actions if there's a non empty selection in the editor
-        code_actions << refactor_code_action(@range, @uri) unless @range.dig(:start) == @range.dig(:end)
+        unless @range.dig(:start) == @range.dig(:end)
+          code_actions << refactor_code_action(@range, @uri)
+          code_actions << extract_code_action(@range, @uri)
+        end
         code_actions
       end
 
@@ -61,7 +67,19 @@ module RubyLsp
       sig { params(range: T::Hash[Symbol, T.untyped], uri: URI::Generic).returns(Interface::CodeAction) }
       def refactor_code_action(range, uri)
         Interface::CodeAction.new(
-          title: "Refactor: Extract Variable",
+          title: VARIABLE_REFACTOR_CODE_ACTION_TITLE,
+          kind: Constant::CodeActionKind::REFACTOR_EXTRACT,
+          data: {
+            range: range,
+            uri: uri.to_s,
+          },
+        )
+      end
+
+      sig { params(range: T::Hash[Symbol, T.untyped], uri: URI::Generic).returns(Interface::CodeAction) }
+      def extract_code_action(range, uri)
+        Interface::CodeAction.new(
+          title: METHOD_REFACTOR_CODE_ACTION_TITLE,
           kind: Constant::CodeActionKind::REFACTOR_EXTRACT,
           data: {
             range: range,

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -498,6 +498,13 @@ module RubyLsp
           ),
         )
         raise Requests::CodeActionResolve::CodeActionError
+      when Requests::CodeActionResolve::Error::UnknownCodeAction
+        send_message(
+          Notification.window_show_error(
+            "Unknown code action",
+          ),
+        )
+        raise Requests::CodeActionResolve::CodeActionError
       else
         send_message(Result.new(id: message[:id], response: result))
       end

--- a/test/expectations/code_action_resolve/call_chained.exp.json
+++ b/test/expectations/code_action_resolve/call_chained.exp.json
@@ -1,6 +1,7 @@
 {
     "params": {
         "kind": "refactor.extract",
+        "title": "Refactor: Extract Variable",
         "data": {
             "range": {
                 "start": {

--- a/test/expectations/code_action_resolve/call_nested_multiline_args.exp.json
+++ b/test/expectations/code_action_resolve/call_nested_multiline_args.exp.json
@@ -1,6 +1,7 @@
 {
     "params": {
         "kind": "refactor.extract",
+        "title": "Refactor: Extract Variable",
         "data": {
             "range": {
                 "start": {

--- a/test/expectations/code_action_resolve/def_extract_variable.exp.json
+++ b/test/expectations/code_action_resolve/def_extract_variable.exp.json
@@ -1,6 +1,7 @@
 {
     "params": {
         "kind": "refactor.extract",
+        "title": "Refactor: Extract Variable",
         "data": {
             "range": {
                 "start": {

--- a/test/expectations/code_action_resolve/def_multiline_params.exp.json
+++ b/test/expectations/code_action_resolve/def_multiline_params.exp.json
@@ -1,6 +1,7 @@
 {
     "params": {
         "kind": "refactor.extract",
+        "title": "Refactor: Extract Variable",
         "data": {
             "range": {
                 "start": {

--- a/test/expectations/code_action_resolve/extract_method.exp.json
+++ b/test/expectations/code_action_resolve/extract_method.exp.json
@@ -1,0 +1,60 @@
+{
+  "params": {
+    "kind": "refactor.extract",
+    "title": "Refactor: Extract Method",
+    "data": {
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 0
+        },
+        "end": {
+          "line": 2,
+          "character": 15
+        }
+      },
+      "uri": "file:///fake"
+    }
+  },
+  "result": {
+    "title": "Refactor: Extract Method",
+    "edit": {
+      "documentChanges": [
+        {
+          "textDocument": {
+            "uri": "file:///fake",
+            "version": null
+          },
+          "edits": [
+            {
+              "range": {
+                "start": {
+                  "line": 4,
+                  "character": 2
+                },
+                "end": {
+                  "line": 4,
+                  "character": 2
+                }
+              },
+              "newText": "\n  def new_method\n        answer = 42\n  end\n\n"
+            },
+            {
+              "range": {
+                "start": {
+                  "line": 2,
+                  "character": 0
+                },
+                "end": {
+                  "line": 2,
+                  "character": 15
+                }
+              },
+              "newText": "new_method"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/test/expectations/code_action_resolve/extract_variable_first_statement.exp.json
+++ b/test/expectations/code_action_resolve/extract_variable_first_statement.exp.json
@@ -1,6 +1,7 @@
 {
     "params": {
         "kind": "refactor.extract",
+        "title": "Refactor: Extract Variable",
         "data": {
             "range": {
                 "start": {

--- a/test/expectations/code_action_resolve/extraction_with_empty_line_between.exp.json
+++ b/test/expectations/code_action_resolve/extraction_with_empty_line_between.exp.json
@@ -1,6 +1,7 @@
 {
     "params": {
         "kind": "refactor.extract",
+        "title": "Refactor: Extract Variable",
         "data": {
             "range": {
                 "start": {

--- a/test/expectations/code_action_resolve/oneline_block_extraction.exp.json
+++ b/test/expectations/code_action_resolve/oneline_block_extraction.exp.json
@@ -1,6 +1,7 @@
 {
     "params": {
         "kind": "refactor.extract",
+        "title": "Refactor: Extract Variable",
         "data": {
             "range": {
                 "start": {

--- a/test/expectations/code_action_resolve/variable_extract.exp.json
+++ b/test/expectations/code_action_resolve/variable_extract.exp.json
@@ -1,6 +1,7 @@
 {
     "params": {
         "kind": "refactor.extract",
+        "title": "Refactor: Extract Variable",
         "data": {
             "range": {
                 "start": {

--- a/test/expectations/code_actions/aref_field.exp.json
+++ b/test/expectations/code_actions/aref_field.exp.json
@@ -35,6 +35,23 @@
         },
         "uri": "file:///fake"
       }
+    },
+    {
+      "title": "Refactor: Extract Method",
+      "kind": "refactor.extract",
+      "data": {
+        "range": {
+          "start": {
+            "line": 2,
+            "character": 9
+          },
+          "end": {
+            "line": 2,
+            "character": 13
+          }
+        },
+        "uri": "file:///fake"
+      }
     }
   ]
 }

--- a/test/fixtures/extract_method.rb
+++ b/test/fixtures/extract_method.rb
@@ -1,0 +1,5 @@
+class Foo
+  def some_method
+    answer = 42
+  end
+end

--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -554,6 +554,7 @@ suite("Client", () => {
       "codeAction/resolve",
       {
         kind: "refactor.extract",
+        title: "Refactor: Extract Variable",
         data: {
           range: {
             start: { line: 1, character: 1 },


### PR DESCRIPTION
### Motivation

Close #1056 

At Code Party, a side event for RubyKaigi 2024, @vinistock helped me to find a good first issue and I tried to implement this.

### Implementation

We started to accepts multiple kinds of action. We have corresponding method to deal with actions and if it doesn't match, it raises an error.

### Automated Tests

Tests added.

### Manual Tests

Select some texts in a method, click "Extract Method" action and find a new method with the same body.
