### PR TITLE
Show doc urls for extension cops

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_formatter.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_formatter.rb
@@ -38,7 +38,11 @@ module RubyLsp
           @diagnostic_runner.run(filename, document.source)
 
           @diagnostic_runner.offenses.map do |offense|
-            Support::RuboCopDiagnostic.new(document, offense, uri).to_lsp_diagnostic
+            Support::RuboCopDiagnostic.new(
+              document,
+              offense,
+              uri,
+            ).to_lsp_diagnostic(@diagnostic_runner.config_for_working_directory)
           end
         end
       end

--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -50,6 +50,9 @@ module RubyLsp
         sig { returns(T::Array[RuboCop::Cop::Offense]) }
         attr_reader :offenses
 
+        sig { returns(::RuboCop::Config) }
+        attr_reader :config_for_working_directory
+
         DEFAULT_ARGS = T.let(
           [
             "--stderr", # Print any output to stderr so that our stdout does not get polluted
@@ -78,6 +81,7 @@ module RubyLsp
           args += DEFAULT_ARGS
           rubocop_options = ::RuboCop::Options.new.parse(args).first
           config_store = ::RuboCop::ConfigStore.new
+          @config_for_working_directory = T.let(config_store.for_pwd, ::RuboCop::Config)
 
           super(rubocop_options, config_store)
         end

--- a/test/expectations/diagnostics/rubocop_extension_cop.exp.json
+++ b/test/expectations/diagnostics/rubocop_extension_cop.exp.json
@@ -1,0 +1,100 @@
+{
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 5,
+          "character": 4
+        },
+        "end": {
+          "line": 5,
+          "character": 25
+        }
+      },
+      "severity": 3,
+      "code": "Minitest/AssertEmptyLiteral",
+      "codeDescription": {
+        "href": "https://docs.rubocop.org/rubocop-minitest/cops_minitest.html#minitestassertemptyliteral"
+      },
+      "source": "RuboCop",
+      "message": "Minitest/AssertEmptyLiteral: Prefer using `assert_empty(foo)`.",
+      "data": {
+        "correctable": true,
+        "code_actions": [
+          {
+            "title": "Autocorrect Minitest/AssertEmptyLiteral",
+            "kind": "quickfix",
+            "isPreferred": true,
+            "edit": {
+              "documentChanges": [
+                {
+                  "textDocument": {
+                    "uri": "file:///fake",
+                    "version": null
+                  },
+                  "edits": [
+                    {
+                      "range": {
+                        "start": {
+                          "line": 5,
+                          "character": 4
+                        },
+                        "end": {
+                          "line": 5,
+                          "character": 16
+                        }
+                      },
+                      "newText": "assert_empty"
+                    },
+                    {
+                      "range": {
+                        "start": {
+                          "line": 5,
+                          "character": 17
+                        },
+                        "end": {
+                          "line": 5,
+                          "character": 24
+                        }
+                      },
+                      "newText": "foo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "title": "Disable Minitest/AssertEmptyLiteral for this line",
+            "kind": "quickfix",
+            "edit": {
+              "documentChanges": [
+                {
+                  "textDocument": {
+                    "uri": "file:///fake",
+                    "version": null
+                  },
+                  "edits": [
+                    {
+                      "range": {
+                        "start": {
+                          "line": 5,
+                          "character": 25
+                        },
+                        "end": {
+                          "line": 5,
+                          "character": 25
+                        }
+                      },
+                      "newText": " # rubocop:disable Minitest/AssertEmptyLiteral"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/rubocop_extension_cop.rb
+++ b/test/fixtures/rubocop_extension_cop.rb
@@ -1,0 +1,8 @@
+# typed: true
+# frozen_string_literal: true
+
+class ExampleTest < Minitest::Test
+  def test_public
+    assert_equal([], foo)
+  end
+end


### PR DESCRIPTION
Requires #2075 and a new RuboCop release.

### Motivation

#2022

### Implementation

https://github.com/rubocop/rubocop/pull/12907 added what was needed to make this work. Doc urls are dependant on `DocumentationBaseURL` from the config, which a class method simply doesn't have access to.

So, pass in the config we have from the runner to construct these. Check the method params to stay compatible with both old and new versions.

### Automated Tests

Yup

### Manual Tests

Open some test file and add a new test case with the following:

```rb
  def test_public
    assert_equal([], foo)
  end 
```

Hover over the diagnostic and check out the hyperlink:
![image](https://github.com/Shopify/ruby-lsp/assets/14981592/ca4fd1ea-21e3-4ea6-bbde-6daa37c73f8f)

Old RuboCop versions will continue to not show these links.