### PR TITLE
Add better initialization error handling

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -20,6 +20,7 @@ export enum Command {
   ShowSyntaxTree = "rubyLsp.showSyntaxTree",
   DisplayAddons = "rubyLsp.displayAddons",
   RunTask = "rubyLsp.runTask",
+  BundleInstall = "rubyLsp.bundleInstall",
 }
 
 export interface RubyInterface {

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -394,6 +394,25 @@ export class RubyLsp {
           }
         },
       ),
+      vscode.commands.registerCommand(
+        Command.BundleInstall,
+        (workspaceUri: string) => {
+          const workspace = this.workspaces.get(workspaceUri);
+
+          if (!workspace) {
+            return;
+          }
+
+          const terminal = vscode.window.createTerminal({
+            name: "Bundle install",
+            cwd: workspace.workspaceFolder.uri.fsPath,
+            env: workspace.ruby.env,
+          });
+
+          terminal.show();
+          terminal.sendText("bundle install");
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
### Motivation

Closes #1769

Add a custom error handler to the LSP client, so that we can provide a nicer experience if activation fails due to Bundler issues or version manager integrations.

This also gets rid of the incredibly annoying 5 attempt restart loop that we find ourselves in these situations.

### Implementation

In the error handler, we unfortunately don't have access to the output of the server, so we can't easily parse it to understand what type of error it is. So the approach I took is the following:

1. Added an error handler class
2. Added some default handling for when the communication errors, which will just shutdown the LSP
3. Added the special handling to when the server connection is closed, which is what happens when we fail to activate. Note that there are other reasons why the connection might be closed, but they are far less frequent than activation issues. For example, if Ruby, YJIT or Prism were to segfault, then the connection would close and we'd hit that error handler path. Even though we cannot be 100% precise, I still think this is a better experience
4. On the special handling, I'm just showing a message saying we failed to activate, explaining the possible reasons, and then showing 2 different set of actions
    - The links in the markdown are debug actions. Those do not close the dialog and so you can click on them however many times you like
    - The two actual dialog buttons are `Retry` and `Shutdown`, which then close the dialog and do exactly what you'd expect them to


https://github.com/Shopify/ruby-lsp/assets/18742907/9bd8c4b7-a57a-430c-8f80-cbbb2a213dd3

