### PR TITLE
Disable certain LSP features for .erb files through registration options

### DIFF
--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -25,9 +25,12 @@ module RubyLsp
       class << self
         extend T::Sig
 
-        sig { returns(Interface::CodeActionOptions) }
+        sig { returns(Interface::CodeActionRegistrationOptions) }
         def provider
-          Interface::CodeActionOptions.new(resolve_provider: true)
+          Interface::CodeActionRegistrationOptions.new(
+            document_selector: [Interface::DocumentFilter.new(language: "ruby")],
+            resolve_provider: true,
+          )
         end
       end
 

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -22,12 +22,13 @@ module RubyLsp
       class << self
         extend T::Sig
 
-        sig { returns(T::Hash[Symbol, T::Boolean]) }
+        sig { returns(Interface::DiagnosticRegistrationOptions) }
         def provider
-          {
-            interFileDependencies: false,
-            workspaceDiagnostics: false,
-          }
+          Interface::DiagnosticRegistrationOptions.new(
+            document_selector: [Interface::DocumentFilter.new(language: "ruby")],
+            inter_file_dependencies: false,
+            workspace_diagnostics: false,
+          )
         end
       end
 

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -23,9 +23,13 @@ module RubyLsp
       class << self
         extend T::Sig
 
-        sig { returns(Interface::FoldingRangeOptions) }
+        sig { returns(Interface::FoldingRangeRegistrationOptions) }
         def provider
-          Interface::FoldingRangeOptions.new
+          Interface::FoldingRangeRegistrationOptions.new(
+            document_selector: [
+              Interface::DocumentFilter.new(language: "ruby"),
+            ],
+          )
         end
       end
 

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -27,6 +27,19 @@ module RubyLsp
 
       class Error < StandardError; end
 
+      class << self
+        extend T::Sig
+
+        sig { returns(Interface::DocumentFormattingRegistrationOptions) }
+        def provider
+          Interface::DocumentFormattingRegistrationOptions.new(
+            document_selector: [
+              Interface::DocumentFilter.new(language: "ruby"),
+            ],
+          )
+        end
+      end
+
       sig { params(global_state: GlobalState, document: Document).void }
       def initialize(global_state, document)
         super()

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -21,9 +21,10 @@ module RubyLsp
       class << self
         extend T::Sig
 
-        sig { returns(Interface::DocumentOnTypeFormattingOptions) }
+        sig { returns(Interface::DocumentOnTypeFormattingRegistrationOptions) }
         def provider
-          Interface::DocumentOnTypeFormattingOptions.new(
+          Interface::DocumentOnTypeFormattingRegistrationOptions.new(
+            document_selector: [Interface::DocumentFilter.new(language: "ruby")],
             first_trigger_character: "{",
             more_trigger_character: ["\n", "|", "d"],
           )


### PR DESCRIPTION
### Motivation

Closes #2394

Also improves the existing approach of disabling requests on erb files.

### Implementation

For editors supporting LSP's [register capability](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#client_registerCapability), the LSP server can tell them which document type the particular request supports.

Currently, VS Code, Emacs (Eglot), and Neovim have all supported it. So I think it's fair to assume most editors should work with this feature.

#### Folding Range

VS Code currently doesn't support multiple folding range providers for the same document. So if Ruby LSP provides folding range for `erb` files, users would lose their original folding range options. Since in most cases folding HTML structure is more useful than folding erb code, I decided to disable folding range for erb files.

**Before**

<img width="80%" alt="Screenshot 2024-07-31 at 22 51 31" src="https://github.com/user-attachments/assets/22d6df17-11c6-4a84-85ba-1956633645f9">

**After**

<img width="80%" alt="Screenshot 2024-07-31 at 23 41 48" src="https://github.com/user-attachments/assets/be4764d2-9bc1-41d4-b8c9-d07273e1cddf">



#### Formatting, OnTypeFormatting, Diagnostics, and Code Action

Instead of using early return to disable these requests, I also migrated them to use document selector to inform the client instead.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
