### PR TITLE
Remove duplicate tag name from extension changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,7 +115,7 @@ jobs:
 
             const changelog = releases
               .filter((release) => release.tag_name.startsWith("vscode-ruby-lsp") && (includePrereleases || !release.prerelease))
-              .map((release) => `# ${release.tag_name}\n${release.body}\n`)
+              .map((release) => `${release.body}\n`)
               .join("\n");
 
             fs.writeFileSync("vscode/CHANGELOG.md", changelog);


### PR DESCRIPTION
The release body already contains the tag

### Motivation

https://marketplace.visualstudio.com/items/Shopify.ruby-lsp/changelog

![image](https://github.com/Shopify/ruby-lsp/assets/14981592/9aa9c94f-7340-4b5b-a560-97ec54442ead)

The release body already contains the tag name, as seen here: https://github.com/Shopify/ruby-lsp/releases https://github.com/Shopify/ruby-lsp/blob/a3791faeb4f3c2c6e16135b06b7e378074409777/.github/workflows/publish.yml#L71


### Manual Tests

The change is very small and straightforward and a such I have not run this code (testing actions is such a bother).
