### PR TITLE
Offer RuboCop autocorrection for contextual offenses

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -42,7 +42,7 @@ module RubyLsp
         def to_lsp_code_actions
           code_actions = []
 
-          code_actions << autocorrect_action if @offense.correctable?
+          code_actions << autocorrect_action if correctable?
           code_actions << disable_line_action
 
           code_actions
@@ -70,7 +70,7 @@ module RubyLsp
               ),
             ),
             data: {
-              correctable: @offense.correctable?,
+              correctable: correctable?,
               code_actions: to_lsp_code_actions,
             },
           )
@@ -81,7 +81,7 @@ module RubyLsp
         sig { returns(String) }
         def message
           message  = @offense.message
-          message += "\n\nThis offense is not auto-correctable.\n" unless @offense.correctable?
+          message += "\n\nThis offense is not auto-correctable.\n" unless correctable?
           message
         end
 
@@ -115,7 +115,7 @@ module RubyLsp
                     uri: @uri.to_s,
                     version: nil,
                   ),
-                  edits: @offense.correctable? ? offense_replacements : [],
+                  edits: correctable? ? offense_replacements : [],
                 ),
               ],
             ),
@@ -192,6 +192,14 @@ module RubyLsp
           else
             line.length
           end
+        end
+
+        # When `RuboCop::LSP.enable` is called, contextual autocorrect will not offer itself
+        # as `correctable?` to prevent annoying changes while typing. Instead check if
+        # a corrector is present. If it is, then that means some code transformation can be applied.
+        sig { returns(T::Boolean) }
+        def correctable?
+          !@offense.corrector.nil?
         end
       end
     end

--- a/test/expectations/diagnostics/rubocop_contextual_autocorrect.exp.json
+++ b/test/expectations/diagnostics/rubocop_contextual_autocorrect.exp.json
@@ -1,0 +1,102 @@
+{
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 2
+        },
+        "end": {
+          "line": 4,
+          "character": 5
+        }
+      },
+      "severity": 2,
+      "source": "Prism",
+      "message": "assigned but unused variable - foo"
+    },
+    {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 2
+        },
+        "end": {
+          "line": 4,
+          "character": 5
+        }
+      },
+      "severity": 2,
+      "code": "Lint/UselessAssignment",
+      "codeDescription": {
+        "href": "https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessassignment"
+      },
+      "source": "RuboCop",
+      "message": "Lint/UselessAssignment: Useless assignment to variable - `foo`.",
+      "data": {
+        "correctable": true,
+        "code_actions": [
+          {
+            "title": "Autocorrect Lint/UselessAssignment",
+            "kind": "quickfix",
+            "isPreferred": true,
+            "edit": {
+              "documentChanges": [
+                {
+                  "textDocument": {
+                    "uri": "file:///fake",
+                    "version": null
+                  },
+                  "edits": [
+                    {
+                      "range": {
+                        "start": {
+                          "line": 4,
+                          "character": 2
+                        },
+                        "end": {
+                          "line": 4,
+                          "character": 13
+                        }
+                      },
+                      "newText": "\"bar\""
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "title": "Disable Lint/UselessAssignment for this line",
+            "kind": "quickfix",
+            "edit": {
+              "documentChanges": [
+                {
+                  "textDocument": {
+                    "uri": "file:///fake",
+                    "version": null
+                  },
+                  "edits": [
+                    {
+                      "range": {
+                        "start": {
+                          "line": 4,
+                          "character": 13
+                        },
+                        "end": {
+                          "line": 4,
+                          "character": 13
+                        }
+                      },
+                      "newText": " # rubocop:disable Lint/UselessAssignment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/rubocop_contextual_autocorrect.rb
+++ b/test/fixtures/rubocop_contextual_autocorrect.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+
+def useless_assignment
+  foo = "bar"
+  baz
+end


### PR DESCRIPTION
### Motivation

Fixes #2168

### Implementation

When `RuboCop::LSP.enable` is called, contextual autocorrect will not offer itself as `correctable?` to prevent annoying changes while typing. Instead check if a corrector is present. If it is, then that means some code transformation can be applied.

I believe this is a reasonable change to make. Since `RuboCop::LSP` contains global state, disabling it for the duration of a run isn't feasable because the other runner used for editor autocorrection can pick this up.

### Manual Tests

See the added fixture and check out the diagnostics for it.
