### PR TITLE
Show progress while initializing the server

### DIFF
--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -109,8 +109,16 @@ export class Workspace implements WorkspaceInterface {
 
     try {
       STATUS_EMITTER.fire(this);
-      await this.lspClient.start();
-      await this.lspClient.afterStart();
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Window,
+          title: "Initializing Ruby LSP",
+        },
+        async () => {
+          await this.lspClient!.start();
+          await this.lspClient!.afterStart();
+        },
+      );
       STATUS_EMITTER.fire(this);
 
       // If something triggered a restart while we were still booting, then now we need to perform the restart since the


### PR DESCRIPTION
### Motivation

Closes #2387

Show a progress indication in the status bar while the server is initializing, before indexing begins.

### Implementation

The ideal solution would be turning on `progressOnInitialization` in the client options and then showing the exact progress of Bundle install.

However, we cannot do that at the moment. We can't read the initialize request from the STDIN pipe while setting up the custom bundle, so we can't figure out if the client supports progress notifications and if the client is sending an initialization progress token for us to stream updates to.

The best we can do is just show our own progress while booting is happening.