### PR TITLE
Remember singleton nesting and method nesting when locating nodes

### DIFF
--- a/lib/ruby_lsp/node_context.rb
+++ b/lib/ruby_lsp/node_context.rb
@@ -16,19 +16,24 @@ module RubyLsp
     sig { returns(T.nilable(Prism::CallNode)) }
     attr_reader :call_node
 
+    sig { returns(T.nilable(String)) }
+    attr_reader :surrounding_method
+
     sig do
       params(
         node: T.nilable(Prism::Node),
         parent: T.nilable(Prism::Node),
         nesting: T::Array[String],
         call_node: T.nilable(Prism::CallNode),
+        surrounding_method: T.nilable(String),
       ).void
     end
-    def initialize(node, parent, nesting, call_node)
+    def initialize(node, parent, nesting, call_node, surrounding_method)
       @node = node
       @parent = parent
       @nesting = nesting
       @call_node = call_node
+      @surrounding_method = surrounding_method
     end
 
     sig { returns(String) }


### PR DESCRIPTION
### Motivation

Step towards #1938 

In order to properly resolve singleton contexts, we need to remember that we are inside of one when we locate nodes.

This PR includes both the singleton nesting and the surrounding method declaration in the node context. This information will allow us to properly resolve constants, methods and ivars inside singleton contexts. In addition to that, it also enables us to provide go to definition for `super` calls.

### Implementation

Started pushing more nodes to our nesting tracker and stored everything in the node context.

### Automated Tests

Added a test demonstrating the expected information on multiple situations.