### PR TITLE
Add some convenience methods for testing index entry behaviour

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -513,6 +513,26 @@ module RubyIndexer
       @ancestors.clear if original_map.any? { |name, hash| updated_map[name] != hash }
     end
 
+    sig { returns(T::Boolean) }
+    def empty?
+      @entries.empty?
+    end
+
+    sig { returns(T::Array[String]) }
+    def names
+      @entries.keys
+    end
+
+    sig { params(name: String).returns(T::Boolean) }
+    def indexed?(name)
+      @entries.key?(name)
+    end
+
+    sig { returns(Integer) }
+    def length
+      @entries.count
+    end
+
     private
 
     # Attempts to resolve an UnresolvedAlias into a resolved Alias. If the unresolved alias is pointing to a constant

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -313,12 +313,12 @@ module RubyIndexer
         @index.index_single(indexable_path)
       end
 
-      refute_empty(@index.instance_variable_get(:@entries))
+      refute_empty(@index)
     end
 
     def test_index_single_does_not_fail_for_non_existing_file
       @index.index_single(IndexablePath.new(nil, "/fake/path/foo.rb"))
-      entries_after_indexing = @index.instance_variable_get(:@entries).keys
+      entries_after_indexing = @index.names
       assert_equal(@default_indexed_entries.keys, entries_after_indexing)
     end
 

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -401,7 +401,7 @@ module RubyIndexer
       assert_entry("foo", Entry::UnresolvedMethodAlias, "/fake/path/foo.rb:2-15:2-19")
       assert_entry("bar", Entry::UnresolvedMethodAlias, "/fake/path/foo.rb:3-15:3-20")
       # Foo plus 3 valid aliases
-      assert_equal(4, @index.instance_variable_get(:@entries).length - @default_indexed_entries.length)
+      assert_equal(4, @index.length - @default_indexed_entries.length)
     end
 
     def test_singleton_methods

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -40,16 +40,12 @@ module RubyIndexer
       assert_nil(entries, "Expected #{expected_name} to not be indexed")
     end
 
-    def assert_no_entries
-      assert_empty(@index.instance_variable_get(:@entries), "Expected nothing to be indexed")
-    end
-
     def assert_no_indexed_entries
       assert_equal(@default_indexed_entries, @index.instance_variable_get(:@entries))
     end
 
     def assert_no_entry(entry)
-      refute(@index.instance_variable_get(:@entries).key?(entry), "Expected '#{entry}' to not be indexed")
+      refute(@index.indexed?(entry), "Expected '#{entry}' to not be indexed")
     end
   end
 end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -166,8 +166,7 @@ class ServerTest < Minitest::Test
       assert_equal("$/progress", @server.pop_response.method)
       assert_equal("$/progress", @server.pop_response.method)
 
-      index = @server.global_state.index
-      refute_empty(index.instance_variable_get(:@entries))
+      refute_empty(@server.global_state.index)
     end
   end
 


### PR DESCRIPTION
### Motivation

We commonly access the index's entries in tests, but we need to awkwardly read the internal state of the index. Let's make this a little cleaner.

### Implementation

Add some convenience methods.

### Automated Tests

None since these are simple delegations.

### Manual Tests

n/a

