### PR TITLE
Only show file operations in the explorer view

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -37,14 +37,14 @@
       "view/title": [
         {
           "command": "rubyLsp.fileOperation",
-          "when": "rubyLsp.activated && view.workbench.explorer.fileView.visible",
+          "when": "rubyLsp.activated && view == 'workbench.explorer.fileView'",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "rubyLsp.fileOperation",
-          "when": "rubyLsp.activated && view.workbench.explorer.fileView.visible",
+          "when": "rubyLsp.activated",
           "group": "2_workspace"
         }
       ]


### PR DESCRIPTION
### Motivation

There was a mistake in our `when` clause for the file operations button. The way to associate a button with a specific view is to check for the view ID (see `view` in the [when clause docs](https://code.visualstudio.com/api/references/when-clause-contexts#available-context-keys)).

### Implementation

Changed the `view/title` contribution to only add the button in the explorer view. The button was appearing in all views, including terminal, output, debug console. Now, it only shows up in the explorer view.

Additionally, there's no need for additional checks for the menu item, because that one is specifically added to the `explorer/context`, which only shows up in the explorer view.