### PR TITLE
Add literal types to inferrer

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -366,7 +366,7 @@ module RubyLsp
 
         return unless range
 
-        guessed_type = type.name
+        guessed_type = type.is_a?(TypeInferrer::GuessedType) && type.name
 
         @index.method_completion_candidates(method_name, type.name).each do |entry|
           entry_name = entry.name

--- a/test/type_inferrer_test.rb
+++ b/test/type_inferrer_test.rb
@@ -262,6 +262,102 @@ module RubyLsp
       assert_equal("Foo", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
+    def test_infer_string_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 3 })
+        "".upcase
+      RUBY
+
+      assert_equal("String", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_symbol_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 5 })
+        :foo.to_s
+      RUBY
+
+      assert_equal("Symbol", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_array_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 3 })
+        [].first
+      RUBY
+
+      assert_equal("Array", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_hash_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 3 })
+        {}.keys
+      RUBY
+
+      assert_equal("Hash", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_integer_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 3 })
+        10.to_s
+      RUBY
+
+      assert_equal("Integer", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_float_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 4 })
+        1.5.to_s
+      RUBY
+
+      assert_equal("Float", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_regexp_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 5 })
+        /abc/.match("abc")
+      RUBY
+
+      assert_equal("Regexp", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_nil_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 4 })
+        nil.to_s
+      RUBY
+
+      assert_equal("NilClass", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_true_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 5 })
+        true.to_s
+      RUBY
+
+      assert_equal("TrueClass", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_false_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 6 })
+        false.to_s
+      RUBY
+
+      assert_equal("FalseClass", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_range_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 8 })
+        (5..10).to_a
+      RUBY
+
+      assert_equal("Range", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_lambda_literal
+      node_context = index_and_locate(<<~RUBY, { line: 0, character: 5 })
+        ->{}.call
+      RUBY
+
+      assert_equal("Proc", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
     private
 
     def index_and_locate(source, position)


### PR DESCRIPTION
### Motivation

This PR starts returning the expected type for literals, so that we can provide completion, go to definition, hover and signature help when something is invoked directly on one.

### Implementation

I also fixed a minor bug that we had not caught. We were showing any type in the completion documentation as if it were a guessed type, but that should only appear if it was guessed.

Then I added a bunch of branches to cover literals.

### Automated Tests

Added tests.