### PR TITLE
Avoid using stubs in test_helper.rb as it depends on Mocha

### DIFF
--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -20,8 +20,8 @@ module RubyLsp
     def with_server(source = nil, uri = Kernel.URI("file:///fake.rb"), stub_no_typechecker: false, load_addons: true,
       &block)
       server = RubyLsp::Server.new(test_mode: true)
-      server.global_state.stubs(:has_type_checker).returns(false) if stub_no_typechecker
       server.global_state.apply_options({ initializationOptions: { experimentalFeaturesEnabled: true } })
+      server.global_state.instance_variable_set(:@has_type_checker, false) if stub_no_typechecker
       language_id = uri.to_s.end_with?(".erb") ? "erb" : "ruby"
 
       if source


### PR DESCRIPTION
### Motivation

Closes #2190 

### Implementation

Simply update the global state when `stub_no_typechecker` is set to `true`.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
