### PR TITLE
Fix grammar for class and module keyword matching

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -65,7 +65,7 @@
         }
       },
       "comment": "class Namespace::ClassName < OtherNamespace::OtherClassName",
-      "match": "(class)\\s+(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)\\s*((<)\\s*(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*))?",
+      "match": "\b(class)\\s+(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)\\s*((<)\\s*(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*))?",
       "name": "meta.class.ruby"
     },
     {
@@ -80,7 +80,7 @@
           "name": "punctuation.separator.namespace.ruby"
         }
       },
-      "match": "(module)\\s+(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)",
+      "match": "\b(module)\\s+(([a-zA-Z0-9_]+)((::)[a-zA-Z0-9_]+)*)",
       "name": "meta.module.ruby"
     },
     {
@@ -92,7 +92,7 @@
           "name": "punctuation.separator.inheritance.ruby"
         }
       },
-      "match": "(class)\\s*(<<)\\s*",
+      "match": "\b(class)\\s*(<<)\\s*",
       "name": "meta.class.ruby"
     },
     {


### PR DESCRIPTION
### Motivation

See https://github.com/Shopify/ruby-lsp/issues/2302

### Implementation

Only match if there is a preceding word boundary character.

Before:
<img width="180" alt="Screenshot 2024-07-26 at 11 43 20 AM" src="https://github.com/user-attachments/assets/746767a4-24f4-4ce2-ae86-da7f7db7018f">

After:
<img width="172" alt="Screenshot 2024-07-26 at 11 43 11 AM" src="https://github.com/user-attachments/assets/4aa6d731-9ae0-4c34-a383-a3546ba98306">

### Automated Tests

None

### Manual Tests

Try enter the same code as the screenshots above.

You will need to launch via the extension host to verify.
