### PR TITLE
Fix incorrect parent class assignment for Object and BasicObject

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -152,8 +152,7 @@ module RubyIndexer
       end
       def initialize(nesting, file_path, location, comments, parent_class)
         super(nesting, file_path, location, comments)
-
-        @parent_class = T.let(parent_class, T.nilable(String))
+        @parent_class = parent_class
       end
 
       sig { override.returns(Integer) }


### PR DESCRIPTION
### Motivation

When the Object and BasicObject classes are reopened, their parent class should remain `BasicObject` and `nil` respectively. This change fixes the current behaviour where the parent class is incorrectly set to `Object`.

The issue was discovered when pairing with @Morriar on #1046 as `Object` are displayed in `Object`'s supertypes list too.

### Implementation

We should check these 2 special cases before deciding the parent class.

### Automated Tests

I added 4 new test cases for it.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
