### PR TITLE
Ensure update server gem command updates the locked server

### DIFF
--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -185,7 +185,11 @@ export class RubyLsp {
     context.subscriptions.push(
       vscode.commands.registerCommand(Command.Update, async () => {
         const workspace = await this.showWorkspacePick();
-        await workspace?.installOrUpdateServer();
+
+        if (workspace) {
+          await workspace.installOrUpdateServer(true);
+          await workspace.restart();
+        }
       }),
       vscode.commands.registerCommand(Command.Start, async () => {
         const workspace = await this.showWorkspacePick();

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -80,7 +80,7 @@ export class Workspace implements WorkspaceInterface {
     }
 
     try {
-      await this.installOrUpdateServer();
+      await this.installOrUpdateServer(false);
     } catch (error: any) {
       this.error = true;
       await vscode.window.showErrorMessage(
@@ -175,7 +175,7 @@ export class Workspace implements WorkspaceInterface {
 
   // Install or update the `ruby-lsp` gem globally with `gem install ruby-lsp` or `gem update ruby-lsp`. We only try to
   // update on a daily basis, not every time the server boots
-  async installOrUpdateServer(): Promise<void> {
+  async installOrUpdateServer(manualInvocation: boolean): Promise<void> {
     // If there's a user configured custom bundle to run the LSP, then we do not perform auto-updates and let the user
     // manage that custom bundle themselves
     const customBundle: string = vscode.workspace
@@ -210,8 +210,24 @@ export class Workspace implements WorkspaceInterface {
       return;
     }
 
-    // If we haven't updated the gem in the last 24 hours, update it
+    // In addition to updating the global installation of the ruby-lsp gem, if the user manually requested an udpate, we
+    // should delete the `.ruby-lsp` to ensure that we'll lock a new version of the server that will actually be booted
+    if (manualInvocation) {
+      try {
+        await vscode.workspace.fs.delete(
+          vscode.Uri.joinPath(this.workspaceFolder.uri, ".ruby-lsp"),
+          { recursive: true },
+        );
+      } catch (error) {
+        this.outputChannel.info(
+          `Tried deleting ${vscode.Uri.joinPath(this.workspaceFolder.uri, ".ruby - lsp")}, but it doesn't exist`,
+        );
+      }
+    }
+
+    // If we haven't updated the gem in the last 24 hours or if the user manually asked for an update, update it
     if (
+      manualInvocation ||
       lastUpdatedAt === undefined ||
       Date.now() - lastUpdatedAt > oneDayInMs
     ) {

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -210,7 +210,7 @@ export class Workspace implements WorkspaceInterface {
       return;
     }
 
-    // In addition to updating the global installation of the ruby-lsp gem, if the user manually requested an udpate, we
+    // In addition to updating the global installation of the ruby-lsp gem, if the user manually requested an update, we
     // should delete the `.ruby-lsp` to ensure that we'll lock a new version of the server that will actually be booted
     if (manualInvocation) {
       try {


### PR DESCRIPTION
### Motivation

Our current implementation of the update language server gem command only runs `gem update ruby-lsp`. But that's actually not relevant for the version of the server that actually gets booted since that's controlled by the version locked in `.ruby-lsp/Gemfile.lock`.

This PR ensures that both the global installation and the locked versions are updated.

### Implementation

We use the method to install or update the server gem in two different places, so I introduced a parameter to indicate when the user manually requested an update.

In those cases, we now also delete the entire `.ruby-lsp` directory, so that the locked server of the gem is updated.

I also started re-booting the server after the update since it doesn't make sense to request an update, but then continue running the old version.