### PR TITLE
Run label check on any PR review

### DIFF
--- a/.github/workflows/require_labels.yml
+++ b/.github/workflows/require_labels.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   check-labels:
-    if: github.event.review.state == 'APPROVED'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Motivation

With the current approach, we have the following problem:

1. You add the labels to the PR
2. Someone approves it
3. The action runs and succeeds 👍 
4. Someone submits a comment review without approving
5. The action runs and is skipped
6. The PR is left in a "waiting for status check" state
7. If you address the person's comments and you're ready to merge, you can't. You need to ask for that person to explicitly approve or switch the labels

We need the action to run on any PR review, even if not approving it.