### PR TITLE
Disable highlightUntyped

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,4 @@
       ]
     }
   ],
-  "sorbet.highlightUntyped": "everywhere-but-tests"
 }


### PR DESCRIPTION
As agreed with @vinistock, we were finding it too distracting.