### PR TITLE
Fix auto indent after end

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -230,7 +230,9 @@ module RubyLsp
           loc = node.location
           next unless loc.start_column == @indentation
 
-          add_edit_with_text("  ", { line: loc.start_line - 1, character: 0 })
+          (loc.start_line..loc.end_line).each do |line|
+            add_edit_with_text("  ", { line: line - 1, character: 0 })
+          end
         end
 
         move_cursor_to(@position[:line], @position[:character])

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -213,7 +213,7 @@ module RubyLsp
       sig { void }
       def auto_indent_after_end_keyword
         current_line = @lines[@position[:line]]
-        return unless current_line&.strip == "end"
+        return unless current_line && current_line.strip == "end"
 
         target, _parent, _nesting = @document.locate_node({
           line: @position[:line],
@@ -226,9 +226,10 @@ module RubyLsp
         end
         return unless statements
 
+        current_indentation = find_indentation(current_line)
         statements.body.each do |node|
           loc = node.location
-          next unless loc.start_column == @indentation
+          next unless loc.start_column == current_indentation
 
           (loc.start_line..loc.end_line).each do |line|
             add_edit_with_text("  ", { line: line - 1, character: 0 })

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -480,6 +480,25 @@ class OnTypeFormattingTest < Minitest::Test
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
 
+  def test_auto_indent_after_end_keyword_does_not_add_extra_indentation
+    document = RubyLsp::RubyDocument.new(source: +"if foo\n  bar\nend", version: 1, uri: URI("file:///fake.rb"))
+    edits = RubyLsp::Requests::OnTypeFormatting.new(
+      document,
+      { line: 2, character: 2 },
+      "d",
+      "Visual Studio Code",
+    ).perform
+
+    expected_edits = [
+      {
+        range: { start: { line: 2, character: 2 }, end: { line: 2, character: 2 } },
+        newText: "$0",
+      },
+    ]
+
+    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
+
   def test_breaking_line_if_a_keyword_is_part_of_method_call
     document = RubyLsp::RubyDocument.new(source: +"  force({", version: 1, uri: URI("file:///fake.rb"))
     edits = RubyLsp::Requests::OnTypeFormatting.new(

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -445,6 +445,41 @@ class OnTypeFormattingTest < Minitest::Test
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
 
+  def test_auto_indent_after_end_keyword_with_complex_body
+    document = RubyLsp::RubyDocument.new(
+      source: +"if foo\nif bar\n  baz\nend\nend",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+    )
+    edits = RubyLsp::Requests::OnTypeFormatting.new(
+      document,
+      { line: 4, character: 2 },
+      "d",
+      "Visual Studio Code",
+    ).perform
+
+    expected_edits = [
+      {
+        range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
+        newText: "  ",
+      },
+      {
+        range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } },
+        newText: "  ",
+      },
+      {
+        range: { start: { line: 3, character: 0 }, end: { line: 3, character: 0 } },
+        newText: "  ",
+      },
+      {
+        range: { start: { line: 4, character: 2 }, end: { line: 4, character: 2 } },
+        newText: "$0",
+      },
+    ]
+
+    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
+
   def test_breaking_line_if_a_keyword_is_part_of_method_call
     document = RubyLsp::RubyDocument.new(source: +"  force({", version: 1, uri: URI("file:///fake.rb"))
     edits = RubyLsp::Requests::OnTypeFormatting.new(


### PR DESCRIPTION
### Motivation

I noticed a few small issues since enabling on-type formatting recently. In particular, it adds incorrect indentation in some cases after typing the `end` keyword. It's not a big deal really because the code will be auto-formatted when saving the file, but I thought I would try to fix the easier ones to make the editing experience a bit nicer.

#### Complex body indentation

| Before | After |
| - | - |
| <img src="https://github.com/Shopify/ruby-lsp/assets/770763/4f2167e7-a20d-4b60-8247-d6d1b01416fd" /> | <img src="https://github.com/Shopify/ruby-lsp/assets/770763/36089928-00d9-4332-8912-4db404172ac7" /> |

#### Existing indentation

| Before | After |
| - | - |
| <img src="https://github.com/Shopify/ruby-lsp/assets/770763/1251cb17-e50d-45ae-8e09-d6551716720e" /> | <img src="https://github.com/Shopify/ruby-lsp/assets/770763/f639721c-eaf8-4528-9b6b-921c7189bcac" /> |

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

- For the complex body indentation, it loops through each line of each node to add indentation as nodes can span multiple lines.
- For existing indentation, it finds the indentation correctly for comparison.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

I've added a test case for each fix to `OnTypeFormattingTest`.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

```rb
if true
  if true
    true
  end
en
```

Then add the final `d`.

```rb
if true
    true
en
```

Then add the final `d`.