### PR TITLE
Document highlight shouldn't include the block for a method invocation

### DIFF
--- a/lib/ruby_lsp/listeners/document_highlight.rb
+++ b/lib/ruby_lsp/listeners/document_highlight.rb
@@ -180,7 +180,11 @@ module RubyLsp
       def on_call_node_enter(node)
         return unless matches?(node, [Prism::CallNode, Prism::DefNode])
 
-        add_highlight(Constant::DocumentHighlightKind::READ, node.location)
+        loc = node.message_loc
+        # if we have `foo.` it's a call node but there is no message yet.
+        return unless loc
+
+        add_highlight(Constant::DocumentHighlightKind::READ, loc)
       end
 
       sig { params(node: Prism::DefNode).void }

--- a/test/expectations/document_highlight/multiple_invocations.exp.json
+++ b/test/expectations/document_highlight/multiple_invocations.exp.json
@@ -1,0 +1,75 @@
+{
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 0,
+          "character": 3
+        }
+      },
+      "kind": 2
+    },
+    {
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 0
+        },
+        "end": {
+          "line": 2,
+          "character": 3
+        }
+      },
+      "kind": 2
+    },
+    {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 3
+        }
+      },
+      "kind": 2
+    },
+    {
+      "range": {
+        "start": {
+          "line": 7,
+          "character": 0
+        },
+        "end": {
+          "line": 7,
+          "character": 3
+        }
+      },
+      "kind": 2
+    },
+    {
+      "range": {
+        "start": {
+          "line": 9,
+          "character": 0
+        },
+        "end": {
+          "line": 9,
+          "character": 3
+        }
+      },
+      "kind": 2
+    }
+  ],
+  "params": [
+    {
+      "line": 0,
+      "character": 2
+    }
+  ]
+}

--- a/test/fixtures/multiple_invocations.rb
+++ b/test/fixtures/multiple_invocations.rb
@@ -1,0 +1,10 @@
+foo()
+
+foo
+
+foo do
+end
+
+foo { }
+
+foo.


### PR DESCRIPTION
### Motivation

Closes #2332 

### Implementation

Highlight only the invocation's name, not its block.

### Automated Tests

Added a new fixture and expectation.

### Manual Tests

Open the fixture, move the cursor over `foo` and ensure only the `foo` part is highlighted in all invocations.
