### PR TITLE
Remove non-existing algorithm path for constant resolution

### DIFF
--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1125,5 +1125,31 @@ module RubyIndexer
       assert_equal("@bar", entry.name)
       assert_equal("Bar", T.must(entry.owner).name)
     end
+
+    def test_resolving_a_qualified_reference
+      index(<<~RUBY)
+        class Base
+          module Third
+            CONST = 1
+          end
+        end
+
+        class Foo
+          module Third
+            CONST = 2
+          end
+
+          class Second < Base
+          end
+        end
+      RUBY
+
+      foo_entry = T.must(@index.resolve("Third::CONST", ["Foo"])&.first)
+      assert_equal(9, foo_entry.location.start_line)
+    end
+
+    def test_resolving_unindexed_constant_with_no_nesting
+      assert_nil(@index.resolve("RSpec", []))
+    end
   end
 end


### PR DESCRIPTION
### Motivation

In #2136, we actually made a mistake. Ruby does not treat qualified or unqualified constant references differently, that was a misunderstanding.

The algorithm is the same for both and will always favour enclosing lexical scopes above inheritance.

### Implementation

Removed the entire path algorithm path for qualified references and kept only the one implementation, which handles all cases.

### Automated Tests

Added a test that catches the mistake in the implementation.