### PR TITLE
Run label check on PR synchronize

### DIFF
--- a/.github/workflows/require_labels.yml
+++ b/.github/workflows/require_labels.yml
@@ -4,7 +4,7 @@ on:
   pull_request_review:
     types: [submitted]
   pull_request:
-    types: [labeled, unlabeled]
+    types: [labeled, unlabeled, synchronize]
 
 jobs:
   check-labels:


### PR DESCRIPTION
### Motivation

Currently, if you push a correction after a PR has already been approved and labeled, we get stuck because the status is invalidated but the check action doesn't run.

If we run the action on PR syncs, we can still guarantee that it won't be run when it's first opened, but we will avoid this stuck state.