### PR TITLE
Add predicate methods for `public?` and `protected?` in `RubyIndexer::Entry`

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -60,6 +60,16 @@ module RubyIndexer
     end
 
     sig { returns(T::Boolean) }
+    def public?
+      visibility == Visibility::PUBLIC
+    end
+
+    sig { returns(T::Boolean) }
+    def protected?
+      visibility == Visibility::PROTECTED
+    end
+
+    sig { returns(T::Boolean) }
     def private?
       visibility == Visibility::PRIVATE
     end


### PR DESCRIPTION
### Motivation

While looking into a feature for Ruby LSP Rails, I wanted to check if a controller method is public. We have a method for `private?` already, but not the other access levels.

### Implementation

See PR.

### Automated Tests

Since this is a very simple comparison, I didn't add a test.

### Manual Tests

n/a
