### PR TITLE
Simplify class and module grammar for more consistency

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -51,20 +51,21 @@
         "2": {
           "name": "entity.name.type.class.ruby"
         },
-        "4": {
-          "name": "entity.other.inherited-class.ruby"
-        },
         "5": {
-          "name": "punctuation.separator.inheritance.ruby"
-        },
-        "6": {
-          "name": "variable.other.object.ruby"
+          "name": "punctuation.separator.namespace.ruby"
         },
         "7": {
-          "name": "punctuation.definition.variable.ruby"
+          "name": "punctuation.separator.inheritance.ruby"
+        },
+        "8": {
+          "name": "entity.other.inherited-class.ruby"
+        },
+        "11": {
+          "name": "punctuation.separator.namespace.ruby"
         }
       },
-      "match": "(?x)\n^\\s*(class)\\s+\n(\n  (\n    [.a-zA-Z0-9_:]+\n    (\\s*(<)\\s*[.a-zA-Z0-9_:]+)?   # class A < B\n  )\n  |\n  ((<<)\\s*[.a-zA-Z0-9_:]+)         # class << C\n)",
+      "comment": "class Namespace::ClassName < OtherNamespace::OtherClassName",
+      "match": "(class)\\s*(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)\\s*((<)\\s*(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*))?",
       "name": "meta.class.ruby"
     },
     {
@@ -75,27 +76,24 @@
         "2": {
           "name": "entity.name.type.module.ruby"
         },
-        "3": {
-          "name": "entity.other.inherited-class.module.first.ruby"
-        },
-        "4": {
-          "name": "punctuation.separator.inheritance.ruby"
-        },
         "5": {
-          "name": "entity.other.inherited-class.module.second.ruby"
+          "name": "punctuation.separator.namespace.ruby"
+        }
+      },
+      "match": "(module)\\s*(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)",
+      "name": "meta.module.ruby"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.control.class.ruby"
         },
-        "6": {
-          "name": "punctuation.separator.inheritance.ruby"
-        },
-        "7": {
-          "name": "entity.other.inherited-class.module.third.ruby"
-        },
-        "8": {
+        "2": {
           "name": "punctuation.separator.inheritance.ruby"
         }
       },
-      "match": "(?x)\n^\\s*(module)\\s+\n(\n  ([A-Z]\\w*(::))?\n  ([A-Z]\\w*(::))?\n  ([A-Z]\\w*(::))*\n  [A-Z]\\w*\n)",
-      "name": "meta.module.ruby"
+      "match": "(class)\\s*(<<)\\s",
+      "name": "meta.class.ruby"
     },
     {
       "comment": "else if is a common mistake carried over from other languages. it works if you put in a second end, but it’s never what you want.",


### PR DESCRIPTION
### Motivation

One tiny thing that bothered me with the syntax highlighting is that our grammar incorrectly considered the `::` separator as part of a class/module declaration, highlighting the entire thing in the same colour. This PR fixes that by simplifying the grammar regex.

### Implementation

I simplified the regex in the grammar. There are things it was trying to account for that were unnecessary. For example, it tried to handle any arbitrary number of line breaks between the `class` keyword and the constant name (which TIL is valid Ruby). That's not necessary because semantic highlighting will catch that constant for us.

Another example is that it included trying to parse a parent class for modules, which is not valid Ruby `module Foo < Bar`.

We also don't need to account for syntax errors since those are already provided by the server. The summary is: we can make these regexes much simpler and easier to understand.

The way the grammar works is:

1. Write a regex in the `match` attribute
2. Define what highlight token should be assigned to each regex capture group