### PR TITLE
Fix display of label details for completion requests

### DIFF
--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -40,7 +40,8 @@ module RubyLsp
       def perform
         # Based on the spec https://microsoft.github.io/language-server-protocol/specification#textDocument_completion,
         # a completion resolve request must always return the original completion item without modifying ANY fields
-        # other than label details and documentation. If we modify anything, the completion behaviour might be broken.
+        # other than detail and documentation (NOT labelDetails). If we modify anything, the completion behaviour might
+        # be broken.
         #
         # For example, forgetting to return the `insertText` included in the original item will make the editor use the
         # `label` for the text edit instead
@@ -59,14 +60,8 @@ module RubyLsp
         first_entry = T.must(entries.first)
 
         if first_entry.is_a?(RubyIndexer::Entry::Member)
-          detail = first_entry.decorated_parameters
           label = "#{label}#{first_entry.decorated_parameters}"
         end
-
-        @item[:labelDetails] = Interface::CompletionItemLabelDetails.new(
-          description: entries.take(MAX_DOCUMENTATION_ENTRIES).map(&:file_name).join(","),
-          detail: detail,
-        )
 
         @item[:documentation] = Interface::MarkupContent.new(
           kind: "markdown",

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -29,9 +29,6 @@ class CompletionResolveTest < Minitest::Test
       result = server.pop_response.response
 
       expected = existing_item.merge(
-        labelDetails: Interface::CompletionItemLabelDetails.new(
-          description: "fake.rb",
-        ),
         documentation: Interface::MarkupContent.new(
           kind: "markdown",
           value: markdown_from_index_entries("Foo::Bar", T.must(server.global_state.index["Foo::Bar"])),
@@ -39,6 +36,7 @@ class CompletionResolveTest < Minitest::Test
       )
       assert_match(/This is a class that does things/, result[:documentation].value)
       assert_equal(expected.to_json, result.to_json)
+      refute(result.key?(:labelDetails))
     end
   end
 
@@ -106,7 +104,6 @@ class CompletionResolveTest < Minitest::Test
       server.process_message(id: 1, method: "completionItem/resolve", params: existing_item)
 
       result = server.pop_response.response
-      assert_equal("(a, b, c)", result[:labelDetails].detail)
       assert_match("(a, b, c)", result[:documentation].value)
     end
   end

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -205,6 +205,7 @@ class CompletionTest < Minitest::Test
         })
         result = server.pop_response.response
         assert_equal(["Foo"], result.map(&:label))
+        assert_equal(["fake.rb"], result.map { _1.label_details.description })
       end
     end
   end
@@ -475,6 +476,7 @@ class CompletionTest < Minitest::Test
         assert_equal(["bar", "baz"], result.map(&:label))
         assert_equal(["bar", "baz"], result.map(&:filter_text))
         assert_equal(["bar", "baz"], result.map { |completion| completion.text_edit.new_text })
+        assert_equal(["fake.rb", "fake.rb"], result.map { _1.label_details.description })
       end
     end
   end
@@ -905,6 +907,7 @@ class CompletionTest < Minitest::Test
       })
       result = server.pop_response.response
       assert_equal(["@foo", "@foobar"], result.map(&:label))
+      assert_equal(["fake.rb", "fake.rb"], result.map { _1.label_details.description })
     end
   end
 


### PR DESCRIPTION
### Motivation

While working on https://github.com/Shopify/ruby-lsp/pull/2243 we noticed that the details for completions weren't appearing. The label details cannot be added in the resolve, they have to be pre-computed.

This PR also introduces a label detail showing where an instance variable is defined.

### Implementation

Move the behaviour from `completion_resolve` to `completion`.

As can be seen below, we're not yet showing the available arguments for Core methods, that will come next.

<img width="838" alt="Screenshot 2024-07-03 at 1 05 32 PM" src="https://github.com/Shopify/ruby-lsp/assets/13400/8363cacf-e13b-4b93-bbfe-e2e68ef7e761">

### Automated Tests

Updated

### Manual Tests

Type a class name, hit `.`, and verify you see the corresponding file names.
