### PR TITLE
Provide a way for addon developers to get an addon by name

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -72,6 +72,15 @@ module RubyLsp
           addon.add_error(e)
         end
       end
+
+      # Intended for use by tests for addons
+      sig { params(addon_name: String).returns(Addon) }
+      def get(addon_name)
+        addon = addons.find { |addon| addon.name == addon_name }
+        raise "Could not find addon '#{addon_name}'" unless addon
+
+        addon
+      end
     end
 
     sig { void }

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -99,5 +99,16 @@ module RubyLsp
         Addon.file_watcher_addons.clear
       end
     end
+
+    def test_get_an_addon_by_name
+      addon = Addon.get("My Addon")
+      assert_equal("My Addon", addon.name)
+    end
+
+    def test_raises_if_an_addon_cannot_be_found
+      assert_raises do
+        Addon.get("Invalid Addon")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Provide a way for addon developers to get an addon by name

As suggested by @st0012: https://github.com/Shopify/ruby-lsp-rails/pull/319#discussion_r1586783177

### Implementation

Just a simple find, or raise if the addon is not found.

### Automated Tests

Included

### Manual Tests

n/a
