### PR TITLE
LazyVim: Expand home directory for easier configuration

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -154,7 +154,7 @@ return {
       servers = {
         ruby_lsp = {
           mason = false,
-          cmd = { "/Users/username/.asdf/shims/ruby-lsp" },
+          cmd = { vim.fn.expand "~/.asdf/shims/ruby-lsp" },
         },
       },
     },


### PR DESCRIPTION
By using Neovim's `vim.fn.expand`, we can expand the `~` to the current user's home dir, allowing the snippet to be used as-is, without having to change it.

### Motivation

This allows the configuration example to be used as-is, without having to remember to change the path after copying it into the nvim config.

### Implementation

n/a
### Automated Tests

n/a

### Manual Tests

n/a