### PR TITLE
Allow `Entry::Method` to be initialized with `Entry::Parameter`s

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -298,7 +298,7 @@ module RubyIndexer
           @file_path,
           node.location,
           comments,
-          node.parameters,
+          list_params(node.parameters),
           current_visibility,
           @owner_stack.last,
         ))
@@ -308,7 +308,7 @@ module RubyIndexer
           @file_path,
           node.location,
           comments,
-          node.parameters,
+          list_params(node.parameters),
           current_visibility,
           singleton_klass,
         ))
@@ -592,6 +592,90 @@ module RubyIndexer
     sig { returns(Entry::Visibility) }
     def current_visibility
       T.must(@visibility_stack.last)
+    end
+
+    sig { params(parameters_node: T.nilable(Prism::ParametersNode)).returns(T::Array[Entry::Parameter]) }
+    def list_params(parameters_node)
+      return [] unless parameters_node
+
+      parameters = []
+
+      parameters_node.requireds.each do |required|
+        name = parameter_name(required)
+        next unless name
+
+        parameters << Entry::RequiredParameter.new(name: name)
+      end
+
+      parameters_node.optionals.each do |optional|
+        name = parameter_name(optional)
+        next unless name
+
+        parameters << Entry::OptionalParameter.new(name: name)
+      end
+
+      rest = parameters_node.rest
+
+      if rest.is_a?(Prism::RestParameterNode)
+        rest_name = rest.name || Entry::RestParameter::DEFAULT_NAME
+        parameters << Entry::RestParameter.new(name: rest_name)
+      end
+
+      parameters_node.keywords.each do |keyword|
+        name = parameter_name(keyword)
+        next unless name
+
+        case keyword
+        when Prism::RequiredKeywordParameterNode
+          parameters << Entry::KeywordParameter.new(name: name)
+        when Prism::OptionalKeywordParameterNode
+          parameters << Entry::OptionalKeywordParameter.new(name: name)
+        end
+      end
+
+      keyword_rest = parameters_node.keyword_rest
+
+      if keyword_rest.is_a?(Prism::KeywordRestParameterNode)
+        keyword_rest_name = parameter_name(keyword_rest) || Entry::KeywordRestParameter::DEFAULT_NAME
+        parameters << Entry::KeywordRestParameter.new(name: keyword_rest_name)
+      end
+
+      parameters_node.posts.each do |post|
+        name = parameter_name(post)
+        next unless name
+
+        parameters << Entry::RequiredParameter.new(name: name)
+      end
+
+      block = parameters_node.block
+      parameters << Entry::BlockParameter.new(name: block.name || Entry::BlockParameter::DEFAULT_NAME) if block
+
+      parameters
+    end
+
+    sig { params(node: T.nilable(Prism::Node)).returns(T.nilable(Symbol)) }
+    def parameter_name(node)
+      case node
+      when Prism::RequiredParameterNode, Prism::OptionalParameterNode,
+        Prism::RequiredKeywordParameterNode, Prism::OptionalKeywordParameterNode,
+        Prism::RestParameterNode, Prism::KeywordRestParameterNode
+        node.name
+      when Prism::MultiTargetNode
+        names = node.lefts.map { |parameter_node| parameter_name(parameter_node) }
+
+        rest = node.rest
+        if rest.is_a?(Prism::SplatNode)
+          name = rest.expression&.slice
+          names << (rest.operator == "*" ? "*#{name}".to_sym : name&.to_sym)
+        end
+
+        names << nil if rest.is_a?(Prism::ImplicitRestNode)
+
+        names.concat(node.rights.map { |parameter_node| parameter_name(parameter_node) })
+
+        names_with_commas = names.join(", ")
+        :"(#{names_with_commas})"
+      end
     end
 
     sig { returns(T.nilable(Entry::Class)) }

--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -112,7 +112,6 @@ module RubyIndexer
       file_path = member.location.buffer.name
       location = to_ruby_indexer_location(member.location)
       comments = Array(member.comment&.string)
-      parameters_node = nil
 
       visibility = case member.visibility
       when :private
@@ -123,7 +122,7 @@ module RubyIndexer
         Entry::Visibility::PUBLIC
       end
 
-      @index.add(Entry::Method.new(name, file_path, location, comments, parameters_node, visibility, owner))
+      @index.add(Entry::Method.new(name, file_path, location, comments, [], visibility, owner))
     end
   end
 end


### PR DESCRIPTION
For indexing methods using RBS, we need to refactor `Entry::Method` so that we can pass an array of `Entry::Parameter`, rather than a `Prism::ArgumentsNode`. The moved code in `list_params`, is a direct cut and paste, the only changes are to add the necessary namespace prefixes.