### PR TITLE
Properly split singleton nesting during linearization

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -448,7 +448,7 @@ module RubyIndexer
 
       # The original nesting where we discovered this namespace, so that we resolve the correct names of the
       # included/prepended/extended modules and parent classes
-      nesting = T.must(namespaces.first).nesting
+      nesting = T.must(namespaces.first).nesting.flat_map { |n| n.split("::") }
 
       if nesting.any?
         singleton_levels.times do

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1789,5 +1789,38 @@ module RubyIndexer
         @index.linearized_ancestors_of("User::<Class:User>"),
       )
     end
+
+    def test_singleton_nesting_is_correctly_split_during_linearization
+      index(<<~RUBY)
+        module Bar; end
+
+        module Foo
+          class Namespace::Parent
+            extend Bar
+          end
+        end
+
+        module Foo
+          class Child < Namespace::Parent
+          end
+        end
+      RUBY
+
+      assert_equal(
+        [
+          "Foo::Child::<Class:Child>",
+          "Foo::Namespace::Parent::<Class:Parent>",
+          "Bar",
+          "Object::<Class:Object>",
+          "BasicObject::<Class:BasicObject>",
+          "Class",
+          "Module",
+          "Object",
+          "Kernel",
+          "BasicObject",
+        ],
+        @index.linearized_ancestors_of("Foo::Child::<Class:Child>"),
+      )
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Another singleton linearization bug fix. We need to ensure that the nesting is properly split before concatenating the singleton levels, otherwise we never search the actual namespaces we're looking for.

For example, if we have the nesting as `ActiveRecord::Base::<Class:Base>`, then we want the corrected nesting for singleton linearization to be `[ActiveRecord, Base, <Class:Base>, <Class:<Class:Base>>]` and not `[ActiveRecord::Base::<Class:Base>, <Class:ActiveRecord::Base::<Class:Base>>]`.

### Implementation

We just need to flat map the nesting splitting on the namespace separators.

### Automated Tests

Added a test that demonstrates the behaviour.