### PR TITLE
Make the first workspace the main one even when lazy

### DIFF
--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -168,7 +168,7 @@ export class RubyLsp {
       workspaceFolder,
       this.telemetry,
       this.testController.createTestItems.bind(this.testController),
-      eager,
+      this.workspaces.size === 0,
     );
     this.workspaces.set(workspaceFolder.uri.toString(), workspace);
 


### PR DESCRIPTION
### Motivation

We only eagerly activate the first workspace if it is a Ruby workspace. In a scenario where the Ruby workspace is not the first one in the code workspace file (see https://github.com/Shopify/ruby-lsp/issues/1897#issuecomment-2211610630), all LSP clients will be launched lazily.

Currently, we're assigning the `mainWorkspace` flag based on whether it was eagerly loaded, but that's not accurate in that scenario. We want the main workspace to be whatever the first one is - regardless of whether it was eagerly or lazily activated.

### Implementation

Swapped the argument that determines the main workspace to not depend on whether it has been eagerly activated, but instead check if it is the first one we are activating.