### PR TITLE
Ignore `test/expectations/` for sorbet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ To add a new expectations test runner for a new request handler:
 
 ```ruby
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class MyRequestExpectationsTest < ExpectationsTestRunner
   # The first argument is the fully qualified name of the request class
@@ -83,7 +83,7 @@ example
 
 ```ruby
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class MyRequestExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::MyRequest, "my_request"

--- a/sorbet/config
+++ b/sorbet/config
@@ -2,4 +2,5 @@
 .
 --ignore=vendor/
 --ignore=test/fixtures/
+--ignore=test/expectations/
 --enable-experimental-requires-ancestor

--- a/test/requests/code_action_resolve_expectations_test.rb
+++ b/test/requests/code_action_resolve_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class CodeActionResolveExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeActionResolve, "code_action_resolve"

--- a/test/requests/code_actions_expectations_test.rb
+++ b/test/requests/code_actions_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class CodeActionsExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeActions, "code_actions"

--- a/test/requests/code_actions_formatting_test.rb
+++ b/test/requests/code_actions_formatting_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 # Tests RuboCop disable directives - before/after on whole file
 class CodeActionsFormattingTest < Minitest::Test

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class CodeLensExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeLens, "code_lens"

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class DefinitionExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Definition, "definition"

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class DiagnosticsExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Diagnostics, "diagnostics"

--- a/test/requests/document_highlight_expectations_test.rb
+++ b/test/requests/document_highlight_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class DocumentHighlightExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::DocumentHighlight, "document_highlight"

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class DocumentLinkExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::DocumentLink, "document_link"

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class DocumentSymbolExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::DocumentSymbol, "document_symbol"

--- a/test/requests/folding_ranges_expectations_test.rb
+++ b/test/requests/folding_ranges_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class FoldingRangesExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::FoldingRanges, "folding_ranges"

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class FormattingExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Formatting, "formatting"

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class HoverExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Hover, "hover"

--- a/test/requests/inlay_hints_expectations_test.rb
+++ b/test/requests/inlay_hints_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class InlayHintsExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::InlayHints, "inlay_hints"

--- a/test/requests/selection_ranges_expectations_test.rb
+++ b/test/requests/selection_ranges_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class SelectionRangesExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::SelectionRanges, "selection_ranges"

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "expectations/expectations_test_runner"
+require_relative "support/expectations_test_runner"
 
 class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::SemanticHighlighting, "semantic_highlighting"

--- a/test/requests/support/expectations_test_runner.rb
+++ b/test/requests/support/expectations_test_runner.rb
@@ -82,7 +82,7 @@ class ExpectationsTestRunner < Minitest::Test
     # from test/fixtures/prism/test/prism/fixtures/unparser/corpus/semantic/and.txt
     # to test_fixtures_prism_test_prism_fixtures_unparser_corpus_semantic_and
     def uniq_name_from_path(path)
-      path.gsub("/", "_").gsub('.txt', '')
+      path.gsub("/", "_").gsub(".txt", "")
     end
   end
 


### PR DESCRIPTION
A expecation currently does something like this:
```rb
def method
end
```

This makes it impossible to call `Object.method` while keeping sorbet happy. There is only one file that sorbet should know about in that folder, just move that somewhere else.

Also fixes two RuboCop offenses in that file since it was previously ignored.

```
[user@DESKTOP-PC ruby-lsp]$ bundle exec srb
lib/ruby_lsp/requests/support/rubocop_formatter.rb:39: Non-private call to private method method on RubyLsp::Requests::Support::RuboCopRunner https://srb.help/7031
    39 |          @diagnostic_runner.method(:"123")
                                     ^^^^^^
    test/expectations/code_actions_formatting/rubocop_multiline_string.exp.rb:1: Defined in Object here
     1 |def method
        ^^^^^^^^^^

lib/ruby_lsp/requests/support/rubocop_formatter.rb:39: Too many arguments provided for method Object#method. Expected: 0, got: 1 https://srb.help/7004
    39 |          @diagnostic_runner.method(:"123")
                                            ^^^^^^
    test/expectations/code_actions_formatting/rubocop_multiline_string.exp.rb:1: method defined here
     1 |def method
        ^^^^^^^^^^
  Autocorrect: Use -a to autocorrect
    lib/ruby_lsp/requests/support/rubocop_formatter.rb:39: Delete
    39 |          @diagnostic_runner.method(:"123")
                                            ^^^^^^
Errors: 2
```

### Motivation

I want to inspect a methods parameters in order to call an updated RuboCop APi while staying compatible with older versions.