### PR TITLE
Make configuration part of the index

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -112,20 +112,20 @@ if options[:time_index]
 end
 
 if options[:doctor]
+  index = RubyIndexer::Index.new
+
   if File.exist?(".index.yml")
     begin
       config = YAML.parse_file(".index.yml").to_ruby
     rescue => e
       abort("Error parsing config: #{e.message}")
     end
-    RubyIndexer.configuration.apply_config(config)
+    index.configuration.apply_config(config)
   end
-
-  index = RubyIndexer::Index.new
 
   puts "Globbing for indexable files"
 
-  RubyIndexer.configuration.indexables.each do |indexable|
+  index.configuration.indexables.each do |indexable|
     puts "indexing: #{indexable.full_path}"
     index.index_single(indexable)
   end

--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -44,7 +44,7 @@ puts "\n"
 puts "Verifying that indexing executes successfully. This may take a while..."
 
 index = RubyIndexer::Index.new
-indexables = RubyIndexer.configuration.indexables
+indexables = index.configuration.indexables
 
 indexables.each_with_index do |indexable, i|
   index.index_single(indexable)

--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -552,7 +552,7 @@ module RubyIndexer
         comment_content = comment.location.slice.chomp
 
         # invalid encodings would raise an "invalid byte sequence" exception
-        if !comment_content.valid_encoding? || comment_content.match?(RubyIndexer.configuration.magic_comment_regex)
+        if !comment_content.valid_encoding? || comment_content.match?(@index.configuration.magic_comment_regex)
           next
         end
 

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -11,6 +11,9 @@ module RubyIndexer
     # The minimum Jaro-Winkler similarity score for an entry to be considered a match for a given fuzzy search query
     ENTRY_SIMILARITY_THRESHOLD = 0.7
 
+    sig { returns(Configuration) }
+    attr_reader :configuration
+
     sig { void }
     def initialize
       # Holds all entries in the index using the following format:
@@ -44,6 +47,8 @@ module RubyIndexer
         {},
         T::Hash[String, T::Array[T.proc.params(index: Index, base: Entry::Namespace).void]],
       )
+
+      @configuration = T.let(RubyIndexer::Configuration.new, Configuration)
     end
 
     # Register an enhancement to the index. Enhancements must conform to the `Enhancement` interface
@@ -296,7 +301,7 @@ module RubyIndexer
         block: T.nilable(T.proc.params(progress: Integer).returns(T::Boolean)),
       ).void
     end
-    def index_all(indexable_paths: RubyIndexer.configuration.indexables, &block)
+    def index_all(indexable_paths: @configuration.indexables, &block)
       RBSIndexer.new(self).index_ruby_core
       # Calculate how many paths are worth 1% of progress
       progress_step = (indexable_paths.length / 100.0).ceil

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -15,12 +15,4 @@ require "ruby_indexer/lib/ruby_indexer/location"
 require "ruby_indexer/lib/ruby_indexer/rbs_indexer"
 
 module RubyIndexer
-  @configuration = T.let(Configuration.new, Configuration)
-
-  class << self
-    extend T::Sig
-
-    sig { returns(Configuration) }
-    attr_reader :configuration
-  end
 end

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -108,7 +108,7 @@ module RubyIndexer
     end
 
     def test_magic_comments_regex
-      regex = RubyIndexer.configuration.magic_comment_regex
+      regex = @config.magic_comment_regex
 
       [
         "# frozen_string_literal:",

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -877,7 +877,7 @@ module RubyLsp
 
       if File.exist?(index_path)
         begin
-          RubyIndexer.configuration.apply_config(YAML.parse_file(index_path).to_ruby)
+          @global_state.index.configuration.apply_config(YAML.parse_file(index_path).to_ruby)
           send_message(
             Notification.new(
               method: "window/showMessage",
@@ -906,7 +906,7 @@ module RubyLsp
       return unless indexing_options
 
       # The index expects snake case configurations, but VS Code standardizes on camel case settings
-      RubyIndexer.configuration.apply_config(
+      @global_state.index.configuration.apply_config(
         indexing_options.transform_keys { |key| key.to_s.gsub(/([A-Z])/, "_\\1").downcase },
       )
     end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -481,8 +481,8 @@ class ServerTest < Minitest::Test
       })
     end
 
-    assert_includes(RubyIndexer.configuration.instance_variable_get(:@excluded_gems), "foo_gem")
-    assert_includes(RubyIndexer.configuration.instance_variable_get(:@included_gems), "bar_gem")
+    assert_includes(@server.global_state.index.configuration.instance_variable_get(:@excluded_gems), "foo_gem")
+    assert_includes(@server.global_state.index.configuration.instance_variable_get(:@included_gems), "bar_gem")
   end
 
   def test_closing_document_before_computing_features_does_not_error


### PR DESCRIPTION
### Motivation

Since an Index's data is scoped by configuration, we should make the configuration part of the index. This is especially true with #2424 coming because changing the state of `RubyIndexer.configuration` to affect the index is surprising.


### Implementation

- Remove `RubyIndexer.configuration`
- Initialize `RubyIndexer::Configuration` inside `RubyIndexer::Index` 
- Update all the `RubyIndexer.cofniguration` references

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
