### PR TITLE
Migrate indexing configuration to editor settings

### DIFF
--- a/.index.yml
+++ b/.index.yml
@@ -1,2 +1,0 @@
-excluded_patterns:
-  - "**/test/fixtures/**/*.rb"

--- a/lsp.code-workspace
+++ b/lsp.code-workspace
@@ -18,6 +18,9 @@
             "**/out": true,
         },
         "rubyLsp.bypassTypechecker": true,
+        "rubyLsp.excludedPatterns": [
+            "**/test/fixtures/**/*.rb"
+        ],
         "typescript.tsc.autoDetect": "off",
     }
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -347,6 +347,47 @@
         "rubyLsp.rubyExecutablePath": {
           "description": "Path to the Ruby installation. This is used as a fallback if version manager activation fails",
           "type": "string"
+        },
+        "rubyLsp.indexing": {
+          "description": "Indexing configurations. Modifying these will impact which declarations are available for definition, completion and other features",
+          "type": "object",
+          "properties": {
+            "excludedPatterns": {
+              "type": "array",
+              "description": "List of glob patterns to exclude from indexing. For excluding gems, use excludedGems instead.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "includedPatterns": {
+              "type": "array",
+              "description": "List of glob patterns to include when indexing. For example, Ruby files that do not have the .rb extension.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "includedGems": {
+              "type": "array",
+              "description": "List of gems to include when indexing. You should only use this setting to include development gems in indexing (which are auto excluded).",
+              "items": {
+                "type": "string"
+              }
+            },
+            "excludedGems": {
+              "type": "array",
+              "description": "List of gems to exclude from indexing. For example, gems that are not intended to have their declarations referenced from the application.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "excludedMagicComments": {
+              "type": "array",
+              "description": "List of magic comments that should not be considered as documentation for declarations.",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -174,6 +174,7 @@ function collectClientOptions(
       featuresConfiguration: configuration.get("featuresConfiguration"),
       formatter: configuration.get("formatter"),
       linters: configuration.get("linters"),
+      indexing: configuration.get("indexing"),
     },
   };
 }


### PR DESCRIPTION
### Motivation

Closes #2156

Deprecate our `.index.yml` file and move to relying on editor settings instead. Editor settings are better suited for configuring language servers, rather than using custom configuration files.

Editor settings already handle different levels of hierarchy. For example, workspace settings and user settings - merging when appropriate. In addition to that, we can show descriptions and examples of settings, which provide a much more intuitive experience. Overall, a custom configuration file is just a worse experience for the users.

A small caveat is that, because editor settings are usually camel case and we use snake case in Ruby, we need to accept both. This is what the settings look like now:

```json
{
  "excludedPatterns": ["**/test/**.rb"],
  "includedPatterns": ["**/bin/**"],
  "excludedGems": ["rubocop", "rubocop-performance"],
  "includedPatterns": ["rake"],
  "excludedMagicComments": ["compiled:true"]
}
```

### Implementation

1. Started showing a warning for projects that are using the deprecated `.index.yml`
2. Started accepting the indexing configuration from `initializationOptions`
3. Added the new settings to the VS Code extension

### Automated Tests

Changed some tests.