### PR TITLE
Only show local completion when there is no receiver

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -328,6 +328,9 @@ module RubyLsp
       def add_local_completions(node, name)
         return if @global_state.has_type_checker
 
+        # If the call node has a receiver, then it cannot possibly be a local variable
+        return if node.receiver
+
         range = range_from_location(T.must(node.message_loc))
 
         @node_context.locals_for_scope.each do |local|

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1136,6 +1136,28 @@ class CompletionTest < Minitest::Test
     end
   end
 
+  def test_completion_for_locals_only_happens_when_there_is_no_receiver
+    source = +<<~RUBY
+      class Child
+        def do_something
+          abc = 123
+
+          foo.a
+        end
+      end
+    RUBY
+
+    with_server(source, stub_no_typechecker: true) do |server, uri|
+      server.process_message(id: 1, method: "textDocument/completion", params: {
+        textDocument: { uri: uri },
+        position: { line: 4, character: 9 },
+      })
+
+      result = server.pop_response.response
+      assert_empty(result.map(&:label))
+    end
+  end
+
   private
 
   def with_file_structure(server, &block)


### PR DESCRIPTION
### Motivation

In #2248, I forgot to check if the call node has a receiver before adding local completions. If there are any receivers for the call node, then it cannot be a local.

### Implementation

Started returning early if the call node has a receiver.

### Automated Tests

Added a test that demonstrates the scenario.