### PR TITLE
Andyw8/detect missing fixtures submodule

### DIFF
--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -299,6 +299,10 @@ module RubyIndexer
     end
 
     def test_indexing_prism_fixtures_succeeds
+      unless Dir.exist?("test/fixtures/prism/test/prism/fixtures")
+        raise "Prism fixtures not found. Run `git submodule update --init` to fetch them."
+      end
+
       fixtures = Dir.glob("test/fixtures/prism/test/prism/fixtures/**/*.txt")
 
       fixtures.each do |fixture|


### PR DESCRIPTION
We have this check already in `bin/test` but if you're running the test some other way then it will be missed and you'll get a confusing failure.