### PR TITLE
Lazily resolve method aliases

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -439,11 +439,16 @@ module RubyIndexer
 
       sig { params(target: T.any(Member, MethodAlias), unresolved_alias: UnresolvedMethodAlias).void }
       def initialize(target, unresolved_alias)
+        full_comments = ["Alias for #{target.name}\n"]
+        full_comments.concat(unresolved_alias.comments)
+        full_comments << "\n"
+        full_comments.concat(target.comments)
+
         super(
           unresolved_alias.new_name,
           unresolved_alias.file_path,
           unresolved_alias.location,
-          unresolved_alias.comments,
+          full_comments,
         )
 
         @target = target
@@ -459,9 +464,9 @@ module RubyIndexer
         @target.parameters
       end
 
-      sig { override.returns(T::Array[String]) }
-      def comments
-        @comments + @target.comments
+      sig { returns(String) }
+      def decorated_parameters
+        @target.decorated_parameters
       end
     end
   end

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -299,7 +299,7 @@ module RubyLsp
             text_edit: Interface::TextEdit.new(range: range, new_text: entry_name),
             kind: Constant::CompletionItemKind::METHOD,
             data: {
-              owner_name: T.cast(entry, RubyIndexer::Entry::Member).owner&.name,
+              owner_name: entry.owner&.name,
             },
           )
         end
@@ -309,7 +309,7 @@ module RubyLsp
 
       sig do
         params(
-          entry: RubyIndexer::Entry::Member,
+          entry: T.any(RubyIndexer::Entry::Member, RubyIndexer::Entry::MethodAlias),
           node: Prism::CallNode,
         ).returns(Interface::CompletionItem)
       end

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -675,6 +675,33 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_definition_for_aliased_methods
+    source = <<~RUBY
+      class Parent
+        def bar; end
+      end
+
+      class Child < Parent
+        alias baz bar
+
+        def do_something
+          baz
+        end
+      end
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 4, line: 8 } },
+      )
+      response = server.pop_response.response
+
+      assert_equal(5, response[0].range.start.line)
+    end
+  end
+
   private
 
   def create_definition_addon


### PR DESCRIPTION
### Motivation

Closes #1940

This PR starts lazily resolving method aliases, so that we can show the correct information for aliases in definition, hover, completion and signature help.

### Implementation

The idea is quite similar to constant aliases. If we encounter an unresolved entry, we try to resolve it recursively (since an alias can point to another alias). Then we store the resolved entry in the index so that we don't have to do it next time.

### Automated Tests

Added tests for the index and for all of the features.