### PR TITLE
Prevent test suite from modifying contributors' Bundler settings

### DIFF
--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -71,7 +71,7 @@ module RubyIndexer
       Bundler.settings.temporary(path: "vendor/bundle") do
         config = Configuration.new
 
-        assert_includes(config.instance_variable_get(:@excluded_patterns), "#{Dir.pwd}/vendor/bundle/**/*")
+        assert_includes(config.instance_variable_get(:@excluded_patterns), "#{Dir.pwd}/vendor/bundle/**/*.rb")
       end
     end
 

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -68,12 +68,11 @@ module RubyIndexer
     end
 
     def test_indexables_avoids_duplicates_if_bundle_path_is_inside_project
-      Bundler.settings.set_global("path", "vendor/bundle")
-      config = Configuration.new
+      Bundler.settings.temporary(path: "vendor/bundle") do
+        config = Configuration.new
 
-      assert_includes(config.instance_variable_get(:@excluded_patterns), "#{Dir.pwd}/vendor/bundle/**/*.rb")
-    ensure
-      Bundler.settings.set_global("path", nil)
+        assert_includes(config.instance_variable_get(:@excluded_patterns), "#{Dir.pwd}/vendor/bundle/**/*")
+      end
     end
 
     def test_indexables_does_not_include_gems_own_installed_files


### PR DESCRIPTION
### Motivation

I install my gems in `vendor/bundle`. While working on #2082, I had to re-configure my bundle path every time I ran the test suite. I realized it was because the test suite was deleting my local bundler config.

### Implementation

I switched the tests to use `Bundler.settings.temporary`. You can read more about it here:
https://medium.com/@0xcolby/how-does-bundle-install-work-part-1-87a4349c192a

### Automated Tests

Current tests still work.

### Manual Tests

I can repeatedly run the test suite without having to set my bundle path to `vendor/bundle` every time.