### PR TITLE
Allow turning off ERB support through setting

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -418,6 +418,11 @@
               }
             }
           }
+        },
+        "rubyLsp.erbSupport": {
+          "description": "Enable ERB support. This can only work with server versions v0.17.5 or above",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -21,6 +21,7 @@ import {
   ErrorAction,
   CloseAction,
   State,
+  DocumentFilter,
 } from "vscode-languageclient/node";
 
 import {
@@ -119,7 +120,7 @@ function collectClientOptions(
   const enabledFeatures = Object.keys(features).filter((key) => features[key]);
 
   const fsPath = workspaceFolder.uri.fsPath.replace(/\/$/, "");
-  const documentSelector: DocumentSelector = SUPPORTED_LANGUAGE_IDS.map(
+  let documentSelector: DocumentSelector = SUPPORTED_LANGUAGE_IDS.map(
     (language) => {
       return { language, pattern: `${fsPath}/**/*` };
     },
@@ -155,6 +156,14 @@ function collectClientOptions(
         language: "ruby",
         pattern: `${gemPath.replace(/lib\/ruby\/gems\/(?=\d)/, "lib/ruby/")}/**/*`,
       });
+    });
+  }
+
+  // This is a temporary solution as an escape hatch for users who cannot upgrade the `ruby-lsp` gem to a version that
+  // supports ERB
+  if (!configuration.get<boolean>("erbSupport")) {
+    documentSelector = documentSelector.filter((selector) => {
+      return (selector as DocumentFilter).language !== "erb";
     });
   }
 


### PR DESCRIPTION
### Motivation

Closes #2282

If the user is working on a project with a dependency that prevents the Ruby LSP server from upgrading, the server will not have ERB support.

Unfortunately, mutating the document selector after the client has already launched doesn't stop it from receiving requests for the removed language IDs. And we have no way of knowing if the server version supports ERB before actually launching. It's a chicken and egg problem.

### Implementation

I believe the best we can do is the following (implemented in this PR):

1. After launching the server, we check if there's ERB support. If there is, then the server is up to date and we don't have to do anything
2. Otherwise, we print a warning to output tab (should it be a dialog?) and then we restart the server, passing a new option to turn off ERB support before launch (which then has the desired effect of preventing requests for ERB files)

### Concerns

Should we even do this? This means that anyone on old server versions will always need to boot the server twice until they manage to upgrade to newer versions.