### PR TITLE
Save untitled files with `.rb` extension by default

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -460,6 +460,7 @@
         ],
         "firstLine": "^#!\\s*/.*(?:ruby|rbx|rake)\\b",
         "extensions": [
+          ".rb",
           ".builder",
           ".eye",
           ".fcgi",
@@ -474,7 +475,6 @@
           ".pryrc",
           ".rabl",
           ".rake",
-          ".rb",
           ".rbi",
           ".rbuild",
           ".rbw",


### PR DESCRIPTION
### Motivation

Closes #2240

### Implementation

VSCode uses the first extension in the list.
I did not find this documented (https://code.visualstudio.com/api/references/contribution-points#contributes.languages) but this is how it currently works.

I'd have put a comment explaining why it must be the first entry but `package.json` doesn't allow that.

### Manual Tests

Start the extension from this branch, create a new untitled file, change the language to Ruby, save
