### PR TITLE
Revert "Make Rails app detection based on Rails::Application superclass"

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -50,7 +50,6 @@ module RubyLsp
       @last_updated_path = T.let(@custom_dir + "last_updated", Pathname)
 
       @dependencies = T.let(load_dependencies, T::Hash[String, T.untyped])
-      @rails_app = T.let(rails_app?, T::Boolean)
       @retry = T.let(false, T::Boolean)
     end
 
@@ -63,7 +62,7 @@ module RubyLsp
       # Do not set up a custom bundle if LSP dependencies are already in the Gemfile
       if @dependencies["ruby-lsp"] &&
           @dependencies["debug"] &&
-          (@rails_app ? @dependencies["ruby-lsp-rails"] : true)
+          (@dependencies["rails"] ? @dependencies["ruby-lsp-rails"] : true)
         $stderr.puts(
           "Ruby LSP> Skipping custom bundle setup since LSP dependencies are already in #{@gemfile}",
         )
@@ -149,7 +148,7 @@ module RubyLsp
         parts << 'gem "debug", require: false, group: :development, platforms: :mri'
       end
 
-      if @rails_app && !@dependencies["ruby-lsp-rails"]
+      if @dependencies["rails"] && !@dependencies["ruby-lsp-rails"]
         parts << 'gem "ruby-lsp-rails", require: false, group: :development'
       end
 
@@ -210,7 +209,7 @@ module RubyLsp
         command << " && bundle update "
         command << "ruby-lsp " unless @dependencies["ruby-lsp"]
         command << "debug " unless @dependencies["debug"]
-        command << "ruby-lsp-rails " if @rails_app && !@dependencies["ruby-lsp-rails"]
+        command << "ruby-lsp-rails " if @dependencies["rails"] && !@dependencies["ruby-lsp-rails"]
         command << "--pre" if @experimental
         command.delete_suffix!(" ")
         command << ")"
@@ -245,7 +244,7 @@ module RubyLsp
     def should_bundle_update?
       # If `ruby-lsp`, `ruby-lsp-rails` and `debug` are in the Gemfile, then we shouldn't try to upgrade them or else it
       # will produce version control changes
-      if @rails_app
+      if @dependencies["rails"]
         return false if @dependencies.values_at("ruby-lsp", "ruby-lsp-rails", "debug").all?
 
         # If the custom lockfile doesn't include `ruby-lsp`, `ruby-lsp-rails` or `debug`, we need to run bundle install
@@ -280,16 +279,6 @@ module RubyLsp
       end
 
       @custom_lockfile.write(content)
-    end
-
-    # Detects if the project is a Rails app by looking if the superclass of the main class is `Rails::Application`
-    sig { returns(T::Boolean) }
-    def rails_app?
-      config = Pathname.new("config/application.rb").expand_path
-      application_contents = config.read if config.exist?
-      return false unless application_contents
-
-      /class .* < (::)?Rails::Application/.match?(application_contents)
     end
   end
 end

--- a/test/fixtures/rails_application.rb
+++ b/test/fixtures/rails_application.rb
@@ -1,4 +1,0 @@
-module MyApp
-  class Application < Rails::Application
-  end
-end

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -79,9 +79,6 @@ class SetupBundlerTest < Minitest::Test
       bundle_env(".ruby-lsp/Gemfile"),
       "(bundle check || bundle install) 1>&2",
     ).returns(true)
-
-    FileUtils.mkdir("config")
-    FileUtils.cp("test/fixtures/rails_application.rb", "config/application.rb")
     Bundler::LockfileParser.any_instance.expects(:dependencies).returns({ "rails" => true }).at_least_once
     run_script
 
@@ -94,7 +91,6 @@ class SetupBundlerTest < Minitest::Test
     assert_match("ruby-lsp-rails", File.read(".ruby-lsp/Gemfile"))
   ensure
     FileUtils.rm_r(".ruby-lsp") if Dir.exist?(".ruby-lsp")
-    FileUtils.rm_r("config") if Dir.exist?("config")
   end
 
   def test_changing_lockfile_causes_custom_bundle_to_be_rebuilt
@@ -484,8 +480,6 @@ class SetupBundlerTest < Minitest::Test
 
   def test_ruby_lsp_rails_is_automatically_included_in_rails_apps
     Dir.mktmpdir do |dir|
-      FileUtils.mkdir("#{dir}/config")
-      FileUtils.cp("test/fixtures/rails_application.rb", "#{dir}/config/application.rb")
       Dir.chdir(dir) do
         File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
           source "https://rubygems.org"


### PR DESCRIPTION
Reverting Shopify/ruby-lsp#2218 while https://github.com/Shopify/ruby-lsp/issues/2463 is better understood.

There are issues with encoding and multibyte characters and it's not yet clear why. This bug blocks people from using the LSP, so we should revert first and then work to figure out what happened.