### PR TITLE
Index files as they are modified

### DIFF
--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -796,7 +796,7 @@ module RubyIndexer
             end
           RUBY
 
-          @index.handle_change(indexable_path)
+          @index.handle_change(indexable_path.to_uri, indexable_path)
           assert_empty(@index.instance_variable_get(:@ancestors))
           assert_equal(["Bar", "Object", "Kernel", "BasicObject"], @index.linearized_ancestors_of("Bar"))
         end
@@ -833,7 +833,7 @@ module RubyIndexer
             end
           RUBY
 
-          @index.handle_change(indexable_path)
+          @index.handle_change(indexable_path.to_uri, indexable_path)
           refute_empty(@index.instance_variable_get(:@ancestors))
           assert_equal(["Bar", "Foo", "Object", "Kernel", "BasicObject"], @index.linearized_ancestors_of("Bar"))
         end
@@ -866,7 +866,7 @@ module RubyIndexer
             end
           RUBY
 
-          @index.handle_change(indexable_path)
+          @index.handle_change(indexable_path.to_uri, indexable_path)
           assert_empty(@index.instance_variable_get(:@ancestors))
           assert_equal(["Bar", "Object", "Kernel", "BasicObject"], @index.linearized_ancestors_of("Bar"))
         end

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -95,6 +95,13 @@ module RubyLsp
       @state.delete(uri.to_s)
     end
 
+    # Returns `true` if the store contains the document with the given URI, which means that document is being managed
+    # by the client
+    sig { params(uri: URI::Generic).returns(T::Boolean) }
+    def has?(uri)
+      @state.key?(uri.to_s)
+    end
+
     sig do
       type_parameters(:T)
         .params(


### PR DESCRIPTION
### Motivation

Closes #1908

Index files as they are modified rather than waiting until they are saved. This better reflects the state of the codebase as the user is coding.

### Implementation

The idea is the following:

1. If a document is changed, without being managed by the client (that is, the file was never opened in the editor and it's not present in our Store), nothing changes. We still index the changes based on their file path
2. If the document is already managed by the client, then we simply add the declaration listener as part of all of the others in the combined requests and re-index the file as we are providing other features

The only extra thing is that we need to be able to handle ancestor changes even if the user hasn't saved the file, so I created a way to track those.

### Automated Tests

Added some tests to ensure that we index declarations in unsaved files as they are being modified and also to ensure that we don't accidentally create duplicate entries, which is a risk if we accidentally forget to clean things up.

### Manual Tests

1. Create a new file in the UI without saving it
2. Change the language mode to Ruby
3. Add a class declaration
4. Verify you get completion for the newly created class