### PR TITLE
List install VS Code extensions as part of `--doctor`

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -129,6 +129,10 @@ if options[:doctor]
     puts "indexing: #{indexable.full_path}"
     index.index_single(indexable)
   end
+
+  # This will fail silently if `code` is not available
+  system("code --list-extensions --show-versions")
+
   return
 end
 


### PR DESCRIPTION
Just a little idea I had: What if we list the extensions as part of `--doctor` to aid with troubleshooting? The intention would be that people can paste this into an issue.