### PR TITLE
Improve performance of finding indexables

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -31,6 +31,7 @@ module RubyIndexer
 
       @excluded_patterns = T.let(
         [
+          File.join("**", "*_test.rb"),
           File.join("node_modules", "**", "*"),
           File.join("spec", "**", "*"),
           File.join("test", "**", "*"),


### PR DESCRIPTION
Currently, all folders and files in the current tree are turned into IndexablePath, and then excluded files are filtered out after.

When there are large file trees that are meant to be excluded, this results in a lot of unnecessary work.

ActiveStorage stores files in the `tmp` directory in many many small folders. So does Bootsnap. Ruby LSP has to traverse all of these files, even though the entire directory should just be ignored.

Rubocop has solved this by breaking the `includes` patterns up into many patterns, applying the exclusions *before* the `Dir.glob`, so I followed in their footsteps. This works great for exclusions that end in "**/*". We still need to loop through all IndexablePath objects and see if they're excluded, in the case that an extension was provided on the excluded path, but this can cut down load time dramatically.

Before this PR in my Rails app, `indexables` took 76 seconds to run. Now it takes, 0.19 seconds. Before and after code both return the same exact file list.

Additionally, I added `node_modules` to the list of excluded trees, since that can be very large and never includes Ruby files.

I also removed the `*.rb` from the bundler path. Having a file extension on that means we need to scan all files. But we simply want to ignore the entire bundler path tree. I kind of wonder if we should always replace `*.rb` with `*`, to help people improve performance. Excluding an actual file name or partial file name makes sense. But excluding the only file extension we scan means we can do it faster by excluding the whole folder.

### Motivation

Opening a ruby file caused my LSP server to print "Ruby LSP: indexing files" for 76 seconds at 0% before the progress bar starts moving.

### Implementation

I knew that Rubocop has solved this problem before, so I looked at [this file](https://github.com/rubocop/rubocop/blob/aee64e2d5d6615ef64803af52c1b82bf95b566ef/lib/rubocop/target_finder.rb#L41) and followed what they did.

### Automated Tests

I added tests for the new pattern `exclude_pattern` that gets used with `fnmatch`, while ensuring I didn't break any existing tests.

### Manual Tests

I made a file that has both implementations of `indexables` on my computer. Then ran this in the Rails Console:

```ruby
Benchmark.measure { RubyIndexer::Configuration.new.indexables }
=>
#<Benchmark::Tms:0x000000012a2dead0
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=0.19083199999295175,
 @stime=0.0784180000000001,
 @total=0.18055299999999974,
 @utime=0.10213499999999964>


Benchmark.measure { RubyIndexer::Configuration.new.old_indexables }
=>
#<Benchmark::Tms:0x000000012a374b20
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=76.83584400010295,
 @stime=13.666566,
 @total=14.943883,
 @utime=1.277317>

old_indexables = RubyIndexer::Configuration.new.old_indexables
indexables = RubyIndexer::Configuration.new.indexables

indexables.size == old_indexables.size
=> true

indexables.map(&:full_path).sort == old_indexables.map(&:full_path).sort
=> true

indexables.size
=> 13933
```

So here you can see that it finds the same ~14k files in 0.25% of the time.