### PR TITLE
Run labels check only after PR approval

### DIFF
--- a/.github/workflows/require_labels.yml
+++ b/.github/workflows/require_labels.yml
@@ -1,11 +1,12 @@
 name: Pull Request Labels
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   check-labels:
+    if: github.event.review.state == 'APPROVED'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Addresses part of https://github.com/Shopify/ruby-lsp/issues/2081

As per https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-when-a-pull-request-is-approved