### PR TITLE
Filter instance variable owners before deduping

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -413,8 +413,8 @@ module RubyIndexer
       entries = T.cast(prefix_search(name).flatten, T::Array[Entry::InstanceVariable])
       ancestors = linearized_ancestors_of(owner_name)
 
-      variables = entries.uniq(&:name)
-      variables.select! { |e| ancestors.any?(e.owner&.name) }
+      variables = entries.select { |e| ancestors.any?(e.owner&.name) }
+      variables.uniq!(&:name)
       variables
     end
 

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1105,5 +1105,25 @@ module RubyIndexer
       foo_entry = T.must(@index.resolve("CONST", ["Namespace", "Index"])&.first)
       assert_equal(1, foo_entry.location.start_line)
     end
+
+    def test_instance_variables_completions_from_different_owners_with_conflicting_names
+      index(<<~RUBY)
+        class Foo
+          def initialize
+            @bar = 1
+          end
+        end
+
+        class Bar
+          def initialize
+            @bar = 2
+          end
+        end
+      RUBY
+
+      entry = T.must(@index.instance_variable_completion_candidates("@", "Bar")&.first)
+      assert_equal("@bar", entry.name)
+      assert_equal("Bar", T.must(entry.owner).name)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

I noticed that I wasn't seeing as many instance variable completion candidates as I expected. The reason is because the order of operations were inverted.

Since we can have the same instance variable name exist multiple times, but belong to different owners, we need to first filter based on owner to find the ones that belong to the type we're searching for and then dedup the names to avoid showing duplicates.

If we do it the other way around, when we run `uniq!` we may be discarding the instance variable entry that belongs to the owner we're searching for - and thus we find no matches.

### Implementation

Just switched the order.

### Automated Tests

Added a test that demonstrates the bug.