### PR TITLE
Update rexml and revert 2405

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
-ruby ">= 3.1"
-
 gem "bundler", "~> 2.5"
 gem "minitest", "~> 5.23"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.0)
       io-console (~> 0.5)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rubocop (1.64.1)
       json (~> 2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,8 +156,5 @@ DEPENDENCIES
   syntax_tree (>= 6.1.1, < 7)
   tapioca (~> 0.13)
 
-RUBY VERSION
-   ruby 3.3.4p94
-
 BUNDLED WITH
    2.5.10


### PR DESCRIPTION
1. Revert #2405's change as it doesn't work and we don't actually need the check for other purposes
2. Bump `rexml` because it has security issue and fails dependabot's vulnerability check