### PR TITLE
Display addons status in the control panel

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -26,9 +26,15 @@ export interface RubyInterface {
   rubyVersion?: string;
 }
 
+export interface Addon {
+  name: string;
+  errored: boolean;
+}
+
 export interface ClientInterface {
   state: State;
   formatter: string;
+  addons?: Addon[];
   serverVersion?: string;
   sendRequest<T>(
     method: string,

--- a/vscode/src/status.ts
+++ b/vscode/src/status.ts
@@ -178,6 +178,32 @@ export class FormatterStatus extends StatusItem {
   }
 }
 
+export class AddonsStatus extends StatusItem {
+  constructor() {
+    super("addons");
+
+    this.item.name = "Ruby LSP Addons";
+    this.item.text = "Fetching addon information";
+  }
+
+  refresh(workspace: WorkspaceInterface): void {
+    if (!workspace.lspClient) {
+      return;
+    }
+    if (workspace.lspClient.addons === undefined) {
+      this.item.text =
+        "Addons: requires server to be v0.17.4 or higher to display this field";
+    } else if (workspace.lspClient.addons.length === 0) {
+      this.item.text = "Addons: none";
+    } else {
+      const addonNames = workspace.lspClient.addons.map((addon) =>
+        addon.errored ? `${addon.name} (errored)` : `${addon.name}`,
+      );
+      this.item.text = `Addons: ${addonNames.join(", ")}`;
+    }
+  }
+}
+
 export class StatusItems {
   private readonly items: StatusItem[] = [];
 
@@ -188,6 +214,7 @@ export class StatusItems {
       new ExperimentalFeaturesStatus(),
       new FeaturesStatus(),
       new FormatterStatus(),
+      new AddonsStatus(),
     ];
 
     STATUS_EMITTER.event((workspace) => {

--- a/vscode/src/test/suite/status.test.ts
+++ b/vscode/src/test/suite/status.test.ts
@@ -13,6 +13,7 @@ import {
   StatusItem,
   FeaturesStatus,
   FormatterStatus,
+  AddonsStatus,
 } from "../../status";
 import { Command, WorkspaceInterface } from "../../common";
 
@@ -35,6 +36,7 @@ suite("StatusItems", () => {
       workspace = {
         ruby,
         lspClient: {
+          addons: [],
           state: State.Running,
           formatter: "none",
           serverVersion: "1.0.0",
@@ -72,6 +74,7 @@ suite("StatusItems", () => {
         ruby,
         lspClient: {
           state: State.Running,
+          addons: [],
           formatter: "none",
           serverVersion: "1.0.0",
           sendRequest: <T>() => Promise.resolve([] as T),
@@ -129,6 +132,7 @@ suite("StatusItems", () => {
       workspace = {
         ruby,
         lspClient: {
+          addons: [],
           state: State.Running,
           formatter,
           serverVersion: "1.0.0",
@@ -157,6 +161,7 @@ suite("StatusItems", () => {
       workspace = {
         ruby,
         lspClient: {
+          addons: [],
           state: State.Running,
           formatter: "none",
           serverVersion: "1.0.0",
@@ -244,6 +249,7 @@ suite("StatusItems", () => {
       workspace = {
         ruby,
         lspClient: {
+          addons: [],
           state: State.Running,
           formatter: "auto",
           serverVersion: "1.0.0",
@@ -260,6 +266,53 @@ suite("StatusItems", () => {
       assert.strictEqual(status.item.name, "Formatter");
       assert.strictEqual(status.item.command?.title, "Help");
       assert.strictEqual(status.item.command.command, Command.FormatterHelp);
+    });
+  });
+
+  suite("AddonsStatus", () => {
+    beforeEach(() => {
+      ruby = {} as Ruby;
+      workspace = {
+        ruby,
+        lspClient: {
+          addons: undefined,
+          state: State.Running,
+          formatter: "auto",
+          serverVersion: "1.0.0",
+          sendRequest: <T>() => Promise.resolve([] as T),
+        },
+        error: false,
+      };
+      status = new AddonsStatus();
+      status.refresh(workspace);
+    });
+
+    test("Status displays the server requirement info when addons is undefined", () => {
+      workspace.lspClient!.addons = undefined;
+      status.refresh(workspace);
+
+      assert.strictEqual(
+        status.item.text,
+        "Addons: requires server to be v0.17.4 or higher to display this field",
+      );
+    });
+
+    test("Status displays no addons when addons is an empty array", () => {
+      workspace.lspClient!.addons = [];
+      status.refresh(workspace);
+
+      assert.strictEqual(status.item.text, "Addons: none");
+    });
+
+    test("Status displays addon names and errored status", () => {
+      workspace.lspClient!.addons = [
+        { name: "foo", errored: false },
+        { name: "bar", errored: true },
+      ];
+
+      status.refresh(workspace);
+
+      assert.strictEqual(status.item.text, "Addons: foo, bar (errored)");
     });
   });
 });

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -111,7 +111,7 @@ export class Workspace implements WorkspaceInterface {
     try {
       STATUS_EMITTER.fire(this);
       await this.lspClient.start();
-      this.lspClient.afterStart();
+      await this.lspClient.afterStart();
       STATUS_EMITTER.fire(this);
 
       // If something triggered a restart while we were still booting, then now we need to perform the restart since the


### PR DESCRIPTION
### Motivation

This will give users a quick overview of the addons that are enabled in their workspace.

We plan to expand this feature to display more information about addons in the future, such as:

- The version of the addon
- The gem name of the addon
- Addons that weren't activated due to errors

But some of these features will require changes to the addon API, so we will plan them for a future release.


### Implementation

The feature is implemented on both the server and the extension:

- Server:
  - The server now has an experimental field in the capabilities object, which currently only has the `addon_detection` field.
  - The server now supports a custom `rubyLsp/workspace/addons` request that returns the list of addons that are enabled in the workspace. At this iteration, each addon only has name and errored attributes.
- Extension:
  - In the client.afterStart callback, the extension now sends a `rubyLsp/workspace/addons` request to the server to fetch and store the list of addons.
  - A new `AddonsStatus` status item is added to display addon's status.
    - If the server doesn't have the capability, the status will mention that server 0.17.4 or later is required.
      <img width="620" alt="Screenshot 2024-06-13 at 13 42 47" src="https://github.com/Shopify/ruby-lsp/assets/5079556/e583d68a-5b46-4e45-86a7-2a44bf07ab1b">
    - If the server supports the capability but the workspace has no addons, the status will mention that no addons are enabled.
      <img width="534" alt="Screenshot 2024-06-13 at 13 29 26" src="https://github.com/Shopify/ruby-lsp/assets/5079556/014e61ce-177e-47e6-851a-c41b44e06756">
    - If the workspace has addons, the status will display the names of the addons that are enabled. If the addon failed to activate, `(errored)` will be added after its name. 
      <img width="526" alt="Screenshot 2024-06-13 at 13 29 55" src="https://github.com/Shopify/ruby-lsp/assets/5079556/894375bd-433f-4a43-b6d3-0cf973194c4d">

I plan to explore better UI in later iterations as simply having the names listed will already make addon development easier.

### Automated Tests

Added some 

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
