### PR TITLE
Fix link to Ruby LSP plugin in EDITORS.md

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -174,4 +174,4 @@ You can use the Ruby LSP with RubyMine (or IntelliJ IDEA Ultimate) through the f
 
 Note that there might be overlapping functionality when using it with RubyMine, given that the IDE provides similar features as the ones coming from the Ruby LSP.
 
-[https://plugins.jetbrains.com/plugin/24413-ruby-lsp](Ruby LSP plugin)
+[Ruby LSP plugin](https://plugins.jetbrains.com/plugin/24413-ruby-lsp)


### PR DESCRIPTION
### Motivation
I couldn't move to the Ruby LSP plugin page, Because the link is broken.
So I gonna fixed it.

### Implementation
Nothing. 
Just edited the EDITORS.md

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

### Additional information
Currently, The destination link is  `https://plugins.jetbrains.com/plugin/24413-ruby-lsp](Ruby`
But It's apparently wrong.

I guess, It's a just simply mistake to writing the Markdown syntax. (Opposite URL and title)
If this PR is not needed, Please close it.
