### PR TITLE
Allow Code Lenses without a command

### DIFF
--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -50,12 +50,12 @@ module RubyLsp
           params(
             node: Prism::Node,
             title: String,
-            command_name: String,
+            command_name: T.nilable(String),
             arguments: T.nilable(T::Array[T.untyped]),
             data: T.nilable(T::Hash[T.untyped, T.untyped]),
           ).returns(Interface::CodeLens)
         end
-        def create_code_lens(node, title:, command_name:, arguments:, data:)
+        def create_code_lens(node, title:, command_name: nil, arguments: nil, data: nil)
           range = range_from_node(node)
 
           Interface::CodeLens.new(


### PR DESCRIPTION
### Motivation

For https://github.com/Shopify/ruby-lsp-rails/pull/241, I'd like to ship a first iteration which shows the Code Lens but doesn't have any associated command.

### Implementation

Allow `command_name` to be nil.

### Automated Tests

n/a

### Manual Tests

* Check out https://github.com/Shopify/ruby-lsp-rails/pull/lookup_route (the Gemfile is temporarily pointing to this branch)
* Open `test/dummy/app/controllers/users_controller.rb`
* Ensure the Code Lenses appear above each action
* Ensure clicking the Code Lens has no affect