### PR TITLE
Require space for class keyword match

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -65,7 +65,7 @@
         }
       },
       "comment": "class Namespace::ClassName < OtherNamespace::OtherClassName",
-      "match": "(class)\\s*(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)\\s*((<)\\s*(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*))?",
+      "match": "(class)\\s+(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)\\s*((<)\\s*(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*))?",
       "name": "meta.class.ruby"
     },
     {


### PR DESCRIPTION
### Motivation

Closes #2269

In order for `class` to be a keyword, there needs to be a space between it and the constant name.

### Implementation

Switched to `\s+` rather than `\s*`.