### PR TITLE
Move Bundler and Minitest outside development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,12 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "bundler", "~> 2.5"
+gem "minitest", "~> 5.23"
+
 group :development do
-  gem "bundler", "~> 2.5"
   gem "debug", "~> 1.9", require: false
   gem "minitest-reporters", "~> 1.6"
-  gem "minitest", "~> 5.23"
   gem "mocha", "~> 2.3"
   gem "psych", "~> 5.1", require: false
   gem "rake", "~> 13.2"


### PR DESCRIPTION
### Motivation

We use the `group :development` in our Gemfile to exclude gems from indexing. However, I was thinking that Bundler and Minitest really shouldn't be excluded. We use Bundler in a bunch of places to hook into the project's dependencies and, when we write tests, it's nice to have assertions completed and the hover show you the expected arguments.
