### PR TITLE
Add create Minitest file operation

### DIFF
--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -74,3 +74,21 @@ export async function openUris(uris: string[]) {
 
   await vscode.commands.executeCommand("vscode.open", pickedFile.uri);
 }
+
+export async function newMinitestFile() {
+  const document = await vscode.workspace.openTextDocument({
+    language: "ruby",
+  });
+  const editor = await vscode.window.showTextDocument(document, {
+    preview: false,
+  });
+
+  const position = new vscode.Position(0, 0);
+
+  await editor.insertSnippet(
+    new vscode.SnippetString(
+      'require "test_helper"\n\nclass $1Test < Minitest::Test\n  def test_$2\n    $3\n  end\nend\n',
+    ),
+    new vscode.Selection(position, position),
+  );
+}

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -25,6 +25,7 @@ export enum Command {
   FileOperation = "rubyLsp.fileOperation",
   RailsGenerate = "rubyLsp.railsGenerate",
   RailsDestroy = "rubyLsp.railsDestroy",
+  NewMinitestFile = "rubyLsp.newMinitestFile",
 }
 
 export interface RubyInterface {

--- a/vscode/src/rails.ts
+++ b/vscode/src/rails.ts
@@ -14,8 +14,11 @@ export class Rails {
   }
 
   // Runs `bin/rails generate` with the given generator (e.g.: `controller`, `model`, etc.) and the desired arguments
-  async generate(generatorWithArguments: string) {
-    const workspace = await this.showWorkspacePick();
+  async generate(
+    generatorWithArguments: string,
+    selectedWorkspace: Workspace | undefined,
+  ) {
+    const workspace = selectedWorkspace ?? (await this.showWorkspacePick());
 
     if (!workspace) {
       return;
@@ -48,8 +51,11 @@ export class Rails {
   }
 
   // Invokes `bin/rails destroy` to undo the changes made by a `generate` command
-  async destroy(generatorWithArguments: string) {
-    const workspace = await this.showWorkspacePick();
+  async destroy(
+    generatorWithArguments: string,
+    selectedWorkspace: Workspace | undefined,
+  ) {
+    const workspace = selectedWorkspace ?? (await this.showWorkspacePick());
 
     if (!workspace) {
       return;

--- a/vscode/src/test/suite/rails.test.ts
+++ b/vscode/src/test/suite/rails.test.ts
@@ -34,8 +34,9 @@ suite("Rails", () => {
     const showDocumentStub = sinon.stub(vscode.window, "showTextDocument");
     const executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
 
+    const selectedWorkspace = undefined;
     const rails = new Rails(() => Promise.resolve(workspace));
-    await rails.generate("model User name:string");
+    await rails.generate("model User name:string", selectedWorkspace);
 
     assert.ok(
       executeStub.calledOnceWithExactly(
@@ -79,8 +80,9 @@ suite("Rails", () => {
 
     const executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
 
+    const selectedWorkspace = undefined;
     const rails = new Rails(() => Promise.resolve(workspace));
-    await rails.destroy("model User name:string");
+    await rails.destroy("model User name:string", selectedWorkspace);
 
     assert.ok(
       executeStub.calledOnceWithExactly(


### PR DESCRIPTION
### Motivation

Building on top of #2257, this PR allows creating a Minitest file through the new Ruby files button.

### Implementation

1. Add a new quick pick item to create Minitest tests
2. When that item is picked, we create a new unsaved file and run a snippet on it, which allows the user to jump (in order) to writing the test class name, the example name and then the example body

After that the user can save the file wherever they want.