### PR TITLE
Run label check when a label is added/removed

### DIFF
--- a/.github/workflows/require_labels.yml
+++ b/.github/workflows/require_labels.yml
@@ -3,6 +3,8 @@ name: Pull Request Labels
 on:
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [labeled, unlabeled]
 
 jobs:
   check-labels:


### PR DESCRIPTION
### Motivation

If we approve a PR and it's missing the labels, we need the action to run again after we add the labels otherwise the CI will remain broken.
