### PR TITLE
Introduce guessed receiver types

### DIFF
--- a/DESIGN_AND_ROADMAP.md
+++ b/DESIGN_AND_ROADMAP.md
@@ -221,7 +221,7 @@ Interested in contributing? Check out the issues tagged with [help-wanted] or [g
 
 ## Guessed types
 
-Guessed types is an experimental features where the Ruby LSP attempts to identify the type of a receiver based on its
+Guessed types is an experimental feature where the Ruby LSP attempts to identify the type of a receiver based on its
 identifier name. For example:
 
 ```ruby
@@ -232,13 +232,13 @@ user.name
 @post.like!
 ```
 
-IMPORTANT: The goal of this experiment is to understand if we can get better accuracy for the code that you already
-have. The hypothesis is that a reasonable amount of code already uses patterns like the ones in the example and, in
-those cases, we can achieve nicer results.
-
-However, identifiers are not the ideal medium for proper type annotations. It would not be possible to express anything
-complex, such as unions, intersections or generics. Additionally, it is very trivial to fool the type guessing by simply
-naming a variable with a type name that doesn't match its actual type.
+> [!IMPORTANT] The goal of this experiment is to understand if we can get better accuracy for the code that you already
+> have. The hypothesis is that a reasonable amount of code already uses patterns like the ones in the example and, in
+> those cases, we can achieve nicer results.
+>
+> However, identifiers are not the ideal medium for proper type annotations. It would not be possible to express anything
+> complex, such as unions, intersections or generics. Additionally, it is very trivial to fool the type guessing by simply
+> naming a variable with a type name that doesn't match its actual type.
 
 ```ruby
 pathname = something_that_returns_an_integer

--- a/DESIGN_AND_ROADMAP.md
+++ b/DESIGN_AND_ROADMAP.md
@@ -218,3 +218,85 @@ Interested in contributing? Check out the issues tagged with [help-wanted] or [g
 [Explore speeding up indexing by caching the index for gems]: https://github.com/Shopify/ruby-lsp/issues/1009
 [Add range formatting support for formatters that do support it]: https://github.com/Shopify/ruby-lsp/issues/203
 [Add ERB support]: https://github.com/Shopify/ruby-lsp/issues/1055
+
+## Guessed types
+
+Guessed types is an experimental features where the Ruby LSP attempts to identify the type of a receiver based on its
+identifier name. For example:
+
+```ruby
+# The receiver identifier here is `user` and so the Ruby LSP will assign to it the `User` type if that class exists
+user.name
+
+# Similarly, the receiver identifier here is `post` and so the LSP searches for the `Post` class
+@post.like!
+```
+
+IMPORTANT: The goal of this experiment is to understand if we can get better accuracy for the code that you already
+have. The hypothesis is that a reasonable amount of code already uses patterns like the ones in the example and, in
+those cases, we can achieve nicer results.
+
+However, identifiers are not the ideal medium for proper type annotations. It would not be possible to express anything
+complex, such as unions, intersections or generics. Additionally, it is very trivial to fool the type guessing by simply
+naming a variable with a type name that doesn't match its actual type.
+
+```ruby
+pathname = something_that_returns_an_integer
+# This will show methods available in `Pathname`, despite the variable being an Integer
+pathname.a
+```
+
+We do not recommend renaming methods, instance variables or local variables for the sole purpose of getting better
+accuracy - readibility should always come first. For example:
+
+```ruby
+# It would not be a good idea to name every string "string" for the sake of getting better accuracy.
+# Using descriptive names will outweight the benefits of the more accurate editor experience
+
+# don't
+string = something.other_thing
+
+# do
+title = something.other_thing
+name = foo
+```
+
+That said, this feature can also be used for quickly exploring methods available in classes. Simply type the lower case
+name of the class and completion can show the methods available.
+
+```ruby
+# Any class name as an identifier
+pathname.a
+integer.a
+file.a
+```
+
+To guess types, the Ruby LSP will first try to resolve a constant based on the receiver identifier and current nesting.
+If that does not identify any valid types, then it will fallback to matching based on the first match for the
+unqualified type name. For example:
+
+```ruby
+module Admin
+  class User
+  end
+
+  # Will match to `Admin::User` because the `user` reference is inside the `Admin` namespace
+  user.a
+end
+
+module Blog
+  class User
+  end
+
+  # Will match to `Blog::User` because the `user` reference is inside the `Blog` namespace
+  user.a
+end
+
+# Will match to the first class that has the unqualified name of `User`. This may return `Admin::User` or `Blog::User`
+# randomly
+user.a
+```
+
+This is an experimental feature and can only be accessed if `initializationOptions.experimentalFeaturesEnabled` is
+`true` (the `"rubyLsp.enableExperimentalFeatures": true` setting for VS Code users). If you have feedback about this
+experiment, please let us know in a GitHub issue.

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -84,6 +84,34 @@ module RubyIndexer
       @require_paths_tree.search(query)
     end
 
+    # Searches for a constant based on an unqualified name and returns the first possible match regardless of whether
+    # there are more possible matching entries
+    sig do
+      params(
+        name: String,
+      ).returns(T.nilable(T::Array[T.any(
+        Entry::Namespace,
+        Entry::Alias,
+        Entry::UnresolvedAlias,
+        Entry::Constant,
+      )]))
+    end
+    def first_unqualified_const(name)
+      _name, entries = @entries.find do |const_name, _entries|
+        const_name.end_with?(name)
+      end
+
+      T.cast(
+        entries,
+        T.nilable(T::Array[T.any(
+          Entry::Namespace,
+          Entry::Alias,
+          Entry::UnresolvedAlias,
+          Entry::Constant,
+        )]),
+      )
+    end
+
     # Searches entries in the index based on an exact prefix, intended for providing autocomplete. All possible matches
     # to the prefix are returned. The return is an array of arrays, where each entry is the array of entries for a given
     # name match. For example:

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1542,6 +1542,21 @@ module RubyIndexer
       assert_empty(@index.method_completion_candidates("bar", "Foo"))
     end
 
+    def test_first_unqualified_const
+      index(<<~RUBY)
+        module Foo
+          class Bar; end
+        end
+
+        module Baz
+          class Bar; end
+        end
+      RUBY
+
+      entry = T.must(@index.first_unqualified_const("Bar")&.first)
+      assert_equal("Foo::Bar", entry.name)
+    end
+
     def test_completion_does_not_duplicate_overridden_methods
       index(<<~RUBY)
         class Foo

--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -36,10 +36,10 @@ module RubyLsp
       @test_library = T.let("minitest", String)
       @has_type_checker = T.let(true, T::Boolean)
       @index = T.let(RubyIndexer::Index.new, RubyIndexer::Index)
-      @type_inferrer = T.let(TypeInferrer.new(@index), TypeInferrer)
       @supported_formatters = T.let({}, T::Hash[String, Requests::Support::Formatter])
       @supports_watching_files = T.let(false, T::Boolean)
       @experimental_features = T.let(false, T::Boolean)
+      @type_inferrer = T.let(TypeInferrer.new(@index, @experimental_features), TypeInferrer)
     end
 
     sig { params(identifier: String, instance: Requests::Support::Formatter).void }
@@ -90,6 +90,7 @@ module RubyLsp
       end
 
       @experimental_features = options.dig(:initializationOptions, :experimentalFeaturesEnabled) || false
+      @type_inferrer.experimental_features = @experimental_features
     end
 
     sig { returns(String) }

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -366,6 +366,8 @@ module RubyLsp
 
         return unless range
 
+        guessed_type = type.is_a?(TypeInferrer::GuessedType)
+
         @index.method_completion_candidates(method_name, type.name).each do |entry|
           entry_name = entry.name
 
@@ -381,6 +383,7 @@ module RubyLsp
             kind: Constant::CompletionItemKind::METHOD,
             data: {
               owner_name: entry.owner&.name,
+              guessed_type: guessed_type,
             },
           )
         end

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -366,10 +366,11 @@ module RubyLsp
 
         return unless range
 
-        guessed_type = type.is_a?(TypeInferrer::GuessedType)
+        guessed_type = type.name
 
         @index.method_completion_candidates(method_name, type.name).each do |entry|
           entry_name = entry.name
+          owner_name = entry.owner&.name
 
           label_details = Interface::CompletionItemLabelDetails.new(
             description: entry.file_name,
@@ -382,7 +383,7 @@ module RubyLsp
             text_edit: Interface::TextEdit.new(range: range, new_text: entry_name),
             kind: Constant::CompletionItemKind::METHOD,
             data: {
-              owner_name: entry.owner&.name,
+              owner_name: owner_name,
               guessed_type: guessed_type,
             },
           )

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -262,7 +262,7 @@ module RubyLsp
         type = @type_inferrer.infer_receiver_type(@node_context)
         return unless type
 
-        @index.instance_variable_completion_candidates(name, type).each do |entry|
+        @index.instance_variable_completion_candidates(name, type.name).each do |entry|
           variable_name = entry.name
 
           label_details = Interface::CompletionItemLabelDetails.new(
@@ -366,7 +366,7 @@ module RubyLsp
 
         return unless range
 
-        @index.method_completion_candidates(method_name, type).each do |entry|
+        @index.method_completion_candidates(method_name, type.name).each do |entry|
           entry_name = entry.name
 
           label_details = Interface::CompletionItemLabelDetails.new(

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -65,7 +65,7 @@ module RubyLsp
 
         # Until we can properly infer the receiver type in erb files (maybe with ruby-lsp-rails),
         # treating method calls' type as `nil` will allow users to get some completion support first
-        if @language_id == Document::LanguageId::ERB && inferrer_receiver_type == "Object"
+        if @language_id == Document::LanguageId::ERB && inferrer_receiver_type&.name == "Object"
           inferrer_receiver_type = nil
         end
 

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -176,7 +176,7 @@ module RubyLsp
         type = @type_inferrer.infer_receiver_type(@node_context)
         return unless type
 
-        entries = @index.resolve_instance_variable(name, type)
+        entries = @index.resolve_instance_variable(name, type.name)
         return unless entries
 
         entries.each do |entry|
@@ -194,10 +194,10 @@ module RubyLsp
         # If by any chance we haven't indexed the owner, then there's no way to find the right declaration
       end
 
-      sig { params(message: String, receiver_type: T.nilable(String), inherited_only: T::Boolean).void }
+      sig { params(message: String, receiver_type: T.nilable(TypeInferrer::Type), inherited_only: T::Boolean).void }
       def handle_method_definition(message, receiver_type, inherited_only: false)
         methods = if receiver_type
-          @index.resolve_method(message, receiver_type, inherited_only: inherited_only)
+          @index.resolve_method(message, receiver_type.name, inherited_only: inherited_only)
         else
           # If the method doesn't have a receiver, then we provide a few candidates to jump to
           # But we don't want to provide too many candidates, as it can be overwhelming

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -171,7 +171,7 @@ module RubyLsp
         type = @type_inferrer.infer_receiver_type(@node_context)
         return unless type
 
-        methods = @index.resolve_method(message, type, inherited_only: inherited_only)
+        methods = @index.resolve_method(message, type.name, inherited_only: inherited_only)
         return unless methods
 
         title = "#{message}#{T.must(methods.first).decorated_parameters}"
@@ -190,7 +190,7 @@ module RubyLsp
         type = @type_inferrer.infer_receiver_type(@node_context)
         return unless type
 
-        entries = @index.resolve_instance_variable(name, type)
+        entries = @index.resolve_instance_variable(name, type.name)
         return unless entries
 
         categorized_markdown_from_index_entries(name, entries).each do |category, content|

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -177,9 +177,8 @@ module RubyLsp
         title = "#{message}#{T.must(methods.first).decorated_parameters}"
 
         if type.is_a?(TypeInferrer::GuessedType)
-          title << " | guessed receiver: #{type.name}"
-          link = "https://github.com/Shopify/ruby-lsp/blob/main/DESIGN_AND_ROADMAP.md#guessed-types"
-          @response_builder.push("[Learn more about guessed types](#{link})\n", category: :links)
+          title << "\n\nGuessed receiver: #{type.name}"
+          @response_builder.push("[Learn more about guessed types](#{GUESSED_TYPES_URL})\n", category: :links)
         end
 
         categorized_markdown_from_index_entries(title, methods).each do |category, content|

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -176,6 +176,12 @@ module RubyLsp
 
         title = "#{message}#{T.must(methods.first).decorated_parameters}"
 
+        if type.is_a?(TypeInferrer::GuessedType)
+          title << " | guessed receiver: #{type.name}"
+          link = "https://github.com/Shopify/ruby-lsp/blob/main/DESIGN_AND_ROADMAP.md#guessed-types"
+          @response_builder.push("[Learn more about guessed types](#{link})\n", category: :links)
+        end
+
         categorized_markdown_from_index_entries(title, methods).each do |category, content|
           @response_builder.push(content, category: category)
         end

--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -64,9 +64,8 @@ module RubyLsp
         title = +""
 
         extra_links = if type.is_a?(TypeInferrer::GuessedType)
-          title << "guessed receiver: #{type.name}"
-          link = "https://github.com/Shopify/ruby-lsp/blob/main/DESIGN_AND_ROADMAP.md#guessed-types"
-          "[Learn more about guessed types](#{link})"
+          title << "\n\nGuessed receiver: #{type.name}"
+          "[Learn more about guessed types](#{GUESSED_TYPES_URL})"
         end
 
         signature_help = Interface::SignatureHelp.new(

--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -36,7 +36,7 @@ module RubyLsp
         type = @type_inferrer.infer_receiver_type(@node_context)
         return unless type
 
-        methods = @index.resolve_method(message, type)
+        methods = @index.resolve_method(message, type.name)
         return unless methods
 
         target_method = methods.first

--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -61,6 +61,14 @@ module RubyLsp
           active_parameter += 1
         end
 
+        title = +""
+
+        extra_links = if type.is_a?(TypeInferrer::GuessedType)
+          title << "guessed receiver: #{type.name}"
+          link = "https://github.com/Shopify/ruby-lsp/blob/main/DESIGN_AND_ROADMAP.md#guessed-types"
+          "[Learn more about guessed types](#{link})"
+        end
+
         signature_help = Interface::SignatureHelp.new(
           signatures: [
             Interface::SignatureInformation.new(
@@ -68,7 +76,7 @@ module RubyLsp
               parameters: parameters.map { |param| Interface::ParameterInformation.new(label: param.name) },
               documentation: Interface::MarkupContent.new(
                 kind: "markdown",
-                value: markdown_from_index_entries("", methods),
+                value: markdown_from_index_entries(title, methods, extra_links: extra_links),
               ),
             ),
           ],

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -47,7 +47,7 @@ module RubyLsp
         #
         # For example, forgetting to return the `insertText` included in the original item will make the editor use the
         # `label` for the text edit instead
-        label = @item[:label]
+        label = @item[:label].dup
         entries = @index[label] || []
 
         owner_name = @item.dig(:data, :owner_name)
@@ -62,12 +62,18 @@ module RubyLsp
         first_entry = T.must(entries.first)
 
         if first_entry.is_a?(RubyIndexer::Entry::Member)
-          label = "#{label}#{first_entry.decorated_parameters}"
+          label = +"#{label}#{first_entry.decorated_parameters}"
+        end
+
+        extra_links = if @item.dig(:data, :guessed_type)
+          label << " | guessed receiver: #{owner_name}"
+          link = "https://github.com/Shopify/ruby-lsp/blob/main/DESIGN_AND_ROADMAP.md#guessed-types"
+          "[Learn more about guessed types](#{link})"
         end
 
         @item[:documentation] = Interface::MarkupContent.new(
           kind: "markdown",
-          value: markdown_from_index_entries(label, entries, MAX_DOCUMENTATION_ENTRIES),
+          value: markdown_from_index_entries(label, entries, MAX_DOCUMENTATION_ENTRIES, extra_links: extra_links),
         )
 
         @item

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -65,10 +65,11 @@ module RubyLsp
           label = +"#{label}#{first_entry.decorated_parameters}"
         end
 
-        extra_links = if @item.dig(:data, :guessed_type)
-          label << " | guessed receiver: #{owner_name}"
-          link = "https://github.com/Shopify/ruby-lsp/blob/main/DESIGN_AND_ROADMAP.md#guessed-types"
-          "[Learn more about guessed types](#{link})"
+        guessed_type = @item.dig(:data, :guessed_type)
+
+        extra_links = if guessed_type
+          label << "\n\nGuessed receiver: #{guessed_type}"
+          "[Learn more about guessed types](#{GUESSED_TYPES_URL})"
         end
 
         @item[:documentation] = Interface::MarkupContent.new(

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -130,13 +130,17 @@ module RubyLsp
             title: String,
             entries: T.any(T::Array[RubyIndexer::Entry], RubyIndexer::Entry),
             max_entries: T.nilable(Integer),
+            extra_links: T.nilable(String),
           ).returns(String)
         end
-        def markdown_from_index_entries(title, entries, max_entries = nil)
+        def markdown_from_index_entries(title, entries, max_entries = nil, extra_links: nil)
           categorized_markdown = categorized_markdown_from_index_entries(title, entries, max_entries)
 
+          markdown = +(categorized_markdown[:title] || "")
+          markdown << "\n\n#{extra_links}" if extra_links
+
           <<~MARKDOWN.chomp
-            #{categorized_markdown[:title]}
+            #{markdown}
 
             #{categorized_markdown[:links]}
 

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -21,7 +21,7 @@ module RubyLsp
       &block)
       server = RubyLsp::Server.new(test_mode: true)
       server.global_state.stubs(:has_type_checker).returns(false) if stub_no_typechecker
-      server.global_state.apply_options({})
+      server.global_state.apply_options({ initializationOptions: { experimentalFeaturesEnabled: true } })
       language_id = uri.to_s.end_with?(".erb") ? "erb" : "ruby"
 
       if source

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -25,6 +25,7 @@ module RubyLsp
     end,
     String,
   )
+  GUESSED_TYPES_URL = "https://github.com/Shopify/ruby-lsp/blob/main/DESIGN_AND_ROADMAP.md#guessed-types"
 
   # A notification to be sent to the client
   class Message

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -122,13 +122,13 @@ class CompletionResolveTest < Minitest::Test
       existing_item = {
         label: "foo",
         kind: RubyLsp::Constant::CompletionItemKind::METHOD,
-        data: { owner_name: "User", guessed_type: true },
+        data: { owner_name: "User", guessed_type: "User" },
       }
 
       server.process_message(id: 1, method: "completionItem/resolve", params: existing_item)
 
       result = server.pop_response.response
-      assert_match("guessed receiver: User", result[:documentation].value)
+      assert_match("Guessed receiver: User", result[:documentation].value)
       assert_match("Learn more about guessed types", result[:documentation].value)
     end
   end

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -107,4 +107,29 @@ class CompletionResolveTest < Minitest::Test
       assert_match("(a, b, c)", result[:documentation].value)
     end
   end
+
+  def test_completion_documentation_for_guessed_types
+    source = +<<~RUBY
+      class User
+        def foo(a, b, c)
+        end
+      end
+
+      user.f
+    RUBY
+
+    with_server(source, stub_no_typechecker: true) do |server, _uri|
+      existing_item = {
+        label: "foo",
+        kind: RubyLsp::Constant::CompletionItemKind::METHOD,
+        data: { owner_name: "User", guessed_type: true },
+      }
+
+      server.process_message(id: 1, method: "completionItem/resolve", params: existing_item)
+
+      result = server.pop_response.response
+      assert_match("guessed receiver: User", result[:documentation].value)
+      assert_match("Learn more about guessed types", result[:documentation].value)
+    end
+  end
 end

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -707,7 +707,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
       )
 
       contents = server.pop_response.response.contents.value
-      assert_match("guessed receiver: User", contents)
+      assert_match("Guessed receiver: User", contents)
       assert_match("Learn more about guessed types", contents)
     end
   end

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -690,6 +690,28 @@ class HoverExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_hover_for_guessed_receivers
+    source = <<~RUBY
+      class User
+        def name; end
+      end
+
+      user.name
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/hover",
+        params: { textDocument: { uri: uri }, position: { character: 5, line: 4 } },
+      )
+
+      contents = server.pop_response.response.contents.value
+      assert_match("guessed receiver: User", contents)
+      assert_match("Learn more about guessed types", contents)
+    end
+  end
+
   private
 
   def create_hover_addon

--- a/test/requests/signature_help_test.rb
+++ b/test/requests/signature_help_test.rb
@@ -392,7 +392,7 @@ class SignatureHelpTest < Minitest::Test
       signature = result.signatures.first
 
       assert_equal("subscribe!(news_letter)", signature.label)
-      assert_match("guessed receiver: User", signature.documentation.value)
+      assert_match("Guessed receiver: User", signature.documentation.value)
     end
   end
 end

--- a/test/requests/signature_help_test.rb
+++ b/test/requests/signature_help_test.rb
@@ -371,4 +371,28 @@ class SignatureHelpTest < Minitest::Test
       assert_nil(server.pop_response.response)
     end
   end
+
+  def test_guessed_types
+    source = <<~RUBY
+      class User
+        def subscribe!(news_letter)
+        end
+      end
+
+      user.subscribe!()
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(id: 1, method: "textDocument/signatureHelp", params: {
+        textDocument: { uri: uri },
+        position: { line: 5, character: 15 },
+        context: {},
+      })
+      result = server.pop_response.response
+      signature = result.signatures.first
+
+      assert_equal("subscribe!(news_letter)", signature.label)
+      assert_match("guessed receiver: User", signature.documentation.value)
+    end
+  end
 end

--- a/test/type_inferrer_test.rb
+++ b/test/type_inferrer_test.rb
@@ -234,7 +234,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo", @type_inferrer.infer_receiver_type(node_context))
+      assert_equal("Foo", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_super_receiver
@@ -246,7 +246,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo", @type_inferrer.infer_receiver_type(node_context))
+      assert_equal("Foo", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     private


### PR DESCRIPTION
### Motivation

This PR adds the experiment of guessed receiver types, where we try to guess the type of receivers based on their identifier.

### Implementation

The relevant part of the implementation is all in `TypeInferrer`, everything else is just displaying to users why we picked a certain type.

The idea is to try to guess the types like this:
1. Take the raw receiver slice
2. Sanitize that name to be camel case and discard `@` symbols
3. First, try to resolve the name inside the current nesting. If we find something, return that
4. Otherwise, search for the first type that matches the unqualified name of the identifier

More details in the Markdown documentation.

### Validation

I used Spoom's access to the Sorbet LSP to compare the guessed types vs the actual types informed by Sorbet. I also compared 4 approaches:

In the Ruby LSP repo, these are the accuracy results for each approach
1. First resolve then fallback to unqualified name: 15% of correct types
2. Unqualified only: 11%
3. Resolve with nesting only: 9%
4. Fuzzy search: 2% (in addition to being the worse accuracy, fuzzy search was also unbearably slow)

In Core, the analysis script took way too long to finish, so I sampled a subset of the codebase. The results there were worse than in the Ruby LSP codebase, peaking at about 5% of correct types.

Surely, the level of accuracy will vary a lot between different codebases. That said, I still believe the experiment would be worth the try and would love to hear feedback from users about the usefulness of this.

Script:

```ruby
# typed: strict
# frozen_string_literal: true

require "spoom"
require "ruby_lsp/internal"

class Visitor < Prism::Visitor
  extend T::Sig

  sig { returns(T.nilable(RubyLsp::Document)) }
  attr_accessor :document

  sig { returns(Integer) }
  attr_reader :total, :correct

  sig { returns(T::Hash[String, T.nilable(String)]) }
  attr_reader :comparison

  sig { params(inferrer: RubyLsp::TypeInferrer, lsp_client: Spoom::LSP::Client).void }
  def initialize(inferrer, lsp_client)
    @inferrer = inferrer
    @lsp_client = lsp_client
    @total = T.let(0, Integer)
    @correct = T.let(0, Integer)
    @document = T.let(nil, T.nilable(RubyLsp::Document))
    super()
  end

  sig { params(node: Prism::CallNode).void }
  def visit_call_node(node)
    receiver_loc = node.receiver&.location
    return super unless receiver_loc

    receiver = node.receiver
    unless receiver.is_a?(Prism::CallNode) || receiver.is_a?(Prism::LocalVariableReadNode) ||
        receiver.is_a?(Prism::InstanceVariableReadNode)
      return super
    end

    hover = @lsp_client.hover(T.must(@document).uri.to_s, receiver_loc.start_line - 1, receiver_loc.start_column)

    if hover
      hovered_type = if /returns\((.*)\)/ =~ hover.contents
        T.must(T.must(hover.contents.match(/returns\((.*)\)/))[1])
      else
        hover.contents
      end

      return super if hovered_type == "T.untyped" || hovered_type == "T::Private::Methods::DeclBuilder"

      loc = T.must(node.message_loc)

      node_context = T.must(@document).locate_node(
        {
          line: loc.start_line - 1,
          character: loc.start_column,
        },
        node_types: [Prism::CallNode],
      )

      type = @inferrer.infer_receiver_type(node_context)

      @total += 1

      if type
        parts = type.split("::")
        parts.reject! { |e| e.include?("<Class:") }
        corrected_type = parts.join("::")

        if hovered_type.include?(corrected_type)
          @correct += 1
        end
      end
    end

    super
  end
end

index = RubyIndexer::Index.new
index.index_all

inferrer = RubyLsp::TypeInferrer.new(index)
workspace_path = Dir.pwd

client = Spoom::LSP::Client.new(
  Spoom::Sorbet::BIN_PATH,
  "--lsp",
  "--enable-all-experimental-lsp-features",
  "--disable-watchman",
)
client.open(workspace_path)

begin
  visitor = Visitor.new(inferrer, client)
  files = Dir.glob("#{workspace_path}/**/*.rb")
  RubyVM::YJIT.enable

  Signal.trap("INT") do
    puts "Total: #{visitor.total}"
    puts "Correct: #{visitor.correct}"
    puts "Accuracy: #{100 * (visitor.correct.to_f / visitor.total)}"
    client.close
    exit
  end

  files.each_with_index do |file, index|
    document = RubyLsp::RubyDocument.new(
      source: File.read(file),
      version: 1,
      uri: URI::Generic.from_path(path: File.expand_path(file)),
    )
    visitor.document = document
    Prism.parse_file(file).value.accept(visitor)

    print("\033[M\033[0KCompleted #{index + 1}/#{files.length}")
  end

  puts "Total: #{visitor.total}"
  puts "Correct: #{visitor.correct}"
  puts "Accuracy: #{100 * (visitor.correct.to_f / visitor.total)}"
ensure
  client.close
end
```

### Automated Tests

Added tests.

### Manual Tests

Type any existing class name as a variable. After typing a dot, you should see completion options for that type (e.g.: `pathname.`).