### PR TITLE
Fix typos in GitHub Markdown Alerts

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -28,7 +28,7 @@ project. That directory contains another `Gemfile`, that includes the `ruby-lsp`
 dependencies. This approach allows us to automatically detect which formatter your project uses and which gems we need
 to index for features such as go to definition.
 
-> ![NOTE]
+> [!NOTE]
 > We are working with the RubyGems/Bundler team to have this type of mechanism properly supported from within
 > Bundler itself, which is currently being experimented with in a plugin called `bundler-compose`. Once
 > `bundler-compose`is production ready, the entire custom bundle created under the `.ruby-lsp` directory will go away
@@ -125,7 +125,7 @@ gem: --install-dir /my/preferred/path/for/gem/install
 One scenario where this is useful is if the user doesn't have permissions for the default gem installation directory and
 `gem install` fails. For example, when using the system Ruby on certain Linux distributions.
 
-> ![NOTE]
+> [!NOTE]
 > Using non-default gem installation paths may lead to other integration issues with version managers. For example, for
 > Ruby 3.3.1 the default `GEM_HOME` is `~/.gem/ruby/3.3.0` (without the patch part of the version). However, `chruby`
 > (and potentially other version managers) override `GEM_HOME` to include the version patch resulting in

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -282,7 +282,7 @@ repository is.
 
 #### Example configurations
 
-> ![NOTE]
+> [!NOTE]
 > To make sure Ruby LSP works well with your multi-root workspace project, please
 > read through the instructions below and configure it following the examples.
 > After configuring, do not forget to tell VS Code to open the workspace from the


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

I came across `![NOTE]` and `[!NOTE]` in the documents. The latter form, i.e., `[!...]`, is correct.

GitHub search for the typo (including correct usages, though):
https://github.com/search?q=repo%3AShopify%2Fruby-lsp+language%3AMarkdown+%28%22%5B%21%22+OR+%22%21%5B%22%29&type=code

See also:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This PR just replaces `![NOTE]` with `[!NOTE]`.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

This is just documentation fixes, so I believe tests are unnecessary.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

N/A
