### PR TITLE
Use URI object when invoking vscode.open

### DIFF
--- a/vscode/src/commands.ts
+++ b/vscode/src/commands.ts
@@ -1,3 +1,5 @@
+import path from "path";
+
 import * as vscode from "vscode";
 
 import { Workspace } from "./workspace";
@@ -51,17 +53,24 @@ export async function openUris(uris: string[]) {
   }
 
   const items: ({ uri: vscode.Uri } & vscode.QuickPickItem)[] = uris.map(
-    (uri) => ({
-      label: uri,
-      uri: vscode.Uri.parse(uri),
-    }),
+    (uriString) => {
+      const uri = vscode.Uri.parse(uriString);
+
+      return {
+        label: path.basename(uri.fsPath),
+        iconPath: new vscode.ThemeIcon("go-to-file"),
+        uri,
+      };
+    },
   );
 
-  const pickedFile = await vscode.window.showQuickPick(items);
+  const pickedFile = await vscode.window.showQuickPick(items, {
+    title: "Select a file to jump to",
+  });
 
   if (!pickedFile) {
     return;
   }
 
-  await vscode.commands.executeCommand("vscode.open", pickedFile.label);
+  await vscode.commands.executeCommand("vscode.open", pickedFile.uri);
 }


### PR DESCRIPTION
### Motivation

While adding jump to view on the Rails addon https://github.com/Shopify/ruby-lsp-rails/pull/412, I noticed a few issues with the `openUris` implementation.

### Implementation

1. The `vscode.open` command expects a URI object, not a string
2. We didn't have a title for the quick pick so the list of files just showed up with no explanation
3. I added go to file icons to further communicate that selecting an option will jump to it
4. The full URI is way too long to display as label. Started using only the file name