### PR TITLE
Support semantic token deltas

### DIFF
--- a/lib/ruby_lsp/listeners/inlay_hints.rb
+++ b/lib/ruby_lsp/listeners/inlay_hints.rb
@@ -69,6 +69,17 @@ module RubyLsp
           tooltip: tooltip,
         )
       end
+
+      private
+
+      sig { params(node: T.nilable(Prism::Node), range: T.nilable(T::Range[Integer])).returns(T::Boolean) }
+      def visible?(node, range)
+        return true if range.nil?
+        return false if node.nil?
+
+        loc = node.location
+        range.cover?(loc.start_line - 1) && range.cover?(loc.end_line - 1)
+      end
     end
   end
 end

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -35,28 +35,125 @@ module RubyLsp
               token_modifiers: ResponseBuilders::SemanticHighlighting::TOKEN_MODIFIERS.keys,
             ),
             range: true,
-            full: { delta: false },
+            full: { delta: true },
           )
+        end
+
+        # The compute_delta method receives the current semantic tokens and the previous semantic tokens and then tries
+        # to compute the smallest possible semantic token edit that will turn previous into current
+        sig do
+          params(
+            current_tokens: T::Array[Integer],
+            previous_tokens: T::Array[Integer],
+            result_id: String,
+          ).returns(Interface::SemanticTokensDelta)
+        end
+        def compute_delta(current_tokens, previous_tokens, result_id)
+          # Find the index of the first token that is different between the two sets of tokens
+          first_different_position = current_tokens.zip(previous_tokens).find_index { |new, old| new != old }
+
+          # When deleting a token from the end, the first_different_position will be nil, but since we're removing at
+          # the end, then we have to initialize it to the length of the current tokens after the deletion
+          if !first_different_position && current_tokens.length < previous_tokens.length
+            first_different_position = current_tokens.length
+          end
+
+          unless first_different_position
+            return Interface::SemanticTokensDelta.new(result_id: result_id, edits: [])
+          end
+
+          # Filter the tokens based on the first different position. This must happen at this stage, before we try to
+          # find the next position from the end or else we risk confusing sets of token that may have different lengths,
+          # but end with the exact same token
+          old_tokens = T.must(previous_tokens[first_different_position...])
+          new_tokens = T.must(current_tokens[first_different_position...])
+
+          # Then search from the end to find the first token that doesn't match. Since the user is normally editing the
+          # middle of the file, this will minimize the number of edits since the end of the token array has not changed
+          first_different_token_from_end = new_tokens.reverse.zip(old_tokens.reverse).find_index do |new, old|
+            new != old
+          end || 0
+
+          # Filter the old and new tokens to only the section that will be replaced/inserted/deleted
+          old_tokens = T.must(old_tokens[...old_tokens.length - first_different_token_from_end])
+          new_tokens = T.must(new_tokens[...new_tokens.length - first_different_token_from_end])
+
+          # And we send back a single edit, replacing an entire section for the new tokens
+          Interface::SemanticTokensDelta.new(
+            result_id: result_id,
+            edits: [{ start: first_different_position, deleteCount: old_tokens.length, data: new_tokens }],
+          )
+        end
+
+        sig { returns(Integer) }
+        def next_result_id
+          @mutex.synchronize do
+            @result_id += 1
+          end
         end
       end
 
-      sig { params(global_state: GlobalState, dispatcher: Prism::Dispatcher, range: T.nilable(T::Range[Integer])).void }
-      def initialize(global_state, dispatcher, range: nil)
+      @result_id = T.let(0, Integer)
+      @mutex = T.let(Mutex.new, Mutex)
+
+      sig do
+        params(
+          global_state: GlobalState,
+          dispatcher: Prism::Dispatcher,
+          document: T.any(RubyDocument, ERBDocument),
+          previous_result_id: T.nilable(String),
+          range: T.nilable(T::Range[Integer]),
+        ).void
+      end
+      def initialize(global_state, dispatcher, document, previous_result_id, range: nil)
         super()
+
+        @document = document
+        @previous_result_id = previous_result_id
+        @range = range
+        @result_id = T.let(SemanticHighlighting.next_result_id.to_s, String)
         @response_builder = T.let(
           ResponseBuilders::SemanticHighlighting.new(global_state.encoding),
           ResponseBuilders::SemanticHighlighting,
         )
-        Listeners::SemanticHighlighting.new(dispatcher, @response_builder, range: range)
+        Listeners::SemanticHighlighting.new(dispatcher, @response_builder)
 
         Addon.addons.each do |addon|
           addon.create_semantic_highlighting_listener(@response_builder, dispatcher)
         end
       end
 
-      sig { override.returns(Interface::SemanticTokens) }
+      sig { override.returns(T.any(Interface::SemanticTokens, Interface::SemanticTokensDelta)) }
       def perform
-        @response_builder.response
+        previous_tokens = @document.semantic_tokens
+        tokens = @response_builder.response
+        encoded_tokens = ResponseBuilders::SemanticHighlighting::SemanticTokenEncoder.new.encode(tokens)
+        full_response = Interface::SemanticTokens.new(result_id: @result_id, data: encoded_tokens)
+        @document.semantic_tokens = full_response
+
+        if @range
+          tokens_within_range = tokens.select { |token| @range.cover?(token.start_line - 1) }
+
+          return Interface::SemanticTokens.new(
+            result_id: @result_id,
+            data: ResponseBuilders::SemanticHighlighting::SemanticTokenEncoder.new.encode(tokens_within_range),
+          )
+        end
+
+        # Semantic tokens full delta
+        if @previous_result_id
+          response = if previous_tokens.is_a?(Interface::SemanticTokens) &&
+              previous_tokens.result_id == @previous_result_id
+            Requests::SemanticHighlighting.compute_delta(encoded_tokens, previous_tokens.data, @result_id)
+          else
+            full_response
+          end
+
+          return response
+        end
+
+        # Semantic tokens full
+        full_response
       end
     end
   end

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -37,15 +37,6 @@ module RubyLsp
           )
         end
 
-        sig { params(node: T.nilable(Prism::Node), range: T.nilable(T::Range[Integer])).returns(T::Boolean) }
-        def visible?(node, range)
-          return true if range.nil?
-          return false if node.nil?
-
-          loc = node.location
-          range.cover?(loc.start_line - 1) && range.cover?(loc.end_line - 1)
-        end
-
         sig do
           params(
             node: Prism::Node,

--- a/lib/ruby_lsp/response_builders/semantic_highlighting.rb
+++ b/lib/ruby_lsp/response_builders/semantic_highlighting.rb
@@ -91,9 +91,9 @@ module RubyLsp
         @stack.last
       end
 
-      sig { override.returns(Interface::SemanticTokens) }
+      sig { override.returns(T::Array[SemanticToken]) }
       def response
-        SemanticTokenEncoder.new.encode(@stack)
+        @stack
       end
 
       class SemanticToken
@@ -162,7 +162,7 @@ module RubyLsp
         sig do
           params(
             tokens: T::Array[SemanticToken],
-          ).returns(Interface::SemanticTokens)
+          ).returns(T::Array[Integer])
         end
         def encode(tokens)
           sorted_tokens = tokens.sort_by.with_index do |token, index|
@@ -176,7 +176,7 @@ module RubyLsp
             compute_delta(token)
           end
 
-          Interface::SemanticTokens.new(data: delta)
+          delta
         end
 
         # The delta array is computed according to the LSP specification:

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -20,7 +20,13 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
     dispatcher = Prism::Dispatcher.new
     global_state = RubyLsp::GlobalState.new
     global_state.apply_options({})
-    listener = RubyLsp::Requests::SemanticHighlighting.new(global_state, dispatcher, range: processed_range)
+    listener = RubyLsp::Requests::SemanticHighlighting.new(
+      global_state,
+      dispatcher,
+      document,
+      nil,
+      range: processed_range,
+    )
 
     dispatcher.dispatch(document.parse_result.value)
     listener.perform

--- a/test/requests/semantic_tokens_delta_test.rb
+++ b/test/requests/semantic_tokens_delta_test.rb
@@ -1,0 +1,319 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SemanticTokensDeltaTest < Minitest::Test
+  def test_inserting_something_at_the_end
+    assert_expected_token_result(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 200, 300, 400, 500],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    )
+  end
+
+  def test_inserting_something_in_the_beginning
+    assert_expected_token_result(
+      [10, 100, 200, 300, 400, 500, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    )
+  end
+
+  def test_inserting_something_in_the_middle
+    assert_expected_token_result(
+      [1, 2, 3, 4, 5, 10, 100, 200, 300, 400, 500, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    )
+  end
+
+  def test_deleting_at_the_end
+    assert_expected_token_result(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 200, 300, 400, 500],
+    )
+  end
+
+  def test_deleting_at_the_beginning
+    assert_expected_token_result(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [10, 100, 200, 300, 400, 500, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    )
+  end
+
+  def test_deleting_in_the_middle
+    assert_expected_token_result(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 10, 100, 200, 300, 400, 500, 6, 7, 8, 9, 10],
+    )
+  end
+
+  # The scenarios below were captured with the responses from the language server automatically, so that we can have a
+  # few more real case tests. There are confounding aspects to these examples, like having the exact same semantic token
+  # in arrays with different lengths
+
+  def test_computing_deltas_1
+    assert_expected_token_result(
+      [3, 4, 3, 13, 1, 1, 2, 1, 8, 0, 1, 0, 1, 13, 0, 1, 2, 9, 13, 0, 1, 2, 1, 8, 0],
+      [3, 4, 3, 13, 1, 1, 2, 1, 8, 0, 2, 2, 9, 13, 0, 1, 2, 1, 8, 0],
+    )
+  end
+
+  def test_computing_deltas_2
+    assert_expected_token_result(
+      [
+        3,
+        4,
+        21,
+        13,
+        1,
+        1,
+        2,
+        12,
+        13,
+        0,
+        0,
+        73,
+        5,
+        13,
+        0,
+        2,
+        2,
+        5,
+        8,
+        0,
+        0,
+        8,
+        7,
+        0,
+        0,
+        0,
+        9,
+        8,
+        0,
+        0,
+        0,
+        10,
+        20,
+        0,
+        0,
+        0,
+        21,
+        13,
+        13,
+        0,
+        4,
+        4,
+        5,
+        13,
+        0,
+        2,
+        0,
+        1,
+        8,
+        0,
+        1,
+        0,
+        1,
+        8,
+        0,
+        2,
+        2,
+        12,
+        13,
+        0,
+        0,
+        73,
+        5,
+        8,
+        0,
+      ],
+      [
+        3,
+        4,
+        21,
+        13,
+        1,
+        1,
+        2,
+        12,
+        13,
+        0,
+        0,
+        73,
+        5,
+        13,
+        0,
+        2,
+        2,
+        5,
+        8,
+        0,
+        0,
+        8,
+        7,
+        0,
+        0,
+        0,
+        9,
+        8,
+        0,
+        0,
+        0,
+        10,
+        20,
+        0,
+        0,
+        0,
+        21,
+        13,
+        13,
+        0,
+        4,
+        4,
+        5,
+        13,
+        0,
+        2,
+        0,
+        1,
+        8,
+        0,
+        3,
+        2,
+        12,
+        13,
+        0,
+        0,
+        73,
+        5,
+        8,
+        0,
+      ],
+    )
+  end
+
+  def test_computing_deltas_3
+    assert_expected_token_result(
+      [3, 6, 3, 2, 1, 0, 0, 3, 0, 0, 1, 6, 4, 13, 1, 1, 4, 1, 8, 0],
+      [3, 6, 3, 2, 1, 0, 0, 3, 0, 0, 1, 6, 4, 13, 1],
+    )
+  end
+
+  def test_computing_delta_4
+    assert_expected_token_result(
+      [3, 6, 3, 2, 1, 0, 0, 3, 0, 0, 1, 6, 4, 13, 1, 1, 4, 1, 8, 0, 1, 4, 1, 8, 0],
+      [3, 6, 3, 2, 1, 0, 0, 3, 0, 0, 1, 6, 4, 13, 1, 1, 4, 1, 8, 0],
+    )
+  end
+
+  def test_computing_delta_5
+    assert_expected_token_result(
+      [3, 6, 3, 2, 1, 0, 0, 3, 0, 0, 1, 6, 4, 13, 1, 1, 4, 1, 8, 0, 1, 4, 1, 8, 0, 0, 2, 4, 13, 0],
+      [3, 6, 3, 2, 1, 0, 0, 3, 0, 0, 1, 6, 4, 13, 1, 1, 4, 1, 8, 0, 1, 4, 1, 8, 0, 0, 2, 4, 13, 0, 1, 4, 1, 8, 0],
+    )
+  end
+
+  def test_computing_delta_6
+    assert_expected_token_result(
+      [3, 6, 3, 2, 1, 0, 0, 3, 0, 0, 1, 6, 4, 13, 1, 1, 4, 1, 8, 0, 1, 4, 1, 8, 0, 0, 2, 4, 13, 0],
+      [3, 6, 3, 2, 1, 0, 0, 3, 0, 0, 1, 6, 4, 13, 1, 1, 4, 1, 8, 0, 1, 4, 1, 8, 0, 1, 4, 1, 8, 0, 0, 2, 4, 13, 0],
+    )
+  end
+
+  def test_computing_delta_7
+    assert_expected_token_result(
+      [
+        3,
+        6,
+        3,
+        2,
+        1,
+        0,
+        0,
+        3,
+        0,
+        0,
+        1,
+        6,
+        4,
+        13,
+        1,
+        1,
+        4,
+        1,
+        8,
+        0,
+        1,
+        4,
+        1,
+        8,
+        0,
+        0,
+        2,
+        2,
+        13,
+        0,
+        1,
+        4,
+        1,
+        8,
+        0,
+        0,
+        2,
+        4,
+        13,
+        0,
+      ],
+      [
+        3,
+        6,
+        3,
+        2,
+        1,
+        0,
+        0,
+        3,
+        0,
+        0,
+        1,
+        6,
+        4,
+        13,
+        1,
+        1,
+        4,
+        1,
+        8,
+        0,
+        1,
+        4,
+        1,
+        8,
+        0,
+        0,
+        2,
+        1,
+        13,
+        0,
+        1,
+        4,
+        1,
+        8,
+        0,
+        0,
+        2,
+        4,
+        13,
+        0,
+      ],
+    )
+  end
+
+  private
+
+  def assert_expected_token_result(current_tokens, previous_tokens)
+    edit = RubyLsp::Requests::SemanticHighlighting.compute_delta(current_tokens, previous_tokens, "1").edits.first
+
+    previous_tokens[edit[:start]...(edit[:start] + edit[:deleteCount])] = edit[:data]
+    assert_equal(current_tokens, previous_tokens)
+  end
+end

--- a/test/requests/support/semantic_token_encoder_test.rb
+++ b/test/requests/support/semantic_token_encoder_test.rb
@@ -38,7 +38,7 @@ class SemanticTokenEncoderTest < Minitest::Test
 
     assert_equal(
       expected_encoding,
-      SemanticTokenEncoder.new.encode(tokens).data,
+      SemanticTokenEncoder.new.encode(tokens),
     )
   end
 
@@ -73,7 +73,7 @@ class SemanticTokenEncoderTest < Minitest::Test
       16,
     ]
 
-    assert_equal(expected_encoding, SemanticTokenEncoder.new.encode(tokens).data)
+    assert_equal(expected_encoding, SemanticTokenEncoder.new.encode(tokens))
   end
 
   def test_encoded_modifiers_with_no_modifiers

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -739,6 +739,17 @@ class RubyDocumentTest < Minitest::Test
     assert_equal("each", T.cast(target, Prism::CallNode).message)
   end
 
+  def test_uncached_requests_return_empty_cache_object
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
+      class Foo
+      end
+    RUBY
+
+    assert_same(document.cache_get("textDocument/codeLens"), RubyLsp::Document::EMPTY_CACHE)
+    document.cache_set("textDocument/codeLens", nil)
+    assert_nil(document.cache_get("textDocument/codeLens"))
+  end
+
   private
 
   def assert_error_edit(actual, error_range)


### PR DESCRIPTION
### Motivation

First step in #2461

This PR adds support for [semantic token deltas](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens_deltaRequest).

Here's how semantic highlighting works before and after this change.

**Before**

On every keypress, the editor sends a `textDocument/semanticTokens/full` request and the server returns all tokens for the entire file. In large files, the editor will sometimes send `textDocument/semanticTokens/range` to compute tokens for a limited range instead of doing it for the entire file.

**After**

When the file is first opened, the editor will send a `textDocument/semanticTokens/full` to compute all tokens for that file. From that point on, the editor will only send `textDocument/semanticTokens/full/delta`, to receive only the difference in tokens between the previous response and the current state of the file.

#### Why does this matter

Computing semantic tokens on the server is cheap. In some of my benchmarks, the Ruby LSP can compute ~20k tokens in roughly ~10ms. However, applying these tokens in the editor is very expensive. The fewer tokens we return, the faster the editor becomes.

In fact, if we return ~20k tokens on every keypress, the editor becomes backlogged with work and the lag prevents users from working normally.

#### Does this PR completely fix the problem

No. It improves the problem, but I will follow this PR up with an audit of our semantic tokens implementations. We start out returning tokens for pretty much everything, but we need to be a lot more conservative and only return tokens for the things that are really ambiguous to avoid performance issues.

### Implementation

There are many important parts in this implementation. First, for semantic token requests to work properly with deltas, we need to keep track of the semantic token result IDs and we need a separate cache for those tokens that cannot be cleared upon typing. The delta request needs to remember the previous result, so clearing upon typing would make it impossible to implement.

Secondly, running the full semantic tokens with the other listeners makes it incredibly difficult to ensure the correct result IDs. Accidentally bumping the ID will make the editor miss the delta and then we lose the benefits. It is clearly more impactful from a performance standpoint to support delta than it is to run semantic highlighting with the other listeners.

Having it separate will also play well with the next step to audit our semantic tokens, because we can convert the implementation to a visitor and have much better control over which tokens are returned.

Finally, the last part is computing the delta. The way the algorithm works is:

1. Find the first token from the start that differs between the previous and the current result. Strip the token arrays up to that point
2. From the end, find the first token that differs and strip the tail of the token arrays

Whatever is left will be the single edit necessary to turn the previous tokens into the current ones.

### Automated Tests

Added a bunch of tests.