### PR TITLE
Handle possible nil call operator location in completion

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -288,12 +288,17 @@ module RubyLsp
         range = if method_name
           range_from_location(T.must(node.message_loc))
         else
-          loc = T.must(node.call_operator_loc)
-          Interface::Range.new(
-            start: Interface::Position.new(line: loc.start_line - 1, character: loc.start_column + 1),
-            end: Interface::Position.new(line: loc.start_line - 1, character: loc.start_column + 1),
-          )
+          loc = node.call_operator_loc
+
+          if loc
+            Interface::Range.new(
+              start: Interface::Position.new(line: loc.start_line - 1, character: loc.start_column + 1),
+              end: Interface::Position.new(line: loc.start_line - 1, character: loc.start_column + 1),
+            )
+          end
         end
+
+        return unless range
 
         @index.method_completion_candidates(method_name, type).each do |entry|
           entry_name = entry.name


### PR DESCRIPTION
### Motivation

This PR fixes a bug we discovered in our telemetry. Apparently, even if we match a call node and the trigger character is a dot, there is still some sort of intermediate code state where the `call_operator_loc` is `nil`.

I'm not sure what code reproduces this exact scenario, so I just fixed the issue.

### Implementation

If we can't figure out a range for the completion, we need to return early.

### Automated Tests

Couldn't figure out what code reproduces this.