### PR TITLE
Add missing error information for telemetry

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -98,7 +98,16 @@ module RubyLsp
     rescue StandardError, LoadError => e
       # If an error occurred in a request, we have to return an error response or else the editor will hang
       if message[:id]
-        send_message(Error.new(id: message[:id], code: Constant::ErrorCodes::INTERNAL_ERROR, message: e.full_message))
+        send_message(Error.new(
+          id: message[:id],
+          code: Constant::ErrorCodes::INTERNAL_ERROR,
+          message: e.full_message,
+          data: {
+            errorClass: e.class.name,
+            errorMessage: e.message,
+            backtrace: e.backtrace&.join("\n"),
+          },
+        ))
       end
 
       $stderr.puts("Error processing #{message[:method]}: #{e.full_message}")


### PR DESCRIPTION
### Motivation

I noticed that I wasn't seeing the error notifications when working on the LSP anymore. It turns out, I forgot to add the error telemetry to the `data` attribute in my server refactor 🤦.

### Implementation

Added the error information to the `data` attribute, so that error reporting works properly.

### Automated Tests

Added a test to ensure we don't regress.
