### PR TITLE
Push disposables to subscriptions

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -57,14 +57,13 @@ export class TestController {
       this.debugTag,
     );
 
-    vscode.window.onDidCloseTerminal((terminal: vscode.Terminal): void => {
-      if (terminal === this.terminal) this.terminal = undefined;
-    });
-
     context.subscriptions.push(
       this.testController,
       this.testDebugProfile,
       this.testRunProfile,
+      vscode.window.onDidCloseTerminal((terminal: vscode.Terminal): void => {
+        if (terminal === this.terminal) this.terminal = undefined;
+      }),
     );
   }
 

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -277,20 +277,22 @@ export class Workspace implements WorkspaceInterface {
 
     // If a configuration that affects the Ruby LSP has changed, update the client options using the latest
     // configuration and restart the server
-    vscode.workspace.onDidChangeConfiguration(async (event) => {
-      if (event.affectsConfiguration("rubyLsp")) {
-        // Re-activate Ruby if the version manager changed
-        if (
-          event.affectsConfiguration("rubyLsp.rubyVersionManager") ||
-          event.affectsConfiguration("rubyLsp.bundleGemfile") ||
-          event.affectsConfiguration("rubyLsp.customRubyCommand")
-        ) {
-          await this.ruby.activateRuby();
-        }
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration(async (event) => {
+        if (event.affectsConfiguration("rubyLsp")) {
+          // Re-activate Ruby if the version manager changed
+          if (
+            event.affectsConfiguration("rubyLsp.rubyVersionManager") ||
+            event.affectsConfiguration("rubyLsp.bundleGemfile") ||
+            event.affectsConfiguration("rubyLsp.customRubyCommand")
+          ) {
+            await this.ruby.activateRuby();
+          }
 
-        await this.restart();
-      }
-    });
+          await this.restart();
+        }
+      }),
+    );
   }
 
   private createRestartWatcher(


### PR DESCRIPTION
### Motivation

Any function from the VS Code API that returns a `Disposable` has to be pushed into `context.subscriptions`, so that they are properly disposed when the extension gets deactivated.

I noticed we weren't doing that in a few cases when trying to understand the problem reported in https://github.com/Shopify/ruby-lsp/issues/1897#issuecomment-2204631894. I'm not sure if this will fix it, but we should make this change anyway.

### Implementation

Started pushing all disposables I could find into the subscriptions list.