### PR TITLE
Fix NodeContext's handling of namespaced singleton method

### DIFF
--- a/lib/ruby_lsp/node_context.rb
+++ b/lib/ruby_lsp/node_context.rb
@@ -89,12 +89,12 @@ module RubyLsp
         when Prism::ClassNode, Prism::ModuleNode
           nesting << node.constant_path.slice
         when Prism::SingletonClassNode
-          nesting << "<Class:#{nesting.last}>"
+          nesting << "<Class:#{nesting.flat_map { |n| n.split("::") }.last}>"
         when Prism::DefNode
           surrounding_method = node.name.to_s
           next unless node.receiver.is_a?(Prism::SelfNode)
 
-          nesting << "<Class:#{nesting.last}>"
+          nesting << "<Class:#{nesting.flat_map { |n| n.split("::") }.last}>"
         end
       end
 

--- a/test/type_inferrer_test.rb
+++ b/test/type_inferrer_test.rb
@@ -138,6 +138,19 @@ module RubyLsp
       assert_equal("Foo::<Class:Foo>::<Class:<Class:Foo>>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
+    def test_infer_receiver_type_in_namespaced_singleton_method
+      node_context = index_and_locate(<<~RUBY, { line: 2, character: 4 })
+        class Foo::Bar
+          def self.foo
+            bar
+          end
+        end
+      RUBY
+
+      result = @type_inferrer.infer_receiver_type(node_context).name
+      assert_equal("Foo::Bar::<Class:Bar>", result)
+    end
+
     def test_infer_receiver_type_instance_variables_in_singleton_block_method
       node_context = index_and_locate(<<~RUBY, { line: 3, character: 6 })
         class Foo


### PR DESCRIPTION
### Motivation

When handling namespaced singleton method, the `handle_nesting_nodes` method should split the current last nesting before creating the singleton class nesting with it.

Failing to do so would let the TypeInferrer infer the wrong type for the singleton method's receiver.

### Implementation

Similar to https://github.com/Shopify/ruby-lsp/pull/2355, we should split the last nesting with `::` too before using it to create the singleton nesting's name.

### Automated Tests

Added a new test case for it.

### Manual Tests

In a non-Sorbet project, add `test.rb` with

```rb
class Foo::Bar
  def self.foo
    bar # go-to-definition here
  end

  def self.bar
  end
end
```

In `main`, the `bar` won't have go-to-definition support. But with this branch, `cmd+click` `bar` should take you to its definition.

