### PR TITLE
Bugfix: Recognise ERB files correctly in Neovim

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -296,7 +296,7 @@ module RubyLsp
       @mutex.synchronize do
         text_document = message.dig(:params, :textDocument)
         language_id = case text_document[:languageId]
-        when "erb"
+        when "erb", "eruby"
           Document::LanguageId::ERB
         else
           Document::LanguageId::Ruby


### PR DESCRIPTION
### Motivation

Though ruby-lsp supports ERB files, in Neovim these were either not being parsed at all, or, following [this update to lspconfig](https://github.com/neovim/nvim-lspconfig/pull/3266), parsed as Ruby (with all the associated errors that brings).

### Implementation

Checking for "eruby" as the filetype, as well as "erb" gets things working.

There is one caveat: I still have a single error in each file being thrown by Rubocop: `Lint/Syntax: unexpected token tLT This offense is not auto-correctable`. I presume this does not occur in VS Code but can’t see any code preventing Rubocop in ERB files, so would appreciate any thoughts on that. Still worth merging as-is, I believe, as it reduces a screen full of errors and no functionality to one error plus functionality.

### Automated Tests

Not applicable

### Manual Tests

In VS Code there should be no change, in Neovim ERB HTML files should now be parsed correctly.
