### PR TITLE
Implement basic Sorbet LSP client

### DIFF
--- a/vscode/src/sorbet.ts
+++ b/vscode/src/sorbet.ts
@@ -24,10 +24,11 @@ export default class SorbetClient extends LanguageClient {
     ruby: Ruby,
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel: WorkspaceChannel,
+    bundleArgs: string[] = ["exec", "srb", "tc", "--lsp"],
   ) {
     const serverOptions: ServerOptions = {
       command: "bundle",
-      args: ["exec", "srb", "tc", "--lsp"],
+      args: bundleArgs,
       options: {
         cwd: workspaceFolder.uri.fsPath,
         env: ruby.env,

--- a/vscode/src/sorbet.ts
+++ b/vscode/src/sorbet.ts
@@ -1,0 +1,50 @@
+import * as vscode from "vscode";
+import {
+  LanguageClient,
+  ServerOptions,
+  LanguageClientOptions,
+  RevealOutputChannelOn,
+} from "vscode-languageclient/node";
+
+import { WorkspaceChannel } from "./workspaceChannel";
+import { Ruby } from "./ruby";
+
+// Experimental Sorbet client to be used along with the Ruby LSP
+// It's turned off if official Sorbet extension is enabled
+//
+// TODO:
+// - Automatic restarts when sorbet/config changes
+// - Allow starting, stopping and restarting the Sorbet client separately
+// - Allow automatic restarts to target a specific client (so that we don't have to restart Sorbet on a rubocop.yml
+// change)
+// - Report Sorbet status (have the server send WorkDoneProgress notifications instead of using a custom built status
+// bar)
+export default class SorbetClient extends LanguageClient {
+  constructor(
+    ruby: Ruby,
+    workspaceFolder: vscode.WorkspaceFolder,
+    outputChannel: WorkspaceChannel,
+  ) {
+    const serverOptions: ServerOptions = {
+      command: "bundle",
+      args: ["exec", "srb", "tc", "--lsp"],
+      options: {
+        cwd: workspaceFolder.uri.fsPath,
+        env: ruby.env,
+        shell: true,
+      },
+    };
+
+    const clientOptions: LanguageClientOptions = {
+      documentSelector: [
+        { language: "ruby", pattern: `${workspaceFolder.uri.fsPath}/**/*` },
+      ],
+      workspaceFolder,
+      diagnosticCollectionName: "sorbet",
+      outputChannel,
+      revealOutputChannelOn: RevealOutputChannelOn.Never,
+    };
+
+    super("sorbet", serverOptions, clientOptions);
+  }
+}

--- a/vscode/src/test/suite/sorbetClient.test.ts
+++ b/vscode/src/test/suite/sorbetClient.test.ts
@@ -149,6 +149,12 @@ async function launchClient(workspaceUri: vscode.Uri) {
 }
 
 suite("SorbetClient", () => {
+  if (os.platform() === "win32") {
+    // eslint-disable-next-line no-console
+    console.log("Skipping SorbetClient tests on Windows");
+    return;
+  }
+
   const workspacePath = path.dirname(
     path.dirname(path.dirname(path.dirname(__dirname))),
   );

--- a/vscode/src/test/suite/sorbetClient.test.ts
+++ b/vscode/src/test/suite/sorbetClient.test.ts
@@ -128,6 +128,7 @@ async function launchClient(workspaceUri: vscode.Uri) {
     ruby,
     workspaceFolder,
     new SorbetWorkspaceChannel("fake", fakeLogger as any),
+    ["exec", "srb", "tc", "--lsp", "--disable-watchman"],
   );
 
   client.clientOptions.initializationFailedHandler = (error) => {

--- a/vscode/src/test/suite/sorbetClient.test.ts
+++ b/vscode/src/test/suite/sorbetClient.test.ts
@@ -1,0 +1,231 @@
+/* eslint-disable no-process-env */
+import assert from "assert";
+import path from "path";
+import os from "os";
+import fs from "fs";
+
+import * as vscode from "vscode";
+import { State } from "vscode-languageclient/node";
+import { after, afterEach, before } from "mocha";
+
+import { Ruby, ManagerIdentifier } from "../../ruby";
+import {
+  SorbetWorkspaceChannel,
+  WorkspaceChannel,
+} from "../../workspaceChannel";
+import { RUBY_VERSION } from "../rubyVersion";
+import SorbetClient from "../../sorbet";
+
+const [major, minor, _patch] = RUBY_VERSION.split(".");
+
+class FakeLogger {
+  receivedMessages = "";
+
+  trace(message: string, ..._args: any[]): void {
+    this.receivedMessages += message;
+  }
+
+  debug(message: string, ..._args: any[]): void {
+    this.receivedMessages += message;
+  }
+
+  info(message: string, ..._args: any[]): void {
+    this.receivedMessages += message;
+  }
+
+  warn(message: string, ..._args: any[]): void {
+    this.receivedMessages += message;
+  }
+
+  error(error: string | Error, ..._args: any[]): void {
+    this.receivedMessages += error.toString();
+  }
+
+  append(value: string): void {
+    this.receivedMessages += value;
+  }
+
+  appendLine(value: string): void {
+    this.receivedMessages += value;
+  }
+}
+
+async function launchClient(workspaceUri: vscode.Uri) {
+  const workspaceFolder: vscode.WorkspaceFolder = {
+    uri: workspaceUri,
+    name: path.basename(workspaceUri.fsPath),
+    index: 0,
+  };
+
+  const context = {
+    extensionMode: vscode.ExtensionMode.Test,
+    subscriptions: [],
+    workspaceState: {
+      get: (_name: string) => undefined,
+      update: (_name: string, _value: any) => Promise.resolve(),
+    },
+  } as unknown as vscode.ExtensionContext;
+  const fakeLogger = new FakeLogger();
+  const outputChannel = new WorkspaceChannel("fake", fakeLogger as any);
+
+  // Ensure that we're activating the correct Ruby version on CI
+  if (process.env.CI) {
+    if (os.platform() === "linux") {
+      await vscode.workspace
+        .getConfiguration("rubyLsp")
+        .update(
+          "rubyVersionManager",
+          { identifier: ManagerIdentifier.Chruby },
+          true,
+        );
+
+      fs.mkdirSync(path.join(os.homedir(), ".rubies"), { recursive: true });
+      fs.symlinkSync(
+        `/opt/hostedtoolcache/Ruby/${RUBY_VERSION}/x64`,
+        path.join(os.homedir(), ".rubies", RUBY_VERSION),
+      );
+    } else if (os.platform() === "darwin") {
+      await vscode.workspace
+        .getConfiguration("rubyLsp")
+        .update(
+          "rubyVersionManager",
+          { identifier: ManagerIdentifier.Chruby },
+          true,
+        );
+
+      fs.mkdirSync(path.join(os.homedir(), ".rubies"), { recursive: true });
+      fs.symlinkSync(
+        `/Users/runner/hostedtoolcache/Ruby/${RUBY_VERSION}/arm64`,
+        path.join(os.homedir(), ".rubies", RUBY_VERSION),
+      );
+    } else {
+      await vscode.workspace
+        .getConfiguration("rubyLsp")
+        .update(
+          "rubyVersionManager",
+          { identifier: ManagerIdentifier.RubyInstaller },
+          true,
+        );
+
+      fs.symlinkSync(
+        path.join(
+          "C:",
+          "hostedtoolcache",
+          "windows",
+          "Ruby",
+          RUBY_VERSION,
+          "x64",
+        ),
+        path.join("C:", `Ruby${major}${minor}-${os.arch()}`),
+      );
+    }
+  }
+
+  const ruby = new Ruby(context, workspaceFolder, outputChannel);
+  await ruby.activateRuby();
+
+  const client = new SorbetClient(
+    ruby,
+    workspaceFolder,
+    new SorbetWorkspaceChannel("fake", fakeLogger as any),
+  );
+
+  client.clientOptions.initializationFailedHandler = (error) => {
+    assert.fail(
+      `Failed to start server ${error.message}\n${fakeLogger.receivedMessages}`,
+    );
+  };
+
+  try {
+    await client.start();
+  } catch (error: any) {
+    assert.fail(`Failed to start server ${error.message}`);
+  }
+
+  assert.strictEqual(client.state, State.Running);
+
+  return client;
+}
+
+suite("SorbetClient", () => {
+  const workspacePath = path.dirname(
+    path.dirname(path.dirname(path.dirname(__dirname))),
+  );
+  const workspaceUri = vscode.Uri.file(workspacePath);
+  const documentUri = vscode.Uri.joinPath(
+    workspaceUri,
+    "lib",
+    "ruby_lsp",
+    "server.rb",
+  );
+  let client: SorbetClient;
+
+  before(async function () {
+    // 60000 should be plenty but we're seeing timeouts on Windows in CI
+
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(90000);
+    client = await launchClient(workspaceUri);
+  });
+
+  after(async function () {
+    // eslint-disable-next-line no-invalid-this
+    this.timeout(20000);
+
+    try {
+      await client.stop();
+      await client.dispose();
+    } catch (error: any) {
+      assert.fail(`Failed to stop server: ${error.message}`);
+    }
+
+    if (process.env.CI) {
+      if (os.platform() === "linux" || os.platform() === "darwin") {
+        fs.rmSync(path.join(os.homedir(), ".rubies"), {
+          recursive: true,
+          force: true,
+        });
+      } else {
+        fs.rmSync(path.join("C:", `Ruby${major}${minor}-${os.arch()}`), {
+          recursive: true,
+          force: true,
+        });
+      }
+    }
+  });
+
+  afterEach(async () => {
+    await client.sendNotification("textDocument/didClose", {
+      textDocument: {
+        uri: documentUri.toString(),
+      },
+    });
+  });
+
+  test("hover", async () => {
+    const text = await vscode.workspace.fs.readFile(documentUri);
+
+    await client.sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri: documentUri.toString(),
+        version: 1,
+        text,
+      },
+    });
+
+    const response: vscode.Hover = await client.sendRequest(
+      "textDocument/hover",
+      {
+        textDocument: {
+          uri: documentUri.toString(),
+        },
+        position: {
+          line: 3,
+          character: 7,
+        },
+      },
+    );
+
+    assert.match((response.contents as any).value, /T.class_of\(RubyLsp\)/);
+  }).timeout(20000);
+});

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -1,3 +1,5 @@
+import os from "os";
+
 import * as vscode from "vscode";
 import { CodeLens, State } from "vscode-languageclient/node";
 
@@ -118,6 +120,7 @@ export class Workspace implements WorkspaceInterface {
     try {
       shouldLaunchSorbetClient =
         !vscode.extensions.getExtension("sorbet.sorbet-vscode-extension") &&
+        os.platform() !== "win32" &&
         (await vscode.workspace.fs.readFile(
           vscode.Uri.joinPath(this.workspaceFolder.uri, "sorbet/config"),
         ));

--- a/vscode/src/workspaceChannel.ts
+++ b/vscode/src/workspaceChannel.ts
@@ -73,3 +73,9 @@ export class WorkspaceChannel implements vscode.LogOutputChannel {
     this.actualChannel.dispose();
   }
 }
+
+export class SorbetWorkspaceChannel extends WorkspaceChannel {
+  constructor(workspaceName: string, actualChannel: vscode.LogOutputChannel) {
+    super(`${workspaceName} [Sorbet]`, actualChannel);
+  }
+}


### PR DESCRIPTION
Thanks to @vinistock who led this work.

### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
This is a WIP prototype for triggering Sorbet LSP from Ruby LSP VS Code extension. It won't be enabled if official Sorbet extension is installed. It's aimed for consolidating the Ruby development experience and increase maintainability.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
This is a WIP implementation and the new `sorbetClient` is intertwined with current `lspClient` during `start`, `stop` and `restart` methods. A cleaner implementation will follow in the future.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

Added.
