### PR TITLE
Upgrade Node to v20.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.9"
+          node-version: "20.15"
           cache: "yarn"
           cache-dependency-path: "vscode"
 
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.9"
+          node-version: "20.15"
           cache: "yarn"
           cache-dependency-path: "vscode"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v4
         name: Use Node.js 18.x
         with:
-          node-version: "20.9"
+          node-version: "20.15"
           cache: "yarn"
           cache-dependency-path: "vscode"
 

--- a/dev.yml
+++ b/dev.yml
@@ -7,7 +7,7 @@ up:
   - bundler
   - node:
       yarn: true
-      version: 20.9.0
+      version: 20.15.0
       packages:
         - vscode
 


### PR DESCRIPTION
### Motivation

Since #2220, we're getting flaky NodeJS crashes in CI which are very annoying. I suggest we try to upgrade Node to the latest minor version.

It's a bit ahead of what VS Code uses, but there shouldn't be any breaking changes in minor versions, so I think it should be fine.

### Implementation

Upgraded NodeJS.