### PR TITLE
Avoid computing ancestors if no ivar is found

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -380,8 +380,10 @@ module RubyIndexer
     sig { params(variable_name: String, owner_name: String).returns(T.nilable(T::Array[Entry::InstanceVariable])) }
     def resolve_instance_variable(variable_name, owner_name)
       entries = T.cast(self[variable_name], T.nilable(T::Array[Entry::InstanceVariable]))
+      return unless entries
+
       ancestors = linearized_ancestors_of(owner_name)
-      return unless entries && ancestors.any?
+      return if ancestors.empty?
 
       entries.select { |e| ancestors.include?(e.owner&.name) }
     end


### PR DESCRIPTION
### Motivation

Addressing https://github.com/Shopify/ruby-lsp/pull/2098#discussion_r1621428134. We don't need to compute linearization if we couldn't find a variable with the given name.
