### PR TITLE
Search for asdf.fish when the shell is fish

### DIFF
--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-process-env */
 
 import os from "os";
+import path from "path";
 
 import * as vscode from "vscode";
 
@@ -37,6 +38,9 @@ export class Asdf extends VersionManager {
 
   // Only public for testing. Finds the ASDF installation URI based on what's advertised in the ASDF documentation
   async findAsdfInstallation(): Promise<vscode.Uri> {
+    const scriptName =
+      path.basename(vscode.env.shell) === "fish" ? "asdf.fish" : "asdf.sh";
+
     // Possible ASDF installation paths as described in https://asdf-vm.com/guide/getting-started.html#_3-install-asdf.
     // In order, the methods of installation are:
     // 1. Git
@@ -44,8 +48,8 @@ export class Asdf extends VersionManager {
     // 3. Homebrew M series
     // 4. Homebrew Intel series
     const possiblePaths = [
-      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".asdf", "asdf.sh"),
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "asdf-vm", "asdf.sh"),
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".asdf", scriptName),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "asdf-vm", scriptName),
       vscode.Uri.joinPath(
         vscode.Uri.file("/"),
         "opt",
@@ -53,7 +57,7 @@ export class Asdf extends VersionManager {
         "opt",
         "asdf",
         "libexec",
-        "asdf.sh",
+        scriptName,
       ),
       vscode.Uri.joinPath(
         vscode.Uri.file("/"),
@@ -62,7 +66,7 @@ export class Asdf extends VersionManager {
         "opt",
         "asdf",
         "libexec",
-        "asdf.sh",
+        scriptName,
       ),
     ];
 

--- a/vscode/src/test/suite/ruby/asdf.test.ts
+++ b/vscode/src/test/suite/ruby/asdf.test.ts
@@ -65,4 +65,56 @@ suite("Asdf", () => {
     findInstallationStub.restore();
     shellStub.restore();
   });
+
+  test("Searches for asdf.fish when using the fish shell", async () => {
+    // eslint-disable-next-line no-process-env
+    const workspacePath = process.env.PWD!;
+    const workspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
+    const asdf = new Asdf(workspaceFolder, outputChannel);
+    const activationScript =
+      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
+
+    const execStub = sinon.stub(common, "asyncExec").resolves({
+      stdout: "",
+      stderr: JSON.stringify({
+        env: { ANY: "true" },
+        yjit: true,
+        version: "3.0.0",
+      }),
+    });
+
+    const findInstallationStub = sinon
+      .stub(asdf, "findAsdfInstallation")
+      .resolves(vscode.Uri.file(`${os.homedir()}/.asdf/asdf.fish`));
+    const shellStub = sinon
+      .stub(vscode.env, "shell")
+      .get(() => "/opt/homebrew/bin/fish");
+
+    const { env, version, yjit } = await asdf.activate();
+
+    assert.ok(
+      execStub.calledOnceWithExactly(
+        `. ${os.homedir()}/.asdf/asdf.fish && asdf exec ruby -W0 -rjson -e '${activationScript}'`,
+        {
+          cwd: workspacePath,
+          shell: "/opt/homebrew/bin/fish",
+          // eslint-disable-next-line no-process-env
+          env: process.env,
+        },
+      ),
+    );
+
+    assert.strictEqual(version, "3.0.0");
+    assert.strictEqual(yjit, true);
+    assert.strictEqual(env.ANY, "true");
+
+    execStub.restore();
+    findInstallationStub.restore();
+    shellStub.restore();
+  });
 });


### PR DESCRIPTION
### Motivation

Closes #2110

When the shell is fish, we need to source `asdf.fish` instead of `asdf.sh`.

### Implementation

Started changing the script name we search for based on the shell.

### Automated Tests

Added another example.