### PR TITLE
Handle unsaved files in main language server client

### DIFF
--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -161,6 +161,7 @@ export class RubyLsp {
       workspaceFolder,
       this.telemetry,
       this.testController.createTestItems.bind(this.testController),
+      eager,
     );
     this.workspaces.set(workspaceFolder.uri.toString(), workspace);
 

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -21,6 +21,7 @@ export class Workspace implements WorkspaceInterface {
   private readonly context: vscode.ExtensionContext;
   private readonly telemetry: Telemetry;
   private readonly outputChannel: WorkspaceChannel;
+  private readonly isMainWorkspace: boolean;
   private needsRestart = false;
   #rebaseInProgress = false;
   #error = false;
@@ -30,6 +31,7 @@ export class Workspace implements WorkspaceInterface {
     workspaceFolder: vscode.WorkspaceFolder,
     telemetry: Telemetry,
     createTestItems: (response: CodeLens[]) => void,
+    isMainWorkspace = false,
   ) {
     this.context = context;
     this.workspaceFolder = workspaceFolder;
@@ -40,6 +42,7 @@ export class Workspace implements WorkspaceInterface {
     this.telemetry = telemetry;
     this.ruby = new Ruby(context, workspaceFolder, this.outputChannel);
     this.createTestItems = createTestItems;
+    this.isMainWorkspace = isMainWorkspace;
 
     this.registerRestarts(context);
     this.registerRebaseWatcher(context);
@@ -102,6 +105,7 @@ export class Workspace implements WorkspaceInterface {
       this.createTestItems,
       this.workspaceFolder,
       this.outputChannel,
+      this.isMainWorkspace,
     );
 
     try {


### PR DESCRIPTION
### Motivation

With the changes in #2101, we regressed with an interesting bug. Because of the narrower document selector, we were simply ignoring unsaved files.

Theoretically, that shouldn't case any issues since we're just ignoring them. However, received reports of https://github.com/Shopify/ruby-lsp/issues/1897#issuecomment-2144452992 happening again and indeed it's easy to reproduce on main.

That issue only happens when we receive an unexpected request for a document before a `textDocument/didOpen` notification gets sent for it (which should never happen).

The reason it's happening is the bug we identified https://github.com/microsoft/vscode-languageserver-node/issues/1487, where the LSP package is sending unexpected semantic token requests without respecting the document selector.

So, the order of the events were:

1. You open an unsaved Ruby file
2. We didn't receive a `textDocument/didOpen` notification for it, because we were accidentally ignoring it in the document selector
3. The LSP package mistakenly sends a semantic token request anyway
4. Since we never got notified that the file was opened in the first place, it breaks the server

Quite an interesting interaction of different issues.

### Implementation

For unsaved files, it's not possible to know to which workspace they belong to. That information only exists after the user chooses where to save the file.

What we need to do is have the main language client (the first one) handle all files while they are unsaved. If the user decides to save the file in a workspace that does not belong to that main client, that is completely fine. VS Code will actually send `didClose` notifications for the `untitled:Untitled-1` uri and then send a `didOpen` notification for the file that was just saved to the correct language client.

The implementation is not the prettiest, but I don't know how else we could go about it.