### PR TITLE
fix(grammar): Fix syntax highlighting for Kernel.` method in Ruby grammar

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -486,7 +486,7 @@
       ]
     },
     {
-      "begin": "`",
+      "begin": "(?<!\\.)`",
       "beginCaptures": {
         "0": {
           "name": "punctuation.definition.string.begin.ruby"

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -270,6 +270,61 @@ suite("Grammars", () => {
       });
     });
 
+    suite("Backtick String Literals", () => {
+      test("Standard backtick string", () => {
+        const ruby = "`ruby`";
+        const expectedTokens = [
+          [
+            "`",
+            [
+              "source.ruby",
+              "string.interpolated.ruby",
+              "punctuation.definition.string.begin.ruby",
+            ],
+          ],
+          ["ruby", ["source.ruby", "string.interpolated.ruby"]],
+          [
+            "`",
+            [
+              "source.ruby",
+              "string.interpolated.ruby",
+              "punctuation.definition.string.end.ruby",
+            ],
+          ],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+
+      test("Kernel backtick method", () => {
+        const ruby = 'Kernel.`"ls"';
+        const expectedTokens = [
+          ["Kernel", ["source.ruby", "variable.other.constant.ruby"]],
+          [".", ["source.ruby", "punctuation.separator.method.ruby"]],
+          ["`", ["source.ruby"]],
+          [
+            '"',
+            [
+              "source.ruby",
+              "string.quoted.double.interpolated.ruby",
+              "punctuation.definition.string.begin.ruby",
+            ],
+          ],
+          ["ls", ["source.ruby", "string.quoted.double.interpolated.ruby"]],
+          [
+            '"',
+            [
+              "source.ruby",
+              "string.quoted.double.interpolated.ruby",
+              "punctuation.definition.string.end.ruby",
+            ],
+          ],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+    });
+
     function tokenizeRuby(ruby: string): [string, string[]][] {
       if (!rubyGrammar) {
         throw new Error("Ruby grammar not loaded");


### PR DESCRIPTION
### Motivation

Closes #1470

The issue was that syntax highlighting breaks when using the ``Kernel.\` `` method in Ruby code. The grammar was incorrectly treating the backtick in this context as the start of an interpolated string literal, leading to incorrect tokenization and highlighting.

### Implementation

To address this, the Ruby grammar was updated to properly distinguish between backtick string literals and the ``Kernel.` `` method calls. Specifically, the `begin` pattern for backticks was modified to include a negative lookbehind `(?<!\\.)`, ensuring that only standalone backticks are treated as string delimiters.

> (?<!…) — Negative Lookbehind. Matches if the provided pattern would not match the preceding characters, but does not advance the current position. The pattern must have a fixed length (unbounded [quantifiers](https://rbuckton.github.io/regexp-features/engines/oniguruma.html#feature-quantifiers) are not permitted).

ref. https://rbuckton.github.io/regexp-features/engines/oniguruma.html

Additionally, I added new test cases to cover both standard backtick strings and ``Kernel.\` `` method calls. These tests verify that the grammar correctly tokenizes each scenario, ensuring that backtick strings are recognized as interpolated strings, while ``Kernel.\` `` methods are handled without string interpretation.

### Automated Tests

Unit tests were added as part of this change to ensure that both scenarios (standard backtick strings and ``Kernel.\` ``method calls) are correctly handled by the grammar.

### Manual Tests
#### Before
<img width="1280" alt="Screenshot 2024-08-27 at 00 37 02" src="https://github.com/user-attachments/assets/2eeaa3c2-52b6-4d56-8b5f-bcd540f751b1">

#### After
<img width="1280" alt="Screenshot 2024-08-27 at 00 36 27" src="https://github.com/user-attachments/assets/96db87d4-c0ca-4a0d-a1c5-6d2072dddffb">

