### PR TITLE
Add completion support for locals

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -277,6 +277,8 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode, name: String).void }
       def complete_methods(node, name)
+        add_local_completions(node, name)
+
         type = @type_inferrer.infer_receiver_type(@node_context)
         return unless type
 
@@ -315,6 +317,28 @@ module RubyLsp
         end
       rescue RubyIndexer::Index::NonExistingNamespaceError
         # We have not indexed this namespace, so we can't provide any completions
+      end
+
+      sig { params(node: Prism::CallNode, name: String).void }
+      def add_local_completions(node, name)
+        return if @global_state.has_type_checker
+
+        range = range_from_location(T.must(node.message_loc))
+
+        @node_context.locals_for_scope.each do |local|
+          local_name = local.to_s
+          next unless local_name.start_with?(name)
+
+          @response_builder << Interface::CompletionItem.new(
+            label: local_name,
+            filter_text: local_name,
+            text_edit: Interface::TextEdit.new(range: range, new_text: local_name),
+            kind: Constant::CompletionItemKind::VARIABLE,
+            data: {
+              skip_resolve: true,
+            },
+          )
+        end
       end
 
       sig { params(label: String, node: Prism::StringNode).returns(Interface::CompletionItem) }

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -38,6 +38,8 @@ module RubyLsp
 
       sig { override.returns(T::Hash[Symbol, T.untyped]) }
       def perform
+        return @item if @item.dig(:data, :skip_resolve)
+
         # Based on the spec https://microsoft.github.io/language-server-protocol/specification#textDocument_completion,
         # a completion resolve request must always return the original completion item without modifying ANY fields
         # other than detail and documentation (NOT labelDetails). If we modify anything, the completion behaviour might

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1076,6 +1076,61 @@ class CompletionTest < Minitest::Test
     end
   end
 
+  def test_completion_for_locals
+    source = +<<~RUBY
+      class Child
+        abc0 = 42
+
+        def do_something(abc1, abc2, abc3)
+          a
+
+          [].each do |abc4, abc5|
+            a
+          end
+        end
+
+        a
+      end
+
+      abc = 12
+      a
+    RUBY
+
+    with_server(source, stub_no_typechecker: true) do |server, uri|
+      server.process_message(id: 1, method: "textDocument/completion", params: {
+        textDocument: { uri: uri },
+        position: { line: 4, character: 5 },
+      })
+
+      result = server.pop_response.response
+      assert_equal(["abc1", "abc2", "abc3"], result.map(&:label))
+
+      server.process_message(id: 1, method: "textDocument/completion", params: {
+        textDocument: { uri: uri },
+        position: { line: 7, character: 7 },
+      })
+
+      result = server.pop_response.response
+      assert_equal(["abc1", "abc2", "abc3", "abc4", "abc5"], result.map(&:label))
+
+      server.process_message(id: 1, method: "textDocument/completion", params: {
+        textDocument: { uri: uri },
+        position: { line: 11, character: 3 },
+      })
+
+      result = server.pop_response.response
+      assert_equal(["abc0"], result.map(&:label))
+
+      server.process_message(id: 1, method: "textDocument/completion", params: {
+        textDocument: { uri: uri },
+        position: { line: 15, character: 1 },
+      })
+
+      result = server.pop_response.response
+      assert_equal(["abc"], result.map(&:label))
+    end
+  end
+
   private
 
   def with_file_structure(server, &block)


### PR DESCRIPTION
### Motivation

Add completion support for locals.

### Implementation

There are two parts to the implementation:

1. We need to start remembering the full nesting nodes inside node context. This is needed because we need to traverse the exact surrounding scopes to determine which locals are available inside the target
2. Started including local variables as part of method completion. This may seem counter intuitive, but until you finish typing the entire name of the local variable, it is actually considered as a method call (since Prism hasn't yet matched it to a local)

### Automated Tests

Added tests.

### Manual Tests

Launch the LSP on this branch and verify you get locals as completion suggestions.

https://github.com/Shopify/ruby-lsp/assets/18742907/97a84a7b-884a-4788-9132-7169b2140b46