### PR TITLE
Move experimental features into global state

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -21,7 +21,7 @@ module RubyLsp
     attr_reader :encoding
 
     sig { returns(T::Boolean) }
-    attr_reader :supports_watching_files
+    attr_reader :supports_watching_files, :experimental_features
 
     sig { returns(TypeInferrer) }
     attr_reader :type_inferrer
@@ -39,6 +39,7 @@ module RubyLsp
       @type_inferrer = T.let(TypeInferrer.new(@index), TypeInferrer)
       @supported_formatters = T.let({}, T::Hash[String, Requests::Support::Formatter])
       @supports_watching_files = T.let(false, T::Boolean)
+      @experimental_features = T.let(false, T::Boolean)
     end
 
     sig { params(identifier: String, instance: Requests::Support::Formatter).void }
@@ -87,6 +88,8 @@ module RubyLsp
       if file_watching_caps&.dig(:dynamicRegistration) && file_watching_caps&.dig(:relativePatternSupport)
         @supports_watching_files = true
       end
+
+      @experimental_features = options.dig(:initializationOptions, :experimentalFeaturesEnabled) || false
     end
 
     sig { returns(String) }

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -137,7 +137,6 @@ module RubyLsp
       progress = options.dig(:capabilities, :window, :workDoneProgress)
       @store.supports_progress = progress.nil? ? true : progress
       configured_features = options.dig(:initializationOptions, :enabledFeatures)
-      @store.experimental_features = options.dig(:initializationOptions, :experimentalFeaturesEnabled) || false
 
       configured_hints = options.dig(:initializationOptions, :featuresConfiguration, :inlayHint)
       T.must(@store.features_configuration.dig(:inlayHint)).configuration.merge!(configured_hints) if configured_hints

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -8,9 +8,6 @@ module RubyLsp
     sig { returns(T::Boolean) }
     attr_accessor :supports_progress
 
-    sig { returns(T::Boolean) }
-    attr_accessor :experimental_features
-
     sig { returns(T::Hash[Symbol, RequestConfig]) }
     attr_accessor :features_configuration
 
@@ -21,7 +18,6 @@ module RubyLsp
     def initialize
       @state = T.let({}, T::Hash[String, Document])
       @supports_progress = T.let(true, T::Boolean)
-      @experimental_features = T.let(false, T::Boolean)
       @features_configuration = T.let(
         {
           inlayHint: RequestConfig.new({

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -176,6 +176,17 @@ module RubyLsp
       assert_empty(state.instance_variable_get(:@linters))
     end
 
+    def test_apply_options_sets_experimental_features
+      state = GlobalState.new
+      refute_predicate(state, :experimental_features)
+
+      state.apply_options({
+        initializationOptions: { experimentalFeaturesEnabled: true },
+      })
+
+      assert_predicate(state, :experimental_features)
+    end
+
     private
 
     def stub_direct_dependencies(dependencies)


### PR DESCRIPTION
### Motivation

The experimental features flag should be a part of the global state, so that every listener and addon can reuse it.

### Implementation

Moved the experimental flag from `Store` to `GlobalState`. We don't have any experimental features right now, so nothing was using it.

### Automated Tests

Added tests.