### PR TITLE
Sanitize backtrace and mark as telemetry trusted

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -339,8 +339,29 @@ export default class Client extends LanguageClient implements ClientInterface {
         await vscode.window.showErrorMessage(
           `Ruby LSP error ${error.data.errorClass}: ${error.data.errorMessage}\n\n${error.data.backtrace}`,
         );
-      } else {
-        this.telemetry.logError(error, { ...error.data });
+      } else if (
+        error.data.errorMessage &&
+        error.data.errorClass &&
+        error.data.backtrace
+      ) {
+        // Sanitize the backtrace coming from the server to remove the user's home directory from it, then mark it as a
+        // trusted value. Otherwise the VS Code telemetry logger redacts the entire backtrace and we are unable to see
+        // where in the server the error occurred
+        const stack = new vscode.TelemetryTrustedValue(
+          error.data.backtrace
+            .split("\n")
+            .map((line: string) => line.replace(os.homedir(), "~"))
+            .join("\n"),
+        ) as any;
+
+        this.telemetry.logError(
+          {
+            message: error.data.errorMessage,
+            name: error.data.errorClass,
+            stack,
+          },
+          { ...error.data },
+        );
       }
 
       throw error;


### PR DESCRIPTION
### Motivation

Every error from the server was being reported under the same entry. The reason is because the VS Code telemetry logger considers the server backtrace to be possible PII and then redacts everything.

In reality, all of the backtrace entries are inside the Ruby LSP's own codebase and its dependencies, so the only piece of PII included would be user's home directory.

This PR sanitizes that from the backtrace and then marks the stack as a trusted value, so that we can get proper error separation.

### Implementation

I rebuilt the error object before sending to telemetry, using the sanitized backtrace.