### PR TITLE
Fix Ruby LSP formatting range to comply with LSP specification

### DIFF
--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -58,14 +58,16 @@ module RubyLsp
         formatted_text = @active_formatter.run_formatting(@uri, @document)
         return unless formatted_text
 
+        lines = @document.source.lines
         size = @document.source.size
+
         return if formatted_text.size == size && formatted_text == @document.source
 
         [
           Interface::TextEdit.new(
             range: Interface::Range.new(
               start: Interface::Position.new(line: 0, character: 0),
-              end: Interface::Position.new(line: size, character: size),
+              end: Interface::Position.new(line: lines.size, character: 0),
             ),
             new_text: formatted_text,
           ),


### PR DESCRIPTION
### Motivation

Hi! While working on the Ruby LSP extension for the IntelliJ platform, I noticed an issue  (or not?) with the formatting response from the Ruby Language Server. Thanks!

### Implementation

The current implementation of formatting
does not use the proper range for a response.
Consider the following Ruby code:

```ruby
class A
  def my_method
   [1]
  end
end
```

Let's pretend that our RuboCop configuration specifies omitting whitespaces inside array declarations, which means the code above is not properly formatted.
The code should be formatted like this:

```ruby
class A
  def my_method
   [ 1 ]
  end
end
```

When a client asks Ruby LSP to format the first code, the server sends a response (taken from the Zed editor) where the reported `end` property of the `Range` interface has `line` and `character` keys that do not match the source document.
Both of them equal the character size of the document.

```json
{
   "id":6,
   "result":[
      {
         "range":{
            "start":{
               "line":0,
               "character":0
            },
            "end":{
               "line":43,
               "character":43
            }
         },
         "newText":"class A\n  def my_method\n    [ 1 ]\n  end\nend\n"
      }
   ],
   "jsonrpc":"2.0"
}
```

For some reason, Visual Studio Code considers this response valid, and the code is formatted properly.
However, some editors perform a check to ensure that the reported response from Ruby LSP is not out of bounds of the current text document.
According to the LSP specification from the link below: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range A range in a text document expressed as (zero-based) start and end positions. The correct response should be:

```json
{
   "id":35,
   "result":[
      {
         "range":{
            "start":{
               "line":0,
               "character":0
            },
            "end":{
               "line":5,
               "character":0
            }
         },
         "newText":"class A\n  def my_method\n    [ 1 ]\n  end\nend\n"
      }
   ],
   "jsonrpc":"2.0"
}
```

### Automated Tests

I am happy to add unit tests for that, but I am not sure where I should start. I didn't find any tests regarding testing requests/responses in accordance with LSP specs.

### Manual Tests

Unfortunately, there is no way to test this in Visual Studio Code because formatting, for some reason, works just fine there.
