### PR TITLE
Add switch block refactor

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -223,6 +223,40 @@ module RubyLsp
       NodeContext.new(closest, parent, nesting_nodes, call_node)
     end
 
+    sig do
+      params(
+        range: T::Hash[Symbol, T.untyped],
+        node_types: T::Array[T.class_of(Prism::Node)],
+      ).returns(T.nilable(Prism::Node))
+    end
+    def locate_first_within_range(range, node_types: [])
+      scanner = create_scanner
+      start_position = scanner.find_char_position(range[:start])
+      end_position = scanner.find_char_position(range[:end])
+      desired_range = (start_position...end_position)
+      queue = T.let(@parse_result.value.child_nodes.compact, T::Array[T.nilable(Prism::Node)])
+
+      until queue.empty?
+        candidate = queue.shift
+
+        # Skip nil child nodes
+        next if candidate.nil?
+
+        # Add the next child_nodes to the queue to be processed. The order here is important! We want to move in the
+        # same order as the visiting mechanism, which means searching the child nodes before moving on to the next
+        # sibling
+        T.unsafe(queue).unshift(*candidate.child_nodes)
+
+        # Skip if the current node doesn't cover the desired position
+        loc = candidate.location
+
+        if desired_range.cover?(loc.start_offset...loc.end_offset) &&
+            (node_types.empty? || node_types.any? { |type| candidate.class == type })
+          return candidate
+        end
+      end
+    end
+
     sig { returns(SorbetLevel) }
     def sorbet_level
       sigil = parse_result.magic_comments.find do |comment|

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -47,6 +47,8 @@ module RubyLsp
 
       sig { override.returns(T.any(Interface::CodeAction, Error)) }
       def perform
+        return Error::EmptySelection if @document.source.empty?
+
         case @code_action[:title]
         when CodeActions::EXTRACT_TO_VARIABLE_TITLE
           refactor_variable
@@ -63,8 +65,6 @@ module RubyLsp
 
       sig { returns(T.any(Interface::CodeAction, Error)) }
       def switch_block_style
-        return Error::EmptySelection if @document.source.empty?
-
         source_range = @code_action.dig(:data, :range)
         return Error::EmptySelection if source_range[:start] == source_range[:end]
 
@@ -78,25 +78,7 @@ module RubyLsp
         node = target.block
         return Error::InvalidTargetRange unless node.is_a?(Prism::BlockNode)
 
-        parameters = node.parameters
-        body = node.body
-
-        # If the block is using `do...end` style, we change it to a single line brace block. Newlines are turned into
-        # semi colons, so that the result is valid Ruby code and still a one liner. If the block is using brace style,
-        # we do the opposite and turn it into a `do...end` block, making all semi colons into newlines.
-        new_source = if node.opening_loc.slice == "do"
-          source = +"{ "
-          source << "#{parameters.slice} " if parameters
-          source << "#{body.slice.gsub("\n", ";")} " if body
-          source << "}"
-        else
-          indentation = " " * target.location.start_column
-          source = +"do"
-          source << " #{parameters.slice}" if parameters
-          source << "\n#{indentation}  "
-          source << body.slice.gsub(";", "\n") if body
-          source << "\n#{indentation}end"
-        end
+        indentation = " " * target.location.start_column unless node.opening_loc.slice == "do"
 
         Interface::CodeAction.new(
           title: CodeActions::SWITCH_BLOCK_STYLE_TITLE,
@@ -108,7 +90,10 @@ module RubyLsp
                   version: nil,
                 ),
                 edits: [
-                  Interface::TextEdit.new(range: range_from_location(node.location), new_text: new_source),
+                  Interface::TextEdit.new(
+                    range: range_from_location(node.location),
+                    new_text: recursively_switch_nested_block_styles(node, indentation),
+                  ),
                 ],
               ),
             ],
@@ -118,8 +103,6 @@ module RubyLsp
 
       sig { returns(T.any(Interface::CodeAction, Error)) }
       def refactor_variable
-        return Error::EmptySelection if @document.source.empty?
-
         source_range = @code_action.dig(:data, :range)
         return Error::EmptySelection if source_range[:start] == source_range[:end]
 
@@ -214,8 +197,6 @@ module RubyLsp
 
       sig { returns(T.any(Interface::CodeAction, Error)) }
       def refactor_method
-        return Error::EmptySelection if @document.source.empty?
-
         source_range = @code_action.dig(:data, :range)
         return Error::EmptySelection if source_range[:start] == source_range[:end]
 
@@ -276,6 +257,64 @@ module RubyLsp
           ),
           new_text: new_text,
         )
+      end
+
+      sig { params(node: Prism::BlockNode, indentation: T.nilable(String)).returns(String) }
+      def recursively_switch_nested_block_styles(node, indentation)
+        parameters = node.parameters
+        body = node.body
+
+        # We use the indentation to differentiate between do...end and brace style blocks because only the do...end
+        # style requires the indentation to build the edit.
+        #
+        # If the block is using `do...end` style, we change it to a single line brace block. Newlines are turned into
+        # semi colons, so that the result is valid Ruby code and still a one liner. If the block is using brace style,
+        # we do the opposite and turn it into a `do...end` block, making all semi colons into newlines.
+        source = +""
+
+        if indentation
+          source << "do"
+          source << " #{parameters.slice}" if parameters
+          source << "\n#{indentation}  "
+          source << switch_block_body(body, indentation) if body
+          source << "\n#{indentation}end"
+        else
+          source << "{ "
+          source << "#{parameters.slice} " if parameters
+          source << switch_block_body(body, nil) if body
+          source << "}"
+        end
+
+        source
+      end
+
+      sig { params(body: Prism::Node, indentation: T.nilable(String)).returns(String) }
+      def switch_block_body(body, indentation)
+        # Check if there are any nested blocks inside of the current block
+        body_loc = body.location
+        nested_block = @document.locate_first_within_range(
+          {
+            start: { line: body_loc.start_line - 1, character: body_loc.start_column },
+            end: { line: body_loc.end_line - 1, character: body_loc.end_column },
+          },
+          node_types: [Prism::BlockNode],
+        )
+
+        body_content = body.slice.dup
+
+        # If there are nested blocks, then we change their style too and we have to mutate the string using the
+        # relative position in respect to the beginning of the body
+        if nested_block.is_a?(Prism::BlockNode)
+          location = nested_block.location
+          correction_start = location.start_offset - body_loc.start_offset
+          correction_end = location.end_offset - body_loc.start_offset
+          next_indentation = indentation ? "#{indentation}  " : nil
+
+          body_content[correction_start...correction_end] =
+            recursively_switch_nested_block_styles(nested_block, next_indentation)
+        end
+
+        indentation ? body_content.gsub(";", "\n") : "#{body_content.gsub("\n", ";")} "
       end
     end
   end

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -21,6 +21,7 @@ module RubyLsp
 
       EXTRACT_TO_VARIABLE_TITLE = "Refactor: Extract Variable"
       EXTRACT_TO_METHOD_TITLE = "Refactor: Extract Method"
+      SWITCH_BLOCK_STYLE_TITLE = "Refactor: Switch block style"
 
       class << self
         extend T::Sig
@@ -67,6 +68,11 @@ module RubyLsp
           code_actions << Interface::CodeAction.new(
             title: EXTRACT_TO_METHOD_TITLE,
             kind: Constant::CodeActionKind::REFACTOR_EXTRACT,
+            data: { range: @range, uri: @uri.to_s },
+          )
+          code_actions << Interface::CodeAction.new(
+            title: SWITCH_BLOCK_STYLE_TITLE,
+            kind: Constant::CodeActionKind::REFACTOR_REWRITE,
             data: { range: @range, uri: @uri.to_s },
           )
         end

--- a/test/expectations/code_action_resolve/aref_call_aref_assign.exp.json
+++ b/test/expectations/code_action_resolve/aref_call_aref_assign.exp.json
@@ -1,0 +1,47 @@
+{
+    "params": {
+        "kind": "refactor.rewrite",
+        "title": "Refactor: Switch block style",
+        "data": {
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 0
+                },
+                "end": {
+                    "line": 0,
+                    "character": 58
+                }
+            },
+            "uri": "file:///fake"
+        }
+    },
+    "result": {
+        "title": "Refactor: Switch block style",
+        "edit": {
+            "documentChanges": [
+                {
+                    "textDocument": {
+                        "uri": "file:///fake",
+                        "version": null
+                    },
+                    "edits": [
+                        {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 26
+                                },
+                                "end": {
+                                    "line": 0,
+                                    "character": 58
+                                }
+                            },
+                            "newText": "do |a|\n  a[\"field\"] == \"expected\"\nend"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/test/expectations/code_action_resolve/nested_block_calls.exp.json
+++ b/test/expectations/code_action_resolve/nested_block_calls.exp.json
@@ -1,0 +1,47 @@
+{
+    "params": {
+        "kind": "refactor.rewrite",
+        "title": "Refactor: Switch block style",
+        "data": {
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 0
+                },
+                "end": {
+                    "line": 3,
+                    "character": 3
+                }
+            },
+            "uri": "file:///fake"
+        }
+    },
+    "result": {
+        "title": "Refactor: Switch block style",
+        "edit": {
+            "documentChanges": [
+                {
+                    "textDocument": {
+                        "uri": "file:///fake",
+                        "version": null
+                    },
+                    "edits": [
+                        {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 29
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "character": 3
+                                }
+                            },
+                            "newText": "{ |a| nested_call(fourth_call).each do |b|;  end }"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/test/expectations/code_action_resolve/nested_oneline_blocks.exp.json
+++ b/test/expectations/code_action_resolve/nested_oneline_blocks.exp.json
@@ -9,8 +9,8 @@
                     "character": 0
                 },
                 "end": {
-                    "line": 3,
-                    "character": 3
+                    "line": 0,
+                    "character": 74
                 }
             },
             "uri": "file:///fake"
@@ -33,11 +33,11 @@
                                     "character": 29
                                 },
                                 "end": {
-                                    "line": 3,
-                                    "character": 3
+                                    "line": 0,
+                                    "character": 74
                                 }
                             },
-                            "newText": "{ |a| nested_call(fourth_call).each { |b| } }"
+                            "newText": "do |a|\n  nested_call(fourth_call).each do |b|\n    \n  end\nend"
                         }
                     ]
                 }

--- a/test/expectations/code_actions/aref_field.exp.json
+++ b/test/expectations/code_actions/aref_field.exp.json
@@ -52,6 +52,23 @@
         },
         "uri": "file:///fake"
       }
+    },
+    {
+      "title": "Refactor: Switch block style",
+      "kind": "refactor.rewrite",
+      "data": {
+        "range": {
+          "start": {
+            "line": 2,
+            "character": 9
+          },
+          "end": {
+            "line": 2,
+            "character": 13
+          }
+        },
+        "uri": "file:///fake"
+      }
     }
   ]
 }

--- a/test/fixtures/nested_block_calls.rb
+++ b/test/fixtures/nested_block_calls.rb
@@ -1,0 +1,4 @@
+method_call(other_call).each do |a|
+  nested_call(fourth_call).each do |b|
+  end
+end

--- a/test/fixtures/nested_oneline_blocks.rb
+++ b/test/fixtures/nested_oneline_blocks.rb
@@ -1,0 +1,1 @@
+method_call(other_call).each { |a| nested_call(fourth_call).each { |b| } }

--- a/test/requests/code_actions_expectations_test.rb
+++ b/test/requests/code_actions_expectations_test.rb
@@ -76,7 +76,7 @@ class CodeActionsExpectationsTest < ExpectationsTestRunner
   def code_action_for_refactor(refactor)
     LanguageServer::Protocol::Interface::CodeAction.new(
       title: refactor["title"],
-      kind: LanguageServer::Protocol::Constant::CodeActionKind::REFACTOR_EXTRACT,
+      kind: refactor["kind"],
       data: {
         range: refactor.dig("data", "range"),
         uri: refactor.dig("data", "uri"),

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -716,6 +716,29 @@ class RubyDocumentTest < Minitest::Test
     assert_equal("qux", node_context.surrounding_method)
   end
 
+  def test_locate_first_within_range
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
+      method_call(other_call).each do |a|
+        nested_call(fourth_call).each do |b|
+        end
+      end
+    RUBY
+
+    target = document.locate_first_within_range(
+      { start: { line: 0, character: 0 }, end: { line: 3, character: 3 } },
+      node_types: [Prism::CallNode],
+    )
+
+    assert_equal("each", T.cast(target, Prism::CallNode).message)
+
+    target = document.locate_first_within_range(
+      { start: { line: 1, character: 2 }, end: { line: 2, character: 5 } },
+      node_types: [Prism::CallNode],
+    )
+
+    assert_equal("each", T.cast(target, Prism::CallNode).message)
+  end
+
   private
 
   def assert_error_edit(actual, error_range)


### PR DESCRIPTION
### Motivation

This PR adds a new refactor code action to switch the style of a block. If the block uses `do..end`, it becomes a one liner brace block and vice-versa.

### Implementation

The first commit adds a new method to locate the first node matching a given list of types within the selected range. This is important for refactors, because users will select the code they want to apply some refactor on and we need to ignore the surrounding extra selection if it doesn't match the expected node.

The second commit adds the code action.

### Automated Tests

Added tests.

### Manual Tests

Select a block, click the light bulb (CMD + .) and select switch block style.


https://github.com/user-attachments/assets/96ee9615-2975-486d-9579-81360cd862fd