### PR TITLE
Introduce `Entry::Signature` to support overloading

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -309,7 +309,7 @@ module RubyIndexer
           node.location,
           node.name_loc,
           comments,
-          list_params(node.parameters),
+          [Entry::Signature.new(list_params(node.parameters))],
           current_visibility,
           @owner_stack.last,
         ))
@@ -322,7 +322,7 @@ module RubyIndexer
           node.location,
           node.name_loc,
           comments,
-          list_params(node.parameters),
+          [Entry::Signature.new(list_params(node.parameters))],
           current_visibility,
           singleton,
         ))

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -294,6 +294,11 @@ module RubyIndexer
       sig { returns(T.nilable(Entry::Namespace)) }
       attr_reader :owner
 
+      sig { returns(T::Array[RubyIndexer::Entry::Parameter]) }
+      def parameters
+        T.must(signatures.first).parameters
+      end
+
       sig do
         params(
           name: String,
@@ -310,32 +315,32 @@ module RubyIndexer
         @owner = owner
       end
 
-      sig { abstract.returns(T::Array[Parameter]) }
-      def parameters; end
+      sig { abstract.returns(T::Array[Entry::Signature]) }
+      def signatures; end
 
       # Returns a string with the decorated names of the parameters of this member. E.g.: `(a, b = 1, c: 2)`
       sig { returns(String) }
       def decorated_parameters
-        "(#{parameters.map(&:decorated_name).join(", ")})"
+        "(#{T.must(signatures.first).parameters.map(&:decorated_name).join(", ")})"
       end
     end
 
     class Accessor < Member
       extend T::Sig
 
-      sig { override.returns(T::Array[Parameter]) }
-      def parameters
+      sig { override.returns(T::Array[Signature]) }
+      def signatures
         params = []
         params << RequiredParameter.new(name: name.delete_suffix("=").to_sym) if name.end_with?("=")
-        params
+        [Entry::Signature.new(params)]
       end
     end
 
     class Method < Member
       extend T::Sig
 
-      sig { override.returns(T::Array[Parameter]) }
-      attr_reader :parameters
+      sig { override.returns(T::Array[Signature]) }
+      attr_reader :signatures
 
       # Returns the location of the method name, excluding parameters or the body
       sig { returns(Location) }
@@ -348,14 +353,14 @@ module RubyIndexer
           location: T.any(Prism::Location, RubyIndexer::Location),
           name_location: T.any(Prism::Location, Location),
           comments: T::Array[String],
-          parameters: T::Array[Parameter],
+          signatures: T::Array[Signature],
           visibility: Visibility,
           owner: T.nilable(Entry::Namespace),
         ).void
       end
-      def initialize(name, file_path, location, name_location, comments, parameters, visibility, owner) # rubocop:disable Metrics/ParameterLists
+      def initialize(name, file_path, location, name_location, comments, signatures, visibility, owner) # rubocop:disable Metrics/ParameterLists
         super(name, file_path, location, comments, visibility, owner)
-        @parameters = parameters
+        @signatures = signatures
         @name_location = T.let(
           if name_location.is_a?(Prism::Location)
             Location.new(
@@ -513,6 +518,18 @@ module RubyIndexer
       sig { returns(String) }
       def decorated_parameters
         @target.decorated_parameters
+      end
+    end
+
+    class Signature
+      extend T::Sig
+
+      sig { returns(T::Array[Parameter]) }
+      attr_reader :parameters
+
+      sig { params(parameters: T::Array[Parameter]).void }
+      def initialize(parameters)
+        @parameters = parameters
       end
     end
   end

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -525,6 +525,9 @@ module RubyIndexer
       end
     end
 
+    # Ruby doesn't support method overloading, so a method will have only one signature.
+    # However RBS can represent the concept of method overloading, with different return types based on the arguments
+    # passed, so we need to store all the signatures.
     class Signature
       extend T::Sig
 

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -330,9 +330,14 @@ module RubyIndexer
 
       sig { override.returns(T::Array[Signature]) }
       def signatures
-        params = []
-        params << RequiredParameter.new(name: name.delete_suffix("=").to_sym) if name.end_with?("=")
-        [Entry::Signature.new(params)]
+        @signatures ||= T.let(
+          begin
+            params = []
+            params << RequiredParameter.new(name: name.delete_suffix("=").to_sym) if name.end_with?("=")
+            [Entry::Signature.new(params)]
+          end,
+          T.nilable(T::Array[Signature]),
+        )
       end
     end
 

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -318,10 +318,9 @@ module RubyIndexer
       sig { abstract.returns(T::Array[Entry::Signature]) }
       def signatures; end
 
-      # Returns a string with the decorated names of the parameters of this member. E.g.: `(a, b = 1, c: 2)`
       sig { returns(String) }
       def decorated_parameters
-        "(#{T.must(signatures.first).parameters.map(&:decorated_name).join(", ")})"
+        "(#{T.must(signatures.first).format})"
       end
     end
 
@@ -535,6 +534,12 @@ module RubyIndexer
       sig { params(parameters: T::Array[Parameter]).void }
       def initialize(parameters)
         @parameters = parameters
+      end
+
+      # Returns a string with the decorated names of the parameters of this member. E.g.: `(a, b = 1, c: 2)`
+      sig { returns(String) }
+      def format
+        @parameters.map(&:decorated_name).join(", ")
       end
     end
   end


### PR DESCRIPTION
### Motivation

As agreed with @vinistock and @Morriar, with RBS we will be getting multiple signatures per method, with potentially different returns types, so it probably better to represent them as specificed, than trying to 'flatten' them, as attempted in https://github.com/Shopify/ruby-lsp/pull/2200.


### Implementation

The first part to this is to introduce the concept of a Signature.

### Automated Tests

No changes. The new `Signature` has no behaviour, so I don't think a new test is necessary.

### Manual Tests

n/a
