### PR TITLE
Fix `decorated_parameters` for when method has no parameters

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -320,7 +320,10 @@ module RubyIndexer
 
       sig { returns(String) }
       def decorated_parameters
-        "(#{T.must(signatures.first).format})"
+        first_signature = signatures.first
+        return "" unless first_signature
+
+        "(#{first_signature.format})"
       end
     end
 

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -321,7 +321,7 @@ module RubyIndexer
       sig { returns(String) }
       def decorated_parameters
         first_signature = signatures.first
-        return "" unless first_signature
+        return "()" unless first_signature
 
         "(#{first_signature.format})"
       end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1541,5 +1541,37 @@ module RubyIndexer
       assert_equal(["bar"], entries.map(&:name))
       assert_equal("Baz", T.must(entries.first.owner).name)
     end
+
+    def test_decorated_parameters
+      index(<<~RUBY)
+        class Foo
+          def bar(a, b = 1, c: 2)
+          end
+        end
+      RUBY
+
+      methods = @index.resolve_method("bar", "Foo")
+      refute_nil(methods)
+
+      entry = T.must(methods.first)
+
+      assert_equal("(a, b = <default>, c: <default>)", entry.decorated_parameters)
+    end
+
+    def test_decorated_parameters_when_method_has_no_parameters
+      index(<<~RUBY)
+        class Foo
+          def bar
+          end
+        end
+      RUBY
+
+      methods = @index.resolve_method("bar", "Foo")
+      refute_nil(methods)
+
+      entry = T.must(methods.first)
+
+      assert_equal("()", entry.decorated_parameters)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

When indexing a method with no arguments, it was failing with:

```
NoMethodError: private method `format' called for an instance of RubyIndexer::Entry::Signature
```

(because `signatures.first` was returning nil, and `format` is defined on `nil` as a private method)

### Implementation

Hand the case of a method with no arguments.

### Automated Tests

Updated

### Manual Tests

Add a file with a method with no parameters. Save it and ensure there are no errors in the console.
