### PR TITLE
Always run Ruby activation using cmd for RubyInstaller

### DIFF
--- a/vscode/src/ruby/rubyInstaller.ts
+++ b/vscode/src/ruby/rubyInstaller.ts
@@ -3,6 +3,8 @@ import os from "os";
 
 import * as vscode from "vscode";
 
+import { asyncExec } from "../common";
+
 import { Chruby } from "./chruby";
 
 interface RubyVersion {
@@ -51,5 +53,22 @@ export class RubyInstaller extends Chruby {
       `Cannot find installation directory for Ruby version ${rubyVersion.version}.\
          Searched in ${possibleInstallationUris.map((uri) => uri.fsPath).join(", ")}`,
     );
+  }
+
+  // Override the `runScript` method to ensure that we do not pass any `shell` to `asyncExec`. The activation script is
+  // only compatible with `cmd.exe`, and not Powershell, due to escaping of quotes. We need to ensure to always run the
+  // script on `cmd.exe`.
+  protected runScript(command: string) {
+    this.outputChannel.info(
+      `Running command: \`${command}\` in ${this.bundleUri.fsPath}`,
+    );
+    this.outputChannel.debug(
+      `Environment used for command: ${JSON.stringify(process.env)}`,
+    );
+
+    return asyncExec(command, {
+      cwd: this.bundleUri.fsPath,
+      env: process.env,
+    });
   }
 }


### PR DESCRIPTION
### Motivation

Closes #2434

Our Ruby environment activation script doesn't work for Windows user who select their default shell as Powershell due to quote escaping issues.

I believe `cmd.exe` will always be available and it's the default option when invoking NodeJS' `exec` function, so instead of trying to escape the script differently depending on the shell, I think we should just always run `RubyInstaller` activation on `cmd.exe`.

### Implementation

I created an override for `runScript`, which removes the `shell` part for `RubyInstaller` only.

### Automated Tests

Added a test verifying that we're not passing `shell` to `exec`.