### PR TITLE
Raise if the attached namespace is missing during linearization

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -389,7 +389,7 @@ module RubyIndexer
       # If we don't have an entry for `name`, raise
       entries = self[fully_qualified_name]
 
-      if singleton_levels > 0 && !entries
+      if singleton_levels > 0 && !entries && indexed?(attached_class_name)
         entries = [existing_or_new_singleton_class(attached_class_name)]
       end
 

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1707,5 +1707,11 @@ module RubyIndexer
         @index.linearized_ancestors_of("A::<Class:A>"),
       )
     end
+
+    def test_linearizing_a_singleton_class_with_no_attached
+      assert_raises(Index::NonExistingNamespaceError) do
+        @index.linearized_ancestors_of("A::<Class:A>")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Linearization for singletons currently fails with a no method error if we have never indexed the attached class.

This happens due to a shortcoming of the current implementation: we only index files once they are saved, rather than indexing them during modifications while computing all of the other features (using the dispatcher).

See the manual tests to understand what I mean.

### Implementation

For now, we need to error properly if the attached class does not exist.

### Automated Tests

Added a test.

### Manual Tests

1. Create a new file
2. Enter the following code (do not save the file)
```ruby
class Foo
  # cursor here
end
```
3. Now, in the position of the cursor, add an `@` symbol

The moment the `@` symbol is added, we need to linearize ancestors for the singleton class of `Foo` to provide completion for class instance variables. However, because the file has not been saved, we never indexed `Foo` in the first place.

On main that fails and on this branch we simply don't show completion until the file is saved.