### PR TITLE
Raise AddonNotFoundError exception when the addon is not found

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -30,6 +30,8 @@ module RubyLsp
     # Addon instances that have declared a handler to accept file watcher events
     @file_watcher_addons = T.let([], T::Array[Addon])
 
+    AddonNotFoundError = Class.new(StandardError)
+
     class << self
       extend T::Sig
 
@@ -78,11 +80,10 @@ module RubyLsp
         errors
       end
 
-      # Intended for use by tests for addons
       sig { params(addon_name: String).returns(Addon) }
       def get(addon_name)
         addon = addons.find { |addon| addon.name == addon_name }
-        raise "Could not find addon '#{addon_name}'" unless addon
+        raise AddonNotFoundError, "Could not find addon '#{addon_name}'" unless addon
 
         addon
       end

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -106,7 +106,7 @@ module RubyLsp
     end
 
     def test_raises_if_an_addon_cannot_be_found
-      assert_raises do
+      assert_raises(Addon::AddonNotFoundError) do
         Addon.get("Invalid Addon")
       end
     end


### PR DESCRIPTION
### Motivation

Fail in more graceful way for addons such as Tapioca LSP.

### Implementation

Raise and error that be e rescued downstream.

### Automated Tests

Added

### Manual Tests

n/a