### PR TITLE
Start indexing RBS constants

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -39,6 +39,9 @@ module RubyIndexer
       case declaration
       when RBS::AST::Declarations::Class, RBS::AST::Declarations::Module
         handle_class_or_module_declaration(declaration, pathname)
+      when RBS::AST::Declarations::Constant
+        namespace_nesting = declaration.name.namespace.path.map(&:to_s)
+        handle_constant(declaration, namespace_nesting, pathname.to_s)
       else # rubocop:disable Style/EmptyElse
         # Other kinds not yet handled
       end
@@ -61,9 +64,12 @@ module RubyIndexer
       add_declaration_mixins_to_entry(declaration, entry)
       @index.add(entry)
       declaration.members.each do |member|
-        next unless member.is_a?(RBS::AST::Members::MethodDefinition)
-
-        handle_method(member, entry)
+        case member
+        when RBS::AST::Members::MethodDefinition
+          handle_method(member, entry)
+        when RBS::AST::Declarations::Constant
+          handle_constant(member, nesting, file_path)
+        end
       end
     end
 
@@ -211,6 +217,31 @@ module RubyIndexer
       name = param.name || Entry::KeywordRestParameter::DEFAULT_NAME
 
       Entry::KeywordRestParameter.new(name: name)
+    end
+
+    # RBS treats constant definitions differently depend on where they are defined.
+    # When constants' rbs defined inside a class/module block, they are treated as
+    # members of the class/module.
+    #
+    # module Encoding
+    #   US_ASCII = ... # US_ASCII is a member of Encoding
+    # end
+    #
+    # When constants' rbs defined outside a class/module block, they are treated as
+    # top-level constants.
+    #
+    # Complex::I = ... # Complex::I is a top-level constant
+    #
+    # And we need to handle their nesting differently.
+    sig { params(declaration: RBS::AST::Declarations::Constant, nesting: T::Array[String], file_path: String).void }
+    def handle_constant(declaration, nesting, file_path)
+      fully_qualified_name = [*nesting, declaration.name.name.to_s].join("::")
+      @index.add(Entry::Constant.new(
+        fully_qualified_name,
+        file_path,
+        to_ruby_indexer_location(declaration.location),
+        Array(declaration.comment&.string),
+      ))
     end
   end
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -220,14 +220,14 @@ module RubyIndexer
     end
 
     # RBS treats constant definitions differently depend on where they are defined.
-    # When constants' rbs defined inside a class/module block, they are treated as
+    # When constants' rbs are defined inside a class/module block, they are treated as
     # members of the class/module.
     #
     # module Encoding
     #   US_ASCII = ... # US_ASCII is a member of Encoding
     # end
     #
-    # When constants' rbs defined outside a class/module block, they are treated as
+    # When constants' rbs are defined outside a class/module block, they are treated as
     # top-level constants.
     #
     # Complex::I = ... # Complex::I is a top-level constant

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -181,17 +181,17 @@ module RubyIndexer
 
     def test_resolving_aliases_to_non_existing_constants_with_conflicting_names
       @index.index_single(IndexablePath.new("/fake", "/fake/path/foo.rb"), <<~RUBY)
-        class Float
+        class Bar
         end
 
         module Foo
-          class Float < self
-            INFINITY = ::Float::INFINITY
+          class Bar < self
+            BAZ = ::Bar::BAZ
           end
         end
       RUBY
 
-      entry = @index.resolve("INFINITY", ["Foo", "Float"]).first
+      entry = @index.resolve("BAZ", ["Foo", "Bar"]).first
       refute_nil(entry)
 
       assert_instance_of(Entry::UnresolvedAlias, entry)

--- a/lib/ruby_indexer/test/rbs_indexer_test.rb
+++ b/lib/ruby_indexer/test/rbs_indexer_test.rb
@@ -40,6 +40,27 @@ module RubyIndexer
       assert_operator(entry.location.end_column, :>, 0)
     end
 
+    def test_index_core_constants
+      entries = @index["RUBY_VERSION"]
+      refute_nil(entries)
+      assert_equal(1, entries.length)
+
+      # Complex::I is defined as `Complex::I = ...`
+      entries = @index["Complex::I"]
+      refute_nil(entries)
+      assert_equal(1, entries.length)
+
+      # Encoding::US_ASCII is defined as
+      # ```
+      # module Encoding
+      #   US_ASCII = ...
+      #   ...
+      # ````
+      entries = @index["Encoding::US_ASCII"]
+      refute_nil(entries)
+      assert_equal(1, entries.length)
+    end
+
     def test_index_methods
       entries = @index["initialize"]
       refute_nil(entries)


### PR DESCRIPTION
### Motivation

Closes #2328

### Implementation

1. Add `RBSIndexer::handle_constant`
2. Invoke `handle_constant` in `process_declaration` and the member loop in `handle_class_or_module_declaration`
    - This is because `rbs` treats constants differently depending on how they're defined. `Foo::CONST = 1` will be a top-level declaration while `class Foo; CONST = 1` will make `CONST` a member under `Foo` declaration.

### Automated Tests

I added a new test case for this.

### Manual Tests

1. pull the branch
2. Add `Encoding::` to a file, you should see a list of completion candidates from `encoding.rbs`
4. Finish typing `Encoding::US_ASCII`
5. `cmd+click` `US_ASCII`, you should see 2 definitions, one in `rbi` and one in `rbs`
