### PR TITLE
Revert "Direct to wiki for community-supported editors"

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -1,10 +1,7 @@
 # Editors
 
-This file contains community driven instructions on how to set up the Ruby LSP in some popular editors.
-For VS Code, use the official [Ruby LSP extension](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp).
-
-Due to reviewing capacity, we aren't able to keep all the available editors documented here.
-For other editors, we encourage the community to the use [public wiki](https://github.com/Shopify/ruby-lsp/wiki).
+This file contains community driven instructions on how to set up the Ruby LSP in editors other than VS Code. For VS
+Code, use the official [Ruby LSP extension](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp).
 
 > [!NOTE]
 > Some Ruby LSP features may be unavailable or limited due to incomplete implementations of the Language Server


### PR DESCRIPTION
Reverts Shopify/ruby-lsp#2414

We have decided against using the wiki at the moment.