### PR TITLE
Use `toggle` block style for code action instead of switch

### DIFF
--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -54,7 +54,7 @@ module RubyLsp
           refactor_variable
         when CodeActions::EXTRACT_TO_METHOD_TITLE
           refactor_method
-        when CodeActions::SWITCH_BLOCK_STYLE_TITLE
+        when CodeActions::TOGGLE_BLOCK_STYLE_TITLE
           switch_block_style
         else
           Error::UnknownCodeAction
@@ -81,7 +81,7 @@ module RubyLsp
         indentation = " " * target.location.start_column unless node.opening_loc.slice == "do"
 
         Interface::CodeAction.new(
-          title: CodeActions::SWITCH_BLOCK_STYLE_TITLE,
+          title: CodeActions::TOGGLE_BLOCK_STYLE_TITLE,
           edit: Interface::WorkspaceEdit.new(
             document_changes: [
               Interface::TextDocumentEdit.new(

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -21,7 +21,7 @@ module RubyLsp
 
       EXTRACT_TO_VARIABLE_TITLE = "Refactor: Extract Variable"
       EXTRACT_TO_METHOD_TITLE = "Refactor: Extract Method"
-      SWITCH_BLOCK_STYLE_TITLE = "Refactor: Switch block style"
+      TOGGLE_BLOCK_STYLE_TITLE = "Refactor: Toggle block style"
 
       class << self
         extend T::Sig
@@ -71,7 +71,7 @@ module RubyLsp
             data: { range: @range, uri: @uri.to_s },
           )
           code_actions << Interface::CodeAction.new(
-            title: SWITCH_BLOCK_STYLE_TITLE,
+            title: TOGGLE_BLOCK_STYLE_TITLE,
             kind: Constant::CodeActionKind::REFACTOR_REWRITE,
             data: { range: @range, uri: @uri.to_s },
           )

--- a/test/expectations/code_action_resolve/aref_call_aref_assign.exp.json
+++ b/test/expectations/code_action_resolve/aref_call_aref_assign.exp.json
@@ -1,7 +1,7 @@
 {
     "params": {
         "kind": "refactor.rewrite",
-        "title": "Refactor: Switch block style",
+        "title": "Refactor: Toggle block style",
         "data": {
             "range": {
                 "start": {
@@ -17,7 +17,7 @@
         }
     },
     "result": {
-        "title": "Refactor: Switch block style",
+        "title": "Refactor: Toggle block style",
         "edit": {
             "documentChanges": [
                 {

--- a/test/expectations/code_action_resolve/nested_block_calls.exp.json
+++ b/test/expectations/code_action_resolve/nested_block_calls.exp.json
@@ -1,7 +1,7 @@
 {
     "params": {
         "kind": "refactor.rewrite",
-        "title": "Refactor: Switch block style",
+        "title": "Refactor: Toggle block style",
         "data": {
             "range": {
                 "start": {
@@ -17,7 +17,7 @@
         }
     },
     "result": {
-        "title": "Refactor: Switch block style",
+        "title": "Refactor: Toggle block style",
         "edit": {
             "documentChanges": [
                 {

--- a/test/expectations/code_action_resolve/nested_oneline_blocks.exp.json
+++ b/test/expectations/code_action_resolve/nested_oneline_blocks.exp.json
@@ -1,7 +1,7 @@
 {
     "params": {
         "kind": "refactor.rewrite",
-        "title": "Refactor: Switch block style",
+        "title": "Refactor: Toggle block style",
         "data": {
             "range": {
                 "start": {
@@ -17,7 +17,7 @@
         }
     },
     "result": {
-        "title": "Refactor: Switch block style",
+        "title": "Refactor: Toggle block style",
         "edit": {
             "documentChanges": [
                 {

--- a/test/expectations/code_actions/aref_field.exp.json
+++ b/test/expectations/code_actions/aref_field.exp.json
@@ -54,7 +54,7 @@
       }
     },
     {
-      "title": "Refactor: Switch block style",
+      "title": "Refactor: Toggle block style",
       "kind": "refactor.rewrite",
       "data": {
         "range": {


### PR DESCRIPTION
### Motivation

We agreed that `Switch` could potentially be confusing with a `switch` statement (even though in Ruby it is called a `when` statement).

This PR just changes the wording of the code action to say `Toggle block style`, which is indeed clearer than `Switch block style`.
