### PR TITLE
Fix broken anchor link in EDITOR doc

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -15,7 +15,7 @@ new H2 header in this file containing the instructions. -->
 
 - [Emacs LSP Mode](https://emacs-lsp.github.io/lsp-mode/page/lsp-ruby-lsp/)
 - [Emacs Eglot](#Emacs-Eglot)
-- [Neovim LSP](#Neovim-LSP)
+- [Neovim LSP](#Neovim)
 - [Sublime Text LSP](#sublime-text-lsp)
 - [Zed](#zed)
 - [RubyMine](#RubyMine)


### PR DESCRIPTION
### Motivation

The link to the neovim lsp config references a non existent header/anchor. This corrects that.

### Implementation

Changed link to match the section header.

### Automated Tests

N/A

### Manual Tests

View file to render the markdown, click the link.