### PR TITLE
Search aliased namespaces in the top level too

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -204,7 +204,7 @@ module RubyIndexer
       return entries if entries
 
       # Finally, as a fallback, Ruby will search for the constant in the top level namespace
-      search_top_level(name, seen_names)
+      direct_or_aliased_constant(name, seen_names)
     rescue UnresolvableAliasError
       nil
     end
@@ -602,11 +602,6 @@ module RubyIndexer
     def direct_or_aliased_constant(full_name, seen_names)
       entries = @entries[full_name] || @entries[follow_aliased_namespace(full_name)]
       entries&.map { |e| e.is_a?(Entry::UnresolvedAlias) ? resolve_alias(e, seen_names) : e }
-    end
-
-    sig { params(name: String, seen_names: T::Array[String]).returns(T.nilable(T::Array[Entry])) }
-    def search_top_level(name, seen_names)
-      @entries[name]&.map { |e| e.is_a?(Entry::UnresolvedAlias) ? resolve_alias(e, seen_names) : e }
     end
 
     # Attempt to resolve a given unresolved method alias. This method returns the resolved alias if we managed to


### PR DESCRIPTION
### Motivation

We were treating the top level differently, but in reality that's a mistake. We can have aliased namespaces in the top level too (and we use that in the Ruby LSP itself).

### Implementation

We don't need special treatment for the top level, we just need to invoke the `direct_or_aliased_constant` with the correct name at the end of resolution.

### Automated Tests

Added a test that reproduces the bug.