### PR TITLE
Turn off telemetry for unhandled errors

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -129,9 +129,7 @@ async function createLogger(context: vscode.ExtensionContext) {
 
   return vscode.env.createTelemetryLogger(sender, {
     ignoreBuiltInCommonProperties: true,
-    ignoreUnhandledErrors:
-      context.extensionMode === vscode.ExtensionMode.Test ||
-      context.extensionMode === vscode.ExtensionMode.Development,
+    ignoreUnhandledErrors: true,
     additionalCommonProperties: {
       extensionVersion: context.extension.packageJSON.version,
       environment: os.platform(),


### PR DESCRIPTION
### Motivation

We've been getting many errors that aren't actually relevant in our telemetry and there's no way to ignore only certain types of errors. It's frankly not useful and we should instead lean into intentional error reporting.

Note: this only stops telemetry for uncaught exceptions that happen in the VS Code extension. Everything we report manually in the code, such as server errors, is still going to show up in Bugsnag.