### PR TITLE
Exclude singleton classes from name based searches

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -148,7 +148,7 @@ module RubyIndexer
           entry.update_singleton_information(node.location, collect_comments(node))
         else
           entry = Entry::SingletonClass.new(@stack, @file_path, node.location, collect_comments(node), nil)
-          @index.add(entry)
+          @index.add(entry, skip_prefix_tree: true)
         end
 
         @owner_stack << entry
@@ -609,7 +609,7 @@ module RubyIndexer
       # If not available, create the singleton class lazily
       nesting = @stack + ["<Class:#{@stack.last}>"]
       entry = Entry::SingletonClass.new(nesting, @file_path, attached_class.location, [], nil)
-      @index.add(entry)
+      @index.add(entry, skip_prefix_tree: true)
       entry
     end
   end

--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -98,7 +98,7 @@ module RubyIndexer
       )
 
       @owner_stack << entry
-      @index << entry
+      @index.add(entry)
       @stack << name
     end
 
@@ -120,7 +120,7 @@ module RubyIndexer
       entry = Entry::Module.new(nesting, @file_path, node.location, comments)
 
       @owner_stack << entry
-      @index << entry
+      @index.add(entry)
       @stack << name
     end
 
@@ -148,7 +148,7 @@ module RubyIndexer
           entry.update_singleton_information(node.location, collect_comments(node))
         else
           entry = Entry::SingletonClass.new(@stack, @file_path, node.location, collect_comments(node), nil)
-          @index << entry
+          @index.add(entry)
         end
 
         @owner_stack << entry
@@ -293,7 +293,7 @@ module RubyIndexer
 
       case node.receiver
       when nil
-        @index << Entry::Method.new(
+        @index.add(Entry::Method.new(
           method_name,
           @file_path,
           node.location,
@@ -301,9 +301,9 @@ module RubyIndexer
           node.parameters,
           current_visibility,
           @owner_stack.last,
-        )
+        ))
       when Prism::SelfNode
-        @index << Entry::Method.new(
+        @index.add(Entry::Method.new(
           method_name,
           @file_path,
           node.location,
@@ -311,7 +311,7 @@ module RubyIndexer
           node.parameters,
           current_visibility,
           singleton_klass,
-        )
+        ))
       end
     end
 
@@ -349,13 +349,15 @@ module RubyIndexer
     def on_alias_method_node_enter(node)
       method_name = node.new_name.slice
       comments = collect_comments(node)
-      @index << Entry::UnresolvedMethodAlias.new(
-        method_name,
-        node.old_name.slice,
-        @owner_stack.last,
-        @file_path,
-        node.new_name.location,
-        comments,
+      @index.add(
+        Entry::UnresolvedMethodAlias.new(
+          method_name,
+          node.old_name.slice,
+          @owner_stack.last,
+          @file_path,
+          node.new_name.location,
+          comments,
+        ),
       )
     end
 
@@ -380,7 +382,7 @@ module RubyIndexer
       # When instance variables are declared inside the class body, they turn into class instance variables rather than
       # regular instance variables
       owner = @inside_def ? @owner_stack.last : singleton_klass
-      @index << Entry::InstanceVariable.new(name, @file_path, loc, collect_comments(node), owner)
+      @index.add(Entry::InstanceVariable.new(name, @file_path, loc, collect_comments(node), owner))
     end
 
     sig { params(node: Prism::CallNode).void }
@@ -435,13 +437,15 @@ module RubyIndexer
       return unless old_name_value
 
       comments = collect_comments(node)
-      @index << Entry::UnresolvedMethodAlias.new(
-        new_name_value,
-        old_name_value,
-        @owner_stack.last,
-        @file_path,
-        new_name.location,
-        comments,
+      @index.add(
+        Entry::UnresolvedMethodAlias.new(
+          new_name_value,
+          old_name_value,
+          @owner_stack.last,
+          @file_path,
+          new_name.location,
+          comments,
+        ),
       )
     end
 
@@ -467,22 +471,24 @@ module RubyIndexer
       value = node.value unless node.is_a?(Prism::ConstantTargetNode) || node.is_a?(Prism::ConstantPathTargetNode)
       comments = collect_comments(node)
 
-      @index << case value
-      when Prism::ConstantReadNode, Prism::ConstantPathNode
-        Entry::UnresolvedAlias.new(value.slice, @stack.dup, name, @file_path, node.location, comments)
-      when Prism::ConstantWriteNode, Prism::ConstantAndWriteNode, Prism::ConstantOrWriteNode,
+      @index.add(
+        case value
+        when Prism::ConstantReadNode, Prism::ConstantPathNode
+          Entry::UnresolvedAlias.new(value.slice, @stack.dup, name, @file_path, node.location, comments)
+        when Prism::ConstantWriteNode, Prism::ConstantAndWriteNode, Prism::ConstantOrWriteNode,
         Prism::ConstantOperatorWriteNode
 
-        # If the right hand side is another constant assignment, we need to visit it because that constant has to be
-        # indexed too
-        Entry::UnresolvedAlias.new(value.name.to_s, @stack.dup, name, @file_path, node.location, comments)
-      when Prism::ConstantPathWriteNode, Prism::ConstantPathOrWriteNode, Prism::ConstantPathOperatorWriteNode,
+          # If the right hand side is another constant assignment, we need to visit it because that constant has to be
+          # indexed too
+          Entry::UnresolvedAlias.new(value.name.to_s, @stack.dup, name, @file_path, node.location, comments)
+        when Prism::ConstantPathWriteNode, Prism::ConstantPathOrWriteNode, Prism::ConstantPathOperatorWriteNode,
         Prism::ConstantPathAndWriteNode
 
-        Entry::UnresolvedAlias.new(value.target.slice, @stack.dup, name, @file_path, node.location, comments)
-      else
-        Entry::Constant.new(name, @file_path, node.location, comments)
-      end
+          Entry::UnresolvedAlias.new(value.target.slice, @stack.dup, name, @file_path, node.location, comments)
+        else
+          Entry::Constant.new(name, @file_path, node.location, comments)
+        end,
+      )
     end
 
     sig { params(node: Prism::Node).returns(T::Array[String]) }
@@ -539,15 +545,20 @@ module RubyIndexer
 
         next unless name && loc
 
-        @index << Entry::Accessor.new(name, @file_path, loc, comments, current_visibility, @owner_stack.last) if reader
-        @index << Entry::Accessor.new(
+        if reader
+          @index.add(Entry::Accessor.new(name, @file_path, loc, comments, current_visibility, @owner_stack.last))
+        end
+
+        next unless writer
+
+        @index.add(Entry::Accessor.new(
           "#{name}=",
           @file_path,
           loc,
           comments,
           current_visibility,
           @owner_stack.last,
-        ) if writer
+        ))
       end
     end
 
@@ -598,7 +609,7 @@ module RubyIndexer
       # If not available, create the singleton class lazily
       nesting = @stack + ["<Class:#{@stack.last}>"]
       entry = Entry::SingletonClass.new(nesting, @file_path, attached_class.location, [], nil)
-      @index << entry
+      @index.add(entry)
       entry
     end
   end

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -65,13 +65,13 @@ module RubyIndexer
       @require_paths_tree.delete(require_path) if require_path
     end
 
-    sig { params(entry: Entry).void }
-    def add(entry)
+    sig { params(entry: Entry, skip_prefix_tree: T::Boolean).void }
+    def add(entry, skip_prefix_tree: false)
       name = entry.name
 
       (@entries[name] ||= []) << entry
       (@files_to_entries[entry.file_path] ||= []) << entry
-      @entries_tree.insert(name, T.must(@entries[name]))
+      @entries_tree.insert(name, T.must(@entries[name])) unless skip_prefix_tree
     end
 
     sig { params(fully_qualified_name: String).returns(T.nilable(T::Array[Entry])) }

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -66,7 +66,7 @@ module RubyIndexer
     end
 
     sig { params(entry: Entry).void }
-    def <<(entry)
+    def add(entry)
       name = entry.name
 
       (@entries[name] ||= []) << entry

--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -50,7 +50,7 @@ module RubyIndexer
       parent_class = declaration.super_class&.name&.name&.to_s
       class_entry = Entry::Class.new(nesting, file_path, location, comments, parent_class)
       add_declaration_mixins_to_entry(declaration, class_entry)
-      @index << class_entry
+      @index.add(class_entry)
       declaration.members.each do |member|
         next unless member.is_a?(RBS::AST::Members::MethodDefinition)
 
@@ -66,7 +66,7 @@ module RubyIndexer
       comments = Array(declaration.comment&.string)
       module_entry = Entry::Module.new(nesting, file_path, location, comments)
       add_declaration_mixins_to_entry(declaration, module_entry)
-      @index << module_entry
+      @index.add(module_entry)
       declaration.members.each do |member|
         next unless member.is_a?(RBS::AST::Members::MethodDefinition)
 
@@ -123,15 +123,7 @@ module RubyIndexer
         Entry::Visibility::PUBLIC
       end
 
-      @index << Entry::Method.new(
-        name,
-        file_path,
-        location,
-        comments,
-        parameters_node,
-        visibility,
-        owner,
-      )
+      @index.add(Entry::Method.new(name, file_path, location, comments, parameters_node, visibility, owner))
     end
   end
 end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1327,5 +1327,16 @@ module RubyIndexer
         "@c",
       )
     end
+
+    def test_singletons_are_excluded_from_prefix_search
+      index(<<~RUBY)
+        class Zwq
+          class << self
+          end
+        end
+      RUBY
+
+      assert_empty(@index.prefix_search("Zwq::<C"))
+    end
   end
 end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1338,5 +1338,18 @@ module RubyIndexer
 
       assert_empty(@index.prefix_search("Zwq::<C"))
     end
+
+    def test_singletons_are_excluded_from_fuzzy_search
+      index(<<~RUBY)
+        class Zwq
+          class << self
+          end
+        end
+      RUBY
+
+      results = @index.fuzzy_search("Zwq")
+      assert_equal(1, results.length)
+      assert_equal("Zwq", results.first.name)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Follow up for #2142.

We store singleton classes using their "name" (e.g.: `<Class:Foo>`), which is convenient because it helps with resolutions and linearization.

However, Ruby doesn't allow you to refer to the singleton classes by name, so we should exclude them from both prefix searches (completion) and fuzzy searches (workspace symbol).

### Implementation

Instead of inserting singleton classes into the prefix tree and then excluding them during the search, I thought it would be more optimal if we simply never added them to the tree.

I split the work by commit:

1. Renamed the `Index#<<` method to `Index#add` so that we can add more arguments
2. Started skipping the addition of singletons to the prefix tree
3. Started excluding singletons from the fuzzy search

### Automated Tests

Added tests.

### Manual Tests

On this branch, you should no longer see `<Class:Whatever>` offered for constant completions.