### PR TITLE
Fix duplicate LSP features appearing in multiroot workspaces

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -91,6 +91,7 @@ function collectClientOptions(
   configuration: vscode.WorkspaceConfiguration,
   workspaceFolder: vscode.WorkspaceFolder,
   outputChannel: WorkspaceChannel,
+  ruby: Ruby,
 ): LanguageClientOptions {
   const pullOn: "change" | "save" | "both" =
     configuration.get("pullDiagnosticsOn")!;
@@ -103,8 +104,27 @@ function collectClientOptions(
   const features: EnabledFeatures = configuration.get("enabledFeatures")!;
   const enabledFeatures = Object.keys(features).filter((key) => features[key]);
 
+  const fsPath = workspaceFolder.uri.fsPath.replace(/\/$/, "");
+  const documentSelector = [
+    {
+      language: "ruby",
+      pattern: `${fsPath}/**/*`,
+    },
+  ];
+
+  if (ruby.env.GEM_PATH) {
+    const parts = ruby.env.GEM_PATH.split(path.delimiter);
+
+    parts.forEach((gemPath) => {
+      documentSelector.push({
+        language: "ruby",
+        pattern: `${gemPath}/**/*`,
+      });
+    });
+  }
+
   return {
-    documentSelector: [{ language: "ruby" }],
+    documentSelector,
     workspaceFolder,
     diagnosticCollectionName: LSP_NAME,
     outputChannel,
@@ -149,6 +169,7 @@ export default class Client extends LanguageClient implements ClientInterface {
         vscode.workspace.getConfiguration("rubyLsp"),
         workspaceFolder,
         outputChannel,
+        ruby,
       ),
     );
 


### PR DESCRIPTION
Closes https://github.com/Shopify/ruby-lsp/issues/2052

Co-authored with @vinistock 

(~TODO: Log an issue for [vscode-languageserver-node](https://github.com/microsoft/vscode-languageserver-node) about seeing unexpected requests for semanticToken for a workspace that isn't even open~) https://github.com/microsoft/vscode-languageserver-node/issues/1487

<img width="1027" alt="Screenshot 2024-05-29 at 12 06 39 PM" src="https://github.com/Shopify/ruby-lsp/assets/13400/62d95b36-e870-4d35-b18c-2b024d35c17e">
