### PR TITLE
Make Index#index_all index rbs files too

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -106,7 +106,7 @@ if options[:time_index]
 
   puts <<~MSG
     Ruby LSP v#{RubyLsp::VERSION}: Indexing took #{result.round(5)} seconds and generated:
-    - #{entries_by_entry_type.map { |k, v| "#{k.name.split("::").last}: #{v.size}" }.join("\n- ")}
+    - #{entries_by_entry_type.sort_by { |k, _| k.to_s }.map { |k, v| "#{k.name.split("::").last}: #{v.size}" }.join("\n- ")}
   MSG
   return
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -276,6 +276,7 @@ module RubyIndexer
       ).void
     end
     def index_all(indexable_paths: RubyIndexer.configuration.indexables, &block)
+      RBSIndexer.new(self).index_ruby_core
       # Calculate how many paths are worth 1% of progress
       progress_step = (indexable_paths.length / 100.0).ceil
 

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -765,8 +765,6 @@ module RubyLsp
       # stuck indexing files
       Thread.new do
         begin
-          RubyIndexer::RBSIndexer.new(@global_state.index).index_ruby_core
-
           @global_state.index.index_all do |percentage|
             progress("indexing-progress", percentage)
             true

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1321,7 +1321,9 @@ class CompletionTest < Minitest::Test
         RubyIndexer::IndexablePath.new(tmpdir, path)
       end
 
-      index.index_all(indexable_paths: indexables)
+      indexables.each do |indexable|
+        index.index_single(indexable)
+      end
 
       block.call(tmpdir)
     ensure


### PR DESCRIPTION
### Motivation

1. Since RBS indexing isn't optional, `index_all` should index RBS files too so the name is not misleading.
2. The `--time-index` flag tracks the time taken to index all but not rbs files. Making `index_all` index rbs files too will make the flag more accurate.
    - Before:
        ```
      Ruby LSP v0.17.10: Indexing took 1.46249 seconds and generated:
      - Accessor: 3024
      - Class: 2633
      - Constant: 1819
      - InstanceVariable: 6701
      - Method: 18875
      - Module: 2376
      - SingletonClass: 796
      - UnresolvedAlias: 155
      - UnresolvedMethodAlias: 898
      ```
    - After:
      ```
      Ruby LSP v0.17.10: Indexing took 1.66698 seconds and generated:
      - Accessor: 3024
      - Class: 2746
      - Constant: 1819
      - InstanceVariable: 6701
      - Method: 20893
      - Module: 2408
      - SingletonClass: 833
      - UnresolvedAlias: 155
      - UnresolvedMethodAlias: 898
      ```

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
