### PR TITLE
Update Homebrew note for `asdf `

### DIFF
--- a/VERSION_MANAGERS.md
+++ b/VERSION_MANAGERS.md
@@ -5,7 +5,7 @@ This document contains information and tips to help Ruby LSP's VS Code extension
 ## asdf
 
 If you use `asdf` and the VS Code extension fails to activate the environment (as described in [this issue](https://github.com/Shopify/ruby-lsp/issues/1985)), you may resolve it by updating `asdf` to the latest version with `asdf update`, and then restart VS Code.
-If `asdf` was installed through Homebrew then you may need to first run `brew update asdf`.
+If `asdf` was installed through Homebrew then you may need to first run `brew upgrade asdf`.
 
 ## Chruby
 


### PR DESCRIPTION
While following the tips in the [VERSION_MANAGERS.md](https://github.com/Shopify/ruby-lsp/blob/main/VERSION_MANAGERS.md) file for asdf, I noticed that the Homebrew update command was not working for me. I had to run the following command to update asdf:

```bash
brew upgrade asdf
``` 


![image](https://github.com/Shopify/ruby-lsp/assets/17851143/45ee226c-ee5a-42d7-b70c-1fb1174e2934)
