### PR TITLE
Standardize version manager script execution

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ruby-lsp",
   "displayName": "Ruby LSP",
   "description": "VS Code plugin for connecting with the Ruby LSP",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "publisher": "Shopify",
   "repository": {
     "type": "git",

--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -5,8 +5,6 @@ import path from "path";
 
 import * as vscode from "vscode";
 
-import { asyncExec } from "../common";
-
 import { VersionManager, ActivationResult } from "./versionManager";
 
 // A tool to manage multiple runtime versions with a single CLI tool
@@ -18,13 +16,8 @@ export class Asdf extends VersionManager {
     const activationScript =
       "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
 
-    const result = await asyncExec(
+    const result = await this.runScript(
       `. ${asdfUri.fsPath} && asdf exec ruby -W0 -rjson -e '${activationScript}'`,
-      {
-        cwd: this.bundleUri.fsPath,
-        shell: vscode.env.shell,
-        env: process.env,
-      },
     );
 
     const parsedResult = this.parseWithErrorHandling(result.stderr);

--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -4,7 +4,6 @@ import path from "path";
 
 import * as vscode from "vscode";
 
-import { asyncExec } from "../common";
 import { WorkspaceChannel } from "../workspaceChannel";
 
 import { ActivationResult, VersionManager } from "./versionManager";
@@ -224,9 +223,8 @@ export class Chruby extends VersionManager {
       "STDERR.print(JSON.dump(data))",
     ].join(";");
 
-    const result = await asyncExec(
+    const result = await this.runScript(
       `${rubyExecutableUri.fsPath} -W0 -rjson -e '${script}'`,
-      { cwd: this.bundleUri.fsPath },
     );
 
     return this.parseWithErrorHandling(result.stderr);

--- a/vscode/src/ruby/custom.ts
+++ b/vscode/src/ruby/custom.ts
@@ -1,8 +1,6 @@
 /* eslint-disable no-process-env */
 import * as vscode from "vscode";
 
-import { asyncExec } from "../common";
-
 import { VersionManager, ActivationResult } from "./versionManager";
 
 // Custom
@@ -15,11 +13,8 @@ export class Custom extends VersionManager {
     const activationScript =
       "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
 
-    const result = await asyncExec(
+    const result = await this.runScript(
       `${this.customCommand()} && ruby -W0 -rjson -e '${activationScript}'`,
-      {
-        cwd: this.bundleUri.fsPath,
-      },
     );
 
     const parsedResult = this.parseWithErrorHandling(result.stderr);

--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -3,8 +3,6 @@ import os from "os";
 
 import * as vscode from "vscode";
 
-import { asyncExec } from "../common";
-
 import { VersionManager, ActivationResult } from "./versionManager";
 
 // Mise (mise en place) is a manager for dev tools, environment variables and tasks
@@ -18,11 +16,8 @@ export class Mise extends VersionManager {
       "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
 
     // The exec command in Mise is called `x`
-    const result = await asyncExec(
+    const result = await this.runScript(
       `${miseUri.fsPath} x -- ruby -W0 -rjson -e '${activationScript}'`,
-      {
-        cwd: this.bundleUri.fsPath,
-      },
     );
 
     const parsedResult = this.parseWithErrorHandling(result.stderr);

--- a/vscode/src/ruby/none.ts
+++ b/vscode/src/ruby/none.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-process-env */
 import * as vscode from "vscode";
 
-import { asyncExec } from "../common";
 import { WorkspaceChannel } from "../workspaceChannel";
 
 import { VersionManager, ActivationResult } from "./versionManager";
@@ -30,11 +29,8 @@ export class None extends VersionManager {
     const activationScript =
       "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
 
-    const result = await asyncExec(
+    const result = await this.runScript(
       `${this.rubyPath} -W0 -rjson -e '${activationScript}'`,
-      {
-        cwd: this.bundleUri.fsPath,
-      },
     );
 
     const parsedResult = this.parseWithErrorHandling(result.stderr);

--- a/vscode/src/ruby/rbenv.ts
+++ b/vscode/src/ruby/rbenv.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-process-env */
 
-import { asyncExec } from "../common";
-
 import { VersionManager, ActivationResult } from "./versionManager";
 
 // Seamlessly manage your app’s Ruby environment with rbenv.
@@ -12,11 +10,8 @@ export class Rbenv extends VersionManager {
     const activationScript =
       "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
 
-    const result = await asyncExec(
+    const result = await this.runScript(
       `rbenv exec ruby -W0 -rjson -e '${activationScript}'`,
-      {
-        cwd: this.bundleUri.fsPath,
-      },
     );
 
     const parsedResult = this.parseWithErrorHandling(result.stderr);

--- a/vscode/src/ruby/rvm.ts
+++ b/vscode/src/ruby/rvm.ts
@@ -3,8 +3,6 @@ import os from "os";
 
 import * as vscode from "vscode";
 
-import { asyncExec } from "../common";
-
 import { ActivationResult, VersionManager } from "./versionManager";
 
 // Ruby enVironment Manager. It manages Ruby application environments and enables switching between them.
@@ -17,12 +15,8 @@ export class Rvm extends VersionManager {
       "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
 
     const installationPath = await this.findRvmInstallation();
-
-    const result = await asyncExec(
+    const result = await this.runScript(
       `${installationPath.fsPath} -W0 -rjson -e '${activationScript}'`,
-      {
-        cwd: this.bundleUri.fsPath,
-      },
     );
 
     const parsedResult = this.parseWithErrorHandling(result.stderr);

--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -26,11 +26,8 @@ export class Shadowenv extends VersionManager {
       "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
 
     try {
-      const result = await asyncExec(
+      const result = await this.runScript(
         `shadowenv exec -- ruby -W0 -rjson -e '${activationScript}'`,
-        {
-          cwd: this.bundleUri.fsPath,
-        },
       );
 
       const parsedResult = this.parseWithErrorHandling(result.stderr);

--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -1,8 +1,10 @@
+/* eslint-disable no-process-env */
 import path from "path";
 
 import * as vscode from "vscode";
 
 import { WorkspaceChannel } from "../workspaceChannel";
+import { asyncExec } from "../common";
 
 export interface ActivationResult {
   env: NodeJS.ProcessEnv;
@@ -53,5 +55,24 @@ export abstract class VersionManager {
 
       throw error;
     }
+  }
+
+  // Runs the given command in the directory for the Bundle, using the user's preferred shell and inheriting the current
+  // process environment
+  protected runScript(command: string) {
+    const shell = vscode.env.shell.length > 0 ? vscode.env.shell : undefined;
+
+    this.outputChannel.info(
+      `Running command: \`${command}\` in ${this.bundleUri.fsPath} using shell: ${shell}`,
+    );
+    this.outputChannel.debug(
+      `Environment used for command: ${JSON.stringify(process.env)}`,
+    );
+
+    return asyncExec(command, {
+      cwd: this.bundleUri.fsPath,
+      shell,
+      env: process.env,
+    });
   }
 }

--- a/vscode/src/test/suite/ruby/custom.test.ts
+++ b/vscode/src/test/suite/ruby/custom.test.ts
@@ -43,7 +43,12 @@ suite("Custom", () => {
     assert.ok(
       execStub.calledOnceWithExactly(
         `my_version_manager activate_env && ruby -W0 -rjson -e '${activationScript}'`,
-        { cwd: uri.fsPath },
+        {
+          cwd: uri.fsPath,
+          shell: vscode.env.shell,
+          // eslint-disable-next-line no-process-env
+          env: process.env,
+        },
       ),
     );
 

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -55,7 +55,12 @@ suite("Mise", () => {
     assert.ok(
       execStub.calledOnceWithExactly(
         `${os.homedir()}/.local/bin/mise x -- ruby -W0 -rjson -e '${activationScript}'`,
-        { cwd: workspacePath },
+        {
+          cwd: workspacePath,
+          shell: vscode.env.shell,
+          // eslint-disable-next-line no-process-env
+          env: process.env,
+        },
       ),
     );
 
@@ -109,7 +114,12 @@ suite("Mise", () => {
     assert.ok(
       execStub.calledOnceWithExactly(
         `${misePath} x -- ruby -W0 -rjson -e '${activationScript}'`,
-        { cwd: workspacePath },
+        {
+          cwd: workspacePath,
+          shell: vscode.env.shell,
+          // eslint-disable-next-line no-process-env
+          env: process.env,
+        },
       ),
     );
 

--- a/vscode/src/test/suite/ruby/none.test.ts
+++ b/vscode/src/test/suite/ruby/none.test.ts
@@ -40,7 +40,12 @@ suite("None", () => {
     assert.ok(
       execStub.calledOnceWithExactly(
         `ruby -W0 -rjson -e '${activationScript}'`,
-        { cwd: uri.fsPath },
+        {
+          cwd: uri.fsPath,
+          shell: vscode.env.shell,
+          // eslint-disable-next-line no-process-env
+          env: process.env,
+        },
       ),
     );
 

--- a/vscode/src/test/suite/ruby/rbenv.test.ts
+++ b/vscode/src/test/suite/ruby/rbenv.test.ts
@@ -44,7 +44,12 @@ suite("Rbenv", () => {
     assert.ok(
       execStub.calledOnceWithExactly(
         `rbenv exec ruby -W0 -rjson -e '${activationScript}'`,
-        { cwd: workspacePath },
+        {
+          cwd: workspacePath,
+          shell: vscode.env.shell,
+          // eslint-disable-next-line no-process-env
+          env: process.env,
+        },
       ),
     );
 
@@ -83,7 +88,12 @@ suite("Rbenv", () => {
     assert.ok(
       execStub.calledOnceWithExactly(
         `rbenv exec ruby -W0 -rjson -e '${activationScript}'`,
-        { cwd: workspacePath },
+        {
+          cwd: workspacePath,
+          shell: vscode.env.shell,
+          // eslint-disable-next-line no-process-env
+          env: process.env,
+        },
       ),
     );
 

--- a/vscode/src/test/suite/ruby/rvm.test.ts
+++ b/vscode/src/test/suite/ruby/rvm.test.ts
@@ -57,7 +57,11 @@ suite("RVM", () => {
     assert.ok(
       execStub.calledOnceWithExactly(
         `${path.join(os.homedir(), ".rvm", "bin", "rvm-auto-ruby")} -W0 -rjson -e '${activationScript}'`,
-        { cwd: workspacePath },
+        {
+          cwd: workspacePath,
+          shell: vscode.env.shell,
+          env: process.env,
+        },
       ),
     );
 


### PR DESCRIPTION
### Motivation

Closes #2114.

We were not passing the process environment or the shell detected by VS Code to version manager activation scripts.

However, it's becoming more evident that many version managers depend on certain environment variables to properly work (e.g.: `$HOME`). In addition to that, Rubygems itself depends on certain environment variables in order to define what the default and user gem paths are.

I think it's worth trying to standardize these script executions to always use the user's selected shell (which some version managers depend on) and make the execution inherit from `process.env`.

Notice that we're still not sourcing shell configuration scripts, since we moved away from that due to several integration issues.

### Implementation

Created a convenience method `runScript` which always inserts the `cwd`, `env` and `shell`. Started using it everywhere we invoke manager integrations.

Small detail: `vscode.env.shell` returns an empty string rather than `null` in operating systems where that value is not set to anything. We do not want to pass an empty string to `exec`, but rather `undefined` or `null`.

### Automated Tests

Adapted our tests.

### Manual Tests

Essentially, launch the extension on this branch and ensure the server boots properly.