### PR TITLE
Fix the hash keys of enabledFeatures

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -134,7 +134,7 @@ module RubyLsp
       when Hash
         # If the configuration is already a hash, merge it with a default value of `true`. That way clients don't have
         # to opt-in to every single feature
-        Hash.new(true).merge!(configured_features)
+        Hash.new(true).merge!(configured_features.transform_keys(&:to_s))
       else
         # If no configuration was passed by the client, just enable every feature
         Hash.new(true)


### PR DESCRIPTION
The enabledFeatures has symbolic keys when configured with hash, which need to be transformed to string keys to work.

bug environment:
- nvim v0.10.0
- ruby-lsp 0.16.6

