### PR TITLE
Eagerly activate workspaces for opened files

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -23,7 +23,12 @@ import {
   State,
 } from "vscode-languageclient/node";
 
-import { LSP_NAME, ClientInterface, Addon } from "./common";
+import {
+  LSP_NAME,
+  ClientInterface,
+  Addon,
+  SUPPORTED_LANGUAGE_IDS,
+} from "./common";
 import { Ruby } from "./ruby";
 import { WorkspaceChannel } from "./workspaceChannel";
 
@@ -114,30 +119,21 @@ function collectClientOptions(
   const enabledFeatures = Object.keys(features).filter((key) => features[key]);
 
   const fsPath = workspaceFolder.uri.fsPath.replace(/\/$/, "");
-  const documentSelector: DocumentSelector = [
-    {
-      language: "ruby",
-      pattern: `${fsPath}/**/*`,
+  const documentSelector: DocumentSelector = SUPPORTED_LANGUAGE_IDS.map(
+    (language) => {
+      return { language, pattern: `${fsPath}/**/*` };
     },
-    {
-      language: "erb",
-      pattern: `${fsPath}/**/*`,
-    },
-  ];
+  );
 
   // Only the first language server we spawn should handle unsaved files, otherwise requests will be duplicated across
   // all workspaces
   if (isMainWorkspace) {
-    documentSelector.push(
-      {
-        language: "ruby",
+    SUPPORTED_LANGUAGE_IDS.forEach((language) => {
+      documentSelector.push({
+        language,
         scheme: "untitled",
-      },
-      {
-        language: "erb",
-        scheme: "untitled",
-      },
-    );
+      });
+    });
   }
 
   // For each workspace, the language client is responsible for handling requests for:

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -63,6 +63,7 @@ export const LSP_NAME = "Ruby LSP";
 export const LOG_CHANNEL = vscode.window.createOutputChannel(LSP_NAME, {
   log: true,
 });
+export const SUPPORTED_LANGUAGE_IDS = ["ruby", "erb"];
 
 // Creates a debounced version of a function with the specified delay. If the function is invoked before the delay runs
 // out, then the previous invocation of the function gets cancelled and a new one is scheduled.

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -3,7 +3,12 @@ import { Range } from "vscode-languageclient/node";
 
 import DocumentProvider from "./documentProvider";
 import { Workspace } from "./workspace";
-import { Command, LOG_CHANNEL, STATUS_EMITTER } from "./common";
+import {
+  Command,
+  LOG_CHANNEL,
+  STATUS_EMITTER,
+  SUPPORTED_LANGUAGE_IDS,
+} from "./common";
 import { ManagerIdentifier, ManagerConfiguration } from "./ruby";
 import { StatusItems } from "./status";
 import { TestController } from "./testController";
@@ -61,7 +66,7 @@ export class RubyLsp {
       }),
       // Lazily activate workspaces that do not contain a lockfile
       vscode.workspace.onDidOpenTextDocument(async (document) => {
-        if (document.languageId !== "ruby") {
+        if (!SUPPORTED_LANGUAGE_IDS.includes(document.languageId)) {
           return;
         }
 
@@ -102,7 +107,10 @@ export class RubyLsp {
     // eagerly activate the workspace for that file too
     const activeDocument = vscode.window.activeTextEditor?.document;
 
-    if (activeDocument && activeDocument.languageId === "ruby") {
+    if (
+      activeDocument &&
+      SUPPORTED_LANGUAGE_IDS.includes(activeDocument.languageId)
+    ) {
       const workspaceFolder = vscode.workspace.getWorkspaceFolder(
         activeDocument.uri,
       );

--- a/vscode/src/status.ts
+++ b/vscode/src/status.ts
@@ -1,7 +1,12 @@
 import * as vscode from "vscode";
 import { State } from "vscode-languageclient";
 
-import { Command, STATUS_EMITTER, WorkspaceInterface } from "./common";
+import {
+  Command,
+  STATUS_EMITTER,
+  WorkspaceInterface,
+  SUPPORTED_LANGUAGE_IDS,
+} from "./common";
 
 const STOPPED_SERVER_OPTIONS = [
   { label: "Ruby LSP: Start", description: Command.Start },
@@ -17,10 +22,11 @@ export abstract class StatusItem {
   public item: vscode.LanguageStatusItem;
 
   constructor(id: string) {
-    this.item = vscode.languages.createLanguageStatusItem(id, {
-      scheme: "file",
-      language: "ruby",
-    });
+    const documentSelector = SUPPORTED_LANGUAGE_IDS.map((language) => ({
+      language,
+    }));
+
+    this.item = vscode.languages.createLanguageStatusItem(id, documentSelector);
   }
 
   abstract refresh(workspace: WorkspaceInterface): void;


### PR DESCRIPTION
### Motivation

Fixes the issue reported in https://github.com/Shopify/ruby-lsp/issues/1897#issuecomment-2219056807

In a multi-root workspace configuration, if you have a Ruby file opened for a secondary workspace, we don't eagerly activate that workspace, despite the file already being opened. You need to switch to another Ruby file for that workspace to have the language server activate, which is a bit odd.

### Implementation

Started eagerly activating the workspace for the currently opened file if it's a Ruby file and if the workspace associated with it is not the same as the first one (to avoid any duplicate activations).