### PR TITLE
Correctly linearize singleton parent classes with namespace

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -657,7 +657,7 @@ module RubyIndexer
 
         if parent_class_name && fully_qualified_name != parent_class_name
 
-          parent_name_parts = [parent_class_name]
+          parent_name_parts = parent_class_name.split("::")
           singleton_levels.times do
             parent_name_parts << "<Class:#{parent_name_parts.last}>"
           end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1765,5 +1765,29 @@ module RubyIndexer
         @index.linearized_ancestors_of("A::<Class:A>")
       end
     end
+
+    def test_linearizing_singleton_parent_class_with_namespace
+      index(<<~RUBY)
+        class ActiveRecord::Base; end
+
+        class User < ActiveRecord::Base
+        end
+      RUBY
+
+      assert_equal(
+        [
+          "User::<Class:User>",
+          "ActiveRecord::Base::<Class:Base>",
+          "Object::<Class:Object>",
+          "BasicObject::<Class:BasicObject>",
+          "Class",
+          "Module",
+          "Object",
+          "Kernel",
+          "BasicObject",
+        ],
+        @index.linearized_ancestors_of("User::<Class:User>"),
+      )
+    end
   end
 end


### PR DESCRIPTION
### Motivation

There was a mistake in the singleton parent class linearization. If the parent class is namespaced, like `ActiveRecord::Base`, we want the singleton parent class name to be `ActiveRecord::Base::<Class:Base>`.

However, because we were not splitting the name before adding the singleton levels, we were actually using `ActiveRecord::Base::<Class:ActiveRecord::Base>` accidentally, which does not exist.

### Implementation

Started splitting the name rather than creating an array with the namespaced name inside.

### Automated Tests

Added a test that reproduces the behaviour.