### PR TITLE
Upgrade Node to 20.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20.9"
           cache: "yarn"
           cache-dependency-path: "vscode"
 
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20.9"
           cache: "yarn"
           cache-dependency-path: "vscode"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v4
         name: Use Node.js 18.x
         with:
-          node-version: "18"
+          node-version: "20.9"
           cache: "yarn"
           cache-dependency-path: "vscode"
 

--- a/dev.yml
+++ b/dev.yml
@@ -7,7 +7,7 @@ up:
   - bundler
   - node:
       yarn: true
-      version: 18.15.0
+      version: 20.9.0
       packages:
         - vscode
 


### PR DESCRIPTION
### Motivation

VS Code is now on NodeJS v20.9.0. We should upgrade to use the same version in development and CI.
