### PR TITLE
Rename constant alias class names

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -504,17 +504,17 @@ module RubyIndexer
       @index.add(
         case value
         when Prism::ConstantReadNode, Prism::ConstantPathNode
-          Entry::UnresolvedAlias.new(value.slice, @stack.dup, name, @file_path, node.location, comments)
+          Entry::UnresolvedConstantAlias.new(value.slice, @stack.dup, name, @file_path, node.location, comments)
         when Prism::ConstantWriteNode, Prism::ConstantAndWriteNode, Prism::ConstantOrWriteNode,
         Prism::ConstantOperatorWriteNode
 
           # If the right hand side is another constant assignment, we need to visit it because that constant has to be
           # indexed too
-          Entry::UnresolvedAlias.new(value.name.to_s, @stack.dup, name, @file_path, node.location, comments)
+          Entry::UnresolvedConstantAlias.new(value.name.to_s, @stack.dup, name, @file_path, node.location, comments)
         when Prism::ConstantPathWriteNode, Prism::ConstantPathOrWriteNode, Prism::ConstantPathOperatorWriteNode,
         Prism::ConstantPathAndWriteNode
 
-          Entry::UnresolvedAlias.new(value.target.slice, @stack.dup, name, @file_path, node.location, comments)
+          Entry::UnresolvedConstantAlias.new(value.target.slice, @stack.dup, name, @file_path, node.location, comments)
         else
           Entry::Constant.new(name, @file_path, node.location, comments)
         end,

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -411,7 +411,7 @@ module RubyIndexer
     # All aliases are inserted as UnresolvedAlias in the index first and then we lazily resolve them to the correct
     # target in [rdoc-ref:Index#resolve]. If the right hand side contains a constant that doesn't exist, then it's not
     # possible to resolve the alias and it will remain an UnresolvedAlias until the right hand side constant exists
-    class UnresolvedAlias < Entry
+    class UnresolvedConstantAlias < Entry
       extend T::Sig
 
       sig { returns(String) }
@@ -439,13 +439,13 @@ module RubyIndexer
     end
 
     # Alias represents a resolved alias, which points to an existing constant target
-    class Alias < Entry
+    class ConstantAlias < Entry
       extend T::Sig
 
       sig { returns(String) }
       attr_reader :target
 
-      sig { params(target: String, unresolved_alias: UnresolvedAlias).void }
+      sig { params(target: String, unresolved_alias: UnresolvedConstantAlias).void }
       def initialize(target, unresolved_alias)
         super(unresolved_alias.name, unresolved_alias.file_path, unresolved_alias.location, unresolved_alias.comments)
 

--- a/lib/ruby_indexer/test/constant_test.rb
+++ b/lib/ruby_indexer/test/constant_test.rb
@@ -200,12 +200,12 @@ module RubyIndexer
       RUBY
 
       unresolve_entry = @index["A::FIRST"].first
-      assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
+      assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("B::C", unresolve_entry.target)
 
       resolved_entry = @index.resolve("A::FIRST", []).first
-      assert_instance_of(Entry::Alias, resolved_entry)
+      assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::B::C", resolved_entry.target)
     end
 
@@ -226,12 +226,12 @@ module RubyIndexer
       RUBY
 
       unresolve_entry = @index["A::ALIAS"].first
-      assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
+      assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("B", unresolve_entry.target)
 
       resolved_entry = @index.resolve("ALIAS", ["A"]).first
-      assert_instance_of(Entry::Alias, resolved_entry)
+      assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::B", resolved_entry.target)
 
       resolved_entry = @index.resolve("ALIAS::C", ["A"]).first
@@ -239,7 +239,7 @@ module RubyIndexer
       assert_equal("A::B::C", resolved_entry.name)
 
       unresolve_entry = @index["Other::ONE_MORE"].first
-      assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
+      assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["Other"], unresolve_entry.nesting)
       assert_equal("A::ALIAS", unresolve_entry.target)
 
@@ -259,12 +259,12 @@ module RubyIndexer
 
       # B and C
       unresolve_entry = @index["A::B"].first
-      assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
+      assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("C", unresolve_entry.target)
 
       resolved_entry = @index.resolve("A::B", []).first
-      assert_instance_of(Entry::Alias, resolved_entry)
+      assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::C", resolved_entry.target)
 
       constant = @index["A::C"].first
@@ -272,38 +272,38 @@ module RubyIndexer
 
       # D and E
       unresolve_entry = @index["A::D"].first
-      assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
+      assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("E", unresolve_entry.target)
 
       resolved_entry = @index.resolve("A::D", []).first
-      assert_instance_of(Entry::Alias, resolved_entry)
+      assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::E", resolved_entry.target)
 
       # F and G::H
       unresolve_entry = @index["A::F"].first
-      assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
+      assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("G::H", unresolve_entry.target)
 
       resolved_entry = @index.resolve("A::F", []).first
-      assert_instance_of(Entry::Alias, resolved_entry)
+      assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::G::H", resolved_entry.target)
 
       # I::J, K::L and M
       unresolve_entry = @index["A::I::J"].first
-      assert_instance_of(Entry::UnresolvedAlias, unresolve_entry)
+      assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("K::L", unresolve_entry.target)
 
       resolved_entry = @index.resolve("A::I::J", []).first
-      assert_instance_of(Entry::Alias, resolved_entry)
+      assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::K::L", resolved_entry.target)
 
       # When we are resolving A::I::J, we invoke `resolve("K::L", ["A"])`, which recursively resolves A::K::L too.
       # Therefore, both A::I::J and A::K::L point to A::M by the end of the previous resolve invocation
       resolved_entry = @index["A::K::L"].first
-      assert_instance_of(Entry::Alias, resolved_entry)
+      assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::M", resolved_entry.target)
 
       constant = @index["A::M"].first
@@ -344,11 +344,11 @@ module RubyIndexer
       RUBY
 
       assert_entry("A::B", Entry::Constant, "/fake/path/foo.rb:1-2:1-3")
-      assert_entry("A::C", Entry::UnresolvedAlias, "/fake/path/foo.rb:1-5:1-6")
-      assert_entry("A::D::E", Entry::UnresolvedAlias, "/fake/path/foo.rb:2-2:2-6")
+      assert_entry("A::C", Entry::UnresolvedConstantAlias, "/fake/path/foo.rb:1-5:1-6")
+      assert_entry("A::D::E", Entry::UnresolvedConstantAlias, "/fake/path/foo.rb:2-2:2-6")
       assert_entry("A::F::G", Entry::Constant, "/fake/path/foo.rb:2-8:2-12")
       assert_entry("A::H", Entry::Constant, "/fake/path/foo.rb:3-2:3-3")
-      assert_entry("A::I::J", Entry::UnresolvedAlias, "/fake/path/foo.rb:3-5:3-9")
+      assert_entry("A::I::J", Entry::UnresolvedConstantAlias, "/fake/path/foo.rb:3-5:3-9")
       assert_entry("A::K", Entry::Constant, "/fake/path/foo.rb:4-2:4-3")
       assert_entry("A::L", Entry::Constant, "/fake/path/foo.rb:4-5:4-6")
     end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -194,7 +194,7 @@ module RubyIndexer
       entry = @index.resolve("BAZ", ["Foo", "Bar"]).first
       refute_nil(entry)
 
-      assert_instance_of(Entry::UnresolvedAlias, entry)
+      assert_instance_of(Entry::UnresolvedConstantAlias, entry)
     end
 
     def test_visitor_does_not_visit_unnecessary_nodes
@@ -1015,11 +1015,11 @@ module RubyIndexer
 
       foo_entry = T.must(@index.resolve("FOO", ["Namespace"])&.first)
       assert_equal(2, foo_entry.location.start_line)
-      assert_instance_of(Entry::Alias, foo_entry)
+      assert_instance_of(Entry::ConstantAlias, foo_entry)
 
       bar_entry = T.must(@index.resolve("BAR", ["Namespace"])&.first)
       assert_equal(3, bar_entry.location.start_line)
-      assert_instance_of(Entry::Alias, bar_entry)
+      assert_instance_of(Entry::ConstantAlias, bar_entry)
     end
 
     def test_resolving_circular_alias_three_levels
@@ -1033,15 +1033,15 @@ module RubyIndexer
 
       foo_entry = T.must(@index.resolve("FOO", ["Namespace"])&.first)
       assert_equal(2, foo_entry.location.start_line)
-      assert_instance_of(Entry::Alias, foo_entry)
+      assert_instance_of(Entry::ConstantAlias, foo_entry)
 
       bar_entry = T.must(@index.resolve("BAR", ["Namespace"])&.first)
       assert_equal(3, bar_entry.location.start_line)
-      assert_instance_of(Entry::Alias, bar_entry)
+      assert_instance_of(Entry::ConstantAlias, bar_entry)
 
       baz_entry = T.must(@index.resolve("BAZ", ["Namespace"])&.first)
       assert_equal(4, baz_entry.location.start_line)
-      assert_instance_of(Entry::Alias, baz_entry)
+      assert_instance_of(Entry::ConstantAlias, baz_entry)
     end
 
     def test_resolving_constants_in_aliased_namespace


### PR DESCRIPTION
### Motivation

This is to match MethodAlias and UnresolvedMethodAlias.

### Implementation

- Alias should be ConstantAlias
- UnresolvedAlias should be UnresolvedConstantAlias

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
