### PR TITLE
Require Ruby 3.1 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
+ruby ">= 3.1"
+
 gem "bundler", "~> 2.5"
 gem "minitest", "~> 5.23"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,5 +156,8 @@ DEPENDENCIES
   syntax_tree (>= 6.1.1, < 7)
   tapioca (~> 0.13)
 
+RUBY VERSION
+   ruby 3.3.4p94
+
 BUNDLED WITH
    2.5.10


### PR DESCRIPTION
The `ruby-lsp` gem supports 3.0 or above, but its `rbi` development dependency requires Ruby 3.1. And because dependabot always uses the lowest required Ruby to run the job, it's always failing to find the right `rbi` version.

Hopefully this change will make dependabot use Ruby 3.1 and above instead.
