### PR TITLE
Improve detection for rails as the testing framework

### DIFF
--- a/lib/ruby_lsp/listeners/rails_app.rb
+++ b/lib/ruby_lsp/listeners/rails_app.rb
@@ -1,0 +1,28 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  module Listeners
+    class RailsApp
+      extend T::Sig
+
+      sig { returns(T::Boolean) }
+      attr_reader :rails_app
+
+      sig { params(dispatcher: Prism::Dispatcher).void }
+      def initialize(dispatcher)
+        @rails_app = T.let(false, T::Boolean)
+        dispatcher.register(self, :on_class_node_enter)
+      end
+
+      sig { params(node: Prism::ClassNode).void }
+      def on_class_node_enter(node)
+        superclass = node.superclass
+        case superclass
+        when Prism::ConstantPathNode
+          @rails_app = true if superclass.full_name == "Rails::Application"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

In some preparation of #2096

Note that this is only for detection of the testing framework, the issue is about installing `ruby-lsp-rails`. It may be relatively straight-forward to do this as well but I'm more familiar with this part of the code.

So, just do it here to talk roughtly about the implementation direction. I do plan to look properly at the issue after this and that should hopefully only involve moving a few things around. 

Perhaps the `GlobalState` can even be created earlier so that `SetupBundler` has access to this method. Though the location of `config/application.rb` depend on `workspace_uri` which does get modified in `apply_options` .

### Implementation

I created a listener for this which checks for `Rails::Application` inheritance.

This does parse the file twice, once on startup and once indexing actually starts. I don't see an easy way around this since proper indexing only starts once the server received `initialized`.

### Automated Tests

One for the happy path, one for the other.

### Manual Tests

I tested this out on my app which doesn't depend on rails but some subcompontents and that works fine.
