### PR TITLE
Fix duplicate nesting when targetting classes/modules

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -170,6 +170,19 @@ module RubyLsp
         end
       end
 
+      # When targeting the constant part of a class/module definition, we do not want the nesting to be duplicated. That
+      # is, when targeting Bar in the following example:
+      #
+      # ```ruby
+      #   class Foo::Bar; end
+      # ```
+      # The correct target is `Foo::Bar` with an empty nesting. `Foo::Bar` should not appear in the nesting stack, even
+      # though the class/module node does indeed enclose the target, because it would lead to incorrect behavior
+      if closest.is_a?(Prism::ConstantReadNode) || closest.is_a?(Prism::ConstantPathNode)
+        last_level = nesting.last
+        nesting.pop if last_level && last_level.constant_path == closest
+      end
+
       NodeContext.new(closest, parent, nesting.map { |n| n.constant_path.location.slice })
     end
 

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -593,6 +593,24 @@ class RubyDocumentTest < Minitest::Test
     refute_predicate(document, :sorbet_sigil_is_true_or_higher)
   end
 
+  def test_locating_compact_namespace_declaration
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
+      class Foo::Bar
+      end
+
+      class Baz
+      end
+    RUBY
+
+    node_context = document.locate_node({ line: 0, character: 11 })
+    assert_empty(node_context.nesting)
+    assert_equal("Foo::Bar", T.must(node_context.node).slice)
+
+    node_context = document.locate_node({ line: 3, character: 6 })
+    assert_empty(node_context.nesting)
+    assert_equal("Baz", T.must(node_context.node).slice)
+  end
+
   private
 
   def assert_error_edit(actual, error_range)


### PR DESCRIPTION
### Motivation

While implementing the complete constant resolution algorithm with ancestors, we uncovered this bug in how we are tracking the nesting for class/module targets.

The constant path would be included both as the closest node and as part of the nesting too. For example

```ruby
class Foo::Bar
          #^ target here
end
```

That would return a node context of the format
```ruby
#<NodeContext node=Foo::Bar nesting=["Foo", "Bar"]>
```
Which is incorrect. In this case, we want the target to be `Foo::Bar` and the nesting to be empty.

### Implementation

The issue is that the class/module node is the parent of the constant path node we're targeting. That means we push the class/module nodes into the nesting first and then later discover that the target was exactly that constant.

To fix it, I'm simply checking for this particular scenario and then popping the nesting if necessary.

### Automated Tests

Added tests that reproduce the scenario.