### PR TITLE
Accept multiple URIs for the open file command

### DIFF
--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -38,3 +38,30 @@ export async function openFile(
     });
   }
 }
+
+// Open the given URIs in the editor, which should follow this format:
+// `file:///path/to/file.rb#Lstart_line,start_column-end_line,end_column`
+export async function openUris(uris: string[]) {
+  if (uris.length === 1) {
+    await vscode.commands.executeCommand(
+      "vscode.open",
+      vscode.Uri.parse(uris[0]),
+    );
+    return;
+  }
+
+  const items: ({ uri: vscode.Uri } & vscode.QuickPickItem)[] = uris.map(
+    (uri) => ({
+      label: uri,
+      uri: vscode.Uri.parse(uri),
+    }),
+  );
+
+  const pickedFile = await vscode.window.showQuickPick(items);
+
+  if (!pickedFile) {
+    return;
+  }
+
+  await vscode.commands.executeCommand("vscode.open", pickedFile.label);
+}

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -12,7 +12,7 @@ import {
 import { ManagerIdentifier, ManagerConfiguration } from "./ruby";
 import { StatusItems } from "./status";
 import { TestController } from "./testController";
-import { openFile } from "./openFile";
+import { openFile, openUris } from "./commands";
 import { Debugger } from "./debugger";
 import { DependenciesTree } from "./dependenciesTree";
 
@@ -444,7 +444,13 @@ export class RubyLsp {
       ),
       vscode.commands.registerCommand(
         Command.OpenFile,
-        (rubySourceLocation: [string, string]) => {
+        (rubySourceLocation: [string, string] | string[]) => {
+          // New command format: accepts an array of URIs
+          if (typeof rubySourceLocation[0] === "string") {
+            return openUris(rubySourceLocation);
+          }
+
+          // Old format: we can remove after the Rails addon has been using the new format for a while
           const [file, line] = rubySourceLocation;
           const workspace = this.currentActiveWorkspace();
           return openFile(this.telemetry, workspace, {


### PR DESCRIPTION
### Motivation

This PR starts accepting a list of URIs for the open file command. This will be necessary for allowing the jump to view feature to exist, since applications may define multiple views for the same controller action with different formats (e.g.: index.html.erb, index.json.jbuilder).

### Implementation

The idea is to accept full URIs from the server. If there's only one, we open that directly. Otherwise, we show a quick pick and allow the user to choose.

Then we invoke `vscode.open` which already handles ranges in the URI fragment for us.