### PR TITLE
Raise explicit NonExistingDocumentError for unseen untitled files

### DIFF
--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -232,4 +232,10 @@ class StoreTest < Minitest::Test
       @store.get(uri),
     )
   end
+
+  def test_raises_non_existing_document_error_on_unknown_unsaved_files
+    assert_raises(RubyLsp::Store::NonExistingDocumentError) do
+      @store.get(URI("untitled:Untitled-1"))
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

I'm not exactly sure what order of operations is required to trigger this problem, but based on our telemetry it seems to be possible to receive a request for an unsaved file before we received a `didOpen` notification for it.

Since the file is unsaved, we cannot try to read it from disk and there's no path associated to it.

### Implementation

Started checking if `path` exists. If we never saw the document before (it's not in the store) and there's no `path`, then we have no hope of figuring out what the document contains. We can only raise.

### Automated Tests

Added a test reproducing the issue.