### PR TITLE
Add file open support for route lookup

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -93,6 +93,11 @@
         "command": "rubyLsp.showSyntaxTree",
         "title": "Show syntax tree",
         "category": "Ruby LSP"
+      },
+      {
+        "command": "rubyLsp.openFile",
+        "title": "Opens a local file at a given position",
+        "category": "Ruby LSP"
       }
     ],
     "configuration": {

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -19,6 +19,7 @@ export enum Command {
   DebugTest = "rubyLsp.debugTest",
   ShowSyntaxTree = "rubyLsp.showSyntaxTree",
   DisplayAddons = "rubyLsp.displayAddons",
+  OpenFile = "rubyLsp.openFile",
 }
 
 export interface RubyInterface {

--- a/vscode/src/fileController.ts
+++ b/vscode/src/fileController.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+
+import { Telemetry } from "./telemetry";
+import { Workspace } from "./workspace";
+
+export class FileController {
+  private readonly telemetry: Telemetry;
+  private readonly currentWorkspace: () => Workspace | undefined;
+
+  constructor(
+    _context: vscode.ExtensionContext,
+    telemetry: Telemetry,
+    currentWorkspace: () => Workspace | undefined,
+  ) {
+    this.telemetry = telemetry;
+    this.currentWorkspace = currentWorkspace;
+  }
+
+  async openFile(sourceLocation: [string, string]) {
+    const workspace = this.currentWorkspace();
+    const file = sourceLocation[0];
+    const line = parseInt(sourceLocation[1], 10) - 1;
+
+    const uri = vscode.Uri.parse(`file://${file}`);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, {
+      selection: new vscode.Range(line, 0, line, 0),
+    });
+
+    if (workspace?.lspClient?.serverVersion) {
+      await this.telemetry.sendCodeLensEvent(
+        "open_file",
+        workspace.lspClient.serverVersion,
+      );
+    }
+  }
+}

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -8,6 +8,7 @@ import { Command, STATUS_EMITTER } from "./common";
 import { ManagerIdentifier, ManagerConfiguration } from "./ruby";
 import { StatusItems } from "./status";
 import { TestController } from "./testController";
+import { FileController } from "./fileController";
 import { Debugger } from "./debugger";
 import { DependenciesTree } from "./dependenciesTree";
 
@@ -20,12 +21,18 @@ export class RubyLsp {
   private readonly context: vscode.ExtensionContext;
   private readonly statusItems: StatusItems;
   private readonly testController: TestController;
+  private readonly fileController: FileController;
   private readonly debug: Debugger;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.telemetry = new Telemetry(context);
     this.testController = new TestController(
+      context,
+      this.telemetry,
+      this.currentActiveWorkspace.bind(this),
+    );
+    this.fileController = new FileController(
       context,
       this.telemetry,
       this.currentActiveWorkspace.bind(this),
@@ -369,6 +376,10 @@ export class RubyLsp {
       vscode.commands.registerCommand(
         Command.DebugTest,
         this.testController.debugTest.bind(this.testController),
+      ),
+      vscode.commands.registerCommand(
+        Command.OpenFile,
+        this.fileController.openFile.bind(this.fileController),
       ),
     );
   }

--- a/vscode/src/telemetry.ts
+++ b/vscode/src/telemetry.ts
@@ -20,7 +20,7 @@ export interface ConfigurationEvent {
 }
 
 export interface CodeLensEvent {
-  type: "test" | "debug" | "test_in_terminal";
+  type: "test" | "debug" | "test_in_terminal" | "open_file";
   lspVersion: string;
 }
 


### PR DESCRIPTION
### Motivation

To support mapping controller actions to routes in Shopify/ruby-lsp-rails#241.

Allows us to open files using a platform-agnostic command.

### Implementation

Implements `rubyLsp.openFile` using a controller.

### Automated Tests

None. Do I need these?

### Manual Tests

Works with corresponding PR over on ruby-lsp-rails.
