### PR TITLE
Prepend vscode for relative image references for prereleases

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -542,7 +542,7 @@
   "scripts": {
     "vscode:prepublish": "yarn run esbuild-base --minify",
     "package": "vsce package --out vscode-ruby-lsp.vsix --baseImagesUrl https://github.com/Shopify/ruby-lsp/raw/HEAD/vscode",
-    "package_prerelease": "vsce package --pre-release --out vscode-ruby-lsp.vsix",
+    "package_prerelease": "vsce package --pre-release --out vscode-ruby-lsp.vsix --baseImagesUrl https://github.com/Shopify/ruby-lsp/raw/HEAD/vscode",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",


### PR DESCRIPTION
Followup to #1601

Apparently the marketplace uses and displays prerelease information on its storefront: https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp

![grafik](https://github.com/Shopify/ruby-lsp/assets/14981592/a4a658f7-4a65-40f1-ac8a-e3d2d262cf3d)

Since prereleases are actually used now, this needs the same fix as normal releases.