### PR TITLE
Add a new command to help users migrate launch.json configurations

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -153,6 +153,11 @@
         "command": "rubyLsp.collectRubyLspInfo",
         "title": "Collect Ruby LSP information for issue reporting",
         "category": "Ruby LSP"
+      },
+      {
+        "command": "rubyLsp.migrateLaunchConfiguration",
+        "title": "Migrate launch.json configurations from rdbg to ruby_lsp",
+        "category": "Ruby LSP"
       }
     ],
     "configuration": {

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -29,6 +29,7 @@ export enum Command {
   NewMinitestFile = "rubyLsp.newMinitestFile",
   CollectRubyLspInfo = "rubyLsp.collectRubyLspInfo",
   StartServerInDebugMode = "rubyLsp.startServerInDebugMode",
+  MigrateLaunchConfiguration = "rubyLsp.migrateLaunchConfiguration",
 }
 
 export interface RubyInterface {

--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -347,10 +347,12 @@ export class Debugger
   }
 
   private logDebuggerMessage(message: string) {
-    const trimmedMessage = message.trimEnd();
-    if (trimmedMessage.length > 0) {
-      LOG_CHANNEL.info(`[debugger]: ${trimmedMessage}`);
-      this.console.append(trimmedMessage);
-    }
+    // In the Output panel, each log automatically gets a new line
+    // And trailing newlines will create one additional line in the panel, so we trimEnd() here to avoid that
+    LOG_CHANNEL.info(`[debugger]: ${message.trimEnd()}`);
+
+    // In the Debug Console, output doesn't get a new line automatically, so we don't trimEnd() here as well as print
+    // the newlines too
+    this.console.append(message);
   }
 }

--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -347,12 +347,12 @@ export class Debugger
   }
 
   private logDebuggerMessage(message: string) {
-    // In the Output panel, each log automatically gets a new line
-    // And trailing newlines will create one additional line in the panel, so we trimEnd() here to avoid that
+    // Log to Output panel: Messages here automatically get newlines appended.
+    // Trim trailing newlines to prevent unwanted blank lines in the output
     LOG_CHANNEL.info(`[debugger]: ${message.trimEnd()}`);
 
-    // In the Debug Console, output doesn't get a new line automatically, so we don't trimEnd() here as well as print
-    // the newlines too
+    // Log to Debug Console: Unlike Output panel, this needs explicit newlines
+    // so we preserve the original message format including any newlines
     this.console.append(message);
   }
 }

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -597,6 +597,68 @@ export class RubyLsp {
         },
       ),
     );
+    vscode.commands.registerCommand(
+      Command.MigrateLaunchConfiguration,
+      async () => {
+        const workspace = await this.showWorkspacePick();
+
+        if (!workspace) {
+          return;
+        }
+
+        const launchConfig =
+          (vscode.workspace
+            .getConfiguration("launch")
+            ?.get("configurations") as any[]) || [];
+
+        const updatedLaunchConfig = launchConfig.map((config: any) => {
+          if (config.type === "rdbg") {
+            if (config.request === "launch") {
+              const newConfig = { ...config };
+              newConfig.type = "ruby_lsp";
+
+              if (newConfig.askParameters !== true) {
+                delete newConfig.rdbgPath;
+                delete newConfig.cwd;
+                delete newConfig.useBundler;
+
+                const command = (newConfig.command || "").replace(
+                  "${workspaceRoot}/",
+                  "",
+                );
+                const script = newConfig.script || "";
+                const args = (newConfig.args || []).join(" ");
+                newConfig.program = `${command} ${script} ${args}`.trim();
+
+                delete newConfig.command;
+                delete newConfig.script;
+                delete newConfig.args;
+                delete newConfig.askParameters;
+              }
+
+              return newConfig;
+            } else if (config.request === "attach") {
+              const newConfig = { ...config };
+              newConfig.type = "ruby_lsp";
+              // rdbg's `debugPort` could be socket path, or port number, or host:port
+              // we don't do complex parsing here, just assume it's socket path
+              newConfig.debugSocketPath = config.debugPort;
+
+              return newConfig;
+            }
+          }
+          return config;
+        });
+
+        await vscode.workspace
+          .getConfiguration("launch")
+          .update(
+            "configurations",
+            updatedLaunchConfig,
+            vscode.ConfigurationTarget.Workspace,
+          );
+      },
+    );
   }
 
   // Get the current active workspace based on which file is opened in the editor

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -640,7 +640,7 @@ export class RubyLsp {
             } else if (config.request === "attach") {
               const newConfig = { ...config };
               newConfig.type = "ruby_lsp";
-              // rdbg's `debugPort` could be socket path, or port number, or host:port
+              // rdbg's `debugPort` could be a socket path, or port number, or host:port
               // we don't do complex parsing here, just assume it's socket path
               newConfig.debugSocketPath = config.debugPort;
 


### PR DESCRIPTION
### Motivation

Ruby LSP now provides better logging and error messages when the debugger failed to start. And we plan to keep improving the debugging experience in the future.

If users are currently using vscode-rdbg and want to try Ruby LSP, we can help them migrate their launch.json configurations to the format used by Ruby LSP.

### Implementation

1. Add a `migrateLaunchConfiguration` command
2. In the command, fetch users' launch configurations and apply the changes needed for the migration

The 2nd commit is to fix the message formatting issue caused by #2957

#### Example Result

This is from a real-world Rails project:

```diff
diff --git a/.vscode/launch.json b/.vscode/launch.json
index cc686cd1069..bd05d0d7c60 100644
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,58 +6,47 @@
   "configurations": [
     {
       "name": "Attach",
-      "type": "rdbg",
+      "type": "ruby_lsp",
       "request": "attach"
     },
     {
       "name": "Rails Server",
-      "type": "rdbg",
-      "cwd": "${workspaceRoot}",
-      "useBundler": true,
+      "type": "ruby_lsp",
       "request": "launch",
       "env": {
         "DISABLE_SPRING": "1"
       },
-      "command": "${workspaceRoot}/bin/rails",
-      "script": "server",
-      "args": [],
-      "askParameters": false
+      "program": "bin/rails server"
     },
     {
       "name": "Minitest - current line",
-      "type": "rdbg",
-      "cwd": "${workspaceRoot}",
-      "useBundler": true,
+      "type": "ruby_lsp",
       "request": "launch",
       "env": {
         "DISABLE_SPRING": "1"
       },
-      "command": "${workspaceRoot}/bin/rails",
-      "script": "test",
-      "args": ["${file}:${lineNumber}"],
-      "askParameters": false
+      "program": "bin/rails test ${file}:${lineNumber}"
     },
     {
       "name": "Minitest - current file",
-      "type": "rdbg",
-      "cwd": "${workspaceRoot}",
-      "useBundler": true,
+      "type": "ruby_lsp",
       "request": "launch",
       "env": {
         "DISABLE_SPRING": "1"
       },
-      "command": "${workspaceRoot}/bin/rails",
-      "script": "test",
-      "args": ["${file}"],
-      "askParameters": false
+      "program": "bin/rails test ${file}"
     },
```

And every action works after the migration.

### Automated Tests

No test

### Manual Tests

1. Find an application that uses `rdbg` in its `launch.json`
2. Run the new `Migrate launch.json configurations from rdbg to ruby_lsp` command through VS Code's command palette
4. Verify that the updated entries still function the same
