### PR TITLE
Handle documents being deleted before processing their requests

### DIFF
--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -5,6 +5,8 @@ module RubyLsp
   class Store
     extend T::Sig
 
+    class NonExistingDocumentError < StandardError; end
+
     sig { returns(T::Boolean) }
     attr_accessor :supports_progress
 
@@ -45,6 +47,8 @@ module RubyLsp
       end
       set(uri: uri, source: File.binread(path), version: 0, language_id: language_id)
       T.must(@state[uri.to_s])
+    rescue Errno::ENOENT
+      raise NonExistingDocumentError, uri.to_s
     end
 
     sig do


### PR DESCRIPTION
### Motivation

We sometimes get `Errno::ENOENT` in our telemetry and I believe I finally figured out why.

Consider this sequence of events:

1. Someone opens a file and the editor fires a bunch of requests
2. All of those requests are placed into the incoming queue
3. Then the user deletes the file
4. The server will receive a `textDocument/didClose` notification. This is handled immediately, removing the document from the store
5. Then the worker picks up a request for the deleted file. Maybe it fell behind processing because the file was large or something caused it to lag
6. Since the document is no longer present in the store, it will try to read it from disk, but the file no longer exists either so it then raises `ENOENT`

### Implementation

I believe we have two options:

Stop processing `textDocument/didClose` synchronously and throw it in the incoming queue. This will guarantee that we only close the document after processing all requests received for it. However, we will waste time processing requests for a file that was already deleted

The second option is what I implemented: we raise a specific error for when documents no longer exist and avoid reporting those to our telemetry.

### Automated Tests

Added a test that reproduces the behaviour. Notice that it's difficult to control the order of execution of messages, so the test itself is not 100% reliable, but it does catch the bug.