### PR TITLE
Associate singleton methods with the right owner objects

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -329,9 +329,6 @@ module RubyIndexer
 
     class Method < Member
       extend T::Sig
-      extend T::Helpers
-
-      abstract!
 
       sig { override.returns(T::Array[Parameter]) }
       attr_reader :parameters
@@ -438,12 +435,6 @@ module RubyIndexer
           :"(#{names_with_commas})"
         end
       end
-    end
-
-    class SingletonMethod < Method
-    end
-
-    class InstanceMethod < Method
     end
 
     # An UnresolvedAlias points to a constant alias with a right hand side that has not yet been resolved. For

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -13,7 +13,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
     end
 
     def test_conditional_method
@@ -24,7 +24,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
     end
 
     def test_singleton_method_using_self_receiver
@@ -35,7 +35,12 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::SingletonMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
+
+      entry = T.must(@index["bar"].first)
+      owner = T.must(entry.owner)
+      assert_equal("Foo", owner.name)
+      assert_instance_of(Entry::SingletonClass, owner)
     end
 
     def test_singleton_method_using_other_receiver_is_not_indexed
@@ -83,9 +88,9 @@ module RubyIndexer
         def baz; end
       RUBY
 
-      assert_entry("foo", Entry::InstanceMethod, "/fake/path/foo.rb:0-8:1-3", visibility: Entry::Visibility::PRIVATE)
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:3-0:3-12", visibility: Entry::Visibility::PUBLIC)
-      assert_entry("baz", Entry::InstanceMethod, "/fake/path/foo.rb:7-0:7-12", visibility: Entry::Visibility::PROTECTED)
+      assert_entry("foo", Entry::Method, "/fake/path/foo.rb:0-8:1-3", visibility: Entry::Visibility::PRIVATE)
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:3-0:3-12", visibility: Entry::Visibility::PUBLIC)
+      assert_entry("baz", Entry::Method, "/fake/path/foo.rb:7-0:7-12", visibility: Entry::Visibility::PROTECTED)
     end
 
     def test_visibility_tracking_with_nested_class_or_modules
@@ -103,9 +108,9 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("foo", Entry::InstanceMethod, "/fake/path/foo.rb:3-2:3-14", visibility: Entry::Visibility::PRIVATE)
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:6-4:6-16", visibility: Entry::Visibility::PUBLIC)
-      assert_entry("baz", Entry::InstanceMethod, "/fake/path/foo.rb:9-2:9-14", visibility: Entry::Visibility::PRIVATE)
+      assert_entry("foo", Entry::Method, "/fake/path/foo.rb:3-2:3-14", visibility: Entry::Visibility::PRIVATE)
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:6-4:6-16", visibility: Entry::Visibility::PUBLIC)
+      assert_entry("baz", Entry::Method, "/fake/path/foo.rb:9-2:9-14", visibility: Entry::Visibility::PRIVATE)
     end
 
     def test_method_with_parameters
@@ -116,7 +121,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
       entry = T.must(@index["bar"].first)
       assert_equal(1, entry.parameters.length)
       parameter = entry.parameters.first
@@ -132,7 +137,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
       entry = T.must(@index["bar"].first)
       assert_equal(1, entry.parameters.length)
       parameter = entry.parameters.first
@@ -148,7 +153,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
       entry = T.must(@index["bar"].first)
       assert_equal(1, entry.parameters.length)
       parameter = entry.parameters.first
@@ -164,7 +169,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
       entry = T.must(@index["bar"].first)
       assert_equal(2, entry.parameters.length)
       a, b = entry.parameters
@@ -184,7 +189,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
       entry = T.must(@index["bar"].first)
       assert_equal(2, entry.parameters.length)
       a, b = entry.parameters
@@ -209,7 +214,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
       entry = T.must(@index["bar"].first)
       assert_equal(2, entry.parameters.length)
       a, b = entry.parameters
@@ -246,7 +251,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
       entry = T.must(@index["bar"].first)
       assert_equal(1, entry.parameters.length)
       param = entry.parameters.first
@@ -287,7 +292,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
       entry = T.must(@index["bar"].first)
       assert_equal(2, entry.parameters.length)
       first, second = entry.parameters
@@ -307,7 +312,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("bar", Entry::InstanceMethod, "/fake/path/foo.rb:1-2:2-5")
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
       entry = T.must(@index["bar"].first)
       assert_empty(entry.parameters)
     end
@@ -397,6 +402,31 @@ module RubyIndexer
       assert_entry("bar", Entry::UnresolvedMethodAlias, "/fake/path/foo.rb:3-15:3-20")
       # Foo plus 3 valid aliases
       assert_equal(4, @index.instance_variable_get(:@entries).length)
+    end
+
+    def test_singleton_methods
+      index(<<~RUBY)
+        class Foo
+          def self.bar; end
+
+          class << self
+            def baz; end
+          end
+        end
+      RUBY
+
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:1-19")
+      assert_entry("baz", Entry::Method, "/fake/path/foo.rb:4-4:4-16")
+
+      bar_owner = T.must(T.must(@index["bar"].first).owner)
+      baz_owner = T.must(T.must(@index["baz"].first).owner)
+
+      assert_instance_of(Entry::SingletonClass, bar_owner)
+      assert_instance_of(Entry::SingletonClass, baz_owner)
+
+      # Regardless of whether the method was added through `self.something` or `class << self`, the owner object must be
+      # the exact same
+      assert_same(bar_owner, baz_owner)
     end
   end
 end


### PR DESCRIPTION
### Motivation

First step for #1939

This PR starts the work to handle singleton contexts properly. It creates the singleton class object and starts associating methods to it.

The next steps are handling constants defined inside singleton contexts and properly handling instance variables.

### Implementation

First commit creates the `SingletonClass` object. Since they have ancestors of their own, I made it a `Namespace`. Note that modules also have singleton classes.

Also, note that singleton classes also have their own singleton class. Ruby allows you to keep chaining it and creates more levels lazily, which is what we're doing too.

The second commit gets rid of the `InstanceMethod` and `SingletonMethod` classes. There are only methods and the distinction is made by their owner.

### Automated Tests

Added a few tests and corrected others.