### PR TITLE
Add run task command

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -19,6 +19,7 @@ export enum Command {
   DebugTest = "rubyLsp.debugTest",
   ShowSyntaxTree = "rubyLsp.showSyntaxTree",
   DisplayAddons = "rubyLsp.displayAddons",
+  RunTask = "rubyLsp.runTask",
 }
 
 export interface RubyInterface {

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -370,6 +370,30 @@ export class RubyLsp {
         Command.DebugTest,
         this.testController.debugTest.bind(this.testController),
       ),
+      vscode.commands.registerCommand(
+        Command.RunTask,
+        async (command: string) => {
+          let workspace = this.currentActiveWorkspace();
+
+          if (!workspace) {
+            workspace = await this.showWorkspacePick();
+          }
+
+          if (!workspace) {
+            return;
+          }
+
+          workspace.outputChannel.show();
+          workspace.outputChannel.info(`Running task: ${command}`);
+          const { stdout, stderr } = await workspace.execute(command);
+
+          if (stderr.length > 0) {
+            workspace.outputChannel.error(stderr);
+          } else {
+            workspace.outputChannel.info(stdout);
+          }
+        },
+      ),
     );
   }
 

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -18,9 +18,9 @@ export class Workspace implements WorkspaceInterface {
   public readonly ruby: Ruby;
   public readonly createTestItems: (response: CodeLens[]) => void;
   public readonly workspaceFolder: vscode.WorkspaceFolder;
+  public readonly outputChannel: WorkspaceChannel;
   private readonly context: vscode.ExtensionContext;
   private readonly telemetry: Telemetry;
-  private readonly outputChannel: WorkspaceChannel;
   private readonly isMainWorkspace: boolean;
   private needsRestart = false;
   #rebaseInProgress = false;
@@ -261,6 +261,13 @@ export class Workspace implements WorkspaceInterface {
 
   get rebaseInProgress() {
     return this.#rebaseInProgress;
+  }
+
+  async execute(command: string) {
+    return asyncExec(command, {
+      env: this.ruby.env,
+      cwd: this.workspaceFolder.uri.fsPath,
+    });
   }
 
   private registerRestarts(context: vscode.ExtensionContext) {


### PR DESCRIPTION
### Motivation

Add a run task command so that addons can associate code lens command to be executed. This will allow us to add code lens for Rails generators or tasks, which all have different commands.

### Implementation

Added a convenience `execute` method to `Workspace`. In the command, we try to get the currently active workspace. If we can't, we show the workspace quick pick. And then we run the command in it.