### PR TITLE
Add extension and server version to telemetry

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -360,7 +360,7 @@ export default class Client extends LanguageClient implements ClientInterface {
             name: error.data.errorClass,
             stack,
           },
-          { ...error.data },
+          { ...error.data, serverVersion: this.serverVersion },
         );
       }
 
@@ -487,7 +487,6 @@ export default class Client extends LanguageClient implements ClientInterface {
         message: new vscode.TelemetryTrustedValue(label),
         lspVersion: this.serverVersion,
         rubyVersion: this.ruby.rubyVersion,
-        environment: os.platform(),
       },
     });
   }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,3 +1,5 @@
+import os from "os";
+
 import * as vscode from "vscode";
 
 import { RubyLsp } from "./rubyLsp";
@@ -128,5 +130,9 @@ async function createLogger(context: vscode.ExtensionContext) {
     ignoreUnhandledErrors:
       context.extensionMode === vscode.ExtensionMode.Test ||
       context.extensionMode === vscode.ExtensionMode.Development,
+    additionalCommonProperties: {
+      extensionVersion: context.extension.packageJSON.version,
+      environment: os.platform(),
+    },
   });
 }


### PR DESCRIPTION
### Motivation

A couple more adjustments to our telemetry. It's useful to have the extension and server versions as part of errors, so that we can more easily tell if something was already fixed.

### Implementation

Add extension version to the common properties of the logger (included for all metrics). Also moved `environment` there.

Started including server version for the errors.