### PR TITLE
Indicate zshenv is to be used when configuring ZSH version managers

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -8,18 +8,18 @@ with the same Ruby version as your projects, we need to properly set these envir
 invoking your Ruby version manager.
 
 The extension runs a command using your shell's interactive mode, so that version managers configured in files such as
-`~/.zshrc` are picked up automatically. The command then exports the environment information into JSON, so that we can
+`~/.zshenv` are picked up automatically. The command then exports the environment information into JSON, so that we can
 inject it into the NodeJS process and appropriately set the Ruby version and gem installation paths.
 
 As an example, the activation script for `zsh` using `rbenv` as a version manager will look something like this:
 
 ```shell
-# Invoke zsh using interactive mode (loads ~/.zshrc) to run a single command
+# Invoke zsh using interactive mode (loads ~/.zshenv) to run a single command
 # The command is `rbenv exec ruby`, which automatically sets all relevant environment variables and selects the
 # specified Ruby version
 # We then print the activated environment as JSON. We read that JSON from the NodeJS process to insert the needed
 # environment variables in order to run Ruby correctly
-/bin/zsh -ic 'rbenv exec ruby -rjson -e "puts JSON.dump(ENV.to_h)"'
+/bin/zsh -c 'rbenv exec ruby -rjson -e "puts JSON.dump(ENV.to_h)"'
 ```
 
 After activating the Ruby version, we then proceed to boot the server gem (`ruby-lsp`). To avoid having users include
@@ -40,7 +40,7 @@ There are two main sources of issues users typically face during activation: she
 
 ### Shell issues
 
-When the extension invokes the shell and loads its config file (`~/.zshrc`, `~/.bashrc`, etc), it is susceptible to
+When the extension invokes the shell and loads its config file (`~/.zshenv`, `~/.bashrc`, etc), it is susceptible to
 issues that may be caused by how the shell or its plugins interact with the NodeJS process. For example
 
 - Some plugins completely redirect the stderr pipe to implement their functionality (fixed on the Ruby LSP side by
@@ -57,6 +57,17 @@ this problem, please try to
   icon)
 
 More context about this issue on https://github.com/Shopify/vscode-ruby-lsp/issues/901.
+
+#### ZSH configuration
+
+If you use zsh, then make sure to configure your version in your ZSH env file (`~/.zshenv`).
+
+```shell
+# ~/.zshenv
+if [[ -o rcs ]]; then
+  eval "$(rbenv init - zsh)"
+fi
+```
 
 ### Bundler issues
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -94,7 +94,7 @@ by clicking `Change version manager` in the language status center or by changin
 ```
 
 To make sure that the Ruby LSP can find the version manager scripts, make sure that they are loaded in the shell's
-configuration script (e.g.: ~/.bashrc, ~/.zshrc) and that the SHELL environment variable is set and pointing to the
+configuration script (e.g.: ~/.bashrc, ~/.zshenv) and that the SHELL environment variable is set and pointing to the
 default shell.
 
 > [!NOTE]


### PR DESCRIPTION
### Motivation

Closes #2202

When configuring your ZSH based shell, we want to make sure the right file is indicated.

### Implementation

Tested the tool via booting up the extension in VS Code.

### Automated Tests

They're just readme changes, so modification of features.

### Manual Tests
(I used rbenv for as my ruby version manager)

- Enable your ruby version manager in ZSH, using `zshrc`, and open VS Code. You'll see the extension fail to initialize
- Enable your ruby version manager in ZSH, using `zshenv`, and open VS Code. You'll see the extension initialize
