### PR TITLE
Output written to $stderr when no explicit device provided

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -135,4 +135,8 @@ if options[:doctor]
   return
 end
 
+# Ensure all output goes out stderr by default to allow puts/p/pp to work
+# without specifying output device.
+$> = $stderr
+
 RubyLsp::Server.new.start


### PR DESCRIPTION
Allow puts/p/pp to work without specifying $stderr as the output device.

Will fix scenarios where debugging information is accidentally written to $stdout, as well as make puts-style debugging work intuitively.

Default output set _after_ OptionParser, since best practice of GNU tools dictates that --help goes to $stdout.

### Motivation

When developing an LSP addon, sometimes it's nice to just `puts "TRIGGERED"` in a method block to see that the code path is actually executing. But this doesn't work by default because it goes out `$stdout` and is consumed by the LSP client.

To work around this, every call to `puts` needs to be prefixed with `$stderr`. But for `pp`, this is more challenging, and the explicit `PP.pp obj, $stderr` needs to be used.

It would be easier if the default output was set to `$stderr`.

### Implementation

The most natural location felt like the exe/entry-point for `ruby-lsp`. I chose to place the redirect almost at the bottom, just above the starting of the server.

GNU suggests sending `--help` to `$stdout`, and there are a few flags (`--doctor`, etc) that perform output, and it seems keeping them the same would be the safest bet.

### Automated Tests

I didn't adjust any tests.

### Manual Tests

I tested the LSP manually via Neovim and everything appeared to function correctly. I simulated a stray `puts` call and it showed up via `$stderr` as expected.