### PR TITLE
Add CallNode field to NodeContext

### DIFF
--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -19,6 +19,8 @@ module RubyLsp
           Prism::InstanceVariableOrWriteNode,
           Prism::InstanceVariableTargetNode,
           Prism::InstanceVariableWriteNode,
+          Prism::SymbolNode,
+          Prism::StringNode,
         ],
         T::Array[T.class_of(Prism::Node)],
       )

--- a/lib/ruby_lsp/node_context.rb
+++ b/lib/ruby_lsp/node_context.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 module RubyLsp
-  # This class allows listeners to access contextual information about a node in the AST, such as its parent
-  # and its namespace nesting.
+  # This class allows listeners to access contextual information about a node in the AST, such as its parent,
+  # its namespace nesting, and the surrounding CallNode (e.g. a method call).
   class NodeContext
     extend T::Sig
 
@@ -13,11 +13,22 @@ module RubyLsp
     sig { returns(T::Array[String]) }
     attr_reader :nesting
 
-    sig { params(node: T.nilable(Prism::Node), parent: T.nilable(Prism::Node), nesting: T::Array[String]).void }
-    def initialize(node, parent, nesting)
+    sig { returns(T.nilable(Prism::CallNode)) }
+    attr_reader :call_node
+
+    sig do
+      params(
+        node: T.nilable(Prism::Node),
+        parent: T.nilable(Prism::Node),
+        nesting: T::Array[String],
+        call_node: T.nilable(Prism::CallNode),
+      ).void
+    end
+    def initialize(node, parent, nesting, call_node)
       @node = node
       @parent = parent
       @nesting = nesting
+      @call_node = call_node
     end
 
     sig { returns(String) }

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -60,6 +60,8 @@ module RubyLsp
             Prism::InstanceVariableOrWriteNode,
             Prism::InstanceVariableTargetNode,
             Prism::InstanceVariableWriteNode,
+            Prism::SymbolNode,
+            Prism::StringNode,
           ],
         )
 
@@ -79,6 +81,9 @@ module RubyLsp
           # If the target is a method call, we need to ensure that the requested position is exactly on top of the
           # method identifier. Otherwise, we risk showing definitions for unrelated things
           target = nil
+        # For methods with block arguments using symbol-to-proc
+        elsif target.is_a?(Prism::SymbolNode) && parent.is_a?(Prism::BlockArgumentNode)
+          target = parent
         end
 
         if target

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -480,6 +480,67 @@ class RubyDocumentTest < Minitest::Test
     assert_equal(["Foo", "Other"], node_context.nesting)
   end
 
+  def test_locate_returns_call_node
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
+      module Foo
+        class Other
+          def do_it
+            hello :foo
+            :bar
+          end
+        end
+      end
+    RUBY
+
+    node_context = document.locate_node({ line: 3, character: 14 })
+    assert_equal(":foo", T.must(node_context.node).slice)
+    assert_equal(:hello, T.must(node_context.call_node).name)
+
+    node_context = document.locate_node({ line: 4, character: 8 })
+    assert_equal(":bar", T.must(node_context.node).slice)
+    assert_nil(node_context.call_node)
+  end
+
+  def test_locate_returns_call_node_nested
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
+      module Foo
+        class Other
+          def do_it
+            goodbye(hello(:foo))
+          end
+        end
+      end
+    RUBY
+
+    node_context = document.locate_node({ line: 3, character: 22 })
+    assert_equal(":foo", T.must(node_context.node).slice)
+    assert_equal(:hello, T.must(node_context.call_node).name)
+  end
+
+  def test_locate_returns_call_node_for_blocks
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
+      foo do
+        "hello"
+      end
+    RUBY
+
+    node_context = document.locate_node({ line: 1, character: 4 })
+    assert_equal(:foo, T.must(node_context.call_node).name)
+  end
+
+  def test_locate_returns_call_node_ZZZ
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
+      foo(
+        if bar(1, 2, 3)
+          "hello" # this is the target
+        end
+      end
+    RUBY
+
+    node_context = document.locate_node({ line: 2, character: 6 })
+    assert_equal(:foo, T.must(node_context.call_node).name)
+  end
+
   def test_locate_returns_correct_nesting_when_specifying_target_classes
     document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
       module Foo


### PR DESCRIPTION
When we listen for node events, there are some situations where we are interested in not just the node, but the surrounding context. For cases such as a DSL call `has_many :users`, we make a definition request for the `:users` symbol, but we also want to know the surrounding method (`has_many` in this case). This will allow features such as https://github.com/Shopify/ruby-lsp-rails/pull/397

The implementation is fairly simple: While iterating over the queue, if the `parent` is a `CallNode`, then we keep track of that. So at the end of the iteration, we have the innermost `CallNode`, which we can then pass to `NodeContext.new`.

