### PR TITLE
Add `case` statement to VS Code snippets

### DIFF
--- a/vscode/snippets.json
+++ b/vscode/snippets.json
@@ -189,7 +189,16 @@
   },
   "Case": {
     "prefix": ["case"],
-    "body": ["case $0", "when  $1", "  $2", "when  $3", "  $4", "else", "  $5", "end"],
+    "body": [
+      "case $0",
+      "when  $1",
+      "  $2",
+      "when  $3",
+      "  $4",
+      "else",
+      "  $5",
+      "end"
+    ],
     "description": "New case statement."
   }
 }

--- a/vscode/snippets.json
+++ b/vscode/snippets.json
@@ -186,5 +186,10 @@
     "prefix": ["unless"],
     "body": ["unless $1", "  $0", "end"],
     "description": "New unless statement."
-  }
+  },
+  "Case": {
+		"prefix": ["case"],
+		"body": ["case $0", "when  $1", "  $2", "when  $3", "  $4", "else", "  $5", "end"],
+		"description": "New case statement."
+	}
 }

--- a/vscode/snippets.json
+++ b/vscode/snippets.json
@@ -188,8 +188,8 @@
     "description": "New unless statement."
   },
   "Case": {
-		"prefix": ["case"],
-		"body": ["case $0", "when  $1", "  $2", "when  $3", "  $4", "else", "  $5", "end"],
-		"description": "New case statement."
-	}
+    "prefix": ["case"],
+    "body": ["case $0", "when  $1", "  $2", "when  $3", "  $4", "else", "  $5", "end"],
+    "description": "New case statement."
+  }
 }


### PR DESCRIPTION
### Motivation

Adds a VScode snippet for the Ruby `case` statement.

<!-- Closes # -->

A pretty trivial one but I've been missing this snippet lately so thought I'd add it here 😁

### Implementation

Pretty straightforward, just adds a snippet that outputs the following:

```ruby
case 
when  
  
when  
  
else
  
end
```

### Automated Tests

No tests, as it's just a snippet, see manual test steps.

### Manual Tests

Type `case` in a ruby file and choose the snippet presented in the context menu.
