### PR TITLE
Fully initialize global state in tests by calling apply_options

### DIFF
--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -21,6 +21,7 @@ module RubyLsp
       &block)
       server = RubyLsp::Server.new(test_mode: true)
       server.global_state.stubs(:typechecker).returns(false) if stub_no_typechecker
+      server.global_state.apply_options({})
 
       if source
         server.process_message({


### PR DESCRIPTION
As stated in this comment: https://github.com/Shopify/ruby-lsp/pull/1926#issuecomment-2056908023 A global state is not fully initialized without `apply_options` being called, which the current `with_server` test helper does not do.

This means that when tests are being run, detections around things like test library are not performed, which can yield unexpected results to developers, especially addon authors.

This commit changes the `with_server` test helper to call `apply_options`.
