### PR TITLE
Add standard to readme's addons list

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ features. This is the mechanism that powers addons like
 - [Ruby LSP RSpec](https://github.com/st0012/ruby-lsp-rspec)
 - [Ruby LSP rubyfmt](https://github.com/jscharf/ruby-lsp-rubyfmt)
 
+Additionally, some tools may include a Ruby LSP addon directly, like
+
+- [Standard Ruby (from v1.39.1)](https://github.com/standardrb/standard/wiki/IDE:-vscode#using-ruby-lsp)
+
 Other community driven addons can be found in [rubygems](https://rubygems.org/search?query=name%3A+ruby-lsp) by
 searching for the `ruby-lsp` prefix.
 


### PR DESCRIPTION
### Motivation

Standard is now officially [shipped with a Ruby LSP addon](https://github.com/standardrb/standard/wiki/IDE:-vscode#using-ruby-lsp), which is the first tool that directly include one. I think it's worth mentioning it in the readme in a separate list.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
