### PR TITLE
Make `RubyIndexer::Index#entries` public

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -97,8 +97,7 @@ if options[:time_index]
   index = RubyIndexer::Index.new
 
   result = Benchmark.realtime { index.index_all }
-  entries = index.instance_variable_get(:@entries)
-  entries_by_entry_type = entries.values.flatten.group_by(&:class)
+  entries_by_entry_type = index.entries.values.flatten.group_by(&:class)
 
   puts <<~MSG
     Ruby LSP v#{RubyLsp::VERSION}: Indexing took #{result.round(5)} seconds and generated:

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -11,6 +11,10 @@ module RubyIndexer
     # The minimum Jaro-Winkler similarity score for an entry to be considered a match for a given fuzzy search query
     ENTRY_SIMILARITY_THRESHOLD = 0.7
 
+    # Returns a hash of all entries in the index. This is intended only for tests.
+    sig { returns(T::Hash[String, T::Array[Entry]]) }
+    attr_reader :entries
+
     sig { void }
     def initialize
       # Holds all entries in the index using the following format:

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -11,10 +11,6 @@ module RubyIndexer
     # The minimum Jaro-Winkler similarity score for an entry to be considered a match for a given fuzzy search query
     ENTRY_SIMILARITY_THRESHOLD = 0.7
 
-    # Returns a hash of all entries in the index. This is intended only for tests.
-    sig { returns(T::Hash[String, T::Array[Entry]]) }
-    attr_reader :entries
-
     sig { void }
     def initialize
       # Holds all entries in the index using the following format:
@@ -515,6 +511,14 @@ module RubyIndexer
       ).to_h { |e| [e.name, e.ancestor_hash] }
 
       @ancestors.clear if original_map.any? { |name, hash| updated_map[name] != hash }
+    end
+
+    # Returns a hash of all entries in the index. This is only available for tests.
+    sig { returns(T::Hash[String, T::Array[Entry]]) }
+    def entries
+      raise "This method is only available for tests." unless ENV["RUBY_LSP_ENV"] == "test"
+
+      @entries
     end
 
     private

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -313,12 +313,12 @@ module RubyIndexer
         @index.index_single(indexable_path)
       end
 
-      refute_empty(@index.instance_variable_get(:@entries))
+      refute_empty(@index.entries)
     end
 
     def test_index_single_does_not_fail_for_non_existing_file
       @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"))
-      entries_after_indexing = @index.instance_variable_get(:@entries).keys
+      entries_after_indexing = @index.entries.keys
       assert_equal(@default_indexed_entries.keys, entries_after_indexing)
     end
 

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -401,7 +401,7 @@ module RubyIndexer
       assert_entry("foo", Entry::UnresolvedMethodAlias, "/fake/path/foo.rb:2-15:2-19")
       assert_entry("bar", Entry::UnresolvedMethodAlias, "/fake/path/foo.rb:3-15:3-20")
       # Foo plus 3 valid aliases
-      assert_equal(4, @index.instance_variable_get(:@entries).length - @default_indexed_entries.length)
+      assert_equal(4, @index.entries.length - @default_indexed_entries.length)
     end
 
     def test_singleton_methods

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -8,7 +8,7 @@ module RubyIndexer
     def setup
       @index = Index.new
       RBSIndexer.new(@index).index_ruby_core
-      @default_indexed_entries = @index.instance_variable_get(:@entries).dup
+      @default_indexed_entries = @index.entries.dup
     end
 
     private
@@ -41,15 +41,15 @@ module RubyIndexer
     end
 
     def assert_no_entries
-      assert_empty(@index.instance_variable_get(:@entries), "Expected nothing to be indexed")
+      assert_empty(@index.entries, "Expected nothing to be indexed")
     end
 
     def assert_no_indexed_entries
-      assert_equal(@default_indexed_entries, @index.instance_variable_get(:@entries))
+      assert_equal(@default_indexed_entries, @index.entries)
     end
 
     def assert_no_entry(entry)
-      refute(@index.instance_variable_get(:@entries).key?(entry), "Expected '#{entry}' to not be indexed")
+      refute(@index.entries.key?(entry), "Expected '#{entry}' to not be indexed")
     end
   end
 end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -167,7 +167,7 @@ class ServerTest < Minitest::Test
       assert_equal("$/progress", @server.pop_response.method)
 
       index = @server.global_state.index
-      refute_empty(index.instance_variable_get(:@entries))
+      refute_empty(index.entries)
     end
   end
 


### PR DESCRIPTION
### Motivation

We commonly access the index's entries in tests, but we need to awkwardly read the internal state of the index. Let's make this public instead.

I've added a note to highlight that this is only intended for tests.

This is a slight risk that addon authors could mis-use this API, but they could have circumvented the access control anyway if they wanted.

### Implementation

Add an `attr_reader`.

### Automated Tests

n/a

### Manual Tests

n/a
