### PR TITLE
Bump rexml to avoid security issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,8 +61,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.0)
       io-console (~> 0.5)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rubocop (1.64.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)


### PR DESCRIPTION
Versions < 3.3.2 has vulnerability issues.
https://github.com/Shopify/ruby-lsp/security/dependabot/33

