### PR TITLE
Turn off semantic highlighting on files with more than 100k chars

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -23,6 +23,10 @@ module RubyLsp
     class SemanticHighlighting < Request
       extend T::Sig
 
+      # This maximum number of characters for providing highlighting is the same limit imposed by the VS Code TypeScript
+      # extension. Even with delta requests, anything above this number lags the editor significantly
+      MAXIMUM_CHARACTERS_FOR_HIGHLIGHT = 100_000
+
       class << self
         extend T::Sig
 

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -66,7 +66,7 @@ module RubyLsp
         version: Integer,
         language_id: Document::LanguageId,
         encoding: Encoding,
-      ).void
+      ).returns(Document[T.untyped])
     end
     def set(uri:, source:, version:, language_id:, encoding: Encoding::UTF_8)
       @state[uri.to_s] = case language_id


### PR DESCRIPTION
### Motivation

Closes #2461

This PR disables semantic highlighting for documents with over 100k characters. The TypeScript extension [does the same thing](https://github.com/microsoft/vscode/blob/0c743d4cd29242e80c5f047d9b5841702a4ccb47/extensions/typescript-language-features/src/languageFeatures/semanticTokens.ts#L13) for performance reasons.

For very large files, it gets to a point where the editor is simply unable to process the amount of tokens returned by the server at an acceptable speed and everything starts to lag. Ideally, we'd still want to highlight large files, but it's better to have the other features working than to make the editor unusable in these situations.

This PR brings our responses down to 200ms for a ~4k line file.

### Implementation

The idea is to show a warning when a document with more characters than the limit is opened and then we return empty responses before doing any processing if that's the case.

### Automated Tests

Added a test.