### PR TITLE
Add configuration options for third-party formatters

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -295,7 +295,7 @@
             "Syntax Tree",
             "Standard (need v0.37 or newer of the standard gem)",
             "Rubyfmt (needs the ruby-lsp-rubyfmt gem)",
-            "None"
+            "Do not use a formatter"
           ],
           "default": "auto"
         },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -285,7 +285,17 @@
             "auto",
             "rubocop",
             "syntax_tree",
+            "standard",
+            "rubyfmt",
             "none"
+          ],
+          "enumDescriptions": [
+            "Auto",
+            "RuboCop",
+            "Syntax Tree",
+            "Standard (need v0.37 or newer of the standard gem)",
+            "Rubyfmt (needs the ruby-lsp-rubyfmt gem)",
+            "None"
           ],
           "default": "auto"
         },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -293,8 +293,8 @@
             "Automatically detect formatter",
             "RuboCop",
             "Syntax Tree",
-            "Standard (need v0.37 or newer of the standard gem)",
-            "Rubyfmt (needs the ruby-lsp-rubyfmt gem)",
+            "Standard (supported by community addon)",
+            "Rubyfmt (supported by community addon)",
             "Do not use a formatter"
           ],
           "default": "auto"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -290,7 +290,7 @@
             "none"
           ],
           "enumDescriptions": [
-            "Auto",
+            "Automatically detect formatter",
             "RuboCop",
             "Syntax Tree",
             "Standard (need v0.37 or newer of the standard gem)",


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby-lsp/issues/1775

To properly support additional formatters, we need to change how formatters are selected when using VS Code.

Currently we use an `enum` with fixed set of choices. We _could_ change this to a text field, but that result in a poorer user experience.

Another option is to add the additional formatters to the enum list.

Although we generally try keep ruby-lsp itself unaware of specific addons, in this case it seems a worthwhile trade-off.

With the new choices being added, there is some additional information we want to show the user. There are two ways we could do this:

Using `enumDescriptions`:

<img width="373" alt="Screenshot 2024-05-27 at 1 12 32 PM" src="https://github.com/Shopify/ruby-lsp/assets/13400/975ae85e-a3d4-4156-9d51-35bf96c5823e">

Using `enumLabels`:

<img width="384" alt="Screenshot 2024-05-27 at 1 11 30 PM" src="https://github.com/Shopify/ruby-lsp/assets/13400/854f1fa7-bbd2-493c-ba76-bc28937fa679">
