### PR TITLE
Enhance debugger attachment requests

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -469,7 +469,14 @@
               }
             }
           },
-          "attach": {}
+          "attach": {
+            "properties": {
+              "debugSocketPath": {
+                "type": "string",
+                "description": "The path to the debug socket. This is used to connect to the debugger"
+              }
+            }
+          }
         },
         "configurationSnippets": [
           {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -474,6 +474,14 @@
               "debugSocketPath": {
                 "type": "string",
                 "description": "The path to the debug socket. This is used to connect to the debugger"
+              },
+              "debugPort": {
+                "type": "number",
+                "description": "The port to use to connect to the debugger"
+              },
+              "debugHost": {
+                "type": "string",
+                "description": "The host to use to connect to the debugger"
               }
             }
           }

--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -189,6 +189,18 @@ export class Debugger
   private async attachDebuggee(
     session: vscode.DebugSession,
   ): Promise<vscode.DebugAdapterDescriptor> {
+    const debugPort = session.configuration.debugPort;
+
+    if (debugPort) {
+      const debugHost = session.configuration.debugHost;
+
+      if (debugHost) {
+        return new vscode.DebugAdapterServer(debugPort, debugHost);
+      }
+
+      return new vscode.DebugAdapterServer(debugPort);
+    }
+
     // When using attach, a process will be launched using Ruby debug and it will create a socket automatically. We have
     // to find the available sockets and ask the user which one they want to attach to
     const sockets = await this.getSockets(session);

--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -161,6 +161,13 @@ export class Debugger
 
   private async getSockets(session: vscode.DebugSession) {
     const configuration = session.configuration;
+
+    const debugSocketPath = session.configuration.debugSocketPath;
+
+    if (debugSocketPath) {
+      return [debugSocketPath];
+    }
+
     let sockets: string[] = [];
 
     try {


### PR DESCRIPTION
### Motivation

Port and host support closes #1787
Socket path support is required for https://github.com/Shopify/team-ruby-dx/issues/926

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

1. Run the extension with a Rails project as the extension development host
2. To test `debugSocketPath`:
    1. Run the server with `RUBY_DEBUG_SOCK_PATH=/tmp/debug-socket-test bundle exec rdbg -O -n -c -- bin/rails s`
    2. Check attaching with the vanilla attaching config failed:
        ```json
            {
                "type": "ruby_lsp",
                "name": "Attach to rdbg server",
                "request": "attach",
            }
        ```
    3. Check attaching with `debugSocketPath` succeeded:
        ```json
            {
                "type": "ruby_lsp",
                "name": "Attach to rdbg server",
                "request": "attach",
                "debugSocketPath": "/tmp/debug-socket-test"
            }
        ```
3. To test `debugPort` and `debugHost`:
    1. Run the server with `bundle exec rdbg -p 1234 -O -n -c -- bin/rails s`
    2. Check attaching with the vanilla attaching config failed:
        ```json
            {
                "type": "ruby_lsp",
                "name": "Attach to rdbg server",
                "request": "attach",
            }
        ```
    3. Check attaching with `debugPort` succeeded:
        ```json
            {
                "type": "ruby_lsp",
                "name": "Attach to rdbg server",
                "request": "attach",
                "debugPort": 1234
            }
        ```
    4. Check attaching with incorrect `debugHost` failed:
        ```json
            {
                "type": "ruby_lsp",
                "name": "Attach to rdbg server",
                "request": "attach",
                "debugPort": 1234,
                "debugHost": "foobar" # should cause `getaddrinfo ENOTFOUND foobar` error
            }
        ```
