### PR TITLE
Ensure test group exists before trying to add examples

### DIFF
--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -1,0 +1,61 @@
+import * as assert from "assert";
+
+import * as vscode from "vscode";
+import { CodeLens } from "vscode-languageclient/node";
+
+import { TestController } from "../../testController";
+import { Command } from "../../common";
+
+import { FAKE_TELEMETRY } from "./fakeTelemetry";
+
+suite("TestController", () => {
+  const context = {
+    extensionMode: vscode.ExtensionMode.Test,
+    subscriptions: [],
+    workspaceState: {
+      get: (_name: string) => undefined,
+      update: (_name: string, _value: any) => Promise.resolve(),
+    },
+  } as unknown as vscode.ExtensionContext;
+
+  test("createTestItems doesn't break when there's a missing group", () => {
+    const controller = new TestController(
+      context,
+      FAKE_TELEMETRY,
+      () => undefined,
+    );
+
+    const codeLensItems: CodeLens[] = [
+      {
+        range: new vscode.Range(0, 0, 10, 10),
+        command: {
+          title: "Run",
+          command: Command.RunTest,
+          arguments: [
+            "test/fake_test.rb",
+            "test_do_something",
+            "bundle exec ruby -Itest test/fake_test.rb --name FakeTest#test_do_something",
+            {
+              /* eslint-disable @typescript-eslint/naming-convention */
+              start_line: 0,
+              start_column: 0,
+              end_line: 10,
+              end_column: 10,
+              /* eslint-enable @typescript-eslint/naming-convention */
+            },
+          ],
+        },
+        data: {
+          type: "test",
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          group_id: 100,
+          kind: "example",
+        },
+      },
+    ];
+
+    assert.doesNotThrow(() => {
+      controller.createTestItems(codeLensItems);
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

This fixes another error found in our telemetry. We are sometimes getting test example code lens that are associated to a `group_id` for a group that doesn't exist.

It's difficult to figure out exactly in what scenario this happens, but given that addons can contribute test code lens, we should protect the extension from invalid data anyway.

### Implementation

We still had code in the test controller to account for the previous behaviour of code lens, which didn't include group IDs. It's been a long time since we released that, so I think it's safe to remove at this point. If anyone reports issues related to very old server versions, we can just ask them to update.

Other than simplifying the code after removing that old code lens handling, the fix is simply the check that the group exists before trying to add children. Otherwise, we print an error to the output channel.

### Automated Tests

Created a test for the test controller, which was missing.