### PR TITLE
Forward initialization settings to addons

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -40,6 +40,12 @@ module RubyLsp
       @supports_watching_files = T.let(false, T::Boolean)
       @experimental_features = T.let(false, T::Boolean)
       @type_inferrer = T.let(TypeInferrer.new(@index, @experimental_features), TypeInferrer)
+      @addon_settings = T.let({}, T::Hash[String, T.untyped])
+    end
+
+    sig { params(addon_name: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    def settings_for_addon(addon_name)
+      @addon_settings[addon_name]
     end
 
     sig { params(identifier: String, instance: Requests::Support::Formatter).void }
@@ -118,6 +124,12 @@ module RubyLsp
 
       @experimental_features = options.dig(:initializationOptions, :experimentalFeaturesEnabled) || false
       @type_inferrer.experimental_features = @experimental_features
+
+      addon_settings = options.dig(:initializationOptions, :addonSettings)
+      if addon_settings
+        addon_settings.transform_keys!(&:to_s)
+        @addon_settings.merge!(addon_settings)
+      end
 
       notifications
     end

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -209,6 +209,20 @@ module RubyLsp
       assert_predicate(state, :has_type_checker)
     end
 
+    def test_addon_settings_are_stored
+      global_state = GlobalState.new
+
+      global_state.apply_options({
+        initializationOptions: {
+          addonSettings: {
+            "Ruby LSP Rails" => { runtimeServerEnabled: false },
+          },
+        },
+      })
+
+      assert_equal({ runtimeServerEnabled: false }, global_state.settings_for_addon("Ruby LSP Rails"))
+    end
+
     private
 
     def stub_direct_dependencies(dependencies)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -294,6 +294,22 @@
             }
           }
         },
+        "rubyLsp.addonSettings": {
+          "description": "Settings that will be forwarded to configure the behavior of Ruby LSP addons. Keys are addon names, values are objects of settings",
+          "type": "object",
+          "examples": [
+            {
+              "Ruby LSP Rails": {
+                "something": true
+              }
+            },
+            {
+              "Standard Ruby": {
+                "something": true
+              }
+            }
+          ]
+        },
         "rubyLsp.rubyVersionManager": {
           "type": "object",
           "properties": {

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -184,6 +184,7 @@ function collectClientOptions(
       formatter: configuration.get("formatter"),
       linters: configuration.get("linters"),
       indexing: configuration.get("indexing"),
+      addonSettings: configuration.get("addonSettings"),
     },
   };
 }


### PR DESCRIPTION
### Motivation

Closes #1204
First step to allow https://github.com/Shopify/ruby-lsp-rails/issues/389

While we work super hard to minimize the amount of configuration for the Ruby LSP, it's not realistic to assume that addons are not going to need any settings to be exposed.

We need a way to allow addons to receive relevant editor settings, so that their behaviour can be customized.

### Implementation

The idea is to allow for configuration objects like

```jsonc
"rubyLsp.addonSettings": {
  "Ruby LSP Rails": {
    "runtimeServerCommand": "bin/dev server",
    "somethingElse": false,
  }
}
```

And then we remember those settings in the global state. Addons will then have access to these settings and can decide what to do accordingly.

### Automated Tests

Added tests.