### PR TITLE
Run multiple Minitest examples via a single ruby command from the VS Code test explorer

### DIFF
--- a/lib/minitest/load.rb
+++ b/lib/minitest/load.rb
@@ -1,0 +1,6 @@
+# typed: false # rubocop:disable Sorbet/StrictSigil
+# frozen_string_literal: true
+
+require "minitest/manual_plugins"
+
+Minitest.load(:ruby_lsp)

--- a/lib/minitest/ruby_lsp_plugin.rb
+++ b/lib/minitest/ruby_lsp_plugin.rb
@@ -1,0 +1,37 @@
+# typed: false # rubocop:disable Sorbet/StrictSigil
+# frozen_string_literal: true
+
+require "json"
+require "minitest"
+
+module Minitest
+  class RubyLspReporter < Reporter
+    def prerecord(klass, name)
+      @id = "#{klass.name}##{name}"
+      io.puts JSON.generate(event: "start", id: @id)
+      io.flush
+    end
+
+    def record(result)
+      if result.failures.any?
+        message = result.failures.map { |f| "#{f.class.name}: #{f.message}" }.join("\n")
+        io.puts JSON.generate(event: "fail", id: @id, message: message)
+      else
+        io.puts JSON.generate(event: "pass", id: @id)
+      end
+      io.flush
+    end
+  end
+
+  class << self
+    def plugin_ruby_lsp_options(opts, options)
+      opts.on("--ruby-lsp", "Outputs structured JSON for Ruby LSP") do
+        options[:ruby_lsp] = true
+      end
+    end
+
+    def plugin_ruby_lsp_init(options)
+      reporter.reporters = [RubyLspReporter.new($stdout)] if options[:ruby_lsp]
+    end
+  end
+end

--- a/test/expectations/code_lens/minitest_nested_classes_and_modules.exp.json
+++ b/test/expectations/code_lens/minitest_nested_classes_and_modules.exp.json
@@ -23,7 +23,8 @@
             "start_column": 2,
             "end_line": 5,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -56,7 +57,8 @@
             "start_column": 2,
             "end_line": 5,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -89,7 +91,8 @@
             "start_column": 2,
             "end_line": 5,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -122,6 +125,11 @@
             "start_column": 4,
             "end_line": 2,
             "end_column": 21
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::FooTest#test_foo"
           }
         ]
       },
@@ -154,6 +162,11 @@
             "start_column": 4,
             "end_line": 2,
             "end_column": 21
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::FooTest#test_foo"
           }
         ]
       },
@@ -186,6 +199,11 @@
             "start_column": 4,
             "end_line": 2,
             "end_column": 21
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::FooTest#test_foo"
           }
         ]
       },
@@ -218,6 +236,11 @@
             "start_column": 4,
             "end_line": 4,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::FooTest#test_foo_2"
           }
         ]
       },
@@ -250,6 +273,11 @@
             "start_column": 4,
             "end_line": 4,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::FooTest#test_foo_2"
           }
         ]
       },
@@ -282,6 +310,11 @@
             "start_column": 4,
             "end_line": 4,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::FooTest#test_foo_2"
           }
         ]
       },
@@ -314,7 +347,8 @@
             "start_column": 4,
             "end_line": 18,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -347,7 +381,8 @@
             "start_column": 4,
             "end_line": 18,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -380,7 +415,8 @@
             "start_column": 4,
             "end_line": 18,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -413,6 +449,11 @@
             "start_column": 6,
             "end_line": 9,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::BarTest#test_bar"
           }
         ]
       },
@@ -445,6 +486,11 @@
             "start_column": 6,
             "end_line": 9,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::BarTest#test_bar"
           }
         ]
       },
@@ -477,6 +523,11 @@
             "start_column": 6,
             "end_line": 9,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::BarTest#test_bar"
           }
         ]
       },
@@ -509,7 +560,8 @@
             "start_column": 8,
             "end_line": 16,
             "end_column": 11
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -542,7 +594,8 @@
             "start_column": 8,
             "end_line": 16,
             "end_column": 11
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -575,7 +628,8 @@
             "start_column": 8,
             "end_line": 16,
             "end_column": 11
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -608,6 +662,11 @@
             "start_column": 10,
             "end_line": 13,
             "end_column": 27
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::BarTest::Baz::BazTest#test_baz"
           }
         ]
       },
@@ -640,6 +699,11 @@
             "start_column": 10,
             "end_line": 13,
             "end_column": 27
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::BarTest::Baz::BazTest#test_baz"
           }
         ]
       },
@@ -672,6 +736,11 @@
             "start_column": 10,
             "end_line": 13,
             "end_column": 27
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::BarTest::Baz::BazTest#test_baz"
           }
         ]
       },
@@ -704,6 +773,11 @@
             "start_column": 10,
             "end_line": 15,
             "end_column": 29
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::BarTest::Baz::BazTest#test_baz_2"
           }
         ]
       },
@@ -736,6 +810,11 @@
             "start_column": 10,
             "end_line": 15,
             "end_column": 29
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::BarTest::Baz::BazTest#test_baz_2"
           }
         ]
       },
@@ -768,6 +847,11 @@
             "start_column": 10,
             "end_line": 15,
             "end_column": 29
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::BarTest::Baz::BazTest#test_baz_2"
           }
         ]
       },
@@ -800,7 +884,8 @@
             "start_column": 4,
             "end_line": 24,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -833,7 +918,8 @@
             "start_column": 4,
             "end_line": 24,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -866,7 +952,8 @@
             "start_column": 4,
             "end_line": 24,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -899,6 +986,11 @@
             "start_column": 6,
             "end_line": 23,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Baz::BazTest#test_baz"
           }
         ]
       },
@@ -931,6 +1023,11 @@
             "start_column": 6,
             "end_line": 23,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Baz::BazTest#test_baz"
           }
         ]
       },
@@ -963,6 +1060,11 @@
             "start_column": 6,
             "end_line": 23,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Baz::BazTest#test_baz"
           }
         ]
       },
@@ -995,7 +1097,8 @@
             "start_column": 2,
             "end_line": 33,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -1028,7 +1131,8 @@
             "start_column": 2,
             "end_line": 33,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -1061,7 +1165,8 @@
             "start_column": 2,
             "end_line": 33,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -1094,6 +1199,11 @@
             "start_column": 4,
             "end_line": 30,
             "end_column": 25
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::FooBarTest#test_foo_bar"
           }
         ]
       },
@@ -1126,6 +1236,11 @@
             "start_column": 4,
             "end_line": 30,
             "end_column": 25
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::FooBarTest#test_foo_bar"
           }
         ]
       },
@@ -1158,6 +1273,11 @@
             "start_column": 4,
             "end_line": 30,
             "end_column": 25
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::FooBarTest#test_foo_bar"
           }
         ]
       },
@@ -1190,6 +1310,11 @@
             "start_column": 4,
             "end_line": 32,
             "end_column": 27
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::FooBarTest#test_foo_bar_2"
           }
         ]
       },
@@ -1222,6 +1347,11 @@
             "start_column": 4,
             "end_line": 32,
             "end_column": 27
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::FooBarTest#test_foo_bar_2"
           }
         ]
       },
@@ -1254,6 +1384,11 @@
             "start_column": 4,
             "end_line": 32,
             "end_column": 27
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::FooBarTest#test_foo_bar_2"
           }
         ]
       },
@@ -1286,7 +1421,8 @@
             "start_column": 2,
             "end_line": 40,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -1319,7 +1455,8 @@
             "start_column": 2,
             "end_line": 40,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -1352,7 +1489,8 @@
             "start_column": 2,
             "end_line": 40,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -1385,6 +1523,11 @@
             "start_column": 4,
             "end_line": 39,
             "end_column": 29
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::FooBar::Test#test_foo_bar_baz"
           }
         ]
       },
@@ -1417,6 +1560,11 @@
             "start_column": 4,
             "end_line": 39,
             "end_column": 29
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::FooBar::Test#test_foo_bar_baz"
           }
         ]
       },
@@ -1449,6 +1597,11 @@
             "start_column": 4,
             "end_line": 39,
             "end_column": 29
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_nested_classes_and_modules.rb --ruby-lsp --name",
+            "id": "Foo::Bar::FooBar::Test#test_foo_bar_baz"
           }
         ]
       },
@@ -1459,5 +1612,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/expectations/code_lens/minitest_spec_tests.exp.json
+++ b/test/expectations/code_lens/minitest_spec_tests.exp.json
@@ -23,7 +23,8 @@
             "start_column": 0,
             "end_line": 14,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -56,7 +57,8 @@
             "start_column": 0,
             "end_line": 14,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -89,7 +91,8 @@
             "start_column": 0,
             "end_line": 14,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -122,7 +125,8 @@
             "start_column": 2,
             "end_line": 1,
             "end_column": 19
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -154,7 +158,8 @@
             "start_column": 2,
             "end_line": 1,
             "end_column": 19
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -186,7 +191,8 @@
             "start_column": 2,
             "end_line": 1,
             "end_column": 19
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -218,7 +224,8 @@
             "start_column": 2,
             "end_line": 11,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -251,7 +258,8 @@
             "start_column": 2,
             "end_line": 11,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -284,7 +292,8 @@
             "start_column": 2,
             "end_line": 11,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -317,7 +326,8 @@
             "start_column": 4,
             "end_line": 4,
             "end_column": 18
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -349,7 +359,8 @@
             "start_column": 4,
             "end_line": 4,
             "end_column": 18
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -381,7 +392,8 @@
             "start_column": 4,
             "end_line": 4,
             "end_column": 18
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -413,7 +425,8 @@
             "start_column": 4,
             "end_line": 8,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -446,7 +459,8 @@
             "start_column": 4,
             "end_line": 8,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -479,7 +493,8 @@
             "start_column": 4,
             "end_line": 8,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -512,7 +527,8 @@
             "start_column": 6,
             "end_line": 7,
             "end_column": 25
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -544,7 +560,8 @@
             "start_column": 6,
             "end_line": 7,
             "end_column": 25
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -576,7 +593,8 @@
             "start_column": 6,
             "end_line": 7,
             "end_column": 25
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -608,7 +626,8 @@
             "start_column": 4,
             "end_line": 10,
             "end_column": 24
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -640,7 +659,8 @@
             "start_column": 4,
             "end_line": 10,
             "end_column": 24
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -672,7 +692,8 @@
             "start_column": 4,
             "end_line": 10,
             "end_column": 24
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -704,7 +725,8 @@
             "start_column": 2,
             "end_line": 13,
             "end_column": 25
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -736,7 +758,8 @@
             "start_column": 2,
             "end_line": 13,
             "end_column": 25
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -768,7 +791,8 @@
             "start_column": 2,
             "end_line": 13,
             "end_column": 25
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -800,7 +824,8 @@
             "start_column": 0,
             "end_line": 18,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -833,7 +858,8 @@
             "start_column": 0,
             "end_line": 18,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -866,7 +892,8 @@
             "start_column": 0,
             "end_line": 18,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -899,7 +926,8 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 29
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -931,7 +959,8 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 29
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -963,7 +992,8 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 29
-          }
+          },
+          null
         ]
       },
       "data": {

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -23,7 +23,8 @@
             "start_column": 0,
             "end_line": 22,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -56,7 +57,8 @@
             "start_column": 0,
             "end_line": 22,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -89,7 +91,8 @@
             "start_column": 0,
             "end_line": 22,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -122,6 +125,11 @@
             "start_column": 2,
             "end_line": 5,
             "end_column": 22
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_public"
           }
         ]
       },
@@ -154,6 +162,11 @@
             "start_column": 2,
             "end_line": 5,
             "end_column": 22
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_public"
           }
         ]
       },
@@ -186,6 +199,11 @@
             "start_column": 2,
             "end_line": 5,
             "end_column": 22
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_public"
           }
         ]
       },
@@ -218,6 +236,11 @@
             "start_column": 9,
             "end_line": 9,
             "end_column": 37
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_public_command"
           }
         ]
       },
@@ -250,6 +273,11 @@
             "start_column": 9,
             "end_line": 9,
             "end_column": 37
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_public_command"
           }
         ]
       },
@@ -282,6 +310,11 @@
             "start_column": 9,
             "end_line": 9,
             "end_column": 37
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_public_command"
           }
         ]
       },
@@ -314,6 +347,11 @@
             "start_column": 9,
             "end_line": 11,
             "end_column": 37
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_another_public"
           }
         ]
       },
@@ -346,6 +384,11 @@
             "start_column": 9,
             "end_line": 11,
             "end_column": 37
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_another_public"
           }
         ]
       },
@@ -378,6 +421,11 @@
             "start_column": 9,
             "end_line": 11,
             "end_column": 37
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_another_public"
           }
         ]
       },
@@ -410,6 +458,11 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 28
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_public_vcall"
           }
         ]
       },
@@ -442,6 +495,11 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 28
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_public_vcall"
           }
         ]
       },
@@ -474,6 +532,11 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 28
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_public_vcall"
           }
         ]
       },
@@ -506,6 +569,11 @@
             "start_column": 2,
             "end_line": 19,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_with_q\\?"
           }
         ]
       },
@@ -538,6 +606,11 @@
             "start_column": 2,
             "end_line": 19,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_with_q\\?"
           }
         ]
       },
@@ -570,6 +643,11 @@
             "start_column": 2,
             "end_line": 19,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "Test#test_with_q\\?"
           }
         ]
       },
@@ -602,7 +680,8 @@
             "start_column": 0,
             "end_line": 32,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -635,7 +714,8 @@
             "start_column": 0,
             "end_line": 32,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -668,7 +748,8 @@
             "start_column": 0,
             "end_line": 32,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -701,6 +782,11 @@
             "start_column": 2,
             "end_line": 25,
             "end_column": 22
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "AnotherTest#test_public"
           }
         ]
       },
@@ -733,6 +819,11 @@
             "start_column": 2,
             "end_line": 25,
             "end_column": 22
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "AnotherTest#test_public"
           }
         ]
       },
@@ -765,6 +856,11 @@
             "start_column": 2,
             "end_line": 25,
             "end_column": 22
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "AnotherTest#test_public"
           }
         ]
       },
@@ -797,6 +893,11 @@
             "start_column": 2,
             "end_line": 31,
             "end_column": 24
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "AnotherTest#test_public_2"
           }
         ]
       },
@@ -829,6 +930,11 @@
             "start_column": 2,
             "end_line": 31,
             "end_column": 24
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "AnotherTest#test_public_2"
           }
         ]
       },
@@ -861,6 +967,11 @@
             "start_column": 2,
             "end_line": 31,
             "end_column": 24
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_tests.rb --ruby-lsp --name",
+            "id": "AnotherTest#test_public_2"
           }
         ]
       },
@@ -871,5 +982,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
+++ b/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
@@ -23,7 +23,8 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -56,7 +57,8 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -89,7 +91,8 @@
             "start_column": 2,
             "end_line": 17,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -122,6 +125,11 @@
             "start_column": 4,
             "end_line": 10,
             "end_column": 27
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::Test#test_something$/"
           }
         ]
       },
@@ -154,6 +162,11 @@
             "start_column": 4,
             "end_line": 10,
             "end_column": 27
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::Test#test_something$/"
           }
         ]
       },
@@ -186,6 +199,11 @@
             "start_column": 4,
             "end_line": 10,
             "end_column": 27
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::Test#test_something$/"
           }
         ]
       },
@@ -218,6 +236,11 @@
             "start_column": 4,
             "end_line": 12,
             "end_column": 32
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::Test#test_something_else$/"
           }
         ]
       },
@@ -250,6 +273,11 @@
             "start_column": 4,
             "end_line": 12,
             "end_column": 32
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::Test#test_something_else$/"
           }
         ]
       },
@@ -282,6 +310,11 @@
             "start_column": 4,
             "end_line": 12,
             "end_column": 32
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::Test#test_something_else$/"
           }
         ]
       },
@@ -314,7 +347,8 @@
             "start_column": 4,
             "end_line": 16,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -347,7 +381,8 @@
             "start_column": 4,
             "end_line": 16,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -380,7 +415,8 @@
             "start_column": 4,
             "end_line": 16,
             "end_column": 7
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -413,6 +449,11 @@
             "start_column": 6,
             "end_line": 15,
             "end_column": 26
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::Test::NestedTest#test_nested$/"
           }
         ]
       },
@@ -445,6 +486,11 @@
             "start_column": 6,
             "end_line": 15,
             "end_column": 26
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::Test::NestedTest#test_nested$/"
           }
         ]
       },
@@ -477,6 +523,11 @@
             "start_column": 6,
             "end_line": 15,
             "end_column": 26
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::Test::NestedTest#test_nested$/"
           }
         ]
       },
@@ -509,7 +560,8 @@
             "start_column": 2,
             "end_line": 23,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -542,7 +594,8 @@
             "start_column": 2,
             "end_line": 23,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -575,7 +628,8 @@
             "start_column": 2,
             "end_line": 23,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -608,6 +662,11 @@
             "start_column": 4,
             "end_line": 20,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::SomeOtherTest#test_stuff$/"
           }
         ]
       },
@@ -640,6 +699,11 @@
             "start_column": 4,
             "end_line": 20,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::SomeOtherTest#test_stuff$/"
           }
         ]
       },
@@ -672,6 +736,11 @@
             "start_column": 4,
             "end_line": 20,
             "end_column": 23
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::SomeOtherTest#test_stuff$/"
           }
         ]
       },
@@ -704,6 +773,11 @@
             "start_column": 4,
             "end_line": 22,
             "end_column": 29
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::SomeOtherTest#test_other_stuff$/"
           }
         ]
       },
@@ -736,6 +810,11 @@
             "start_column": 4,
             "end_line": 22,
             "end_column": 29
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::SomeOtherTest#test_other_stuff$/"
           }
         ]
       },
@@ -768,6 +847,11 @@
             "start_column": 4,
             "end_line": 22,
             "end_column": 29
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/minitest_with_dynamic_constant_path.rb --ruby-lsp --name",
+            "id": "/::SomeOtherTest#test_other_stuff$/"
           }
         ]
       },
@@ -778,5 +862,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/expectations/code_lens/nested_minitest_tests.exp.json
+++ b/test/expectations/code_lens/nested_minitest_tests.exp.json
@@ -23,7 +23,8 @@
             "start_column": 0,
             "end_line": 20,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -56,7 +57,8 @@
             "start_column": 0,
             "end_line": 20,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -89,7 +91,8 @@
             "start_column": 0,
             "end_line": 20,
             "end_column": 3
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -122,6 +125,11 @@
             "start_column": 2,
             "end_line": 1,
             "end_column": 22
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest#test_public"
           }
         ]
       },
@@ -154,6 +162,11 @@
             "start_column": 2,
             "end_line": 1,
             "end_column": 22
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest#test_public"
           }
         ]
       },
@@ -186,6 +199,11 @@
             "start_column": 2,
             "end_line": 1,
             "end_column": 22
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest#test_public"
           }
         ]
       },
@@ -218,7 +236,8 @@
             "start_column": 2,
             "end_line": 9,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -251,7 +270,8 @@
             "start_column": 2,
             "end_line": 9,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -284,7 +304,8 @@
             "start_column": 2,
             "end_line": 9,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -317,6 +338,11 @@
             "start_column": 4,
             "end_line": 6,
             "end_column": 24
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest::FirstChildTest#test_public"
           }
         ]
       },
@@ -349,6 +375,11 @@
             "start_column": 4,
             "end_line": 6,
             "end_column": 24
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest::FirstChildTest#test_public"
           }
         ]
       },
@@ -381,6 +412,11 @@
             "start_column": 4,
             "end_line": 6,
             "end_column": 24
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest::FirstChildTest#test_public"
           }
         ]
       },
@@ -413,7 +449,8 @@
             "start_column": 2,
             "end_line": 15,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -446,7 +483,8 @@
             "start_column": 2,
             "end_line": 15,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -479,7 +517,8 @@
             "start_column": 2,
             "end_line": 15,
             "end_column": 5
-          }
+          },
+          null
         ]
       },
       "data": {
@@ -512,6 +551,11 @@
             "start_column": 4,
             "end_line": 14,
             "end_column": 24
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest::SecondChildTest#test_public"
           }
         ]
       },
@@ -544,6 +588,11 @@
             "start_column": 4,
             "end_line": 14,
             "end_column": 24
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest::SecondChildTest#test_public"
           }
         ]
       },
@@ -576,6 +625,11 @@
             "start_column": 4,
             "end_line": 14,
             "end_column": 24
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest::SecondChildTest#test_public"
           }
         ]
       },
@@ -608,6 +662,11 @@
             "start_column": 2,
             "end_line": 19,
             "end_column": 28
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest#test_public_again"
           }
         ]
       },
@@ -640,6 +699,11 @@
             "start_column": 2,
             "end_line": 19,
             "end_column": 28
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest#test_public_again"
           }
         ]
       },
@@ -672,6 +736,11 @@
             "start_column": 2,
             "end_line": 19,
             "end_column": 28
+          },
+          {
+            "type": "regex",
+            "command": "bundle exec ruby -Itest -r/lib/minitest/load.rb /fixtures/nested_minitest_tests.rb --ruby-lsp --name",
+            "id": "ParentTest#test_public_again"
           }
         ]
       },
@@ -682,5 +751,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -9,6 +9,13 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
   def setup
     @global_state = RubyLsp::GlobalState.new
+
+    @minitest_load_path = RubyLsp::Listeners::CodeLens::MINITEST_LOAD_PATH
+    RubyLsp::Listeners::CodeLens.const_set(:MINITEST_LOAD_PATH, "/lib/minitest/load.rb")
+  end
+
+  def teardown
+    RubyLsp::Listeners::CodeLens.const_set(:MINITEST_LOAD_PATH, @minitest_load_path)
   end
 
   def run_expectations(source)


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Running multiple tests in the VS Code test explorer or via the "Run test" code lens link is currently quite slow. That's because it executes a separate command per example, even if the test runner is capable of running multiple examples at once. That means any start up cost is incurred for each example. This PR attempts to improve that situation for Minitest, by combining the examples into a single command.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

We can't use the default Minitest test reporter (or whichever custom reporter the host project is using) for this, because it doesn't have enough structured output in order to know which tests have started or finished, and it's difficult to correlate any failure/error messages to the test in the explorer. This PR introduces a custom reporter that outputs structured JSON, and overrides whatever reporter is normally in place for the host project.

This relies on Minitest conventions to find the plugin, but it also injects some code to disable other Minitest plugins except our custom reporter. This is probably not ideal, but I wasn't sure how to force Minitest to use our custom reporter, other than disabling any other ones. Perhaps there is a way to guarantee our plugin is loaded last, so it overrides any other plugins? Alternatively, maybe our custom reporter could _augment_ the existing reporter and output JSON to a temporary log file instead stdout.

We also need some way to generate a combined test command from a series of separate examples. We're doing this by setting up some "combining" options that include the full name for each example and describe how those names should be combined into a command (in this case via a regex in passed to the `--name` argument). Ideally this should be extensible enough that it could be used by other test frameworks and runners—in particular I'd like to use this for testing Rails apps which often have a multi-second start up cost to running a test.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

I have updated the expectation tests, I'm not sure how to add automated tests for the VS Code extension part.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

Open a Minitest test file and click the "Run" code lens link. Try also selecting an arbitrary selection of tests in the explorer and running just those tests.

### Demo

Here's a before/after demo with a fake 1s start up cost.

https://github.com/Shopify/ruby-lsp/assets/770763/0643cf92-40a5-428e-8254-4d062f26c1de

