### PR TITLE
Disable diagnostics on large files

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -16,6 +16,10 @@ module RubyLsp
     extend T::Generic
 
     ParseResultType = type_member
+
+    # This maximum number of characters for providing expensive features, like semantic highlighting and diagnostics.
+    # This is the same number used by the TypeScript extension in VS Code
+    MAXIMUM_CHARACTERS_FOR_EXPENSIVE_FEATURES = 100_000
     EMPTY_CACHE = T.let(Object.new.freeze, Object)
 
     abstract!
@@ -111,6 +115,11 @@ module RubyLsp
     sig { returns(Scanner) }
     def create_scanner
       Scanner.new(@source, @encoding)
+    end
+
+    sig { returns(T::Boolean) }
+    def past_expensive_limit?
+      @source.length > MAXIMUM_CHARACTERS_FOR_EXPENSIVE_FEATURES
     end
 
     class Scanner

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -46,7 +46,9 @@ module RubyLsp
         diagnostics.concat(syntax_error_diagnostics, syntax_warning_diagnostics)
 
         # Running RuboCop is slow, so to avoid excessive runs we only do so if the file is syntactically valid
-        return diagnostics if @document.syntax_error? || @active_linters.empty?
+        if @document.syntax_error? || @active_linters.empty? || @document.past_expensive_limit?
+          return diagnostics
+        end
 
         @active_linters.each do |linter|
           linter_diagnostics = linter.run_diagnostic(@uri, @document)

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -33,10 +33,6 @@ module RubyLsp
     class SemanticHighlighting < Request
       extend T::Sig
 
-      # This maximum number of characters for providing highlighting is the same limit imposed by the VS Code TypeScript
-      # extension. Even with delta requests, anything above this number lags the editor significantly
-      MAXIMUM_CHARACTERS_FOR_HIGHLIGHT = 100_000
-
       class << self
         extend T::Sig
 

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -315,13 +315,14 @@ module RubyLsp
           language_id: language_id,
         )
 
-        if document.source.length > Requests::SemanticHighlighting::MAXIMUM_CHARACTERS_FOR_HIGHLIGHT
+        if document.past_expensive_limit?
           send_message(
             Notification.new(
               method: "window/showMessage",
               params: Interface::ShowMessageParams.new(
                 type: Constant::MessageType::WARNING,
-                message: "This file is too long. For performance reasons, semantic highlighting will be disabled",
+                message: "This file is too long. For performance reasons, semantic highlighting and " \
+                  "diagnostics will be disabled",
               ),
             ),
           )
@@ -427,7 +428,7 @@ module RubyLsp
     def text_document_semantic_tokens_full(message)
       document = @store.get(message.dig(:params, :textDocument, :uri))
 
-      if document.source.length > Requests::SemanticHighlighting::MAXIMUM_CHARACTERS_FOR_HIGHLIGHT
+      if document.past_expensive_limit?
         send_empty_response(message[:id])
         return
       end
@@ -448,7 +449,7 @@ module RubyLsp
     def text_document_semantic_tokens_delta(message)
       document = @store.get(message.dig(:params, :textDocument, :uri))
 
-      if document.source.length > Requests::SemanticHighlighting::MAXIMUM_CHARACTERS_FOR_HIGHLIGHT
+      if document.past_expensive_limit?
         send_empty_response(message[:id])
         return
       end
@@ -476,7 +477,7 @@ module RubyLsp
       uri = params.dig(:textDocument, :uri)
       document = @store.get(uri)
 
-      if document.source.length > Requests::SemanticHighlighting::MAXIMUM_CHARACTERS_FOR_HIGHLIGHT
+      if document.past_expensive_limit?
         send_empty_response(message[:id])
         return
       end


### PR DESCRIPTION
### Motivation

Similar to #2481, this PR disables "external diagnostics" for files with over 100k characters. Diagnostics such as syntax errors (collected by Prism) are still displayed, but linters like RuboCop are not shown.

Diagnostics runs on every keypress and trying to compute it for very large files ends up causing too much lag in the editor. After this PR, working on a ~4k line file is fully responsive, with response times around ~10-50ms.

### Implementation

Just changed the message on did open and started returning before running RuboCop in large files.

### Automated Tests

We don't have such a large file inside our codebase and we intentionally don't run diagnostics on files that are outside of the workspace, so I couldn't use Prism's `node.rb` file to write a test. I think this is simple enough that it's okay to skip it.