### PR TITLE
Create a new issue template for non-VS Code editor users

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template_non_vscode.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template_non_vscode.yml
@@ -1,0 +1,46 @@
+---
+name: Ruby LSP bug (non-VS Code editors)
+description: File a bug report about the Ruby LSP with non-VS Code editors
+labels:
+  - bug
+  - non-vscode
+  - help-wanted
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filing a bug report!
+        Please note that the maintainers only have bandwidth to prioritize VS Code support and lean on the community to assist with supporting other editors.
+        If you are using a non-VS Code editor, please follow these steps **before submitting a bug report**:
+
+        1. Follow the instructions on [troubleshooting](https://github.com/Shopify/ruby-lsp/blob/main/TROUBLESHOOTING.md)
+        2. Check if the editor and LSP plugin you use are up to date, and if they support the latest [Language Server Protocol Specification](https://microsoft.github.io/language-server-protocol).
+        3. Seek help in the [Ruby DX Slack](https://join.slack.com/t/ruby-dx/shared_invite/zt-2c8zjlir6-uUDJl8oIwcen_FS_aA~b6Q).
+        4. Seek help in the related editor/plugin's issue tracker.
+
+        Describing prior discussions and troubleshooting steps will help us understand the issue and respond more quickly.
+  - type: textarea
+    attributes:
+      label: Description
+      description: Reproduction steps
+      value: |
+        ### Reproduction steps
+
+        <!--
+        **IMPORTANT NOTE**
+        Please provide as much detail about your development setup as possible. Often issues with the Ruby LSP are
+        specific to a combination of operating system, Ruby version, Ruby version manager, the editor being used and
+        project setup. The easier it is to reproduce the problem, the quicker it will likely take to fix it.
+        -->
+
+        <!-- Suggested structure -->
+        1. Start the Ruby LSP using a certain editor
+        2. Open a Ruby file
+        3. Do something
+        4. See unexpected behavior
+
+        **Code snippet or error message**
+        ```ruby
+        ```
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_template_vscode.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template_vscode.yml
@@ -1,18 +1,15 @@
 ---
-name: Ruby LSP bug
-description: File a bug report about the Ruby LSP
+name: Ruby LSP bug (VS Code)
+description: File a bug report about the Ruby LSP with VS Code
 labels:
   - bug
+  - vscode
 body:
   - type: markdown
     attributes:
-      value: >
-        Thank you for filing a bug report! Please answer the following questions to help us understand the issue.
-  - type: textarea
-    attributes:
-      label: Description
-      description: Reproduction steps
       value: |
+        Thank you for filing a bug report! Please answer the following questions to help us understand the issue.
+
         ### Before submitting
 
         Please follow the instructions on
@@ -21,9 +18,11 @@ body:
         1. On the latest version of the Ruby LSP VS Code extension
         2. On the latest version of the Ruby LSP server gem
         3. On the latest version of VS Code
-
-        If the issue persist, please deleted this section and submit the report.
-
+  - type: textarea
+    attributes:
+      label: Description
+      description: Reproduction steps
+      value: |
         ### Reproduction steps
 
         <!--


### PR DESCRIPTION
### Motivation

To make sure we can properly report and investigate issues for the Ruby LSP project, we need to create two different templates: one for VS Code and another for non-VS Code editors. Here's why:

1. **Maintainer Expertise**: Our maintainers mainly use VS Code and don't have setups for other editors. This means we can give better guidance and support for issues in VS Code but not as much for other editors.

2. **LSP Compatibility**: Different editors and their LSP plugins might not always be up-to-date with the latest LSP specs. This can cause differences in how issues show up between VS Code and other editors.

3. **Reporting Tools**: Our VS Code extension has specific tools for reporting issues, like a status panel and an addons list, which aren't available in other editors. These tools are super helpful for diagnosing and fixing issues in VS Code.

By having separate templates, we can make the issue reporting process clearer and get the most relevant info for each setup.


### Implementation


### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
