### PR TITLE
Remove notes related to neovim 0.9 and cleanup docs

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -28,6 +28,8 @@ When you run `eglot` command it will run `ruby-lsp` process for you.
 
 ## Neovim
 
+**Note**: Ensure that you are using Neovim 0.10 or newer.
+
 ### nvim-lspconfig
 
 The [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/ruby_lsp.lua)
@@ -61,7 +63,7 @@ mason_lspconfig.setup_handlers {
 }
 ```
 
-### Neovim Limitations
+### Additional setup (optional)
 
 `rubyLsp/workspace/dependencies` is a custom method currently supported only in the VS Code plugin.
 The following snippet adds `ShowRubyDeps` command to show dependencies in the quickfix list.

--- a/EDITORS.md
+++ b/EDITORS.md
@@ -67,44 +67,33 @@ mason_lspconfig.setup_handlers {
 The following snippet adds `ShowRubyDeps` command to show dependencies in the quickfix list.
 
 ```lua
--- add the `all` argument to show indirect dependencies as well
 local function add_ruby_deps_command(client, bufnr)
-    vim.api.nvim_buf_create_user_command(bufnr, "ShowRubyDeps",
-                                          function(opts)
+  vim.api.nvim_buf_create_user_command(bufnr, "ShowRubyDeps", function(opts)
+    local params = vim.lsp.util.make_text_document_params()
+    local showAll = opts.args == "all"
 
-        local params = vim.lsp.util.make_text_document_params()
+    client.request("rubyLsp/workspace/dependencies", params, function(error, result)
+      if error then
+        print("Error showing deps: " .. error)
+        return
+      end
 
-        local showAll = opts.args == "all"
+      local qf_list = {}
+      for _, item in ipairs(result) do
+        if showAll or item.dependency then
+          table.insert(qf_list, {
+            text = string.format("%s (%s) - %s", item.name, item.version, item.dependency),
+            filename = item.path
+          })
+        end
+      end
 
-        client.request("rubyLsp/workspace/dependencies", params,
-                        function(error, result)
-            if error then
-                print("Error showing deps: " .. error)
-                return
-            end
-
-            local qf_list = {}
-            for _, item in ipairs(result) do
-                if showAll or item.dependency then
-                    table.insert(qf_list, {
-                        text = string.format("%s (%s) - %s",
-                                              item.name,
-                                              item.version,
-                                              item.dependency),
-
-                        filename = item.path
-                    })
-                end
-            end
-
-            vim.fn.setqflist(qf_list)
-            vim.cmd('copen')
-        end, bufnr)
-    end, {nargs = "?", complete = function()
-        return {"all"}
-    end})
+      vim.fn.setqflist(qf_list)
+      vim.cmd('copen')
+    end, bufnr)
+  end,
+  {nargs = "?", complete = function() return {"all"} end})
 end
-
 
 require("lspconfig").ruby_lsp.setup({
   on_attach = function(client, buffer)

--- a/EDITORS.md
+++ b/EDITORS.md
@@ -63,53 +63,7 @@ mason_lspconfig.setup_handlers {
 
 ### Neovim Limitations
 
-Ruby LSP only supports pull diagnostics, and neovim versions prior to v0.10.0-dev-695+g58f948614 only support [publishDiagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics).
-Additional setup is required to enable diagnostics from Ruby LSP to appear in neovim.
-
 ```lua
--- textDocument/diagnostic support until 0.10.0 is released
-_timers = {}
-local function setup_diagnostics(client, buffer)
-  if require("vim.lsp.diagnostic")._enable then
-    return
-  end
-
-  local diagnostic_handler = function()
-    local params = vim.lsp.util.make_text_document_params(buffer)
-    client.request("textDocument/diagnostic", { textDocument = params }, function(err, result)
-      if err then
-        local err_msg = string.format("diagnostics error - %s", vim.inspect(err))
-        vim.lsp.log.error(err_msg)
-      end
-      local diagnostic_items = {}
-      if result then
-        diagnostic_items = result.items
-      end
-      vim.lsp.diagnostic.on_publish_diagnostics(
-        nil,
-        vim.tbl_extend("keep", params, { diagnostics = diagnostic_items }),
-        { client_id = client.id }
-      )
-    end)
-  end
-
-  diagnostic_handler() -- to request diagnostics on buffer when first attaching
-
-  vim.api.nvim_buf_attach(buffer, false, {
-    on_lines = function()
-      if _timers[buffer] then
-        vim.fn.timer_stop(_timers[buffer])
-      end
-      _timers[buffer] = vim.fn.timer_start(200, diagnostic_handler)
-    end,
-    on_detach = function()
-      if _timers[buffer] then
-        vim.fn.timer_stop(_timers[buffer])
-      end
-    end,
-  })
-end
-
 -- adds ShowRubyDeps command to show dependencies in the quickfix list.
 -- add the `all` argument to show indirect dependencies as well
 local function add_ruby_deps_command(client, bufnr)
@@ -152,7 +106,6 @@ end
 
 require("lspconfig").ruby_lsp.setup({
   on_attach = function(client, buffer)
-    setup_diagnostics(client, buffer)
     add_ruby_deps_command(client, buffer)
   end,
 })

--- a/EDITORS.md
+++ b/EDITORS.md
@@ -63,8 +63,10 @@ mason_lspconfig.setup_handlers {
 
 ### Neovim Limitations
 
+`rubyLsp/workspace/dependencies` is a custom method currently supported only in the VS Code plugin.
+The following snippet adds `ShowRubyDeps` command to show dependencies in the quickfix list.
+
 ```lua
--- adds ShowRubyDeps command to show dependencies in the quickfix list.
 -- add the `all` argument to show indirect dependencies as well
 local function add_ruby_deps_command(client, bufnr)
     vim.api.nvim_buf_create_user_command(bufnr, "ShowRubyDeps",


### PR DESCRIPTION
Neovim 0.10 has been released with support for `publishDiagnostics` so there is no need to suggest manually adding support for it.

The snippet also contained code for adding `ShowRubyDeps` command, so I added a description for that instead. I also cleaned up the formatting of the code snippet in a separate commit.