### PR TITLE
Show method parameters on hover

### DIFF
--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -110,7 +110,9 @@ module RubyLsp
         methods = @index.resolve_method(message, @node_context.fully_qualified_name)
         return unless methods
 
-        categorized_markdown_from_index_entries(message, methods).each do |category, content|
+        title = "#{message}(#{T.must(methods.first).parameters.map(&:decorated_name).join(", ")})"
+
+        categorized_markdown_from_index_entries(title, methods).each do |category, content|
           @response_builder.push(content, category: category)
         end
       end

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -426,6 +426,30 @@ class HoverExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_hover_for_methods_shows_parameters
+    source = <<~RUBY
+      class Foo
+        def bar(a, b = 1, *c, d:, e: 1, **f, &g)
+        end
+
+        def baz
+          bar
+        end
+      end
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/hover",
+        params: { textDocument: { uri: uri }, position: { character: 4, line: 5 } },
+      )
+
+      contents = server.pop_response.response.contents.value
+      assert_match("bar(a, b = <default>, *c, d:, e: <default>, **f, &g)", contents)
+    end
+  end
+
   private
 
   def create_hover_addon

--- a/test/requests/signature_help_test.rb
+++ b/test/requests/signature_help_test.rb
@@ -151,7 +151,7 @@ class SignatureHelpTest < Minitest::Test
       })
       result = server.pop_response.response
       signature = result.signatures.first
-      assert_equal("bar(a, b, c:, d:)", signature.label)
+      assert_equal("bar(a, b = <default>, c:, d:)", signature.label)
       assert_equal(2, result.active_parameter)
     end
   end


### PR DESCRIPTION
### Motivation

I was pretty sure we had this at some point, but I noticed that we were not showing method parameters on hover, which we definitely want to show.

### Implementation

1. Changed the decorated names for optional positional and keyword arguments to show a fake `DEFAULT`. We don't store the actual default values to save memory, but I think that at least showing it's a default is worth it
2. I also noticed that we were inserting the rest argument in an unexpected order. Rest arguments always come before keywords
3. Started showing the parameter decorated names in hover

### Automated Tests

Added a test.