### PR TITLE
Handle Sorbet levels to prevent some feature duplication

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -10,6 +10,16 @@ module RubyLsp
       end
     end
 
+    class SorbetLevel < T::Enum
+      enums do
+        None = new("none")
+        Ignore = new("ignore")
+        False = new("false")
+        True = new("true")
+        Strict = new("strict")
+      end
+    end
+
     extend T::Sig
     extend T::Helpers
 
@@ -213,10 +223,23 @@ module RubyLsp
       NodeContext.new(closest, parent, nesting_nodes, call_node)
     end
 
-    sig { returns(T::Boolean) }
-    def sorbet_sigil_is_true_or_higher
-      parse_result.magic_comments.any? do |comment|
-        comment.key == "typed" && ["true", "strict", "strong"].include?(comment.value)
+    sig { returns(SorbetLevel) }
+    def sorbet_level
+      sigil = parse_result.magic_comments.find do |comment|
+        comment.key == "typed"
+      end&.value
+
+      case sigil
+      when "ignore"
+        SorbetLevel::Ignore
+      when "false"
+        SorbetLevel::False
+      when "true"
+        SorbetLevel::True
+      when "strict", "strong"
+        SorbetLevel::Strict
+      else
+        SorbetLevel::None
       end
     end
 

--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -13,11 +13,11 @@ module RubyLsp
           global_state: GlobalState,
           node_context: NodeContext,
           dispatcher: Prism::Dispatcher,
-          typechecker_enabled: T::Boolean,
+          sorbet_level: Document::SorbetLevel,
         ).void
       end
-      def initialize(response_builder, global_state, node_context, dispatcher, typechecker_enabled)
-        @typechecker_enabled = typechecker_enabled
+      def initialize(response_builder, global_state, node_context, dispatcher, sorbet_level)
+        @sorbet_level = sorbet_level
         @response_builder = response_builder
         @global_state = global_state
         @index = T.let(global_state.index, RubyIndexer::Index)
@@ -28,7 +28,7 @@ module RubyLsp
 
       sig { params(node: Prism::CallNode).void }
       def on_call_node_enter(node)
-        return if @typechecker_enabled
+        return if sorbet_level_true_or_higher?(@sorbet_level)
 
         message = node.message
         return unless message

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -49,11 +49,11 @@ module RubyLsp
           document: Document,
           global_state: GlobalState,
           params: T::Hash[Symbol, T.untyped],
-          typechecker_enabled: T::Boolean,
+          sorbet_level: Document::SorbetLevel,
           dispatcher: Prism::Dispatcher,
         ).void
       end
-      def initialize(document, global_state, params, typechecker_enabled, dispatcher)
+      def initialize(document, global_state, params, sorbet_level, dispatcher)
         super()
         @target = T.let(nil, T.nilable(Prism::Node))
         @dispatcher = dispatcher
@@ -84,7 +84,7 @@ module RubyLsp
           @response_builder,
           global_state,
           node_context,
-          typechecker_enabled,
+          sorbet_level,
           dispatcher,
           document.uri,
           params.dig(:context, :triggerCharacter),

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -36,10 +36,10 @@ module RubyLsp
           global_state: GlobalState,
           position: T::Hash[Symbol, T.untyped],
           dispatcher: Prism::Dispatcher,
-          typechecker_enabled: T::Boolean,
+          sorbet_level: Document::SorbetLevel,
         ).void
       end
-      def initialize(document, global_state, position, dispatcher, typechecker_enabled)
+      def initialize(document, global_state, position, dispatcher, sorbet_level)
         super()
         @response_builder = T.let(
           ResponseBuilders::CollectionResponseBuilder[T.any(Interface::Location, Interface::LocationLink)].new,
@@ -96,7 +96,7 @@ module RubyLsp
             document.uri,
             node_context,
             dispatcher,
-            typechecker_enabled,
+            sorbet_level,
           )
 
           Addon.addons.each do |addon|

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -36,10 +36,10 @@ module RubyLsp
           global_state: GlobalState,
           position: T::Hash[Symbol, T.untyped],
           dispatcher: Prism::Dispatcher,
-          typechecker_enabled: T::Boolean,
+          sorbet_level: Document::SorbetLevel,
         ).void
       end
-      def initialize(document, global_state, position, dispatcher, typechecker_enabled)
+      def initialize(document, global_state, position, dispatcher, sorbet_level)
         super()
         node_context = document.locate_node(position, node_types: Listeners::Hover::ALLOWED_TARGETS)
         target = node_context.node
@@ -65,7 +65,7 @@ module RubyLsp
         @target = T.let(target, T.nilable(Prism::Node))
         uri = document.uri
         @response_builder = T.let(ResponseBuilders::Hover.new, ResponseBuilders::Hover)
-        Listeners::Hover.new(@response_builder, global_state, uri, node_context, dispatcher, typechecker_enabled)
+        Listeners::Hover.new(@response_builder, global_state, uri, node_context, dispatcher, sorbet_level)
         Addon.addons.each do |addon|
           addon.create_hover_listener(@response_builder, node_context, dispatcher)
         end

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -46,10 +46,10 @@ module RubyLsp
           position: T::Hash[Symbol, T.untyped],
           context: T.nilable(T::Hash[Symbol, T.untyped]),
           dispatcher: Prism::Dispatcher,
-          typechecker_enabled: T::Boolean,
+          sorbet_level: Document::SorbetLevel,
         ).void
       end
-      def initialize(document, global_state, position, context, dispatcher, typechecker_enabled) # rubocop:disable Metrics/ParameterLists
+      def initialize(document, global_state, position, context, dispatcher, sorbet_level) # rubocop:disable Metrics/ParameterLists
         super()
         node_context = document.locate_node(
           { line: position[:line], character: position[:character] },
@@ -61,7 +61,7 @@ module RubyLsp
         @target = T.let(target, T.nilable(Prism::Node))
         @dispatcher = dispatcher
         @response_builder = T.let(ResponseBuilders::SignatureHelp.new, ResponseBuilders::SignatureHelp)
-        Listeners::SignatureHelp.new(@response_builder, global_state, node_context, dispatcher, typechecker_enabled)
+        Listeners::SignatureHelp.new(@response_builder, global_state, node_context, dispatcher, sorbet_level)
       end
 
       sig { override.returns(T.nilable(Interface::SignatureHelp)) }

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -204,6 +204,11 @@ module RubyLsp
             Constant::SymbolKind::FIELD
           end
         end
+
+        sig { params(sorbet_level: Document::SorbetLevel).returns(T::Boolean) }
+        def sorbet_level_true_or_higher?(sorbet_level)
+          sorbet_level == Document::SorbetLevel::True || sorbet_level == Document::SorbetLevel::Strict
+        end
       end
     end
   end

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -477,15 +477,17 @@ module RubyLsp
             @global_state,
             params[:position],
             dispatcher,
-            typechecker_enabled?(document),
+            sorbet_level(document),
           ).perform,
         ),
       )
     end
 
-    sig { params(document: Document).returns(T::Boolean) }
-    def typechecker_enabled?(document)
-      @global_state.has_type_checker && document.sorbet_sigil_is_true_or_higher
+    sig { params(document: Document).returns(Document::SorbetLevel) }
+    def sorbet_level(document)
+      return Document::SorbetLevel::Ignore unless @global_state.has_type_checker
+
+      document.sorbet_level
     end
 
     sig { params(message: T::Hash[Symbol, T.untyped]).void }
@@ -594,7 +596,7 @@ module RubyLsp
             document,
             @global_state,
             params,
-            typechecker_enabled?(document),
+            sorbet_level(document),
             dispatcher,
           ).perform,
         ),
@@ -624,7 +626,7 @@ module RubyLsp
             params[:position],
             params[:context],
             dispatcher,
-            typechecker_enabled?(document),
+            sorbet_level(document),
           ).perform,
         ),
       )
@@ -644,7 +646,7 @@ module RubyLsp
             @global_state,
             params[:position],
             dispatcher,
-            typechecker_enabled?(document),
+            sorbet_level(document),
           ).perform,
         ),
       )

--- a/test/requests/signature_help_test.rb
+++ b/test/requests/signature_help_test.rb
@@ -345,4 +345,30 @@ class SignatureHelpTest < Minitest::Test
       assert_equal(0, result.active_parameter)
     end
   end
+
+  def test_help_is_disabled_on_typed_true
+    source = +<<~RUBY
+      # typed: true
+      class Foo
+        def bar(a, b)
+        end
+
+        def baz
+          bar()
+        end
+      end
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(id: 1, method: "textDocument/signatureHelp", params: {
+        textDocument: { uri: uri },
+        position: { line: 6, character: 7 },
+        context: {
+          triggerCharacter: "(",
+          activeSignatureHelp: nil,
+        },
+      })
+      assert_nil(server.pop_response.response)
+    end
+  end
 end

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -601,32 +601,32 @@ class RubyDocumentTest < Minitest::Test
       version: 1,
       uri: URI("file:///foo/bar.rb"),
     )
-    refute_predicate(document, :sorbet_sigil_is_true_or_higher)
+    assert_equal(RubyLsp::Document::SorbetLevel::None, document.sorbet_level)
   end
 
   def test_sigil_ignore
-    document = RubyLsp::RubyDocument.new(source: +"# typed: ignored", version: 1, uri: URI("file:///foo/bar.rb"))
-    refute_predicate(document, :sorbet_sigil_is_true_or_higher)
+    document = RubyLsp::RubyDocument.new(source: +"# typed: ignore", version: 1, uri: URI("file:///foo/bar.rb"))
+    assert_equal(RubyLsp::Document::SorbetLevel::Ignore, document.sorbet_level)
   end
 
   def test_sigil_false
     document = RubyLsp::RubyDocument.new(source: +"# typed: false", version: 1, uri: URI("file:///foo/bar.rb"))
-    refute_predicate(document, :sorbet_sigil_is_true_or_higher)
+    assert_equal(RubyLsp::Document::SorbetLevel::False, document.sorbet_level)
   end
 
   def test_sigil_true
     document = RubyLsp::RubyDocument.new(source: +"# typed: true", version: 1, uri: URI("file:///foo/bar.rb"))
-    assert_predicate(document, :sorbet_sigil_is_true_or_higher)
+    assert_equal(RubyLsp::Document::SorbetLevel::True, document.sorbet_level)
   end
 
   def test_sigil_strict
     document = RubyLsp::RubyDocument.new(source: +"# typed: strict", version: 1, uri: URI("file:///foo/bar.rb"))
-    assert_predicate(document, :sorbet_sigil_is_true_or_higher)
+    assert_equal(RubyLsp::Document::SorbetLevel::Strict, document.sorbet_level)
   end
 
   def test_sigil_strong
     document = RubyLsp::RubyDocument.new(source: +"# typed: strong", version: 1, uri: URI("file:///foo/bar.rb"))
-    assert_predicate(document, :sorbet_sigil_is_true_or_higher)
+    assert_equal(RubyLsp::Document::SorbetLevel::Strict, document.sorbet_level)
   end
 
   def test_sorbet_sigil_only_in_magic_comment
@@ -651,7 +651,7 @@ class RubyDocumentTest < Minitest::Test
         CODE
       end
     RUBY
-    refute_predicate(document, :sorbet_sigil_is_true_or_higher)
+    assert_equal(RubyLsp::Document::SorbetLevel::False, document.sorbet_level)
   end
 
   def test_locating_compact_namespace_declaration


### PR DESCRIPTION
### Motivation

This PR is a step towards #2294

We added a bunch of new features recently, but we weren't super careful about checking which parts overlapped with Sorbet's behaviour and under which scenarios. This resulted in a bit of duplicate behaviour and we can improve that.

Note that full removal of any kind of duplication is going to require deep integration with the type checker and is a much more involved effort.

### Implementation

Essentially, requests have to know the level of Sorbet type checking available for a file to make decisions about what to provide.

Instead of trying to use a blanket statement like `typechecker_enabled?`, I switched to passing the Sorbet level of type checking to the relevant requests.

I left some comments on the PR to help understand the decisions.

### Automated Tests

Added tests.