### PR TITLE
Switch to storing URIs in entries instead of file paths

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/indexable_path.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/indexable_path.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 module RubyIndexer
+  # Represents a file system path that can be indexed. This class should only be used for files in the file system and
+  # not for other URIs that may be indexed, such as unsaved file URIs using the `untitled` scheme
   class IndexablePath
     extend T::Sig
 
@@ -24,6 +26,11 @@ module RubyIndexer
         load_path_entry ? full_path.delete_prefix("#{load_path_entry}/").delete_suffix(".rb") : nil,
         T.nilable(String),
       )
+    end
+
+    sig { returns(URI::Generic) }
+    def to_uri
+      URI::Generic.from_path(path: @full_path)
     end
   end
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -49,14 +49,14 @@ module RubyIndexer
     end
     def handle_class_or_module_declaration(declaration, pathname)
       nesting = [declaration.name.name.to_s]
-      file_path = pathname.to_s
+      uri = URI::Generic.from_path(path: pathname.to_s)
       location = to_ruby_indexer_location(declaration.location)
       comments = Array(declaration.comment&.string)
       entry = if declaration.is_a?(RBS::AST::Declarations::Class)
         parent_class = declaration.super_class&.name&.name&.to_s
-        Entry::Class.new(nesting, file_path, location, location, comments, parent_class)
+        Entry::Class.new(nesting, uri, location, location, comments, parent_class)
       else
-        Entry::Module.new(nesting, file_path, location, location, comments)
+        Entry::Module.new(nesting, uri, location, location, comments)
       end
       add_declaration_mixins_to_entry(declaration, entry)
       @index.add(entry)
@@ -101,7 +101,7 @@ module RubyIndexer
     sig { params(member: RBS::AST::Members::MethodDefinition, owner: Entry::Namespace).void }
     def handle_method(member, owner)
       name = member.name.name
-      file_path = member.location.buffer.name
+      uri = URI::Generic.from_path(path: member.location.buffer.name)
       location = to_ruby_indexer_location(member.location)
       comments = Array(member.comment&.string)
 
@@ -116,7 +116,7 @@ module RubyIndexer
 
       real_owner = member.singleton? ? @index.existing_or_new_singleton_class(owner.name) : owner
       signatures = signatures(member)
-      @index.add(Entry::Method.new(name, file_path, location, location, comments, signatures, visibility, real_owner))
+      @index.add(Entry::Method.new(name, uri, location, location, comments, signatures, visibility, real_owner))
     end
 
     sig { params(member: RBS::AST::Members::MethodDefinition).returns(T::Array[Entry::Signature]) }

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -346,7 +346,7 @@ module RubyIndexer
       fixtures = Dir.glob("test/fixtures/prism/test/prism/fixtures/**/*.txt")
 
       fixtures.each do |fixture|
-        indexable_path = IndexablePath.new("", fixture)
+        indexable_path = IndexablePath.new("", File.expand_path(fixture))
         @index.index_single(indexable_path)
       end
 

--- a/lib/ruby_indexer/test/rbs_indexer_test.rb
+++ b/lib/ruby_indexer/test/rbs_indexer_test.rb
@@ -11,7 +11,7 @@ module RubyIndexer
       # Array is a class but also an instance method on Kernel
       assert_equal(2, entries.length)
       entry = entries.find { |entry| entry.is_a?(RubyIndexer::Entry::Class) }
-      assert_match(%r{/gems/rbs-.*/core/array.rbs}, entry.file_path)
+      assert_match(%r{/gems/rbs-.*/core/array.rbs}, entry.uri.to_standardized_path)
       assert_equal("array.rbs", entry.file_name)
       assert_equal("Object", entry.parent_class)
       assert_equal(1, entry.mixin_operations.length)
@@ -30,7 +30,7 @@ module RubyIndexer
       refute_nil(entries)
       assert_equal(1, entries.length)
       entry = entries.first
-      assert_match(%r{/gems/rbs-.*/core/kernel.rbs}, entry.file_path)
+      assert_match(%r{/gems/rbs-.*/core/kernel.rbs}, entry.uri.to_standardized_path)
       assert_equal("kernel.rbs", entry.file_name)
 
       # Using fixed positions would be fragile, so let's just check some basics.
@@ -44,7 +44,7 @@ module RubyIndexer
       entries = @index["initialize"]
       refute_nil(entries)
       entry = entries.find { |entry| entry.owner.name == "Array" }
-      assert_match(%r{/gems/rbs-.*/core/array.rbs}, entry.file_path)
+      assert_match(%r{/gems/rbs-.*/core/array.rbs}, entry.uri.to_standardized_path)
       assert_equal("array.rbs", entry.file_name)
       assert_equal(Entry::Visibility::PUBLIC, entry.visibility)
 
@@ -317,7 +317,7 @@ module RubyIndexer
       _, _, declarations = RBS::Parser.parse_signature(buffer)
       index = RubyIndexer::Index.new
       indexer = RubyIndexer::RBSIndexer.new(index)
-      pathname = Pathname.new("file.rbs")
+      pathname = Pathname.new("/fake/file.rbs")
       indexer.process_signature(pathname, declarations)
       entry = T.must(index[method_name]).first
       T.cast(entry, Entry::Method).signatures

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -27,7 +27,7 @@ module RubyIndexer
 
       location = entry.location
       location_string =
-        "#{entry.file_path}:#{location.start_line - 1}-#{location.start_column}" \
+        "#{entry.uri.to_standardized_path}:#{location.start_line - 1}-#{location.start_column}" \
           ":#{location.end_line - 1}-#{location.end_column}"
 
       assert_equal(expected_location, location_string)

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -171,7 +171,7 @@ module RubyLsp
           location = entry.location
 
           @response_builder << Interface::Location.new(
-            uri: URI::Generic.from_path(path: entry.file_path).to_s,
+            uri: entry.uri.to_s,
             range: Interface::Range.new(
               start: Interface::Position.new(line: location.start_line - 1, character: location.start_column),
               end: Interface::Position.new(line: location.end_line - 1, character: location.end_column),
@@ -195,11 +195,12 @@ module RubyLsp
         return unless methods
 
         methods.each do |target_method|
-          file_path = target_method.file_path
-          next if @typechecker_enabled && not_in_dependencies?(file_path)
+          uri = target_method.uri
+          file_path = uri.to_standardized_path
+          next if @typechecker_enabled && (!file_path || not_in_dependencies?(file_path))
 
           @response_builder << Interface::LocationLink.new(
-            target_uri: URI::Generic.from_path(path: file_path).to_s,
+            target_uri: uri.to_s,
             target_range: range_from_location(target_method.location),
             target_selection_range: range_from_location(target_method.name_location),
           )
@@ -252,14 +253,15 @@ module RubyLsp
         return if first_entry.private? && first_entry.name != "#{@node_context.fully_qualified_name}::#{value}"
 
         entries.each do |entry|
+          uri = entry.uri
           # If the project has Sorbet, then we only want to handle go to definition for constants defined in gems, as an
           # additional behavior on top of jumping to RBIs. Sorbet can already handle go to definition for all constants
           # in the project, even if the files are typed false
-          file_path = entry.file_path
-          next if @typechecker_enabled && not_in_dependencies?(file_path)
+          file_path = uri.to_standardized_path
+          next if @typechecker_enabled && (!file_path || not_in_dependencies?(file_path))
 
           @response_builder << Interface::LocationLink.new(
-            target_uri: URI::Generic.from_path(path: file_path).to_s,
+            target_uri: uri.to_s,
             target_range: range_from_location(entry.location),
             target_selection_range: range_from_location(entry.name_location),
           )

--- a/lib/ruby_lsp/requests/prepare_type_hierarchy.rb
+++ b/lib/ruby_lsp/requests/prepare_type_hierarchy.rb
@@ -77,7 +77,7 @@ module RubyLsp
           Interface::TypeHierarchyItem.new(
             name: first_entry.name,
             kind: kind_for_entry(first_entry),
-            uri: URI::Generic.from_path(path: first_entry.file_path).to_s,
+            uri: first_entry.uri.to_s,
             range: range,
             selection_range: range,
           ),

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -96,18 +96,7 @@ module RubyLsp
           entries = Array(entries)
           entries_to_format = max_entries ? entries.take(max_entries) : entries
           entries_to_format.each do |entry|
-            loc = entry.location
-
-            # We always handle locations as zero based. However, for file links in Markdown we need them to be one
-            # based, which is why instead of the usual subtraction of 1 to line numbers, we are actually adding 1 to
-            # columns. The format for VS Code file URIs is
-            # `file:///path/to/file.rb#Lstart_line,start_column-end_line,end_column`
-            uri = URI::Generic.from_path(
-              path: entry.file_path,
-              fragment: "L#{loc.start_line},#{loc.start_column + 1}-#{loc.end_line},#{loc.end_column + 1}",
-            )
-
-            definitions << "[#{entry.file_name}](#{uri})"
+            definitions << "[#{entry.file_name}](#{entry.declaration_uri})"
             content << "\n\n#{entry.comments.join("\n")}" unless entry.comments.empty?
           end
 

--- a/lib/ruby_lsp/requests/type_hierarchy_supertypes.rb
+++ b/lib/ruby_lsp/requests/type_hierarchy_supertypes.rb
@@ -76,7 +76,7 @@ module RubyLsp
         Interface::TypeHierarchyItem.new(
           name: entry.name,
           kind: kind_for_entry(entry),
-          uri: URI::Generic.from_path(path: entry.file_path).to_s,
+          uri: entry.uri.to_s,
           range: range_from_location(entry.location),
           selection_range: range_from_location(entry.name_location),
           detail: entry.file_name,

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -33,10 +33,11 @@ module RubyLsp
       sig { override.returns(T::Array[Interface::WorkspaceSymbol]) }
       def perform
         @index.fuzzy_search(@query).filter_map do |entry|
-          file_path = entry.file_path
+          uri = entry.uri
+          file_path = uri.to_standardized_path
 
           # We only show symbols declared in the workspace
-          in_dependencies = !not_in_dependencies?(file_path)
+          in_dependencies = file_path && !not_in_dependencies?(file_path)
           next if in_dependencies
 
           # We should never show private symbols when searching the entire workspace
@@ -55,7 +56,7 @@ module RubyLsp
             container_name: container.join("::"),
             kind: kind,
             location: Interface::Location.new(
-              uri: URI::Generic.from_path(path: file_path).to_s,
+              uri: uri.to_s,
               range:  Interface::Range.new(
                 start: Interface::Position.new(line: loc.start_line - 1, character: loc.start_column),
                 end: Interface::Position.new(line: loc.end_line - 1, character: loc.end_column),


### PR DESCRIPTION
### Motivation

First step towards #2340 and #1908

Currently, we save the file paths for entries in the index. This decision is incompatible with how language servers work, because you can have files that exist in different URI schemes (such as the one for unsaved files like `untitled:Untitled-1`).

In general, we should always strive to use URIs everywhere and only get the file paths when we want to return something or when we're reading from disk.

This PR changes our entries to store the URIs where they were declared, rather than tying ourselves with file paths. This change is necessary in order to fix #1908, because if we index files before they are saved, there's no file path associated to the declarations being made in the unsaved file.

### Implementation

The change is essentially switching from `file_path` to URI pretty much everywhere.

As an added benefit, we now no longer need to build the URI when serving features, because that's already available directly in the entries - which is another indication that standardizing on URIs is likely the best choice.

### Automated Tests

Adapted existing tests.