### PR TITLE
Prevent clash with `Kernel#format` method

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -320,7 +320,7 @@ module RubyIndexer
 
       sig { returns(String) }
       def decorated_parameters
-        "(#{T.must(signatures.first).format})"
+        "(#{T.must(signatures.first).formatted})"
       end
     end
 
@@ -538,9 +538,10 @@ module RubyIndexer
         @parameters = parameters
       end
 
-      # Returns a string with the decorated names of the parameters of this member. E.g.: `(a, b = 1, c: 2)`
+      # Returns a string with the decorated names of the parameters of this member.
+      # e.g.: `(a, b = <default>, c: <default>)`
       sig { returns(String) }
-      def format
+      def formatted
         @parameters.map(&:decorated_name).join(", ")
       end
     end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1541,5 +1541,21 @@ module RubyIndexer
       assert_equal(["bar"], entries.map(&:name))
       assert_equal("Baz", T.must(entries.first.owner).name)
     end
+
+    def test_decorated_parameters
+      index(<<~RUBY)
+        class Foo
+          def bar(a, b = 1, c: 2)
+          end
+        end
+      RUBY
+
+      methods = @index.resolve_method("bar", "Foo")
+      refute_nil(methods)
+
+      entry = T.must(methods.first)
+
+      assert_equal("(a, b = <default>, c: <default>)", entry.decorated_parameters)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

I noticed that after https://github.com/Shopify/ruby-lsp/pull/2221/files, Ruby LSP was failing on startup with:

```
NoMethodError: private method `format' called for an instance of RubyIndexer::Entry::Signature
```

(the PR was merged but didn't yet ship in a release)

### Implementation

I've renamed the method to avoid this clash. 

### Automated Tests

I added a test, but it doesn't actually catch the problem.

### Manual Tests

Verify Ruby LSP starts successfully.
