### PR TITLE
Consider that the project has a type checker if `sorbet-static` is present as transitive dependency

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -93,7 +93,7 @@ module RubyLsp
       @test_library = detect_test_library(direct_dependencies)
       notifications << Notification.window_log_message("Detected test library: #{@test_library}")
 
-      @has_type_checker = detect_typechecker(direct_dependencies)
+      @has_type_checker = detect_typechecker(all_dependencies)
       if @has_type_checker
         notifications << Notification.window_log_message(
           "Ruby LSP detected this is a Sorbet project and will defer to the Sorbet LSP for some functionality",

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -199,6 +199,16 @@ module RubyLsp
       assert_predicate(state, :experimental_features)
     end
 
+    def test_type_checker_is_detected_based_on_transitive_sorbet_static
+      state = GlobalState.new
+
+      Bundler.locked_gems.stubs(dependencies: {})
+      stub_all_dependencies("sorbet-static")
+      state.apply_options({ initializationOptions: {} })
+
+      assert_predicate(state, :has_type_checker)
+    end
+
     private
 
     def stub_direct_dependencies(dependencies)


### PR DESCRIPTION
### Motivation

I'm not sure how exactly we regressed on this, but we were again checking for a direct dependency on `sorbet-static` to determine if the application is using Sorbet. This is not the appropriate check because the direct dependency could be on `sorbet-static-and-runtime` and we would then show duplicate features (which is currently happening).

### Implementation

Moved back to checking for `sorbet-static` in transitive dependencies.

### Automated Tests

Added a test that fails with the current implementation in main.