### PR TITLE
Use window log messages instead of printing to stderr

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -65,7 +65,7 @@ module RubyLsp
         when "initialize", "initialized", "textDocument/didOpen", "textDocument/didClose", "textDocument/didChange"
           process_message(message)
         when "shutdown"
-          $stderr.puts("Shutting down Ruby LSP...")
+          send_log_message("Shutting down Ruby LSP...")
 
           shutdown
 
@@ -76,7 +76,7 @@ module RubyLsp
         when "exit"
           @mutex.synchronize do
             status = @incoming_queue.closed? ? 0 : 1
-            $stderr.puts("Shutdown complete with status #{status}")
+            send_log_message("Shutdown complete with status #{status}")
             exit(status)
           end
         else
@@ -144,6 +144,11 @@ module RubyLsp
     sig { params(id: Integer).void }
     def send_empty_response(id)
       send_message(Result.new(id: id, response: nil))
+    end
+
+    sig { params(message: String, type: Integer).void }
+    def send_log_message(message, type: Constant::MessageType::LOG)
+      send_message(Notification.window_log_message(message, type: Constant::MessageType::LOG))
     end
   end
 end

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -53,6 +53,7 @@ module RubyLsp
   class Notification < Message
     class << self
       extend T::Sig
+
       sig { params(message: String).returns(Notification) }
       def window_show_error(message)
         new(
@@ -61,6 +62,14 @@ module RubyLsp
             type: Constant::MessageType::ERROR,
             message: message,
           ),
+        )
+      end
+
+      sig { params(message: String, type: Integer).returns(Notification) }
+      def window_log_message(message, type: Constant::MessageType::LOG)
+        new(
+          method: "window/logMessage",
+          params: Interface::LogMessageParams.new(type: type, message: message),
         )
       end
     end
@@ -121,6 +130,9 @@ module RubyLsp
 
     sig { returns(T.untyped) }
     attr_reader :response
+
+    sig { returns(Integer) }
+    attr_reader :id
 
     sig { params(id: Integer, response: T.untyped).void }
     def initialize(id:, response:)


### PR DESCRIPTION
### Motivation

Closes #2057

This PR adds some extra logging to our automatic detections and gets rid of most `$stderr.puts` usages in the code (in tests it's fine).

We should always use `window/logMessage` when showing some trace to the user, which allows us to set the type and follows the specification.

The only remaining usages of puts are in the indexer, which I will follow up with another PR to get rid of.

### Implementation

Added a convenience method to create log messages and started using it everywhere instead of printing.

As an added benefit, this PR forces us to separate presentation from logic instead of just putting puts everywhere.

### Automated Tests

Made a few adjustments to the server test to make it more robust.