### PR TITLE
Detect RuboCop as a linter when its a transitive dependency

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -69,7 +69,7 @@ module RubyLsp
       @formatter = detect_formatter(direct_dependencies, all_dependencies) if @formatter == "auto"
 
       specified_linters = options.dig(:initializationOptions, :linters)
-      @linters = specified_linters || detect_linters(direct_dependencies)
+      @linters = specified_linters || detect_linters(direct_dependencies, all_dependencies)
       @test_library = detect_test_library(direct_dependencies)
       @has_type_checker = detect_typechecker(direct_dependencies)
 
@@ -127,10 +127,14 @@ module RubyLsp
 
     # Try to detect if there are linters in the project's dependencies. For auto-detection, we always only consider a
     # single linter. To have multiple linters running, the user must configure them manually
-    sig { params(dependencies: T::Array[String]).returns(T::Array[String]) }
-    def detect_linters(dependencies)
+    sig { params(dependencies: T::Array[String], all_dependencies: T::Array[String]).returns(T::Array[String]) }
+    def detect_linters(dependencies, all_dependencies)
       linters = []
-      linters << "rubocop" if dependencies.any?(/^rubocop/)
+
+      if dependencies.any?(/^rubocop/) || (all_dependencies.include?("rubocop") && dot_rubocop_yml_present)
+        linters << "rubocop"
+      end
+
       linters
     end
 

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -176,6 +176,18 @@ module RubyLsp
       assert_empty(state.instance_variable_get(:@linters))
     end
 
+    def test_linter_auto_detection_with_rubocop_as_transitive_dependency
+      state = GlobalState.new
+
+      stub_direct_dependencies("gem_with_config" => "1.2.3")
+      stub_all_dependencies("gem_with_config", "rubocop")
+      state.stubs(:dot_rubocop_yml_present).returns(true)
+
+      state.apply_options({})
+
+      assert_includes(state.instance_variable_get(:@linters), "rubocop")
+    end
+
     def test_apply_options_sets_experimental_features
       state = GlobalState.new
       refute_predicate(state, :experimental_features)


### PR DESCRIPTION
### Motivation

We made the changes to detect the formatter as RuboCop when there's a `.rubocop.yml` file and the gem is a transitive dependency, but we never did the same for detecting it as a linter - which is used for diagnostics.

### Implementation

Replicated the behaviour when detecting the linters.

### Automated Tests

Added a test.