### PR TITLE
Rely always on workspace URI instead of Dir.pwd

### DIFF
--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -250,7 +250,7 @@ module RubyLsp
         when :require_relative
           required_file = "#{node.content}.rb"
           path = @uri.to_standardized_path
-          current_folder = path ? Pathname.new(CGI.unescape(path)).dirname : Dir.pwd
+          current_folder = path ? Pathname.new(CGI.unescape(path)).dirname : @global_state.workspace_path
           candidate = File.expand_path(File.join(current_folder, required_file))
 
           @response_builder << Interface::Location.new(

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1000,10 +1000,10 @@ module RubyLsp
 
       return unless indexing_options
 
+      configuration = @global_state.index.configuration
+      configuration.workspace_path = @global_state.workspace_path
       # The index expects snake case configurations, but VS Code standardizes on camel case settings
-      @global_state.index.configuration.apply_config(
-        indexing_options.transform_keys { |key| key.to_s.gsub(/([A-Z])/, "_\\1").downcase },
-      )
+      configuration.apply_config(indexing_options.transform_keys { |key| key.to_s.gsub(/([A-Z])/, "_\\1").downcase })
     end
   end
 end

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -43,7 +43,7 @@ module RubyLsp
       @gemfile_name = T.let(@gemfile&.basename&.to_s || "Gemfile", String)
 
       # Custom bundle paths
-      @custom_dir = T.let(Pathname.new(".ruby-lsp").expand_path(Dir.pwd), Pathname)
+      @custom_dir = T.let(Pathname.new(".ruby-lsp").expand_path(@project_path), Pathname)
       @custom_gemfile = T.let(@custom_dir + @gemfile_name, Pathname)
       @custom_lockfile = T.let(@custom_dir + (@lockfile&.basename || "Gemfile.lock"), Pathname)
       @lockfile_hash_path = T.let(@custom_dir + "main_lockfile_hash", Pathname)
@@ -183,14 +183,14 @@ module RubyLsp
       # `.ruby-lsp` folder, which is not the user's intention. For example, if the path is configured as `vendor`, we
       # want to install it in the top level `vendor` and not `.ruby-lsp/vendor`
       path = Bundler.settings["path"]
-      expanded_path = File.expand_path(path, Dir.pwd) if path
+      expanded_path = File.expand_path(path, @project_path) if path
 
       # Use the absolute `BUNDLE_PATH` to prevent accidentally creating unwanted folders under `.ruby-lsp`
       env = {}
       env["BUNDLE_GEMFILE"] = bundle_gemfile.to_s
       env["BUNDLE_PATH"] = expanded_path if expanded_path
 
-      local_config_path = File.join(Dir.pwd, ".bundle")
+      local_config_path = File.join(@project_path, ".bundle")
       env["BUNDLE_APP_CONFIG"] = local_config_path if Dir.exist?(local_config_path)
 
       # If `ruby-lsp` and `debug` (and potentially `ruby-lsp-rails`) are already in the Gemfile, then we shouldn't try

--- a/sorbet/rbi/shims/file.rbi
+++ b/sorbet/rbi/shims/file.rbi
@@ -1,0 +1,8 @@
+# typed: true
+
+class File
+  class << self
+    sig { params(path: String).returns(T::Boolean) }
+    def absolute_path?(path); end
+  end
+end

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -34,16 +34,6 @@ class SetupBundlerTest < Minitest::Test
     FileUtils.rm_r(".ruby-lsp") if Dir.exist?(".ruby-lsp")
   end
 
-  def test_in_a_rails_app_does_nothing_if_ruby_lsp_and_ruby_lsp_rails_and_debug_are_in_the_bundle
-    Object.any_instance.expects(:system).with(bundle_env, "(bundle check || bundle install) 1>&2").returns(true)
-    Bundler::LockfileParser.any_instance.expects(:dependencies)
-      .returns({ "ruby-lsp" => true, "ruby-lsp-rails" => true, "debug" => true })
-    run_script
-    refute_path_exists(".ruby-lsp")
-  ensure
-    FileUtils.rm_r(".ruby-lsp") if Dir.exist?(".ruby-lsp")
-  end
-
   def test_in_a_rails_app_removes_ruby_lsp_folder_if_all_gems_were_added_to_the_bundle
     Object.any_instance.expects(:system).with(bundle_env, "(bundle check || bundle install) 1>&2").returns(true)
     Bundler::LockfileParser.any_instance.expects(:dependencies)
@@ -57,7 +47,7 @@ class SetupBundlerTest < Minitest::Test
 
   def test_creates_custom_bundle
     Object.any_instance.expects(:system).with(
-      bundle_env(".ruby-lsp/Gemfile"),
+      bundle_env(Dir.pwd, ".ruby-lsp/Gemfile"),
       "(bundle check || bundle install) 1>&2",
     ).returns(true)
     Bundler::LockfileParser.any_instance.expects(:dependencies).returns({}).at_least_once
@@ -76,7 +66,7 @@ class SetupBundlerTest < Minitest::Test
 
   def test_creates_custom_bundle_for_a_rails_app
     Object.any_instance.expects(:system).with(
-      bundle_env(".ruby-lsp/Gemfile"),
+      bundle_env(Dir.pwd, ".ruby-lsp/Gemfile"),
       "(bundle check || bundle install) 1>&2",
     ).returns(true)
 
@@ -111,7 +101,7 @@ class SetupBundlerTest < Minitest::Test
             system("bundle install")
 
             # Run the script once to generate a custom bundle
-            run_script
+            run_script(dir)
           end
         end
 
@@ -136,11 +126,11 @@ class SetupBundlerTest < Minitest::Test
         # we evaluate lazily, then we only find dependencies after the lockfile was copied, and then run bundle install
         # instead, which re-locks and adds the ruby-lsp
         Object.any_instance.expects(:system).with(
-          bundle_env(".ruby-lsp/Gemfile"),
+          bundle_env(dir, ".ruby-lsp/Gemfile"),
           "(bundle check || bundle install) 1>&2",
         ).returns(true)
         Bundler.with_unbundled_env do
-          run_script
+          run_script(dir)
         end
       end
     end
@@ -160,7 +150,7 @@ class SetupBundlerTest < Minitest::Test
             system("bundle install")
 
             # Run the script once to generate a custom bundle
-            run_script
+            run_script(dir)
           end
         end
 
@@ -168,7 +158,7 @@ class SetupBundlerTest < Minitest::Test
 
         capture_subprocess_io do
           Object.any_instance.expects(:system).with(
-            bundle_env(".ruby-lsp/Gemfile"),
+            bundle_env(dir, ".ruby-lsp/Gemfile"),
             "((bundle check && bundle update ruby-lsp debug) || bundle install) 1>&2",
           ).returns(true)
 
@@ -176,7 +166,7 @@ class SetupBundlerTest < Minitest::Test
 
           Bundler.with_unbundled_env do
             # Run the script again without having the lockfile modified
-            run_script
+            run_script(dir)
           end
         end
       end
@@ -197,7 +187,7 @@ class SetupBundlerTest < Minitest::Test
             system("bundle install")
 
             # Run the script once to generate a custom bundle
-            run_script
+            run_script(dir)
           end
         end
 
@@ -205,13 +195,13 @@ class SetupBundlerTest < Minitest::Test
 
         capture_subprocess_io do
           Object.any_instance.expects(:system).with(
-            bundle_env(".ruby-lsp/Gemfile"),
+            bundle_env(dir, ".ruby-lsp/Gemfile"),
             "(bundle check || bundle install) 1>&2",
           ).returns(true)
 
           Bundler.with_unbundled_env do
             # Run the script again without having the lockfile modified
-            run_script
+            run_script(dir)
           end
         end
       end
@@ -221,7 +211,7 @@ class SetupBundlerTest < Minitest::Test
   def test_uses_absolute_bundle_path_for_bundle_install
     Bundler.settings.temporary(path: "vendor/bundle") do
       Object.any_instance.expects(:system).with(
-        bundle_env(".ruby-lsp/Gemfile"),
+        bundle_env(Dir.pwd, ".ruby-lsp/Gemfile"),
         "(bundle check || bundle install) 1>&2",
       ).returns(true)
       Bundler::LockfileParser.any_instance.expects(:dependencies).returns({}).at_least_once
@@ -235,14 +225,14 @@ class SetupBundlerTest < Minitest::Test
     # Create a temporary directory with no Gemfile or Gemfile.lock
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
-        bundle_gemfile = Pathname.new(".ruby-lsp").expand_path(Dir.pwd) + "Gemfile"
+        bundle_gemfile = Pathname.new(".ruby-lsp").expand_path(dir) + "Gemfile"
         Object.any_instance.expects(:system).with(
-          bundle_env(bundle_gemfile.to_s),
+          bundle_env(dir, bundle_gemfile.to_s),
           "(bundle check || bundle install) 1>&2",
         ).returns(true)
 
         Bundler.with_unbundled_env do
-          run_script
+          run_script(dir)
         end
 
         assert_path_exists(".ruby-lsp")
@@ -261,7 +251,7 @@ class SetupBundlerTest < Minitest::Test
 
         Bundler.with_unbundled_env do
           assert_raises(RubyLsp::SetupBundler::BundleNotLocked) do
-            run_script
+            run_script(dir)
           end
         end
       end
@@ -301,9 +291,12 @@ class SetupBundlerTest < Minitest::Test
         FileUtils.touch(File.join(dir, "Gemfile.lock"))
 
         Bundler.with_unbundled_env do
-          Object.any_instance.expects(:system).with(bundle_env, "(bundle check || bundle install) 1>&2").returns(true)
+          Object.any_instance.expects(:system).with(
+            bundle_env(File.realpath(dir)),
+            "(bundle check || bundle install) 1>&2",
+          ).returns(true)
           Bundler::LockfileParser.any_instance.expects(:dependencies).returns({})
-          run_script
+          run_script(dir)
         end
 
         refute_path_exists(".ruby-lsp")
@@ -316,12 +309,12 @@ class SetupBundlerTest < Minitest::Test
       Dir.chdir(dir) do
         bundle_gemfile = Pathname.new(".ruby-lsp").expand_path(Dir.pwd) + "Gemfile"
         Object.any_instance.expects(:system).with(
-          bundle_env(bundle_gemfile.to_s),
+          bundle_env(dir, bundle_gemfile.to_s),
           "(bundle check || bundle install) 1>&2",
         ).returns(true)
 
         Bundler.with_unbundled_env do
-          run_script(branch: "test-branch")
+          run_script(File.realpath(dir), branch: "test-branch")
         end
 
         assert_path_exists(".ruby-lsp")
@@ -346,18 +339,18 @@ class SetupBundlerTest < Minitest::Test
             system("bundle install")
 
             # Run the script once to generate a custom bundle
-            run_script
+            run_script(dir)
           end
         end
 
         capture_subprocess_io do
           Object.any_instance.expects(:system).with(
-            bundle_env(".ruby-lsp/Gemfile"),
+            bundle_env(dir, ".ruby-lsp/Gemfile"),
             "((bundle check && bundle update ruby-lsp debug --pre) || bundle install) 1>&2",
           ).returns(true)
 
           Bundler.with_unbundled_env do
-            run_script(experimental: true)
+            run_script(dir, experimental: true)
           end
         end
       end
@@ -371,11 +364,11 @@ class SetupBundlerTest < Minitest::Test
         Bundler.with_unbundled_env do
           Bundler.settings.temporary(without: "production") do
             Object.any_instance.expects(:system).with(
-              bundle_env(bundle_gemfile.to_s),
+              bundle_env(dir, bundle_gemfile.to_s),
               "(bundle check || bundle install) 1>&2",
             ).returns(true)
 
-            run_script
+            run_script(File.realpath(dir))
           end
         end
       end
@@ -393,7 +386,7 @@ class SetupBundlerTest < Minitest::Test
         Bundler.with_unbundled_env do
           capture_subprocess_io do
             system("bundle install")
-            run_script
+            run_script(dir)
           end
         end
 
@@ -471,7 +464,7 @@ class SetupBundlerTest < Minitest::Test
         Bundler.with_unbundled_env do
           capture_subprocess_io do
             system("bundle install")
-            run_script
+            run_script(File.realpath(dir))
           end
         end
 
@@ -500,11 +493,11 @@ class SetupBundlerTest < Minitest::Test
         end
 
         Object.any_instance.expects(:system).with(
-          bundle_env(".ruby-lsp/Gemfile"),
+          bundle_env(dir, ".ruby-lsp/Gemfile"),
           "(bundle check || bundle install) 1>&2",
         ).returns(true)
         Bundler.with_unbundled_env do
-          run_script
+          run_script(dir)
         end
 
         assert_path_exists(".ruby-lsp/Gemfile")
@@ -569,7 +562,7 @@ class SetupBundlerTest < Minitest::Test
         LOCKFILE
 
         Bundler.with_unbundled_env do
-          run_script
+          run_script(dir)
         end
 
         # Verify that the script recovered and re-generated the custom bundle from scratch
@@ -584,7 +577,7 @@ class SetupBundlerTest < Minitest::Test
 
   # This method runs the script and then immediately unloads it. This allows us to make assertions against the effects
   # of running the script multiple times
-  def run_script(path = "/fake/project/path", expected_path: nil, **options)
+  def run_script(path = Dir.pwd, expected_path: nil, **options)
     bundle_path = T.let(nil, T.nilable(String))
 
     stdout, _stderr = capture_subprocess_io do
@@ -595,12 +588,12 @@ class SetupBundlerTest < Minitest::Test
     assert_equal(expected_path, bundle_path) if expected_path
   end
 
-  def bundle_env(bundle_gemfile = "Gemfile")
-    bundle_gemfile_path = Pathname.new(bundle_gemfile)
+  def bundle_env(base_path = Dir.pwd, bundle_gemfile = "Gemfile")
+    bundle_gemfile_path = Pathname.new(base_path).join(bundle_gemfile)
     path = Bundler.settings["path"]
 
     env = {}
-    env["BUNDLE_PATH"] = File.expand_path(path, Dir.pwd) if path
+    env["BUNDLE_PATH"] = File.expand_path(path, base_path) if path
     env["BUNDLE_GEMFILE"] =
       bundle_gemfile_path.absolute? ? bundle_gemfile_path.to_s : bundle_gemfile_path.expand_path(Dir.pwd).to_s
 


### PR DESCRIPTION
### Motivation

Closes #2382

This PR stops using `Dir.pwd` and starts relying exclusively on the workspace URI provided by the client. `Dir.pwd` is not adequate because clients may spawn the language server in a directory that isn't the workspace. In addition to that, `Dir.pwd` may be a symlink, which can also cause issues in certain situations (as we received reports in the past).

### Important note

There's one major caveat here. We are still unable to get rid of [this usage of Dir.pwd](https://github.com/Shopify/ruby-lsp/blob/94ed71a0ab8a14a69cf96c0ea4fce3d38adefe69/exe/ruby-lsp#L67) when setting up the custom bundle.

The reason is because the way Bundler works is a bit incompatible with how language servers work and that prevents us from doing the right thing here. What the LSP spec dictates is that a language server should spawn and immediately respond to the `initialize` request.

However, for user convenience, we first setup the custom bundle, so that people don't have to add `ruby-lsp` to their Gemfiles. Ideally, we would

- Spawn the server
- Read the initialize request to get the workspace URI
- Then setup the custom bundle
- After a successful custom bundle setup, re-invoke `Bundler.setup` to organize the load paths as necessary
- And then respond back to the editor

Bundler doesn't allow you to invoke `Bundler.setup` twice. And even if we only invoke it once, we would not be able to require anything until the `Bundler.setup` call happens because that may lead to required gem version mismatches.

This is the reason why we setup the custom bundle and then [replace the existing process with a bundle exec version of it](https://github.com/Shopify/ruby-lsp/blob/94ed71a0ab8a14a69cf96c0ea4fce3d38adefe69/exe/ruby-lsp#L76).

Because of the process replacement thing, we cannot read the `initialize` request from STDIN while setting up the custom bundle or else the parameters for initialization would be completely lost after re-launching the process with bundle exec.

Finally, since we cannot read the request parameters during custom bundle initialization, we do not know what the workspace URI is.

My hope is to work more closely with the Bundler team and brainstorm some way that dependency setup can be better integrated into the way language servers work. That would not only improve the `Dir.pwd` thing, but it would allow us to display custom error messages depending on which failures happened during the custom bundle setup. For now, this is the best we can do.

### Implementation

Started using the provided workspace URI everywhere and removed all `Dir.pwd` usages that aren't in tests.

### Automated Tests

Adapted existing tests.