### PR TITLE
Add inlay hint support for addons

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -193,5 +193,15 @@ module RubyLsp
       ).void
     end
     def create_completion_listener(response_builder, node_context, dispatcher, uri); end
+
+    sig do
+      overridable.params(
+        response_builder: ResponseBuilders::CollectionResponseBuilder[Interface::InlayHint],
+        dispatcher: Prism::Dispatcher,
+        document: T.any(RubyDocument, ERBDocument),
+        range: T::Hash[Symbol, T.untyped],
+      ).void
+    end
+    def create_inlay_hint_listener(response_builder, dispatcher, document, range); end
   end
 end

--- a/lib/ruby_lsp/requests/inlay_hints.rb
+++ b/lib/ruby_lsp/requests/inlay_hints.rb
@@ -68,6 +68,10 @@ module RubyLsp
           ResponseBuilders::CollectionResponseBuilder[Interface::InlayHint],
         )
         Listeners::InlayHints.new(@response_builder, start_line..end_line, hints_configuration, dispatcher)
+
+        Addon.addons.each do |addon|
+          addon.create_inlay_hint_listener(@response_builder, dispatcher, document, range)
+        end
       end
 
       sig { override.returns(T::Array[Interface::InlayHint]) }


### PR DESCRIPTION
### Motivation

Closes #2485

Extend the LSP to support inlay hints in addons.

### Implementation

1. Add a for loop calling `Addon#create_inlay_hint_listener` for each addon in  `Requests::InlayHint`. So each addon can add more responses to the response_builder.
2. Add method `create_inlay_hint_listener` to base addon.

### Automated Tests

1. Added test for addon responses in inlay hint request (same as completion and hover addon extensions).

### Manual Tests

Create an addon that extend the inlay hints request and read a constant node (as in the automated test). You should see the inlay hint added by the addon.
