### PR TITLE
Add support for running Rails generators from the UI

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -20,6 +20,7 @@ The Ruby LSP features include
 - Showing documentaton on hover for classes, modules and constants
 - Completion for classes, modules, constants and require paths
 - Fuzzy search classes, modules and constants anywhere in the project and its dependencies (workspace symbol)
+- Running Rails generators from the UI
 
 Adding method support for definition, completion, hover and workspace symbol is planned, but not yet completed.
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -93,6 +93,16 @@
         "command": "rubyLsp.showSyntaxTree",
         "title": "Show syntax tree",
         "category": "Ruby LSP"
+      },
+      {
+        "command": "rubyLsp.railsGenerate",
+        "title": "Rails generate",
+        "category": "Ruby LSP"
+      },
+      {
+        "command": "rubyLsp.railsDestroy",
+        "title": "Rails destroy",
+        "category": "Ruby LSP"
       }
     ],
     "configuration": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -33,6 +33,20 @@
           "command": "workbench.action.terminal.runSelectedText",
           "group": "9_cutcopypaste"
         }
+      ],
+      "view/title": [
+        {
+          "command": "rubyLsp.fileOperation",
+          "when": "rubyLsp.activated && view.workbench.explorer.fileView.visible",
+          "group": "navigation"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "rubyLsp.fileOperation",
+          "when": "rubyLsp.activated && view.workbench.explorer.fileView.visible",
+          "group": "2_workspace"
+        }
       ]
     },
     "commands": [
@@ -103,6 +117,12 @@
         "command": "rubyLsp.railsDestroy",
         "title": "Rails destroy",
         "category": "Ruby LSP"
+      },
+      {
+        "command": "rubyLsp.fileOperation",
+        "title": "Ruby file operations",
+        "category": "Ruby LSP",
+        "icon": "$(ruby)"
       }
     ],
     "configuration": {

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -22,6 +22,8 @@ export enum Command {
   RunTask = "rubyLsp.runTask",
   BundleInstall = "rubyLsp.bundleInstall",
   OpenFile = "rubyLsp.openFile",
+  RailsGenerate = "rubyLsp.railsGenerate",
+  RailsDestroy = "rubyLsp.railsDestroy",
 }
 
 export interface RubyInterface {

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -22,6 +22,7 @@ export enum Command {
   RunTask = "rubyLsp.runTask",
   BundleInstall = "rubyLsp.bundleInstall",
   OpenFile = "rubyLsp.openFile",
+  FileOperation = "rubyLsp.fileOperation",
   RailsGenerate = "rubyLsp.railsGenerate",
   RailsDestroy = "rubyLsp.railsDestroy",
 }

--- a/vscode/src/rails.ts
+++ b/vscode/src/rails.ts
@@ -1,6 +1,10 @@
+import os from "os";
+
 import * as vscode from "vscode";
 
 import { Workspace } from "./workspace";
+
+const BASE_COMMAND = os.platform() === "win32" ? "ruby bin/rails" : "bin/rails";
 
 export class Rails {
   private readonly showWorkspacePick: () => Promise<Workspace | undefined>;
@@ -18,7 +22,7 @@ export class Rails {
     }
 
     const createdFiles: string[] = [];
-    const command = `bin/rails generate ${generatorWithArguments}`;
+    const command = `${BASE_COMMAND} generate ${generatorWithArguments}`;
 
     await vscode.window.withProgress(
       {
@@ -30,7 +34,7 @@ export class Rails {
         const { stdout } = await workspace.execute(command, true);
 
         stdout.split("\n").forEach((line) => {
-          const match = /create\s*(.*)/.exec(line);
+          const match = /create\s*(.*\..*)/.exec(line);
 
           if (match) {
             createdFiles.push(match[1]);
@@ -52,7 +56,7 @@ export class Rails {
     }
 
     const deletedFiles: string[] = [];
-    const command = `bin/rails destroy ${generatorWithArguments}`;
+    const command = `${BASE_COMMAND} destroy ${generatorWithArguments}`;
 
     await vscode.window.withProgress(
       {
@@ -64,7 +68,7 @@ export class Rails {
         const { stdout } = await workspace.execute(command, true);
 
         stdout.split("\n").forEach((line) => {
-          const match = /remove\s*(.*)/.exec(line);
+          const match = /remove\s*(.*\..*)/.exec(line);
 
           if (match) {
             deletedFiles.push(match[1]);

--- a/vscode/src/rails.ts
+++ b/vscode/src/rails.ts
@@ -1,0 +1,98 @@
+import * as vscode from "vscode";
+
+import { Workspace } from "./workspace";
+
+export class Rails {
+  private readonly showWorkspacePick: () => Promise<Workspace | undefined>;
+
+  constructor(showWorkspacePick: () => Promise<Workspace | undefined>) {
+    this.showWorkspacePick = showWorkspacePick;
+  }
+
+  // Runs `bin/rails generate` with the given generator (e.g.: `controller`, `model`, etc.) and the desired arguments
+  async generate(generatorWithArguments: string) {
+    const workspace = await this.showWorkspacePick();
+
+    if (!workspace) {
+      return;
+    }
+
+    const createdFiles: string[] = [];
+    const command = `bin/rails generate ${generatorWithArguments}`;
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Running Rails generate",
+      },
+      async (progress) => {
+        progress.report({ message: `Running "${command}"` });
+        const { stdout } = await workspace.execute(command, true);
+
+        stdout.split("\n").forEach((line) => {
+          const match = /create\s*(.*)/.exec(line);
+
+          if (match) {
+            createdFiles.push(match[1]);
+          }
+        });
+
+        progress.report({ message: "Revealing generated files" });
+        await this.revealFormattedFiles(workspace, createdFiles);
+      },
+    );
+  }
+
+  // Invokes `bin/rails destroy` to undo the changes made by a `generate` command
+  async destroy(generatorWithArguments: string) {
+    const workspace = await this.showWorkspacePick();
+
+    if (!workspace) {
+      return;
+    }
+
+    const deletedFiles: string[] = [];
+    const command = `bin/rails destroy ${generatorWithArguments}`;
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Running Rails destroy",
+      },
+      async (progress) => {
+        progress.report({ message: `Running "${command}"` });
+        const { stdout } = await workspace.execute(command, true);
+
+        stdout.split("\n").forEach((line) => {
+          const match = /remove\s*(.*)/.exec(line);
+
+          if (match) {
+            deletedFiles.push(match[1]);
+          }
+        });
+
+        progress.report({ message: "Closing deleted files" });
+
+        for (const file of deletedFiles) {
+          await vscode.commands.executeCommand(
+            "workbench.action.closeActiveEditor",
+            vscode.Uri.joinPath(workspace.workspaceFolder.uri, file),
+          );
+        }
+      },
+    );
+  }
+
+  private async revealFormattedFiles(
+    workspace: Workspace,
+    createdFiles: string[],
+  ) {
+    for (const file of createdFiles) {
+      const uri = vscode.Uri.joinPath(workspace.workspaceFolder.uri, file);
+
+      await vscode.window.showTextDocument(uri, { preview: false });
+      await vscode.commands.executeCommand("editor.action.formatDocument", uri);
+      await vscode.commands.executeCommand("workbench.action.files.save", uri);
+    }
+  }
+}

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -494,6 +494,32 @@ export class RubyLsp {
           await this.rails.destroy(command);
         },
       ),
+      vscode.commands.registerCommand(Command.FileOperation, async () => {
+        const items: ({ command: string } & vscode.QuickPickItem)[] = [
+          {
+            label: "Rails generate",
+            description: "Run Rails generate",
+            iconPath: new vscode.ThemeIcon("new-file"),
+            command: Command.RailsGenerate,
+          },
+          {
+            label: "Rails destroy",
+            description: "Run Rails destroy",
+            iconPath: new vscode.ThemeIcon("trash"),
+            command: Command.RailsDestroy,
+          },
+        ];
+
+        const pick = await vscode.window.showQuickPick(items, {
+          title: "Select a Ruby file operation",
+        });
+
+        if (!pick) {
+          return;
+        }
+
+        await vscode.commands.executeCommand(pick.command);
+      }),
     );
   }
 

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -495,20 +495,34 @@ export class RubyLsp {
         },
       ),
       vscode.commands.registerCommand(Command.FileOperation, async () => {
-        const items: ({ command: string } & vscode.QuickPickItem)[] = [
-          {
-            label: "Rails generate",
-            description: "Run Rails generate",
-            iconPath: new vscode.ThemeIcon("new-file"),
-            command: Command.RailsGenerate,
-          },
-          {
-            label: "Rails destroy",
-            description: "Run Rails destroy",
-            iconPath: new vscode.ThemeIcon("trash"),
-            command: Command.RailsDestroy,
-          },
-        ];
+        const workspace = await this.showWorkspacePick();
+
+        if (!workspace) {
+          return;
+        }
+
+        const items: ({ command: string } & vscode.QuickPickItem)[] = [];
+
+        if (
+          workspace.lspClient?.addons?.some(
+            (addon) => addon.name === "Ruby LSP Rails",
+          )
+        ) {
+          items.push(
+            {
+              label: "Rails generate",
+              description: "Run Rails generate",
+              iconPath: new vscode.ThemeIcon("new-file"),
+              command: Command.RailsGenerate,
+            },
+            {
+              label: "Rails destroy",
+              description: "Run Rails destroy",
+              iconPath: new vscode.ThemeIcon("trash"),
+              command: Command.RailsDestroy,
+            },
+          );
+        }
 
         const pick = await vscode.window.showQuickPick(items, {
           title: "Select a Ruby file operation",

--- a/vscode/src/test/suite/rails.test.ts
+++ b/vscode/src/test/suite/rails.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import os from "os";
 import path from "path";
 
 import * as vscode from "vscode";
@@ -6,6 +7,8 @@ import sinon from "sinon";
 
 import { Rails } from "../../rails";
 import { Workspace } from "../../workspace";
+
+const BASE_COMMAND = os.platform() === "win32" ? "ruby bin/rails" : "bin/rails";
 
 suite("Rails", () => {
   const workspacePath = path.dirname(
@@ -36,7 +39,7 @@ suite("Rails", () => {
 
     assert.ok(
       executeStub.calledOnceWithExactly(
-        "bin/rails generate model User name:string",
+        `${BASE_COMMAND} generate model User name:string`,
         true,
       ),
     );
@@ -81,7 +84,7 @@ suite("Rails", () => {
 
     assert.ok(
       executeStub.calledOnceWithExactly(
-        "bin/rails destroy model User name:string",
+        `${BASE_COMMAND} destroy model User name:string`,
         true,
       ),
     );

--- a/vscode/src/test/suite/rails.test.ts
+++ b/vscode/src/test/suite/rails.test.ts
@@ -1,0 +1,110 @@
+import * as assert from "assert";
+import path from "path";
+
+import * as vscode from "vscode";
+import sinon from "sinon";
+
+import { Rails } from "../../rails";
+import { Workspace } from "../../workspace";
+
+suite("Rails", () => {
+  const workspacePath = path.dirname(
+    path.dirname(path.dirname(path.dirname(__dirname))),
+  );
+  const workspaceUri = vscode.Uri.file(workspacePath);
+  const workspaceFolder: vscode.WorkspaceFolder = {
+    uri: workspaceUri,
+    name: path.basename(workspaceUri.fsPath),
+    index: 0,
+  };
+
+  test("generate", async () => {
+    const executeStub = sinon.stub();
+    const workspace = {
+      workspaceFolder,
+      execute: executeStub.resolves({
+        stdout:
+          "create db/migrate/20210901123456_create_users.rb\ncreate app/models/user.rb\n",
+      }),
+    } as unknown as Workspace;
+
+    const showDocumentStub = sinon.stub(vscode.window, "showTextDocument");
+    const executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+
+    const rails = new Rails(() => Promise.resolve(workspace));
+    await rails.generate("model User name:string");
+
+    assert.ok(
+      executeStub.calledOnceWithExactly(
+        "bin/rails generate model User name:string",
+        true,
+      ),
+    );
+
+    assert.ok(
+      showDocumentStub
+        .getCall(0)
+        .calledWithExactly(
+          vscode.Uri.joinPath(
+            workspaceUri,
+            "db/migrate/20210901123456_create_users.rb",
+          ),
+          { preview: false },
+        ),
+    );
+    assert.ok(
+      showDocumentStub
+        .getCall(1)
+        .calledWithExactly(
+          vscode.Uri.joinPath(workspaceUri, "app/models/user.rb"),
+          { preview: false },
+        ),
+    );
+    showDocumentStub.restore();
+    executeCommandStub.restore();
+  });
+
+  test("destroy", async () => {
+    const executeStub = sinon.stub();
+    const workspace = {
+      workspaceFolder,
+      execute: executeStub.resolves({
+        stdout:
+          "remove db/migrate/20210901123456_create_users.rb\nremove app/models/user.rb\n",
+      }),
+    } as unknown as Workspace;
+
+    const executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+
+    const rails = new Rails(() => Promise.resolve(workspace));
+    await rails.destroy("model User name:string");
+
+    assert.ok(
+      executeStub.calledOnceWithExactly(
+        "bin/rails destroy model User name:string",
+        true,
+      ),
+    );
+
+    assert.ok(
+      executeCommandStub
+        .getCall(0)
+        .calledWithExactly(
+          "workbench.action.closeActiveEditor",
+          vscode.Uri.joinPath(
+            workspaceUri,
+            "db/migrate/20210901123456_create_users.rb",
+          ),
+        ),
+    );
+    assert.ok(
+      executeCommandStub
+        .getCall(1)
+        .calledWithExactly(
+          "workbench.action.closeActiveEditor",
+          vscode.Uri.joinPath(workspaceUri, "app/models/user.rb"),
+        ),
+    );
+    executeCommandStub.restore();
+  });
+});

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -17,7 +17,7 @@ export class Workspace implements WorkspaceInterface {
   public readonly ruby: Ruby;
   public readonly createTestItems: (response: CodeLens[]) => void;
   public readonly workspaceFolder: vscode.WorkspaceFolder;
-  private readonly outputChannel: WorkspaceChannel;
+  public readonly outputChannel: WorkspaceChannel;
   private readonly context: vscode.ExtensionContext;
   private readonly isMainWorkspace: boolean;
   private readonly telemetry: vscode.TelemetryLogger;


### PR DESCRIPTION
### Motivation

This PR adds a Rails class to our VS Code extension capable of running generators from the UI. This is useful on its own, but it is also necessary for other functionality that may want to invoke generators programatically.

### Implementation

I split the work into two commits:

1. Add the `Rails` class with a `generate` and `destroy` command and associate both with commands
2. Expose a `Ruby file operations` command, where we can aggregate all of these under the same menu item. Then expose it in the explorer title and menu context

### Automated Tests

Added tests.

### Manual Tests

1. Start the extension on this branch
2. Open a Rails app
3. Click on the new button in the explorer title view
4. Use the generator
5. Verify that it executes the Rails generator properly


https://github.com/Shopify/ruby-lsp/assets/18742907/ed13018d-4edd-4202-9a4f-d2aece96cacc