### PR TITLE
Don't assign non-vscode issues to the team

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -29,8 +29,14 @@ jobs:
               "KaanOzkan"
             ];
             const author = "${{ github.event.issue.user.login }}";
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.issue.number }}
+            });
+            const hasNonVSCodeLabel = issue.data.labels.some(label => label.name === 'non-vscode');
 
-            if (!fullTeam.includes(author)) {
+            if (!fullTeam.includes(author) && !hasNonVSCodeLabel) {
               const dxReviewers = [
                 "andyw8",
                 "vinistock",


### PR DESCRIPTION
### Motivation

Given the current team capacity, we won't be actively triaging non-vscode issues. So assigning team members to them only creates noise.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
