### PR TITLE
Revert "Allow Code Lenses without a command"

### DIFF
--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -50,12 +50,12 @@ module RubyLsp
           params(
             node: Prism::Node,
             title: String,
-            command_name: T.nilable(String),
+            command_name: String,
             arguments: T.nilable(T::Array[T.untyped]),
             data: T.nilable(T::Hash[T.untyped, T.untyped]),
           ).returns(Interface::CodeLens)
         end
-        def create_code_lens(node, title:, command_name: nil, arguments: nil, data: nil)
+        def create_code_lens(node, title:, command_name:, arguments:, data:)
           range = range_from_node(node)
 
           Interface::CodeLens.new(


### PR DESCRIPTION
As mentioned in https://github.com/Shopify/ruby-lsp/pull/2069#issuecomment-2132237013, we cannot allow a `nil` command because that is telling the client to send a `codeLens/resolve` request for lazy command resolution - which we do not support.