### PR TITLE
Change RDoc docs path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /**/spec/reports/
 /**/tmp/
 /**/.dev/
-/docs
+/rdoc_docs
 
 vscode/out
 vscode/dist

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ RDoc::Task.new do |rdoc|
   rdoc.main = "README.md"
   rdoc.title = "Ruby LSP documentation"
   rdoc.rdoc_files.include("*.md", "lib/**/*.rb")
-  rdoc.rdoc_dir = "docs"
+  rdoc.rdoc_dir = "rdoc_docs"
   rdoc.markup = "markdown"
   rdoc.generator = "snapper"
   rdoc.options.push("--copy-files", "misc")


### PR DESCRIPTION
### Motivation

We're considering a new Documentation site (https://github.com/Shopify/ruby-lsp/pull/2233). Let's rename the RDoc output directory so that we can use `/docs` for the new one.

### Implementation

Change output directory, update `.gitignore`.

### Automated Tests

n/a

### Manual Tests

Run `bundle exec rake rdoc` verify the docs are generated in `rdoc_docs`, but git ignored.
