### PR TITLE
Improve method extract target location

### DIFF
--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -19,8 +19,8 @@ module RubyLsp
     class CodeActions < Request
       extend T::Sig
 
-      VARIABLE_REFACTOR_CODE_ACTION_TITLE = "Refactor: Extract Variable"
-      METHOD_REFACTOR_CODE_ACTION_TITLE = "Refactor: Extract Method"
+      EXTRACT_TO_VARIABLE_TITLE = "Refactor: Extract Variable"
+      EXTRACT_TO_METHOD_TITLE = "Refactor: Extract Method"
 
       class << self
         extend T::Sig
@@ -56,36 +56,19 @@ module RubyLsp
 
         # Only add refactor actions if there's a non empty selection in the editor
         unless @range.dig(:start) == @range.dig(:end)
-          code_actions << refactor_code_action(@range, @uri)
-          code_actions << extract_code_action(@range, @uri)
+          code_actions << Interface::CodeAction.new(
+            title: EXTRACT_TO_VARIABLE_TITLE,
+            kind: Constant::CodeActionKind::REFACTOR_EXTRACT,
+            data: { range: @range, uri: @uri.to_s },
+          )
+          code_actions << Interface::CodeAction.new(
+            title: EXTRACT_TO_METHOD_TITLE,
+            kind: Constant::CodeActionKind::REFACTOR_EXTRACT,
+            data: { range: @range, uri: @uri.to_s },
+          )
         end
+
         code_actions
-      end
-
-      private
-
-      sig { params(range: T::Hash[Symbol, T.untyped], uri: URI::Generic).returns(Interface::CodeAction) }
-      def refactor_code_action(range, uri)
-        Interface::CodeAction.new(
-          title: VARIABLE_REFACTOR_CODE_ACTION_TITLE,
-          kind: Constant::CodeActionKind::REFACTOR_EXTRACT,
-          data: {
-            range: range,
-            uri: uri.to_s,
-          },
-        )
-      end
-
-      sig { params(range: T::Hash[Symbol, T.untyped], uri: URI::Generic).returns(Interface::CodeAction) }
-      def extract_code_action(range, uri)
-        Interface::CodeAction.new(
-          title: METHOD_REFACTOR_CODE_ACTION_TITLE,
-          kind: Constant::CodeActionKind::REFACTOR_EXTRACT,
-          data: {
-            range: range,
-            uri: uri.to_s,
-          },
-        )
       end
     end
   end

--- a/test/expectations/code_action_resolve/extract_method.exp.json
+++ b/test/expectations/code_action_resolve/extract_method.exp.json
@@ -29,15 +29,15 @@
             {
               "range": {
                 "start": {
-                  "line": 4,
-                  "character": 2
+                  "line": 3,
+                  "character": 5
                 },
                 "end": {
-                  "line": 4,
-                  "character": 2
+                  "line": 3,
+                  "character": 5
                 }
               },
-              "newText": "\n  def new_method\n        answer = 42\n  end\n\n"
+              "newText": "\n\n  def new_method\n        answer = 42\n  end"
             },
             {
               "range": {


### PR DESCRIPTION
### Motivation

The way that extract to method targeting was implemented was a bit brittle and failed if there was no new line between `end` token and the next method declaration. This PR fixes that.

### Implementation

Started basing the `end_line` on the location of the `end` token, so that we insert the new method source on the same line.

Also applied a few renames, nothing major.

### Automated Tests

Fixed the test expectation, which was actually expecting the bug behaviour.

### Manual Tests

1. Launch the LSP on this branch
2. In the following example, select `5 + 5` and then extract to method
3. Verify that the refactor produces valid code (it didn't before)

```ruby
class Foo
  def bar
    5 + 5
  end
end
```