### PR TITLE
Make Rails app detection based on Rails::Application superclass

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -285,13 +285,11 @@ module RubyLsp
     # Detects if the project is a Rails app by looking if the superclass of the main class is `Rails::Application`
     sig { returns(T::Boolean) }
     def rails_app?
-      /class .* < Rails::Application/.match?(rails_application_content)
-    end
-
-    sig { returns(T.nilable(String)) }
-    def rails_application_content
       config = Pathname.new("config/application.rb").expand_path
-      config.read if config.exist?
+      application_contents = config.read if config.exist?
+      return false unless application_contents
+
+      /class .* < Rails::Application/.match?(application_contents)
     end
   end
 end

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -289,7 +289,7 @@ module RubyLsp
       application_contents = config.read if config.exist?
       return false unless application_contents
 
-      /class .* < Rails::Application/.match?(application_contents)
+      /class .* < (::)?Rails::Application/.match?(application_contents)
     end
   end
 end

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -50,6 +50,7 @@ module RubyLsp
       @last_updated_path = T.let(@custom_dir + "last_updated", Pathname)
 
       @dependencies = T.let(load_dependencies, T::Hash[String, T.untyped])
+      @rails_app = T.let(rails_app?, T::Boolean)
       @retry = T.let(false, T::Boolean)
     end
 
@@ -62,7 +63,7 @@ module RubyLsp
       # Do not set up a custom bundle if LSP dependencies are already in the Gemfile
       if @dependencies["ruby-lsp"] &&
           @dependencies["debug"] &&
-          (@dependencies["rails"] ? @dependencies["ruby-lsp-rails"] : true)
+          (@rails_app ? @dependencies["ruby-lsp-rails"] : true)
         $stderr.puts(
           "Ruby LSP> Skipping custom bundle setup since LSP dependencies are already in #{@gemfile}",
         )
@@ -148,7 +149,7 @@ module RubyLsp
         parts << 'gem "debug", require: false, group: :development, platforms: :mri'
       end
 
-      if @dependencies["rails"] && !@dependencies["ruby-lsp-rails"]
+      if @rails_app && !@dependencies["ruby-lsp-rails"]
         parts << 'gem "ruby-lsp-rails", require: false, group: :development'
       end
 
@@ -209,7 +210,7 @@ module RubyLsp
         command << " && bundle update "
         command << "ruby-lsp " unless @dependencies["ruby-lsp"]
         command << "debug " unless @dependencies["debug"]
-        command << "ruby-lsp-rails " if @dependencies["rails"] && !@dependencies["ruby-lsp-rails"]
+        command << "ruby-lsp-rails " if @rails_app && !@dependencies["ruby-lsp-rails"]
         command << "--pre" if @experimental
         command.delete_suffix!(" ")
         command << ")"
@@ -244,7 +245,7 @@ module RubyLsp
     def should_bundle_update?
       # If `ruby-lsp`, `ruby-lsp-rails` and `debug` are in the Gemfile, then we shouldn't try to upgrade them or else it
       # will produce version control changes
-      if @dependencies["rails"]
+      if @rails_app
         return false if @dependencies.values_at("ruby-lsp", "ruby-lsp-rails", "debug").all?
 
         # If the custom lockfile doesn't include `ruby-lsp`, `ruby-lsp-rails` or `debug`, we need to run bundle install
@@ -279,6 +280,16 @@ module RubyLsp
       end
 
       @custom_lockfile.write(content)
+    end
+
+    # Detects if the project is a Rails app by looking if the superclass of the main class is `Rails::Application`
+    sig { returns(T::Boolean) }
+    def rails_app?
+      config = Pathname.new("config/application.rb").expand_path
+      application_contents = config.read if config.exist?
+      return false unless application_contents
+
+      /class .* < Rails::Application/.match?(application_contents)
     end
   end
 end

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -285,11 +285,13 @@ module RubyLsp
     # Detects if the project is a Rails app by looking if the superclass of the main class is `Rails::Application`
     sig { returns(T::Boolean) }
     def rails_app?
-      config = Pathname.new("config/application.rb").expand_path
-      application_contents = config.read if config.exist?
-      return false unless application_contents
+      /class .* < Rails::Application/.match?(rails_application_content)
+    end
 
-      /class .* < Rails::Application/.match?(application_contents)
+    sig { returns(T.nilable(String)) }
+    def rails_application_content
+      config = Pathname.new("config/application.rb").expand_path
+      config.read if config.exist?
     end
   end
 end

--- a/test/fixtures/rails_application.rb
+++ b/test/fixtures/rails_application.rb
@@ -1,0 +1,4 @@
+module MyApp
+  class Application < Rails::Application
+  end
+end

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -94,7 +94,7 @@ class SetupBundlerTest < Minitest::Test
     assert_match("ruby-lsp-rails", File.read(".ruby-lsp/Gemfile"))
   ensure
     FileUtils.rm_r(".ruby-lsp") if Dir.exist?(".ruby-lsp")
-    FileUtils.rm_rf("config") if Dir.exist?("config")
+    FileUtils.rm_r("config") if Dir.exist?("config")
   end
 
   def test_changing_lockfile_causes_custom_bundle_to_be_rebuilt

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -484,19 +484,13 @@ class SetupBundlerTest < Minitest::Test
 
   def test_ruby_lsp_rails_is_automatically_included_in_rails_apps
     Dir.mktmpdir do |dir|
+      FileUtils.mkdir("#{dir}/config")
+      FileUtils.cp("test/fixtures/rails_application.rb", "#{dir}/config/application.rb")
       Dir.chdir(dir) do
         File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
           source "https://rubygems.org"
           gem "rails"
         GEMFILE
-
-        FileUtils.mkdir(File.join(dir, "config"))
-        File.write(File.join(dir, "config", "application.rb"), <<~RUBY)
-          module MyApp
-            class Application < Rails::Application
-            end
-          end
-        RUBY
 
         capture_subprocess_io do
           Bundler.with_unbundled_env do


### PR DESCRIPTION
### Motivation

closes https://github.com/Shopify/ruby-lsp/issues/2096

This change makes the Rails app detection based on the superclass of the main class being `Rails::Application`. This is a more reliable way to detect Rails apps than looking for the presence of the `rails` gem in the Gemfile. Application can require some of the Rails components without requiring the `rails` gem itself.

### Implementation

The implementation is strongly inspired  from #2161, hat tip to @Earlopain. I've added you as a co-author; let me know if that's ok.

### Automated Tests

The test all pass individually. However, when the full file is executed, one of the test doesn't pass. It's most certainly related to something I have changed. I wasn't able to pinpoint if context is leaking between tests or if something else is happening. Since this is also my first time using minitest, an experienced eye would be appreciated.

The problem can be reproduced with:
```
SPEC_REPORTER=1 bundle exec rake TEST="test/setup_bundler_test.rb" TESTOPTS="--seed=55457"
```

Relevant snip in case it doesn't fail:
```
  test_ruby_lsp_rails_is_automatically_included_in_rails_apps     PASS (1.39s)
  test_creates_custom_bundle_for_a_rails_app                      FAIL (0.00s)
        Expected path '.ruby-lsp/Gemfile.lock' to exist.
        /Users/louim/repositories/ruby-lsp/test/setup_bundler_test.rb:97:in `block (2 levels) in test_creates_custom_bundle_for_a_rails_app'
        /Users/louim/repositories/ruby-lsp/test/setup_bundler_test.rb:79:in `chdir'
        /Users/louim/repositories/ruby-lsp/test/setup_bundler_test.rb:79:in `block in test_creates_custom_bundle_for_a_rails_app'
        /Users/louim/.local/share/mise/installs/ruby/3.3.1/lib/ruby/3.3.0/tmpdir.rb:99:in `mktmpdir'
        /Users/louim/repositories/ruby-lsp/test/setup_bundler_test.rb:78:in `test_creates_custom_bundle_for_a_rails_app'
```
### Manual Tests

I haven't yet tested in our app, will do so as soon as possible.
