### PR TITLE
Correct path for enabling ruby-lsp with LazyVim

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -112,10 +112,10 @@ require("lspconfig").ruby_lsp.setup({
 
 ## LazyVim LSP
 
-For LazyVim, you can add the ruby-lsp by creating a file in your plugins folder (`~/.config/nvim/plugins/ruby_lsp.lua`) and adding the following:
+For LazyVim, you can add the ruby-lsp by creating a file in your plugins folder (`~/.config/nvim/lua/plugins/ruby_lsp.lua`) and adding the following:
 
 ```lua
--- ~/.config/nvim/plugins/ruby_lsp.lua
+-- ~/.config/nvim/lua/plugins/ruby_lsp.lua
 
 return {
   {


### PR DESCRIPTION
### Motivation

Hi! The current listed configuration for disabling solargraph and ruby-lsp will not work because `lazyvim` will not load that plugin.

### Implementation

According to the LazyVim documentation (http://www.lazyvim.org/configuration/plugins),
it loads plugins from `<neovim_config_dir>/lua/plugins`, so this pull request corrects the path 
from `<neovim_config_dir>/plugins` to `<neovim_config_dir>/lua/plugins`. Thanks.

### Automated Tests

N/A

### Manual Tests

N/A