### PR TITLE
Fix RBS singleton method owner assignment

### DIFF
--- a/lib/ruby_indexer/test/rbs_indexer_test.rb
+++ b/lib/ruby_indexer/test/rbs_indexer_test.rb
@@ -54,5 +54,14 @@ module RubyIndexer
       assert_equal(2, entry.location.start_column)
       assert_operator(entry.location.end_column, :>, 0)
     end
+
+    def test_attaches_correct_owner_to_singleton_methods
+      entries = @index["basename"]
+      refute_nil(entries)
+
+      owner = entries.first.owner
+      assert_instance_of(Entry::SingletonClass, owner)
+      assert_equal("File::<Class:File>", owner.name)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

In #2177, we prevented the build from failing, but we didn't have a test for singleton methods which made us miss the fact that they're all being associated to the attached class/module.

This PR ensures that we assign the right owner for singleton methods.

### Implementation

If RBS marked the method as `singleton?`, then we need to put it in the singleton class of the current owner.

### Automated Tests

Added a test that prevents regression.