### PR TITLE
Fix singleton class nesting when inside top level reference

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -152,16 +152,17 @@ module RubyIndexer
 
       if current_owner
         expression = node.expression
-        @stack << (expression.is_a?(Prism::SelfNode) ? "<Class:#{@stack.last}>" : "<Class:#{expression.slice}>")
+        name = (expression.is_a?(Prism::SelfNode) ? "<Class:#{@stack.last}>" : "<Class:#{expression.slice}>")
+        real_nesting = actual_nesting(name)
 
-        existing_entries = T.cast(@index[@stack.join("::")], T.nilable(T::Array[Entry::SingletonClass]))
+        existing_entries = T.cast(@index[real_nesting.join("::")], T.nilable(T::Array[Entry::SingletonClass]))
 
         if existing_entries
           entry = T.must(existing_entries.first)
           entry.update_singleton_information(node.location, expression.location, collect_comments(node))
         else
           entry = Entry::SingletonClass.new(
-            @stack,
+            real_nesting,
             @file_path,
             node.location,
             expression.location,
@@ -172,6 +173,7 @@ module RubyIndexer
         end
 
         @owner_stack << entry
+        @stack << name
       end
     end
 


### PR DESCRIPTION
### Motivation

Fixes the bug reported in https://github.com/Shopify/ruby-lsp/issues/2287#issuecomment-2299656280

We need to use our proper nesting resolution `actual_nesting` to discover the correct place where we discovered a singleton class, just like we're doing for regular classes. Otherwise, we incorrectly insert a name prefixed with `::` in the index state, which we do not want.

### Implementation

Started using our `actual_nesting` method to figure out the right nesting.

### Automated Tests

Added a test.