### PR TITLE
Set `DISABLE_V8_COMPILE_CACHE=1` for Yarn in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Node
+        env:
+          DISABLE_V8_COMPILE_CACHE: "1"
         uses: actions/setup-node@v4
         with:
           node-version: "20.9"
@@ -78,6 +80,8 @@ jobs:
 
       - name: Set up Node
         uses: actions/setup-node@v4
+        env:
+          DISABLE_V8_COMPILE_CACHE: 1
         with:
           node-version: "20.9"
           cache: "yarn"


### PR DESCRIPTION
We're seeing a common failure recently for Node in CI:

> Could not get yarn cache folder path for /home/runner/work/ruby-lsp/ruby-lsp/vscode/.vscode"

https://github.com/Shopify/ruby-lsp/actions/runs/9783340748/job/27011714149

The post at https://github.com/nodejs/node/issues/51555 suggests this may help to avoid it.

