### PR TITLE
Correct capability objects for document symbol, folding range, and hover

### DIFF
--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -34,14 +34,9 @@ module RubyLsp
       class << self
         extend T::Sig
 
-        sig { returns(Interface::DocumentSymbolClientCapabilities) }
+        sig { returns(Interface::DocumentSymbolOptions) }
         def provider
-          Interface::DocumentSymbolClientCapabilities.new(
-            hierarchical_document_symbol_support: true,
-            symbol_kind: {
-              value_set: (Constant::SymbolKind::FILE..Constant::SymbolKind::TYPE_PARAMETER).to_a,
-            },
-          )
+          Interface::DocumentSymbolOptions.new
         end
       end
 

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -23,9 +23,9 @@ module RubyLsp
       class << self
         extend T::Sig
 
-        sig { returns(Interface::FoldingRangeClientCapabilities) }
+        sig { returns(Interface::FoldingRangeOptions) }
         def provider
-          Interface::FoldingRangeClientCapabilities.new(line_folding_only: true)
+          Interface::FoldingRangeOptions.new
         end
       end
 

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -22,9 +22,9 @@ module RubyLsp
       class << self
         extend T::Sig
 
-        sig { returns(Interface::HoverClientCapabilities) }
+        sig { returns(Interface::HoverOptions) }
         def provider
-          Interface::HoverClientCapabilities.new(dynamic_registration: false)
+          Interface::HoverOptions.new
         end
       end
 


### PR DESCRIPTION
### Motivation

ClientCapabilities are for the client (editor) to tell the server (ruby-lsp) what it can do. The server should not be sending these back to the client. Instead, the server should be sending back either boolean values or Options objects.

We can use [Document Symbol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol) to prove that we're currently sending the wrong value back. Its **Server Capability** says:

```
property name (optional): documentSymbolProvider
property type: boolean | DocumentSymbolOptions where [DocumentSymbolOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbolOptions) is defined as follows:

export interface [DocumentSymbolOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbolOptions) extends [WorkDoneProgressOptions](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workDoneProgressOptions) {
	/**
	 * A human-readable string that is shown when multiple outlines trees
	 * are shown for the same document.
	 *
	 * @since 3.16.0
	 */
	label?: string;
}
```

This indicates that if we send back `DocumentSymbolOptions` with `label` value, we can change DocumentSymbol's tree label. And when I changed `DocumentSymbol.provider` to

```rb
          Interface::DocumentSymbolOptions.new(label: "From Ruby LSP")
```

We can see it does change the tree label:

<img width="80%" alt="Screenshot 2024-07-31 at 20 52 53" src="https://github.com/user-attachments/assets/ad1ae2e8-13b4-4e78-86cc-f9174cb8bd53">


### Implementation

This commit corrects the responses for the document symbol, folding range, and hover requests to send back the correct values.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
