### PR TITLE
Build complete ancestors list with RBS classes and modules

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -67,6 +67,8 @@ module RubyIndexer
       parent_class = case superclass
       when Prism::ConstantReadNode, Prism::ConstantPathNode
         superclass.slice
+      else
+        "::Object"
       end
 
       nesting = name.start_with?("::") ? [name.delete_prefix("::")] : @stack + [name.delete_prefix("::")]

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -191,7 +191,8 @@ module RubyIndexer
 
       @index.delete(IndexablePath.new(nil, "/fake/path/foo.rb"))
       refute_entry("Foo")
-      assert_empty(@index.instance_variable_get(:@files_to_entries))
+
+      assert_no_indexed_entries
     end
 
     def test_comments_can_be_attached_to_a_class
@@ -323,7 +324,7 @@ module RubyIndexer
       assert_equal("Bar", foo.parent_class)
 
       baz = T.must(@index["Baz"].first)
-      assert_nil(baz.parent_class)
+      assert_equal("::Object", baz.parent_class)
 
       qux = T.must(@index["Something::Qux"].first)
       assert_equal("::Baz", qux.parent_class)

--- a/lib/ruby_indexer/test/constant_test.rb
+++ b/lib/ruby_indexer/test/constant_test.rb
@@ -105,7 +105,7 @@ module RubyIndexer
         self.class::FOO = 1
       RUBY
 
-      assert_no_entries
+      assert_no_indexed_entries
     end
 
     def test_private_constant_indexing

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -396,7 +396,7 @@ module RubyIndexer
       assert_entry("foo", Entry::UnresolvedMethodAlias, "/fake/path/foo.rb:2-15:2-19")
       assert_entry("bar", Entry::UnresolvedMethodAlias, "/fake/path/foo.rb:3-15:3-20")
       # Foo plus 3 valid aliases
-      assert_equal(4, @index.instance_variable_get(:@entries).length)
+      assert_equal(4, @index.instance_variable_get(:@entries).length - @default_indexed_entries.length)
     end
   end
 end

--- a/lib/ruby_indexer/test/rbs_indexer_test.rb
+++ b/lib/ruby_indexer/test/rbs_indexer_test.rb
@@ -5,11 +5,6 @@ require_relative "test_case"
 
 module RubyIndexer
   class RBSIndexerTest < TestCase
-    def setup
-      @index = RubyIndexer::Index.new
-      RBSIndexer.new(@index).index_core_classes
-    end
-
     def test_index_core_classes
       entries = @index["Array"]
       refute_nil(entries)
@@ -18,6 +13,24 @@ module RubyIndexer
       assert_match(%r{/gems/rbs-.*/core/array.rbs}, entry.file_path)
       assert_equal("array.rbs", entry.file_name)
       assert_equal("Object", entry.parent_class)
+      assert_equal(1, entry.mixin_operations.length)
+      enumerable_include = entry.mixin_operations.first
+      assert_equal("Enumerable", enumerable_include.module_name)
+
+      # Using fixed positions would be fragile, so let's just check some basics.
+      assert_operator(entry.location.start_line, :>, 0)
+      assert_operator(entry.location.end_line, :>, entry.location.start_line)
+      assert_equal(0, entry.location.start_column)
+      assert_operator(entry.location.end_column, :>, 0)
+    end
+
+    def test_index_core_modules
+      entries = @index["Kernel"]
+      refute_nil(entries)
+      assert_equal(1, entries.length)
+      entry = entries.first
+      assert_match(%r{/gems/rbs-.*/core/kernel.rbs}, entry.file_path)
+      assert_equal("kernel.rbs", entry.file_name)
 
       # Using fixed positions would be fragile, so let's just check some basics.
       assert_operator(entry.location.start_line, :>, 0)

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -7,6 +7,8 @@ module RubyIndexer
   class TestCase < Minitest::Test
     def setup
       @index = Index.new
+      RBSIndexer.new(@index).index_ruby_core
+      @default_indexed_entries = @index.instance_variable_get(:@entries).dup
     end
 
     private
@@ -40,6 +42,10 @@ module RubyIndexer
 
     def assert_no_entries
       assert_empty(@index.instance_variable_get(:@entries), "Expected nothing to be indexed")
+    end
+
+    def assert_no_indexed_entries
+      assert_equal(@default_indexed_entries, @index.instance_variable_get(:@entries))
     end
 
     def assert_no_entry(entry)

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -690,13 +690,13 @@ module RubyLsp
 
     sig { params(config_hash: T::Hash[String, T.untyped]).void }
     def perform_initial_indexing(config_hash)
-      index_core_classes
+      index_ruby_core
       index_ruby_code(config_hash)
     end
 
     sig { void }
-    def index_core_classes
-      RubyIndexer::RBSIndexer.new(@global_state.index).index_core_classes
+    def index_ruby_core
+      RubyIndexer::RBSIndexer.new(@global_state.index).index_ruby_core
     end
 
     sig { params(config_hash: T::Hash[String, T.untyped]).void }


### PR DESCRIPTION
### Motivation

Now that we use `rbs` to provide core classes, we can also index core modules through it, and build the entire ancestors list for Ruby classes (mostly: `Object`, `Kernel`, and `BasicObject`).

### Implementation

1. Start indexing modules through RBS as well
2. Make `Object` the default parent for indexed classes

### Automated Tests

Most tests in `index_test.rb` should take those core classes and modules into account.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
