### PR TITLE
Allow for indexing enhancements through included hooks

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -293,8 +293,8 @@ module RubyIndexer
 
       @enhancements.each do |enhancement|
         enhancement.on_call_node(@index, @owner_stack.last, node, @file_path)
-      rescue StandardError
-        @indexing_errors << "Error occurred when indexing #{@file_path} with '#{enhancement.class.name}' enhancement"
+      rescue StandardError => e
+        @indexing_errors << "Indexing error in #{@file_path} with '#{enhancement.class.name}' enhancement: #{e.message}"
       end
     end
 

--- a/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
@@ -1,0 +1,24 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyIndexer
+  module Enhancement
+    extend T::Sig
+    extend T::Helpers
+
+    interface!
+
+    # The `on_extend` indexing enhancement is invoked whenever an extend is encountered in the code. It can be used to
+    # register for an included callback, similar to what `ActiveSupport::Concern` does in order to auto-extend the
+    # `ClassMethods` modules
+    sig do
+      abstract.params(
+        index: Index,
+        owner: T.nilable(Entry::Namespace),
+        node: Prism::CallNode,
+        file_path: String,
+      ).void
+    end
+    def on_call_node(index, owner, node, file_path); end
+  end
+end

--- a/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
@@ -8,6 +8,8 @@ module RubyIndexer
 
     interface!
 
+    requires_ancestor { Object }
+
     # The `on_extend` indexing enhancement is invoked whenever an extend is encountered in the code. It can be used to
     # register for an included callback, similar to what `ActiveSupport::Concern` does in order to auto-extend the
     # `ClassMethods` modules

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -6,6 +6,7 @@ require "did_you_mean"
 
 require "ruby_indexer/lib/ruby_indexer/indexable_path"
 require "ruby_indexer/lib/ruby_indexer/declaration_listener"
+require "ruby_indexer/lib/ruby_indexer/enhancement"
 require "ruby_indexer/lib/ruby_indexer/index"
 require "ruby_indexer/lib/ruby_indexer/entry"
 require "ruby_indexer/lib/ruby_indexer/configuration"

--- a/lib/ruby_indexer/test/enhancements_test.rb
+++ b/lib/ruby_indexer/test/enhancements_test.rb
@@ -1,0 +1,163 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module RubyIndexer
+  class EnhancementTest < TestCase
+    def test_enhancing_indexing_included_hook
+      enhancement_class = Class.new do
+        include Enhancement
+
+        def on_call_node(index, owner, node, file_path)
+          return unless owner
+          return unless node.name == :extend
+
+          arguments = node.arguments&.arguments
+          return unless arguments
+
+          location = node.location
+
+          arguments.each do |node|
+            next unless node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
+
+            module_name = node.full_name
+            next unless module_name == "ActiveSupport::Concern"
+
+            index.register_included_hook(owner.name) do |index, base|
+              class_methods_name = "#{owner.name}::ClassMethods"
+
+              if index.indexed?(class_methods_name)
+                singleton = index.existing_or_new_singleton_class(base.name)
+                singleton.mixin_operations << Entry::Include.new(class_methods_name)
+              end
+            end
+
+            index.add(Entry::Method.new(
+              "new_method",
+              file_path,
+              location,
+              location,
+              [],
+              [Entry::Signature.new([Entry::RequiredParameter.new(name: :a)])],
+              Entry::Visibility::PUBLIC,
+              owner,
+            ))
+          rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError,
+                 Prism::ConstantPathNode::MissingNodesInConstantPathError
+            # Do nothing
+          end
+        end
+      end
+
+      @index.register_enhancement(enhancement_class.new)
+      index(<<~RUBY)
+        module ActiveSupport
+          module Concern
+            def self.extended(base)
+              base.class_eval("def new_method(a); end")
+            end
+          end
+        end
+
+        module ActiveRecord
+          module Associations
+            extend ActiveSupport::Concern
+
+            module ClassMethods
+              def belongs_to(something); end
+            end
+          end
+
+          class Base
+            include Associations
+          end
+        end
+
+        class User < ActiveRecord::Base
+        end
+      RUBY
+
+      assert_equal(
+        [
+          "User::<Class:User>",
+          "ActiveRecord::Base::<Class:Base>",
+          "ActiveRecord::Associations::ClassMethods",
+          "Object::<Class:Object>",
+          "BasicObject::<Class:BasicObject>",
+          "Class",
+          "Module",
+          "Object",
+          "Kernel",
+          "BasicObject",
+        ],
+        @index.linearized_ancestors_of("User::<Class:User>"),
+      )
+
+      assert_entry("new_method", Entry::Method, "/fake/path/foo.rb:10-4:10-33")
+    end
+
+    def test_enhancing_indexing_configuration_dsl
+      enhancement_class = Class.new do
+        include Enhancement
+
+        def on_call_node(index, owner, node, file_path)
+          return unless owner
+
+          name = node.name
+          return unless name == :has_many
+
+          arguments = node.arguments&.arguments
+          return unless arguments
+
+          association_name = arguments.first
+          return unless association_name.is_a?(Prism::SymbolNode)
+
+          location = association_name.location
+
+          index.add(Entry::Method.new(
+            T.must(association_name.value),
+            file_path,
+            location,
+            location,
+            [],
+            [],
+            Entry::Visibility::PUBLIC,
+            owner,
+          ))
+        end
+      end
+
+      @index.register_enhancement(enhancement_class.new)
+      index(<<~RUBY)
+        module ActiveSupport
+          module Concern
+            def self.extended(base)
+              base.class_eval("def new_method(a); end")
+            end
+          end
+        end
+
+        module ActiveRecord
+          module Associations
+            extend ActiveSupport::Concern
+
+            module ClassMethods
+              def belongs_to(something); end
+            end
+          end
+
+          class Base
+            include Associations
+          end
+        end
+
+        class User < ActiveRecord::Base
+          has_many :posts
+        end
+      RUBY
+
+      assert_entry("posts", Entry::Method, "/fake/path/foo.rb:23-11:23-17")
+    end
+  end
+end

--- a/lib/ruby_indexer/test/enhancements_test.rb
+++ b/lib/ruby_indexer/test/enhancements_test.rb
@@ -189,7 +189,7 @@ module RubyIndexer
         RUBY
       end
 
-      assert_match(%r{Error occurred when indexing /fake/path/foo\.rb with 'TestEnhancement' enhancement}, stderr)
+      assert_match(%r{Indexing error in /fake/path/foo\.rb with 'TestEnhancement' enhancement}, stderr)
       # The module should still be indexed
       assert_entry("ActiveSupport::Concern", Entry::Module, "/fake/path/foo.rb:1-2:5-5")
     end


### PR DESCRIPTION
### Motivation

This PR is the first step for allowing addons to enhance the indexing mechanism and a proposal of how we could handle included hooks.

Example usages https://github.com/Shopify/ruby-lsp-rails/pull/422, https://github.com/Shopify/ruby-lsp-rails/pull/423

**What does a concern do?**

For context, in order to make a module into a concern one has to `extend ActiveSupport::Concern`. Upon extending, the concern module will then dynamically define an `included` hook into the module that has extended it. Finally, the included hook will dynamically extend any `ClassMethods` module that exists inside of the original module.

```ruby
module Concern
  def self.extended(mod)
    mod.define_singleton_method(:included) do |other_module|
      other_module.extend(mod.const_get(:ClassMethods))
    end
  end
end
```

So we need a way to
- Handle the extend event, so that we can remember that a module has been made a concern
- Provide a way to run included callbacks during ancestor linearization, so that the ancestor chain can be modified dynamically

**Other use cases**

I have also considered other use cases, like creating a new instance method during an `extend` or handling something like `belongs_to` (which creates new methods on the receiver).

```ruby
module Concern
  def self.extended(base)
    base.define_method(:new_method) {}
  end
end
```

### Naming

I ended up going with "indexing augmentations" for the name of concept. The idea is to avoid using extension and plugin (too associated with editors) or addon (now associated with the language server).

Do we agree with the naming? Is indexing enhancement better? Indexing contribution?

### Implementation

The implementation has a few parts:

1. We need a way to register for augmentations and those have to be passed down to the declaration listener, so that we can invoke the events as needed
2. As with most things, we want to expose the minimum amount of methods to addons to help guide authors in their implementations. I created an interface that any object can implement, containing the only events we want to allow
3. Finally, the bulk of the logic and decisions are part of the included hooks. The augmentations will need to be able to register lazy included hooks, because during indexing we have no guarantees that we won't find an include for a concern that hasn't been found yet. We also have no guarantees that we will know which module an include refers to before we finished indexing. The idea is to allow registering blocks that get invoked once per linearization. These hooks should mutate the index with the extra information they want to include. The only time we run these blocks again is if the ancestor cache gets busted, which is exactly what we want otherwise we would lose the information forever

### Notes

I believe we do not have to support lazy extended, prepended or inherited hooks. The reason is because the concern pattern is broadly used to mix instance and class methods in a single operation. You include one module and then you get everything you need.

The opposite pattern of extending a module and then getting a dynamic include is not really common and would essentially just be the exact same thing as a concern.

And inheriting from a class already carries both instance and class methods, so there's also reduced need for meta-programming on that side.

We may discover other scenarios later, but I think it should be fine to handle included hooks only for now.

### Automated Tests

Added tests.

### Manual Tests

There's no way to test this without the changes being made to the Rails addon too. I did it locally and recorded it in action in a toy app.

https://github.com/user-attachments/assets/08255211-6bcf-4d21-b6f9-4dd264791ee8