### PR TITLE
Run signature blocks ahead of time and compact after indexing

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -81,6 +81,8 @@ require "ruby_lsp/load_sorbet"
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "ruby_lsp/internal"
 
+T::Utils.run_all_sig_blocks
+
 if options[:debug]
   if ["x64-mingw-ucrt", "x64-mingw32"].include?(RUBY_PLATFORM)
     $stderr.puts "Debugging is not supported on Windows"

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -876,6 +876,11 @@ module RubyLsp
           send_message(Notification.window_show_error("Error while indexing: #{error.message}"))
         end
 
+        # Indexing produces a high number of short lived object allocations. That might lead to some fragmentation and
+        # an unnecessarily expanded heap. Compacting ensures that the heap is as small as possible and that future
+        # allocations and garbage collections are faster
+        GC.compact
+
         # Always end the progress notification even if indexing failed or else it never goes away and the user has no
         # way of dismissing it
         end_progress("indexing-progress")


### PR DESCRIPTION
### Motivation

This PR adds two minor changes that may provide some performance gains.

### Running all signatures ahead of time

This eliminates the need to run them on the first invocation of each method and eagerly unwraps the original method back in place. This will spend a bit more time during boot, but it should ensure that we see fewer of Sorbet's method wrapping logic in our stacks.

### Compacting the GC after indexing

Indexing produces a lot of short lived objects for all of the ASTs of every file we interact with. This expands the heap pages a lot and may lead to some fragmentation. Compacting the GC helps us ensure that we're using the minimum number of pages needed and should make future GC runs a bit faster.