### PR TITLE
Fix custom bundle reference to Gemfile above top level of working directory

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -42,6 +42,8 @@ module RubyLsp
 
       @gemfile_name = T.let(@gemfile&.basename&.to_s || "Gemfile", String)
 
+      $stderr.puts("Ruby LSP> Gemfile: #{@gemfile}") if @gemfile && @gemfile != Pathname.pwd.join("Gemfile")
+
       # Custom bundle paths
       @custom_dir = T.let(Pathname.new(".ruby-lsp").expand_path(Dir.pwd), Pathname)
       @custom_gemfile = T.let(@custom_dir + @gemfile_name, Pathname)
@@ -133,7 +135,8 @@ module RubyLsp
       # If there's a top level Gemfile, we want to evaluate from the custom bundle. We get the source from the top level
       # Gemfile, so if there isn't one we need to add a default source
       if @gemfile&.exist?
-        parts << "eval_gemfile(File.expand_path(\"../#{@gemfile_name}\", __dir__))"
+        gemfile_path = @gemfile.relative_path_from(@custom_dir)
+        parts << "eval_gemfile(File.expand_path(\"#{gemfile_path}\", __dir__))"
       else
         parts.unshift('source "https://rubygems.org"')
       end


### PR DESCRIPTION
### Motivation

When running ruby-lsp from a directory where the gemfile is in a parent directory, it works fine if the bundle includes the required dependencies (ruby-lsp and debug). If it doesn't, the custom bundle built at `.ruby-lsp/Gemfile` has `eval_gemfile('../Gemfile')` which causes the `bundle install` to fail.

It also fails if the project has a custom gemfile path set via the bundle config. This PR doesn't address that but will help with fixing it.

### Implementation

Updated `write_custom_gemfile` to use the correct path for the project gemfile.

### Automated Tests

Added a test for the change and another that was missing.

### Manual Tests

With a directory tree like:

```
test/
|- Gemfile
|- Gemfile.lock
|- proj/
|  |- test.rb
```

Run `ruby-lsp` from `proj/` or open `proj` in VSCode and open `test.rb` to trigger the extension to activate in the workspace.
