### PR TITLE
Require space after module keyword

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -80,7 +80,7 @@
           "name": "punctuation.separator.namespace.ruby"
         }
       },
-      "match": "(module)\\s*(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)",
+      "match": "(module)\\s+(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)",
       "name": "meta.module.ruby"
     },
     {


### PR DESCRIPTION
### Motivation

Similar to #2270, I forgot to require the space for modules too.

### Implementation

Switched the regex to `\s+` instead of `\s*`.