### PR TITLE
Linearize singleton ancestors

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -96,7 +96,6 @@ module RubyIndexer
 
     class Include < ModuleOperation; end
     class Prepend < ModuleOperation; end
-    class Extend < ModuleOperation; end
 
     class Namespace < Entry
       extend T::Sig

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -461,13 +461,13 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo"][0])
+      foo = T.must(@index["Foo::<Class:Foo>"][0])
       assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.mixin_operation_module_names)
 
-      qux = T.must(@index["Foo::Qux"][0])
+      qux = T.must(@index["Foo::Qux::<Class:Qux>"][0])
       assert_equal(["Corge", "Corge", "Baz"], qux.mixin_operation_module_names)
 
-      constant_path_references = T.must(@index["ConstantPathReferences"][0])
+      constant_path_references = T.must(@index["ConstantPathReferences::<Class:ConstantPathReferences>"][0])
       assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.mixin_operation_module_names)
     end
 

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1358,11 +1358,6 @@ module RubyIndexer
       entries = @index.instance_variable_completion_candidates("@", "Foo::Bar::<Class:Bar>").map(&:name)
       assert_includes(entries, "@a")
       assert_includes(entries, "@b")
-
-      assert_includes(
-        @index.instance_variable_completion_candidates("@", "Foo::Bar::<Class:Bar>::<Class:<Class:Bar>>").map(&:name),
-        "@c",
-      )
     end
 
     def test_singletons_are_excluded_from_prefix_search
@@ -1572,6 +1567,145 @@ module RubyIndexer
       entry = T.must(methods.first)
 
       assert_equal("()", entry.decorated_parameters)
+    end
+
+    def test_linearizing_singleton_singleton_ancestors_when_class_has_parent
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
+        class Foo; end
+
+        class Bar < Foo
+        end
+
+        class Baz < Bar
+          class << self
+            class << self
+            end
+          end
+        end
+      RUBY
+
+      assert_equal(
+        [
+          "Baz::<Class:Baz>::<Class:<Class:Baz>>",
+          "Bar::<Class:Bar>::<Class:<Class:Bar>>",
+          "Foo::<Class:Foo>::<Class:<Class:Foo>>",
+          "Object::<Class:Object>::<Class:<Class:Object>>",
+          "BasicObject::<Class:BasicObject>::<Class:<Class:BasicObject>>",
+          "Class::<Class:Class>",
+          "Module::<Class:Module>",
+          "Object::<Class:Object>",
+          "BasicObject::<Class:BasicObject>",
+          "Class",
+          "Module",
+          "Object",
+          "Kernel",
+          "BasicObject",
+        ],
+        @index.linearized_ancestors_of("Baz::<Class:Baz>::<Class:<Class:Baz>>"),
+      )
+    end
+
+    def test_linearizing_singleton_object
+      assert_equal(
+        [
+          "Object::<Class:Object>",
+          "BasicObject::<Class:BasicObject>",
+          "Class",
+          "Module",
+          "Object",
+          "Kernel",
+          "BasicObject",
+        ],
+        @index.linearized_ancestors_of("Object::<Class:Object>"),
+      )
+    end
+
+    def test_linearizing_singleton_ancestors
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
+        module First
+        end
+
+        module Second
+          include First
+        end
+
+        module Foo
+          class Bar
+            class << self
+              class Baz
+                extend Second
+
+                class << self
+                  include First
+                end
+              end
+            end
+          end
+        end
+      RUBY
+
+      assert_equal(
+        [
+          "Foo::Bar::<Class:Bar>::Baz::<Class:Baz>",
+          "Second",
+          "First",
+          "Object::<Class:Object>",
+          "BasicObject::<Class:BasicObject>",
+          "Class",
+          "Module",
+          "Object",
+          "Kernel",
+          "BasicObject",
+        ],
+        @index.linearized_ancestors_of("Foo::Bar::<Class:Bar>::Baz::<Class:Baz>"),
+      )
+    end
+
+    def test_linearizing_singleton_ancestors_when_class_has_parent
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
+        class Foo; end
+
+        class Bar < Foo
+        end
+
+        class Baz < Bar
+          class << self
+          end
+        end
+      RUBY
+
+      assert_equal(
+        [
+          "Baz::<Class:Baz>",
+          "Bar::<Class:Bar>",
+          "Foo::<Class:Foo>",
+          "Object::<Class:Object>",
+          "BasicObject::<Class:BasicObject>",
+          "Class",
+          "Module",
+          "Object",
+          "Kernel",
+          "BasicObject",
+        ],
+        @index.linearized_ancestors_of("Baz::<Class:Baz>"),
+      )
+    end
+
+    def test_linearizing_a_module_singleton_class
+      @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
+        module A; end
+      RUBY
+
+      assert_equal(
+        [
+          "A::<Class:A>",
+          "Module",
+          "Object",
+          "Kernel",
+          "BasicObject",
+        ],
+        @index.linearized_ancestors_of("A::<Class:A>"),
+      )
     end
   end
 end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1569,7 +1569,7 @@ module RubyIndexer
       assert_equal("()", entry.decorated_parameters)
     end
 
-    def test_linearizing_singleton_singleton_ancestors_when_class_has_parent
+    def test_linearizing_singleton_ancestors_of_singleton_when_class_has_parent
       @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"), <<~RUBY)
         class Foo; end
 

--- a/lib/ruby_lsp/requests/type_hierarchy_supertypes.rb
+++ b/lib/ruby_lsp/requests/type_hierarchy_supertypes.rb
@@ -54,8 +54,6 @@ module RubyLsp
           end
 
           entry.mixin_operations.each do |mixin_operation|
-            next if mixin_operation.is_a?(RubyIndexer::Entry::Extend)
-
             mixin_name = mixin_operation.module_name
             resolved_mixin_entries = @index.resolve(mixin_name, entry.nesting)
             next unless resolved_mixin_entries


### PR DESCRIPTION
### Motivation

Closes #1939, closes #1938, closes #1333

This PR adds lazy singleton ancestor linearization, which allows us to properly handle constants, methods and instance variables that are inherited by a singleton class.

### Implementation

1. We already had lazy creation of singleton classes spreading across three different places. Moved that to the Index, which is the entity that's actually concerned with those. Started using it in RBSIndexer and the regular declaration listener
2. Removed the concept of `extend`. An extend is nothing but a convenience to include something in the singleton class. If we simply treat all extends as singleton class inclusions, the entire algorithm works as is and we don't have to handle another type of operation
3. Finally, the most important part is how to lazily determine the ancestors based on how many levels of singleton we are checking. Here's how the algorithm works:

For each level of singleton, the ancestors are: the linearization of the same level of singleton + the linearization of the level - 1 of the `Class` class. For example:
```ruby
class Foo; end
class Bar < Foo; end

# First singleton
Bar.singleton_class.ancestors
# => [Bar::<Class:Bar>,
#     Foo::<Class:Foo>,
#     Object::<Class:Object>,
#     BasicObject::<Class:BasicObject>, # <<<< Until here, it's the ancestors of <Class:Bar>
#     Class, Module, Object, Kernel, BasicObject] # <<< Ancestors of Class

# Second singleton
Bar.singleton_class.singleton_class.ancestors
# => [Bar::<Class:Bar>::<Class:<Class:Bar>>,
#     Foo::<Class:Foo>::<Class:<Class:Foo>>,
#     Object::<Class:Object>::<Class:<Class:Object>>,
#     BasicObject::<Class:BasicObject>::<Class:<Class:BasicObject>>,
#     ^^^^^^^ until here, it's the ancestors of <Class:<Class:Bar>>
#     Class::<Class:Class>, Module::<Class:Module>, Object::<Class:Object>,
#     BasicObject::<Class:BasicObject>,
#     ^^^^^^^ then the ancestors of <Class:Class> (the singleton level - 1)
#     Class, Module, Object, Kernel, BasicObject]
#     ^^^^^^^ And finally the ancestors of Class
```

### Automated Tests

Added tests.

### Manual Tests

1. Launch LSP on this branch
5. Type `File.` in any file
6. Verify that you see methods inherited from the `IO` class, such as the method `pipe`