### PR TITLE
Indicate multiple signatures for Hover and Completion Resolve

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -542,6 +542,11 @@ module RubyIndexer
       def decorated_parameters
         @target.decorated_parameters
       end
+
+      sig { returns(T::Array[Signature]) }
+      def signatures
+        @target.signatures
+      end
     end
 
     # Ruby doesn't support method overloading, so a method will have only one signature.

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -342,6 +342,19 @@ module RubyIndexer
 
         "(#{first_signature.format})"
       end
+
+      sig { returns(String) }
+      def formatted_signatures
+        overloads_count = signatures.size
+        case overloads_count
+        when 1
+          ""
+        when 2
+          "\n(+1 overload)"
+        else
+          "\n(+#{overloads_count - 1} overloads)"
+        end
+      end
     end
 
     class Accessor < Member
@@ -541,6 +554,11 @@ module RubyIndexer
       sig { returns(String) }
       def decorated_parameters
         @target.decorated_parameters
+      end
+
+      sig { returns(String) }
+      def formatted_signatures
+        @target.formatted_signatures
       end
 
       sig { returns(T::Array[Signature]) }

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -177,12 +177,7 @@ module RubyLsp
         first_method = T.must(methods.first)
 
         title = "#{message}#{first_method.decorated_parameters}"
-        overloads_count = first_method.signatures.size
-        if overloads_count == 2
-          title << "\n(+1 overload)"
-        elsif overloads_count > 2
-          title << "\n(+#{overloads_count - 1} overloads)"
-        end
+        title << first_method.formatted_signatures
 
         if type.is_a?(TypeInferrer::GuessedType)
           title << "\n\nGuessed receiver: #{type.name}"

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -174,7 +174,15 @@ module RubyLsp
         methods = @index.resolve_method(message, type.name, inherited_only: inherited_only)
         return unless methods
 
-        title = "#{message}#{T.must(methods.first).decorated_parameters}"
+        first_method = T.must(methods.first)
+
+        title = "#{message}#{first_method.decorated_parameters}"
+        overloads_count = first_method.signatures.size
+        if overloads_count == 2
+          title << "\n(+1 overload)"
+        elsif overloads_count > 2
+          title << "\n(+#{overloads_count - 1} overloads)"
+        end
 
         if type.is_a?(TypeInferrer::GuessedType)
           title << "\n\nGuessed receiver: #{type.name}"

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -63,6 +63,13 @@ module RubyLsp
 
         if first_entry.is_a?(RubyIndexer::Entry::Member)
           label = +"#{label}#{first_entry.decorated_parameters}"
+
+          overloads_count = first_entry.signatures.size
+          if overloads_count == 2
+            label << "\n(+1 overload)"
+          elsif overloads_count > 2
+            label << "\n(+#{overloads_count - 1} overloads)"
+          end
         end
 
         guessed_type = @item.dig(:data, :guessed_type)

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -63,13 +63,7 @@ module RubyLsp
 
         if first_entry.is_a?(RubyIndexer::Entry::Member)
           label = +"#{label}#{first_entry.decorated_parameters}"
-
-          overloads_count = first_entry.signatures.size
-          if overloads_count == 2
-            label << "\n(+1 overload)"
-          elsif overloads_count > 2
-            label << "\n(+#{overloads_count - 1} overloads)"
-          end
+          label << first_entry.formatted_signatures
         end
 
         guessed_type = @item.dig(:data, :guessed_type)


### PR DESCRIPTION
### Motivation

Partially addresses https://github.com/Shopify/ruby-lsp/issues/2363

Co-authored with @vinistock 

### Implementation

We are following TypeScript's lead on how to indicate that there are overloads.

In a follow-up we will start trying to intelligently match the correct signature as the arguments are typed.

### Automated Tests

Included

### Manual Tests

* Enter a method with overloads, e.g. `String.try_convert`
* Verify that hovering indicates there are multiple overloads
* Verify that completion indicates there are multiple overloads
