### PR TITLE
Resolve missed conflicts

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -106,8 +106,8 @@ module RubyIndexer
       end
     end
 
-    sig { params(member: RBS::AST::Members::MethodDefinition, entry: Entry::Namespace).void }
-    def handle_method(member, entry)
+    sig { params(member: RBS::AST::Members::MethodDefinition, owner: Entry::Namespace).void }
+    def handle_method(member, owner)
       name = member.name.name
       file_path = member.location.buffer.name
       location = to_ruby_indexer_location(member.location)
@@ -123,11 +123,7 @@ module RubyIndexer
         Entry::Visibility::PUBLIC
       end
 
-      owner = entry
-
-      klass = member.instance? ? Entry::InstanceMethod : Entry::SingletonMethod
-
-      entry = klass.new(
+      @index << Entry::Method.new(
         name,
         file_path,
         location,
@@ -136,7 +132,6 @@ module RubyIndexer
         visibility,
         owner,
       )
-      @index << entry if entry
     end
   end
 end

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -374,13 +374,13 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.cast(@index["first_method"]&.first, Entry::InstanceMethod)
+      entry = T.cast(@index["first_method"]&.first, Entry::Method)
       assert_equal("Foo", T.must(entry.owner).name)
 
-      entry = T.cast(@index["second_method"]&.first, Entry::InstanceMethod)
+      entry = T.cast(@index["second_method"]&.first, Entry::Method)
       assert_equal("Foo::Bar", T.must(entry.owner).name)
 
-      entry = T.cast(@index["third_method"]&.first, Entry::InstanceMethod)
+      entry = T.cast(@index["third_method"]&.first, Entry::Method)
       assert_equal("Foo", T.must(entry.owner).name)
     end
 


### PR DESCRIPTION
PR #2157 relies on `Entry::InstanceMethod` and `Entry::SingletonMethod`, which were merged together in #2142. But because the PRs are merged side-by-side without rebase, this resulted in a broken build.

This commit reflects the class changes in the RBSIndexer.