### PR TITLE
Check if error data is present before using it

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -28,6 +28,8 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   const logger = await createLogger(context);
+  context.subscriptions.push(logger);
+
   extension = new RubyLsp(context, logger);
   await extension.activate();
 }


### PR DESCRIPTION
### Motivation

In #2285, I made a mistake an didn't check for `error.data` before using it. That `catch` statement may rescue more than just server error. For example, if we try to send a request when the connection has already been disposed, then we'll land on that `catch`, but the `data` attribute won't exist, which would then try to read it and throw another error.

### Implementation

Made two changes:

1. Started checking if `data` is there before accessing it
2. Started disposing of the logger, which we weren't doing before (by pushing it to subscriptions)