### PR TITLE
Return early when fetching dependencies if client is not running

### DIFF
--- a/vscode/src/dependenciesTree.ts
+++ b/vscode/src/dependenciesTree.ts
@@ -1,6 +1,7 @@
 import path from "path";
 
 import * as vscode from "vscode";
+import { State } from "vscode-languageclient";
 
 import { STATUS_EMITTER, WorkspaceInterface } from "./common";
 
@@ -148,11 +149,17 @@ export class DependenciesTree
   private async fetchDependencies(): Promise<BundlerTreeNode[]> {
     this.gemRootFolders = {};
 
-    if (!this.currentWorkspace || !this.currentWorkspace.lspClient) {
+    if (!this.currentWorkspace) {
       return [];
     }
 
-    const resp = (await this.currentWorkspace.lspClient.sendRequest(
+    const client = this.currentWorkspace.lspClient;
+
+    if (!client || client.state !== State.Running) {
+      return [];
+    }
+
+    const resp = (await client.sendRequest(
       "rubyLsp/workspace/dependencies",
       {},
     )) as [


### PR DESCRIPTION
### Motivation

Another one caught by our telemetry. If the client is not running yet (or failed to launch), trying to send a request to it will try to initialize it a second time, which then may trigger `Client is not running and can't be stopped. It's current state is: starting`.

### Implementation

Since launching the server depends on first bundling dependencies, we ideally want only one thing in the extension controlling the launching of the server - otherwise we get into situations like these.