### PR TITLE
Fix minitest code lens filter patterns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,12 @@ class MyRequestExpectationsTest < ExpectationsTestRunner
 end
 ```
 
+To automatically create or update `.exp.json` files, you can use the `WRITE_EXPECTATIONS` environment variable. For example:
+
+```sh
+WRITE_EXPECTATIONS=1 bin/test test/requests/code_lens_expectations_test.rb
+```
+
 ## Debugging with VS Code
 
 ## Debugging Tests

--- a/test/expectations/code_lens/minitest_nested_classes_and_modules.exp.json
+++ b/test/expectations/code_lens/minitest_nested_classes_and_modules.exp.json
@@ -16,14 +16,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "FooTest",
+          "Foo::FooTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::FooTest(#|::)/\"",
           {
             "start_line": 1,
             "start_column": 2,
             "end_line": 5,
             "end_column": 5
-          }
+          },
+          "FooTest"
         ]
       },
       "data": {
@@ -49,14 +50,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "FooTest",
+          "Foo::FooTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::FooTest(#|::)/\"",
           {
             "start_line": 1,
             "start_column": 2,
             "end_line": 5,
             "end_column": 5
-          }
+          },
+          "FooTest"
         ]
       },
       "data": {
@@ -82,14 +84,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "FooTest",
+          "Foo::FooTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::FooTest(#|::)/\"",
           {
             "start_line": 1,
             "start_column": 2,
             "end_line": 5,
             "end_column": 5
-          }
+          },
+          "FooTest"
         ]
       },
       "data": {
@@ -115,14 +118,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo",
+          "Foo::FooTest#test_foo",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo",
           {
             "start_line": 2,
             "start_column": 4,
             "end_line": 2,
             "end_column": 21
-          }
+          },
+          "test_foo"
         ]
       },
       "data": {
@@ -147,14 +151,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo",
+          "Foo::FooTest#test_foo",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo",
           {
             "start_line": 2,
             "start_column": 4,
             "end_line": 2,
             "end_column": 21
-          }
+          },
+          "test_foo"
         ]
       },
       "data": {
@@ -179,14 +184,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo",
+          "Foo::FooTest#test_foo",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo",
           {
             "start_line": 2,
             "start_column": 4,
             "end_line": 2,
             "end_column": 21
-          }
+          },
+          "test_foo"
         ]
       },
       "data": {
@@ -211,14 +217,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_2",
+          "Foo::FooTest#test_foo_2",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo_2",
           {
             "start_line": 4,
             "start_column": 4,
             "end_line": 4,
             "end_column": 23
-          }
+          },
+          "test_foo_2"
         ]
       },
       "data": {
@@ -243,14 +250,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_2",
+          "Foo::FooTest#test_foo_2",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo_2",
           {
             "start_line": 4,
             "start_column": 4,
             "end_line": 4,
             "end_column": 23
-          }
+          },
+          "test_foo_2"
         ]
       },
       "data": {
@@ -275,14 +283,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_2",
+          "Foo::FooTest#test_foo_2",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo_2",
           {
             "start_line": 4,
             "start_column": 4,
             "end_line": 4,
             "end_column": 23
-          }
+          },
+          "test_foo_2"
         ]
       },
       "data": {
@@ -307,14 +316,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "BarTest",
+          "Foo::Bar::BarTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest(#|::)/\"",
           {
             "start_line": 8,
             "start_column": 4,
             "end_line": 18,
             "end_column": 7
-          }
+          },
+          "BarTest"
         ]
       },
       "data": {
@@ -340,14 +350,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "BarTest",
+          "Foo::Bar::BarTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest(#|::)/\"",
           {
             "start_line": 8,
             "start_column": 4,
             "end_line": 18,
             "end_column": 7
-          }
+          },
+          "BarTest"
         ]
       },
       "data": {
@@ -373,14 +384,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "BarTest",
+          "Foo::Bar::BarTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest(#|::)/\"",
           {
             "start_line": 8,
             "start_column": 4,
             "end_line": 18,
             "end_column": 7
-          }
+          },
+          "BarTest"
         ]
       },
       "data": {
@@ -406,14 +418,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_bar",
+          "Foo::Bar::BarTest#test_bar",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest#test_bar",
           {
             "start_line": 9,
             "start_column": 6,
             "end_line": 9,
             "end_column": 23
-          }
+          },
+          "test_bar"
         ]
       },
       "data": {
@@ -438,14 +451,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_bar",
+          "Foo::Bar::BarTest#test_bar",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest#test_bar",
           {
             "start_line": 9,
             "start_column": 6,
             "end_line": 9,
             "end_column": 23
-          }
+          },
+          "test_bar"
         ]
       },
       "data": {
@@ -470,14 +484,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_bar",
+          "Foo::Bar::BarTest#test_bar",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest#test_bar",
           {
             "start_line": 9,
             "start_column": 6,
             "end_line": 9,
             "end_column": 23
-          }
+          },
+          "test_bar"
         ]
       },
       "data": {
@@ -502,14 +517,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "BazTest",
+          "Foo::Bar::BarTest::Baz::BazTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest::Baz::BazTest(#|::)/\"",
           {
             "start_line": 12,
             "start_column": 8,
             "end_line": 16,
             "end_column": 11
-          }
+          },
+          "BazTest"
         ]
       },
       "data": {
@@ -535,14 +551,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "BazTest",
+          "Foo::Bar::BarTest::Baz::BazTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest::Baz::BazTest(#|::)/\"",
           {
             "start_line": 12,
             "start_column": 8,
             "end_line": 16,
             "end_column": 11
-          }
+          },
+          "BazTest"
         ]
       },
       "data": {
@@ -568,14 +585,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "BazTest",
+          "Foo::Bar::BarTest::Baz::BazTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest::Baz::BazTest(#|::)/\"",
           {
             "start_line": 12,
             "start_column": 8,
             "end_line": 16,
             "end_column": 11
-          }
+          },
+          "BazTest"
         ]
       },
       "data": {
@@ -601,14 +619,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_baz",
+          "Foo::Bar::BarTest::Baz::BazTest#test_baz",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz",
           {
             "start_line": 13,
             "start_column": 10,
             "end_line": 13,
             "end_column": 27
-          }
+          },
+          "test_baz"
         ]
       },
       "data": {
@@ -633,14 +652,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_baz",
+          "Foo::Bar::BarTest::Baz::BazTest#test_baz",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz",
           {
             "start_line": 13,
             "start_column": 10,
             "end_line": 13,
             "end_column": 27
-          }
+          },
+          "test_baz"
         ]
       },
       "data": {
@@ -665,14 +685,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_baz",
+          "Foo::Bar::BarTest::Baz::BazTest#test_baz",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz",
           {
             "start_line": 13,
             "start_column": 10,
             "end_line": 13,
             "end_column": 27
-          }
+          },
+          "test_baz"
         ]
       },
       "data": {
@@ -697,14 +718,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_baz_2",
+          "Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
           {
             "start_line": 15,
             "start_column": 10,
             "end_line": 15,
             "end_column": 29
-          }
+          },
+          "test_baz_2"
         ]
       },
       "data": {
@@ -729,14 +751,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_baz_2",
+          "Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
           {
             "start_line": 15,
             "start_column": 10,
             "end_line": 15,
             "end_column": 29
-          }
+          },
+          "test_baz_2"
         ]
       },
       "data": {
@@ -761,14 +784,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_baz_2",
+          "Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
           {
             "start_line": 15,
             "start_column": 10,
             "end_line": 15,
             "end_column": 29
-          }
+          },
+          "test_baz_2"
         ]
       },
       "data": {
@@ -793,14 +817,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "BazTest",
+          "Foo::Baz::BazTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Baz::BazTest(#|::)/\"",
           {
             "start_line": 22,
             "start_column": 4,
             "end_line": 24,
             "end_column": 7
-          }
+          },
+          "BazTest"
         ]
       },
       "data": {
@@ -826,14 +851,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "BazTest",
+          "Foo::Baz::BazTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Baz::BazTest(#|::)/\"",
           {
             "start_line": 22,
             "start_column": 4,
             "end_line": 24,
             "end_column": 7
-          }
+          },
+          "BazTest"
         ]
       },
       "data": {
@@ -859,14 +885,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "BazTest",
+          "Foo::Baz::BazTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Baz::BazTest(#|::)/\"",
           {
             "start_line": 22,
             "start_column": 4,
             "end_line": 24,
             "end_column": 7
-          }
+          },
+          "BazTest"
         ]
       },
       "data": {
@@ -892,14 +919,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_baz",
+          "Foo::Baz::BazTest#test_baz",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Baz::BazTest#test_baz",
           {
             "start_line": 23,
             "start_column": 6,
             "end_line": 23,
             "end_column": 23
-          }
+          },
+          "test_baz"
         ]
       },
       "data": {
@@ -924,14 +952,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_baz",
+          "Foo::Baz::BazTest#test_baz",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Baz::BazTest#test_baz",
           {
             "start_line": 23,
             "start_column": 6,
             "end_line": 23,
             "end_column": 23
-          }
+          },
+          "test_baz"
         ]
       },
       "data": {
@@ -956,14 +985,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_baz",
+          "Foo::Baz::BazTest#test_baz",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Baz::BazTest#test_baz",
           {
             "start_line": 23,
             "start_column": 6,
             "end_line": 23,
             "end_column": 23
-          }
+          },
+          "test_baz"
         ]
       },
       "data": {
@@ -988,14 +1018,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "FooBarTest",
+          "Foo::Bar::FooBarTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBarTest(#|::)/\"",
           {
             "start_line": 29,
             "start_column": 2,
             "end_line": 33,
             "end_column": 5
-          }
+          },
+          "FooBarTest"
         ]
       },
       "data": {
@@ -1021,14 +1052,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "FooBarTest",
+          "Foo::Bar::FooBarTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBarTest(#|::)/\"",
           {
             "start_line": 29,
             "start_column": 2,
             "end_line": 33,
             "end_column": 5
-          }
+          },
+          "FooBarTest"
         ]
       },
       "data": {
@@ -1054,14 +1086,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "FooBarTest",
+          "Foo::Bar::FooBarTest",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBarTest(#|::)/\"",
           {
             "start_line": 29,
             "start_column": 2,
             "end_line": 33,
             "end_column": 5
-          }
+          },
+          "FooBarTest"
         ]
       },
       "data": {
@@ -1087,14 +1120,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_bar",
+          "Foo::Bar::FooBarTest#test_foo_bar",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar",
           {
             "start_line": 30,
             "start_column": 4,
             "end_line": 30,
             "end_column": 25
-          }
+          },
+          "test_foo_bar"
         ]
       },
       "data": {
@@ -1119,14 +1153,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_bar",
+          "Foo::Bar::FooBarTest#test_foo_bar",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar",
           {
             "start_line": 30,
             "start_column": 4,
             "end_line": 30,
             "end_column": 25
-          }
+          },
+          "test_foo_bar"
         ]
       },
       "data": {
@@ -1151,14 +1186,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_bar",
+          "Foo::Bar::FooBarTest#test_foo_bar",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar",
           {
             "start_line": 30,
             "start_column": 4,
             "end_line": 30,
             "end_column": 25
-          }
+          },
+          "test_foo_bar"
         ]
       },
       "data": {
@@ -1183,14 +1219,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_bar_2",
+          "Foo::Bar::FooBarTest#test_foo_bar_2",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar_2",
           {
             "start_line": 32,
             "start_column": 4,
             "end_line": 32,
             "end_column": 27
-          }
+          },
+          "test_foo_bar_2"
         ]
       },
       "data": {
@@ -1215,14 +1252,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_bar_2",
+          "Foo::Bar::FooBarTest#test_foo_bar_2",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar_2",
           {
             "start_line": 32,
             "start_column": 4,
             "end_line": 32,
             "end_column": 27
-          }
+          },
+          "test_foo_bar_2"
         ]
       },
       "data": {
@@ -1247,14 +1285,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_bar_2",
+          "Foo::Bar::FooBarTest#test_foo_bar_2",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar_2",
           {
             "start_line": 32,
             "start_column": 4,
             "end_line": 32,
             "end_column": 27
-          }
+          },
+          "test_foo_bar_2"
         ]
       },
       "data": {
@@ -1279,14 +1318,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "FooBar::Test",
+          "Foo::Bar::FooBar::Test",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBar::Test(#|::)/\"",
           {
             "start_line": 38,
             "start_column": 2,
             "end_line": 40,
             "end_column": 5
-          }
+          },
+          "FooBar::Test"
         ]
       },
       "data": {
@@ -1312,14 +1352,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "FooBar::Test",
+          "Foo::Bar::FooBar::Test",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBar::Test(#|::)/\"",
           {
             "start_line": 38,
             "start_column": 2,
             "end_line": 40,
             "end_column": 5
-          }
+          },
+          "FooBar::Test"
         ]
       },
       "data": {
@@ -1345,14 +1386,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "FooBar::Test",
+          "Foo::Bar::FooBar::Test",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBar::Test(#|::)/\"",
           {
             "start_line": 38,
             "start_column": 2,
             "end_line": 40,
             "end_column": 5
-          }
+          },
+          "FooBar::Test"
         ]
       },
       "data": {
@@ -1378,14 +1420,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_bar_baz",
+          "Foo::Bar::FooBar::Test#test_foo_bar_baz",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBar::Test#test_foo_bar_baz",
           {
             "start_line": 39,
             "start_column": 4,
             "end_line": 39,
             "end_column": 29
-          }
+          },
+          "test_foo_bar_baz"
         ]
       },
       "data": {
@@ -1410,14 +1453,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_bar_baz",
+          "Foo::Bar::FooBar::Test#test_foo_bar_baz",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBar::Test#test_foo_bar_baz",
           {
             "start_line": 39,
             "start_column": 4,
             "end_line": 39,
             "end_column": 29
-          }
+          },
+          "test_foo_bar_baz"
         ]
       },
       "data": {
@@ -1442,14 +1486,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
-          "test_foo_bar_baz",
+          "Foo::Bar::FooBar::Test#test_foo_bar_baz",
           "bundle exec ruby -Itest /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBar::Test#test_foo_bar_baz",
           {
             "start_line": 39,
             "start_column": 4,
             "end_line": 39,
             "end_column": 29
-          }
+          },
+          "test_foo_bar_baz"
         ]
       },
       "data": {
@@ -1459,5 +1504,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/expectations/code_lens/minitest_spec_tests.exp.json
+++ b/test/expectations/code_lens/minitest_spec_tests.exp.json
@@ -17,7 +17,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -50,7 +50,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -83,7 +83,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -116,7 +116,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
           {
             "start_line": 1,
             "start_column": 2,
@@ -148,7 +148,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
           {
             "start_line": 1,
             "start_column": 2,
@@ -180,7 +180,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
           {
             "start_line": 1,
             "start_column": 2,
@@ -212,7 +212,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
@@ -245,7 +245,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
@@ -278,7 +278,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
@@ -311,7 +311,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
           {
             "start_line": 4,
             "start_column": 4,
@@ -343,7 +343,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
           {
             "start_line": 4,
             "start_column": 4,
@@ -375,7 +375,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
           {
             "start_line": 4,
             "start_column": 4,
@@ -407,7 +407,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
@@ -440,7 +440,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
@@ -473,7 +473,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
@@ -506,7 +506,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
           {
             "start_line": 7,
             "start_column": 6,
@@ -538,7 +538,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
           {
             "start_line": 7,
             "start_column": 6,
@@ -570,7 +570,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_deep_nested",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_deep_nested/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
           {
             "start_line": 7,
             "start_column": 6,
@@ -602,7 +602,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
           {
             "start_line": 10,
             "start_column": 4,
@@ -634,7 +634,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
           {
             "start_line": 10,
             "start_column": 4,
@@ -666,7 +666,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_nested_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_nested_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
           {
             "start_line": 10,
             "start_column": 4,
@@ -698,7 +698,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
           {
             "start_line": 13,
             "start_column": 2,
@@ -730,7 +730,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
           {
             "start_line": 13,
             "start_column": 2,
@@ -762,7 +762,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_level_one_again",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_level_one_again/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
           {
             "start_line": 13,
             "start_column": 2,
@@ -794,7 +794,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo::Bar",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo::Bar/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
           {
             "start_line": 16,
             "start_column": 0,
@@ -827,7 +827,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo::Bar",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo::Bar/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
           {
             "start_line": 16,
             "start_column": 0,
@@ -860,7 +860,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Foo::Bar",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Foo::Bar/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
           {
             "start_line": 16,
             "start_column": 0,
@@ -893,7 +893,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_class_constant_path",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_class_constant_path/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
           {
             "start_line": 17,
             "start_column": 2,
@@ -925,7 +925,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_class_constant_path",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_class_constant_path/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
           {
             "start_line": 17,
             "start_column": 2,
@@ -957,7 +957,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "it_class_constant_path",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /it_class_constant_path/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
           {
             "start_line": 17,
             "start_column": 2,
@@ -989,7 +989,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Baz",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Baz/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz(#|::)/\"",
           {
             "start_line": 20,
             "start_column": 0,
@@ -1022,7 +1022,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Baz",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Baz/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz(#|::)/\"",
           {
             "start_line": 20,
             "start_column": 0,
@@ -1055,7 +1055,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "Baz",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Baz/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz(#|::)/\"",
           {
             "start_line": 20,
             "start_column": 0,
@@ -1088,7 +1088,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "#foo",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#foo/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
           {
             "start_line": 21,
             "start_column": 2,
@@ -1121,7 +1121,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "#foo",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#foo/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
           {
             "start_line": 21,
             "start_column": 2,
@@ -1154,7 +1154,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "#foo",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#foo/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
           {
             "start_line": 21,
             "start_column": 2,
@@ -1187,7 +1187,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "works",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
           {
             "start_line": 22,
             "start_column": 4,
@@ -1219,7 +1219,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "works",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
           {
             "start_line": 22,
             "start_column": 4,
@@ -1251,7 +1251,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "works",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
           {
             "start_line": 22,
             "start_column": 4,
@@ -1283,7 +1283,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "#bar",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#bar/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
           {
             "start_line": 25,
             "start_column": 2,
@@ -1316,7 +1316,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "#bar",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#bar/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
           {
             "start_line": 25,
             "start_column": 2,
@@ -1349,7 +1349,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "#bar",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#bar/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
           {
             "start_line": 25,
             "start_column": 2,
@@ -1382,7 +1382,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "works",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
           {
             "start_line": 26,
             "start_column": 4,
@@ -1414,7 +1414,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "works",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
           {
             "start_line": 26,
             "start_column": 4,
@@ -1446,7 +1446,7 @@
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
           "works",
-          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
           {
             "start_line": 26,
             "start_column": 4,

--- a/test/expectations/code_lens/minitest_spec_tests.exp.json
+++ b/test/expectations/code_lens/minitest_spec_tests.exp.json
@@ -23,7 +23,8 @@
             "start_column": 0,
             "end_line": 14,
             "end_column": 3
-          }
+          },
+          "Foo"
         ]
       },
       "data": {
@@ -56,7 +57,8 @@
             "start_column": 0,
             "end_line": 14,
             "end_column": 3
-          }
+          },
+          "Foo"
         ]
       },
       "data": {
@@ -89,7 +91,8 @@
             "start_column": 0,
             "end_line": 14,
             "end_column": 3
-          }
+          },
+          "Foo"
         ]
       },
       "data": {
@@ -115,14 +118,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_level_one",
+          "Foo#test_0001_it_level_one",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
           {
             "start_line": 1,
             "start_column": 2,
             "end_line": 1,
             "end_column": 19
-          }
+          },
+          "it_level_one"
         ]
       },
       "data": {
@@ -147,14 +151,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_level_one",
+          "Foo#test_0001_it_level_one",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
           {
             "start_line": 1,
             "start_column": 2,
             "end_line": 1,
             "end_column": 19
-          }
+          },
+          "it_level_one"
         ]
       },
       "data": {
@@ -179,14 +184,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_level_one",
+          "Foo#test_0001_it_level_one",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
           {
             "start_line": 1,
             "start_column": 2,
             "end_line": 1,
             "end_column": 19
-          }
+          },
+          "it_level_one"
         ]
       },
       "data": {
@@ -211,14 +217,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "nested",
+          "Foo::nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
             "end_line": 11,
             "end_column": 5
-          }
+          },
+          "nested"
         ]
       },
       "data": {
@@ -244,14 +251,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "nested",
+          "Foo::nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
             "end_line": 11,
             "end_column": 5
-          }
+          },
+          "nested"
         ]
       },
       "data": {
@@ -277,14 +285,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "nested",
+          "Foo::nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
             "end_line": 11,
             "end_column": 5
-          }
+          },
+          "nested"
         ]
       },
       "data": {
@@ -310,14 +319,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_nested",
+          "Foo::nested#test_0001_it_nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
           {
             "start_line": 4,
             "start_column": 4,
             "end_line": 4,
             "end_column": 18
-          }
+          },
+          "it_nested"
         ]
       },
       "data": {
@@ -342,14 +352,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_nested",
+          "Foo::nested#test_0001_it_nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
           {
             "start_line": 4,
             "start_column": 4,
             "end_line": 4,
             "end_column": 18
-          }
+          },
+          "it_nested"
         ]
       },
       "data": {
@@ -374,14 +385,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_nested",
+          "Foo::nested#test_0001_it_nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
           {
             "start_line": 4,
             "start_column": 4,
             "end_line": 4,
             "end_column": 18
-          }
+          },
+          "it_nested"
         ]
       },
       "data": {
@@ -406,14 +418,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "deep_nested",
+          "Foo::nested::deep_nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
             "end_line": 8,
             "end_column": 7
-          }
+          },
+          "deep_nested"
         ]
       },
       "data": {
@@ -439,14 +452,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "deep_nested",
+          "Foo::nested::deep_nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
             "end_line": 8,
             "end_column": 7
-          }
+          },
+          "deep_nested"
         ]
       },
       "data": {
@@ -472,14 +486,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "deep_nested",
+          "Foo::nested::deep_nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
             "end_line": 8,
             "end_column": 7
-          }
+          },
+          "deep_nested"
         ]
       },
       "data": {
@@ -505,14 +520,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_deep_nested",
+          "Foo::nested::deep_nested#test_0001_it_deep_nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
           {
             "start_line": 7,
             "start_column": 6,
             "end_line": 7,
             "end_column": 25
-          }
+          },
+          "it_deep_nested"
         ]
       },
       "data": {
@@ -537,14 +553,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_deep_nested",
+          "Foo::nested::deep_nested#test_0001_it_deep_nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
           {
             "start_line": 7,
             "start_column": 6,
             "end_line": 7,
             "end_column": 25
-          }
+          },
+          "it_deep_nested"
         ]
       },
       "data": {
@@ -569,14 +586,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_deep_nested",
+          "Foo::nested::deep_nested#test_0001_it_deep_nested",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
           {
             "start_line": 7,
             "start_column": 6,
             "end_line": 7,
             "end_column": 25
-          }
+          },
+          "it_deep_nested"
         ]
       },
       "data": {
@@ -601,14 +619,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_nested_again",
+          "Foo::nested#test_0002_it_nested_again",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
           {
             "start_line": 10,
             "start_column": 4,
             "end_line": 10,
             "end_column": 24
-          }
+          },
+          "it_nested_again"
         ]
       },
       "data": {
@@ -633,14 +652,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_nested_again",
+          "Foo::nested#test_0002_it_nested_again",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
           {
             "start_line": 10,
             "start_column": 4,
             "end_line": 10,
             "end_column": 24
-          }
+          },
+          "it_nested_again"
         ]
       },
       "data": {
@@ -665,14 +685,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_nested_again",
+          "Foo::nested#test_0002_it_nested_again",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
           {
             "start_line": 10,
             "start_column": 4,
             "end_line": 10,
             "end_column": 24
-          }
+          },
+          "it_nested_again"
         ]
       },
       "data": {
@@ -697,14 +718,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_level_one_again",
+          "Foo#test_0003_it_level_one_again",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
           {
             "start_line": 13,
             "start_column": 2,
             "end_line": 13,
             "end_column": 25
-          }
+          },
+          "it_level_one_again"
         ]
       },
       "data": {
@@ -729,14 +751,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_level_one_again",
+          "Foo#test_0003_it_level_one_again",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
           {
             "start_line": 13,
             "start_column": 2,
             "end_line": 13,
             "end_column": 25
-          }
+          },
+          "it_level_one_again"
         ]
       },
       "data": {
@@ -761,14 +784,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_level_one_again",
+          "Foo#test_0003_it_level_one_again",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
           {
             "start_line": 13,
             "start_column": 2,
             "end_line": 13,
             "end_column": 25
-          }
+          },
+          "it_level_one_again"
         ]
       },
       "data": {
@@ -800,7 +824,8 @@
             "start_column": 0,
             "end_line": 18,
             "end_column": 3
-          }
+          },
+          "Foo::Bar"
         ]
       },
       "data": {
@@ -833,7 +858,8 @@
             "start_column": 0,
             "end_line": 18,
             "end_column": 3
-          }
+          },
+          "Foo::Bar"
         ]
       },
       "data": {
@@ -866,7 +892,8 @@
             "start_column": 0,
             "end_line": 18,
             "end_column": 3
-          }
+          },
+          "Foo::Bar"
         ]
       },
       "data": {
@@ -892,14 +919,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_class_constant_path",
+          "Foo::Bar#test_0001_it_class_constant_path",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
           {
             "start_line": 17,
             "start_column": 2,
             "end_line": 17,
             "end_column": 29
-          }
+          },
+          "it_class_constant_path"
         ]
       },
       "data": {
@@ -924,14 +952,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_class_constant_path",
+          "Foo::Bar#test_0001_it_class_constant_path",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
           {
             "start_line": 17,
             "start_column": 2,
             "end_line": 17,
             "end_column": 29
-          }
+          },
+          "it_class_constant_path"
         ]
       },
       "data": {
@@ -956,14 +985,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "it_class_constant_path",
+          "Foo::Bar#test_0001_it_class_constant_path",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
           {
             "start_line": 17,
             "start_column": 2,
             "end_line": 17,
             "end_column": 29
-          }
+          },
+          "it_class_constant_path"
         ]
       },
       "data": {
@@ -995,7 +1025,8 @@
             "start_column": 0,
             "end_line": 28,
             "end_column": 3
-          }
+          },
+          "Baz"
         ]
       },
       "data": {
@@ -1028,7 +1059,8 @@
             "start_column": 0,
             "end_line": 28,
             "end_column": 3
-          }
+          },
+          "Baz"
         ]
       },
       "data": {
@@ -1061,7 +1093,8 @@
             "start_column": 0,
             "end_line": 28,
             "end_column": 3
-          }
+          },
+          "Baz"
         ]
       },
       "data": {
@@ -1087,14 +1120,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "#foo",
+          "Baz::#foo",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
           {
             "start_line": 21,
             "start_column": 2,
             "end_line": 23,
             "end_column": 5
-          }
+          },
+          "#foo"
         ]
       },
       "data": {
@@ -1120,14 +1154,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "#foo",
+          "Baz::#foo",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
           {
             "start_line": 21,
             "start_column": 2,
             "end_line": 23,
             "end_column": 5
-          }
+          },
+          "#foo"
         ]
       },
       "data": {
@@ -1153,14 +1188,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "#foo",
+          "Baz::#foo",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
           {
             "start_line": 21,
             "start_column": 2,
             "end_line": 23,
             "end_column": 5
-          }
+          },
+          "#foo"
         ]
       },
       "data": {
@@ -1186,14 +1222,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "works",
+          "Baz::#foo#test_0001_works",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
           {
             "start_line": 22,
             "start_column": 4,
             "end_line": 22,
             "end_column": 14
-          }
+          },
+          "works"
         ]
       },
       "data": {
@@ -1218,14 +1255,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "works",
+          "Baz::#foo#test_0001_works",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
           {
             "start_line": 22,
             "start_column": 4,
             "end_line": 22,
             "end_column": 14
-          }
+          },
+          "works"
         ]
       },
       "data": {
@@ -1250,14 +1288,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "works",
+          "Baz::#foo#test_0001_works",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
           {
             "start_line": 22,
             "start_column": 4,
             "end_line": 22,
             "end_column": 14
-          }
+          },
+          "works"
         ]
       },
       "data": {
@@ -1282,14 +1321,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "#bar",
+          "Baz::#bar",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
           {
             "start_line": 25,
             "start_column": 2,
             "end_line": 27,
             "end_column": 5
-          }
+          },
+          "#bar"
         ]
       },
       "data": {
@@ -1315,14 +1355,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "#bar",
+          "Baz::#bar",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
           {
             "start_line": 25,
             "start_column": 2,
             "end_line": 27,
             "end_column": 5
-          }
+          },
+          "#bar"
         ]
       },
       "data": {
@@ -1348,14 +1389,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "#bar",
+          "Baz::#bar",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
           {
             "start_line": 25,
             "start_column": 2,
             "end_line": 27,
             "end_column": 5
-          }
+          },
+          "#bar"
         ]
       },
       "data": {
@@ -1381,14 +1423,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "works",
+          "Baz::#bar#test_0001_works",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
           {
             "start_line": 26,
             "start_column": 4,
             "end_line": 26,
             "end_column": 14
-          }
+          },
+          "works"
         ]
       },
       "data": {
@@ -1413,14 +1456,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "works",
+          "Baz::#bar#test_0001_works",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
           {
             "start_line": 26,
             "start_column": 4,
             "end_line": 26,
             "end_column": 14
-          }
+          },
+          "works"
         ]
       },
       "data": {
@@ -1445,14 +1489,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
-          "works",
+          "Baz::#bar#test_0001_works",
           "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
           {
             "start_line": 26,
             "start_column": 4,
             "end_line": 26,
             "end_column": 14
-          }
+          },
+          "works"
         ]
       },
       "data": {

--- a/test/expectations/code_lens/minitest_spec_tests.exp.json
+++ b/test/expectations/code_lens/minitest_spec_tests.exp.json
@@ -971,6 +971,495 @@
         "group_id": 4,
         "kind": "example"
       }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 20,
+          "character": 0
+        },
+        "end": {
+          "line": 28,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "Baz",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Baz/",
+          {
+            "start_line": 20,
+            "start_column": 0,
+            "end_line": 28,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": null,
+        "kind": "group",
+        "id": 5
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 20,
+          "character": 0
+        },
+        "end": {
+          "line": 28,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "Baz",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Baz/",
+          {
+            "start_line": 20,
+            "start_column": 0,
+            "end_line": 28,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": null,
+        "kind": "group",
+        "id": 5
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 20,
+          "character": 0
+        },
+        "end": {
+          "line": 28,
+          "character": 3
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "Baz",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /Baz/",
+          {
+            "start_line": 20,
+            "start_column": 0,
+            "end_line": 28,
+            "end_column": 3
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": null,
+        "kind": "group",
+        "id": 5
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 21,
+          "character": 2
+        },
+        "end": {
+          "line": 23,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "#foo",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#foo/",
+          {
+            "start_line": 21,
+            "start_column": 2,
+            "end_line": 23,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 5,
+        "kind": "group",
+        "id": 6
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 21,
+          "character": 2
+        },
+        "end": {
+          "line": 23,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "#foo",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#foo/",
+          {
+            "start_line": 21,
+            "start_column": 2,
+            "end_line": 23,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 5,
+        "kind": "group",
+        "id": 6
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 21,
+          "character": 2
+        },
+        "end": {
+          "line": 23,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "#foo",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#foo/",
+          {
+            "start_line": 21,
+            "start_column": 2,
+            "end_line": 23,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 5,
+        "kind": "group",
+        "id": 6
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 22,
+          "character": 4
+        },
+        "end": {
+          "line": 22,
+          "character": 14
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "works",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          {
+            "start_line": 22,
+            "start_column": 4,
+            "end_line": 22,
+            "end_column": 14
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 6,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 22,
+          "character": 4
+        },
+        "end": {
+          "line": 22,
+          "character": 14
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "works",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          {
+            "start_line": 22,
+            "start_column": 4,
+            "end_line": 22,
+            "end_column": 14
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 6,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 22,
+          "character": 4
+        },
+        "end": {
+          "line": 22,
+          "character": 14
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "works",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          {
+            "start_line": 22,
+            "start_column": 4,
+            "end_line": 22,
+            "end_column": 14
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 6,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 25,
+          "character": 2
+        },
+        "end": {
+          "line": 27,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "#bar",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#bar/",
+          {
+            "start_line": 25,
+            "start_column": 2,
+            "end_line": 27,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 5,
+        "kind": "group",
+        "id": 7
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 25,
+          "character": 2
+        },
+        "end": {
+          "line": 27,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "#bar",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#bar/",
+          {
+            "start_line": 25,
+            "start_column": 2,
+            "end_line": 27,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 5,
+        "kind": "group",
+        "id": 7
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 25,
+          "character": 2
+        },
+        "end": {
+          "line": 27,
+          "character": 5
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "#bar",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /\\#bar/",
+          {
+            "start_line": 25,
+            "start_column": 2,
+            "end_line": 27,
+            "end_column": 5
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 5,
+        "kind": "group",
+        "id": 7
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 26,
+          "character": 4
+        },
+        "end": {
+          "line": 26,
+          "character": 14
+        }
+      },
+      "command": {
+        "title": "Run",
+        "command": "rubyLsp.runTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "works",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          {
+            "start_line": 26,
+            "start_column": 4,
+            "end_line": 26,
+            "end_column": 14
+          }
+        ]
+      },
+      "data": {
+        "type": "test",
+        "group_id": 7,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 26,
+          "character": 4
+        },
+        "end": {
+          "line": 26,
+          "character": 14
+        }
+      },
+      "command": {
+        "title": "Run In Terminal",
+        "command": "rubyLsp.runTestInTerminal",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "works",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          {
+            "start_line": 26,
+            "start_column": 4,
+            "end_line": 26,
+            "end_column": 14
+          }
+        ]
+      },
+      "data": {
+        "type": "test_in_terminal",
+        "group_id": 7,
+        "kind": "example"
+      }
+    },
+    {
+      "range": {
+        "start": {
+          "line": 26,
+          "character": 4
+        },
+        "end": {
+          "line": 26,
+          "character": 14
+        }
+      },
+      "command": {
+        "title": "Debug",
+        "command": "rubyLsp.debugTest",
+        "arguments": [
+          "/fixtures/minitest_spec_tests.rb",
+          "works",
+          "bundle exec ruby -Itest /fixtures/minitest_spec_tests.rb --name /works/",
+          {
+            "start_line": 26,
+            "start_column": 4,
+            "end_line": 26,
+            "end_column": 14
+          }
+        ]
+      },
+      "data": {
+        "type": "debug",
+        "group_id": 7,
+        "kind": "example"
+      }
     }
   ],
   "params": [

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -23,7 +23,8 @@
             "start_column": 0,
             "end_line": 22,
             "end_column": 3
-          }
+          },
+          "Test"
         ]
       },
       "data": {
@@ -56,7 +57,8 @@
             "start_column": 0,
             "end_line": 22,
             "end_column": 3
-          }
+          },
+          "Test"
         ]
       },
       "data": {
@@ -89,7 +91,8 @@
             "start_column": 0,
             "end_line": 22,
             "end_column": 3
-          }
+          },
+          "Test"
         ]
       },
       "data": {
@@ -115,14 +118,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public",
+          "Test#test_public",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_public",
           {
             "start_line": 5,
             "start_column": 2,
             "end_line": 5,
             "end_column": 22
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -147,14 +151,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public",
+          "Test#test_public",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_public",
           {
             "start_line": 5,
             "start_column": 2,
             "end_line": 5,
             "end_column": 22
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -179,14 +184,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public",
+          "Test#test_public",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_public",
           {
             "start_line": 5,
             "start_column": 2,
             "end_line": 5,
             "end_column": 22
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -211,14 +217,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public_command",
+          "Test#test_public_command",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_public_command",
           {
             "start_line": 9,
             "start_column": 9,
             "end_line": 9,
             "end_column": 37
-          }
+          },
+          "test_public_command"
         ]
       },
       "data": {
@@ -243,14 +250,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public_command",
+          "Test#test_public_command",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_public_command",
           {
             "start_line": 9,
             "start_column": 9,
             "end_line": 9,
             "end_column": 37
-          }
+          },
+          "test_public_command"
         ]
       },
       "data": {
@@ -275,14 +283,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public_command",
+          "Test#test_public_command",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_public_command",
           {
             "start_line": 9,
             "start_column": 9,
             "end_line": 9,
             "end_column": 37
-          }
+          },
+          "test_public_command"
         ]
       },
       "data": {
@@ -307,14 +316,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_another_public",
+          "Test#test_another_public",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_another_public",
           {
             "start_line": 11,
             "start_column": 9,
             "end_line": 11,
             "end_column": 37
-          }
+          },
+          "test_another_public"
         ]
       },
       "data": {
@@ -339,14 +349,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_another_public",
+          "Test#test_another_public",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_another_public",
           {
             "start_line": 11,
             "start_column": 9,
             "end_line": 11,
             "end_column": 37
-          }
+          },
+          "test_another_public"
         ]
       },
       "data": {
@@ -371,14 +382,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_another_public",
+          "Test#test_another_public",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_another_public",
           {
             "start_line": 11,
             "start_column": 9,
             "end_line": 11,
             "end_column": 37
-          }
+          },
+          "test_another_public"
         ]
       },
       "data": {
@@ -403,14 +415,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public_vcall",
+          "Test#test_public_vcall",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_public_vcall",
           {
             "start_line": 17,
             "start_column": 2,
             "end_line": 17,
             "end_column": 28
-          }
+          },
+          "test_public_vcall"
         ]
       },
       "data": {
@@ -435,14 +448,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public_vcall",
+          "Test#test_public_vcall",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_public_vcall",
           {
             "start_line": 17,
             "start_column": 2,
             "end_line": 17,
             "end_column": 28
-          }
+          },
+          "test_public_vcall"
         ]
       },
       "data": {
@@ -467,14 +481,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public_vcall",
+          "Test#test_public_vcall",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_public_vcall",
           {
             "start_line": 17,
             "start_column": 2,
             "end_line": 17,
             "end_column": 28
-          }
+          },
+          "test_public_vcall"
         ]
       },
       "data": {
@@ -499,14 +514,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_with_q?",
+          "Test#test_with_q?",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_with_q\\?",
           {
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
             "end_column": 23
-          }
+          },
+          "test_with_q?"
         ]
       },
       "data": {
@@ -531,14 +547,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_with_q?",
+          "Test#test_with_q?",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_with_q\\?",
           {
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
             "end_column": 23
-          }
+          },
+          "test_with_q?"
         ]
       },
       "data": {
@@ -563,14 +580,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_with_q?",
+          "Test#test_with_q?",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name Test#test_with_q\\?",
           {
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
             "end_column": 23
-          }
+          },
+          "test_with_q?"
         ]
       },
       "data": {
@@ -602,7 +620,8 @@
             "start_column": 0,
             "end_line": 32,
             "end_column": 3
-          }
+          },
+          "AnotherTest"
         ]
       },
       "data": {
@@ -635,7 +654,8 @@
             "start_column": 0,
             "end_line": 32,
             "end_column": 3
-          }
+          },
+          "AnotherTest"
         ]
       },
       "data": {
@@ -668,7 +688,8 @@
             "start_column": 0,
             "end_line": 32,
             "end_column": 3
-          }
+          },
+          "AnotherTest"
         ]
       },
       "data": {
@@ -694,14 +715,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public",
+          "AnotherTest#test_public",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name AnotherTest#test_public",
           {
             "start_line": 25,
             "start_column": 2,
             "end_line": 25,
             "end_column": 22
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -726,14 +748,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public",
+          "AnotherTest#test_public",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name AnotherTest#test_public",
           {
             "start_line": 25,
             "start_column": 2,
             "end_line": 25,
             "end_column": 22
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -758,14 +781,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public",
+          "AnotherTest#test_public",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name AnotherTest#test_public",
           {
             "start_line": 25,
             "start_column": 2,
             "end_line": 25,
             "end_column": 22
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -790,14 +814,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public_2",
+          "AnotherTest#test_public_2",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name AnotherTest#test_public_2",
           {
             "start_line": 31,
             "start_column": 2,
             "end_line": 31,
             "end_column": 24
-          }
+          },
+          "test_public_2"
         ]
       },
       "data": {
@@ -822,14 +847,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public_2",
+          "AnotherTest#test_public_2",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name AnotherTest#test_public_2",
           {
             "start_line": 31,
             "start_column": 2,
             "end_line": 31,
             "end_column": 24
-          }
+          },
+          "test_public_2"
         ]
       },
       "data": {
@@ -854,14 +880,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
-          "test_public_2",
+          "AnotherTest#test_public_2",
           "bundle exec ruby -Itest /fixtures/minitest_tests.rb --name AnotherTest#test_public_2",
           {
             "start_line": 31,
             "start_column": 2,
             "end_line": 31,
             "end_column": 24
-          }
+          },
+          "test_public_2"
         ]
       },
       "data": {
@@ -871,5 +898,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
+++ b/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
@@ -16,14 +16,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "Test",
+          "<dynamic_reference>::Test",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
           {
             "start_line": 9,
             "start_column": 2,
             "end_line": 17,
             "end_column": 5
-          }
+          },
+          "Test"
         ]
       },
       "data": {
@@ -49,14 +50,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "Test",
+          "<dynamic_reference>::Test",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
           {
             "start_line": 9,
             "start_column": 2,
             "end_line": 17,
             "end_column": 5
-          }
+          },
+          "Test"
         ]
       },
       "data": {
@@ -82,14 +84,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "Test",
+          "<dynamic_reference>::Test",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
           {
             "start_line": 9,
             "start_column": 2,
             "end_line": 17,
             "end_column": 5
-          }
+          },
+          "Test"
         ]
       },
       "data": {
@@ -115,14 +118,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_something",
+          "<dynamic_reference>::Test#test_something",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something$/",
           {
             "start_line": 10,
             "start_column": 4,
             "end_line": 10,
             "end_column": 27
-          }
+          },
+          "test_something"
         ]
       },
       "data": {
@@ -147,14 +151,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_something",
+          "<dynamic_reference>::Test#test_something",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something$/",
           {
             "start_line": 10,
             "start_column": 4,
             "end_line": 10,
             "end_column": 27
-          }
+          },
+          "test_something"
         ]
       },
       "data": {
@@ -179,14 +184,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_something",
+          "<dynamic_reference>::Test#test_something",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something$/",
           {
             "start_line": 10,
             "start_column": 4,
             "end_line": 10,
             "end_column": 27
-          }
+          },
+          "test_something"
         ]
       },
       "data": {
@@ -211,14 +217,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_something_else",
+          "<dynamic_reference>::Test#test_something_else",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something_else$/",
           {
             "start_line": 12,
             "start_column": 4,
             "end_line": 12,
             "end_column": 32
-          }
+          },
+          "test_something_else"
         ]
       },
       "data": {
@@ -243,14 +250,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_something_else",
+          "<dynamic_reference>::Test#test_something_else",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something_else$/",
           {
             "start_line": 12,
             "start_column": 4,
             "end_line": 12,
             "end_column": 32
-          }
+          },
+          "test_something_else"
         ]
       },
       "data": {
@@ -275,14 +283,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_something_else",
+          "<dynamic_reference>::Test#test_something_else",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something_else$/",
           {
             "start_line": 12,
             "start_column": 4,
             "end_line": 12,
             "end_column": 32
-          }
+          },
+          "test_something_else"
         ]
       },
       "data": {
@@ -307,14 +316,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "NestedTest",
+          "<dynamic_reference>::Test::NestedTest",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
           {
             "start_line": 14,
             "start_column": 4,
             "end_line": 16,
             "end_column": 7
-          }
+          },
+          "NestedTest"
         ]
       },
       "data": {
@@ -340,14 +350,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "NestedTest",
+          "<dynamic_reference>::Test::NestedTest",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
           {
             "start_line": 14,
             "start_column": 4,
             "end_line": 16,
             "end_column": 7
-          }
+          },
+          "NestedTest"
         ]
       },
       "data": {
@@ -373,14 +384,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "NestedTest",
+          "<dynamic_reference>::Test::NestedTest",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
           {
             "start_line": 14,
             "start_column": 4,
             "end_line": 16,
             "end_column": 7
-          }
+          },
+          "NestedTest"
         ]
       },
       "data": {
@@ -406,14 +418,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_nested",
+          "<dynamic_reference>::Test::NestedTest#test_nested",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest#test_nested$/",
           {
             "start_line": 15,
             "start_column": 6,
             "end_line": 15,
             "end_column": 26
-          }
+          },
+          "test_nested"
         ]
       },
       "data": {
@@ -438,14 +451,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_nested",
+          "<dynamic_reference>::Test::NestedTest#test_nested",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest#test_nested$/",
           {
             "start_line": 15,
             "start_column": 6,
             "end_line": 15,
             "end_column": 26
-          }
+          },
+          "test_nested"
         ]
       },
       "data": {
@@ -470,14 +484,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_nested",
+          "<dynamic_reference>::Test::NestedTest#test_nested",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest#test_nested$/",
           {
             "start_line": 15,
             "start_column": 6,
             "end_line": 15,
             "end_column": 26
-          }
+          },
+          "test_nested"
         ]
       },
       "data": {
@@ -502,14 +517,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "SomeOtherTest",
+          "<dynamic_reference>::SomeOtherTest",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
           {
             "start_line": 19,
             "start_column": 2,
             "end_line": 23,
             "end_column": 5
-          }
+          },
+          "SomeOtherTest"
         ]
       },
       "data": {
@@ -535,14 +551,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "SomeOtherTest",
+          "<dynamic_reference>::SomeOtherTest",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
           {
             "start_line": 19,
             "start_column": 2,
             "end_line": 23,
             "end_column": 5
-          }
+          },
+          "SomeOtherTest"
         ]
       },
       "data": {
@@ -568,14 +585,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "SomeOtherTest",
+          "<dynamic_reference>::SomeOtherTest",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
           {
             "start_line": 19,
             "start_column": 2,
             "end_line": 23,
             "end_column": 5
-          }
+          },
+          "SomeOtherTest"
         ]
       },
       "data": {
@@ -601,14 +619,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_stuff",
+          "<dynamic_reference>::SomeOtherTest#test_stuff",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_stuff$/",
           {
             "start_line": 20,
             "start_column": 4,
             "end_line": 20,
             "end_column": 23
-          }
+          },
+          "test_stuff"
         ]
       },
       "data": {
@@ -633,14 +652,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_stuff",
+          "<dynamic_reference>::SomeOtherTest#test_stuff",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_stuff$/",
           {
             "start_line": 20,
             "start_column": 4,
             "end_line": 20,
             "end_column": 23
-          }
+          },
+          "test_stuff"
         ]
       },
       "data": {
@@ -665,14 +685,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_stuff",
+          "<dynamic_reference>::SomeOtherTest#test_stuff",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_stuff$/",
           {
             "start_line": 20,
             "start_column": 4,
             "end_line": 20,
             "end_column": 23
-          }
+          },
+          "test_stuff"
         ]
       },
       "data": {
@@ -697,14 +718,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_other_stuff",
+          "<dynamic_reference>::SomeOtherTest#test_other_stuff",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_other_stuff$/",
           {
             "start_line": 22,
             "start_column": 4,
             "end_line": 22,
             "end_column": 29
-          }
+          },
+          "test_other_stuff"
         ]
       },
       "data": {
@@ -729,14 +751,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_other_stuff",
+          "<dynamic_reference>::SomeOtherTest#test_other_stuff",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_other_stuff$/",
           {
             "start_line": 22,
             "start_column": 4,
             "end_line": 22,
             "end_column": 29
-          }
+          },
+          "test_other_stuff"
         ]
       },
       "data": {
@@ -761,14 +784,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
-          "test_other_stuff",
+          "<dynamic_reference>::SomeOtherTest#test_other_stuff",
           "bundle exec ruby -Itest /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_other_stuff$/",
           {
             "start_line": 22,
             "start_column": 4,
             "end_line": 22,
             "end_column": 29
-          }
+          },
+          "test_other_stuff"
         ]
       },
       "data": {
@@ -778,5 +802,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/expectations/code_lens/nested_minitest_tests.exp.json
+++ b/test/expectations/code_lens/nested_minitest_tests.exp.json
@@ -23,7 +23,8 @@
             "start_column": 0,
             "end_line": 20,
             "end_column": 3
-          }
+          },
+          "ParentTest"
         ]
       },
       "data": {
@@ -56,7 +57,8 @@
             "start_column": 0,
             "end_line": 20,
             "end_column": 3
-          }
+          },
+          "ParentTest"
         ]
       },
       "data": {
@@ -89,7 +91,8 @@
             "start_column": 0,
             "end_line": 20,
             "end_column": 3
-          }
+          },
+          "ParentTest"
         ]
       },
       "data": {
@@ -115,14 +118,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public",
+          "ParentTest#test_public",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest#test_public",
           {
             "start_line": 1,
             "start_column": 2,
             "end_line": 1,
             "end_column": 22
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -147,14 +151,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public",
+          "ParentTest#test_public",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest#test_public",
           {
             "start_line": 1,
             "start_column": 2,
             "end_line": 1,
             "end_column": 22
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -179,14 +184,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public",
+          "ParentTest#test_public",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest#test_public",
           {
             "start_line": 1,
             "start_column": 2,
             "end_line": 1,
             "end_column": 22
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -211,14 +217,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "FirstChildTest",
+          "ParentTest::FirstChildTest",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::FirstChildTest(#|::)/\"",
           {
             "start_line": 5,
             "start_column": 2,
             "end_line": 9,
             "end_column": 5
-          }
+          },
+          "FirstChildTest"
         ]
       },
       "data": {
@@ -244,14 +251,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "FirstChildTest",
+          "ParentTest::FirstChildTest",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::FirstChildTest(#|::)/\"",
           {
             "start_line": 5,
             "start_column": 2,
             "end_line": 9,
             "end_column": 5
-          }
+          },
+          "FirstChildTest"
         ]
       },
       "data": {
@@ -277,14 +285,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "FirstChildTest",
+          "ParentTest::FirstChildTest",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::FirstChildTest(#|::)/\"",
           {
             "start_line": 5,
             "start_column": 2,
             "end_line": 9,
             "end_column": 5
-          }
+          },
+          "FirstChildTest"
         ]
       },
       "data": {
@@ -310,14 +319,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public",
+          "ParentTest::FirstChildTest#test_public",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest::FirstChildTest#test_public",
           {
             "start_line": 6,
             "start_column": 4,
             "end_line": 6,
             "end_column": 24
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -342,14 +352,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public",
+          "ParentTest::FirstChildTest#test_public",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest::FirstChildTest#test_public",
           {
             "start_line": 6,
             "start_column": 4,
             "end_line": 6,
             "end_column": 24
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -374,14 +385,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public",
+          "ParentTest::FirstChildTest#test_public",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest::FirstChildTest#test_public",
           {
             "start_line": 6,
             "start_column": 4,
             "end_line": 6,
             "end_column": 24
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -406,14 +418,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "SecondChildTest",
+          "ParentTest::SecondChildTest",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::SecondChildTest(#|::)/\"",
           {
             "start_line": 13,
             "start_column": 2,
             "end_line": 15,
             "end_column": 5
-          }
+          },
+          "SecondChildTest"
         ]
       },
       "data": {
@@ -439,14 +452,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "SecondChildTest",
+          "ParentTest::SecondChildTest",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::SecondChildTest(#|::)/\"",
           {
             "start_line": 13,
             "start_column": 2,
             "end_line": 15,
             "end_column": 5
-          }
+          },
+          "SecondChildTest"
         ]
       },
       "data": {
@@ -472,14 +486,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "SecondChildTest",
+          "ParentTest::SecondChildTest",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::SecondChildTest(#|::)/\"",
           {
             "start_line": 13,
             "start_column": 2,
             "end_line": 15,
             "end_column": 5
-          }
+          },
+          "SecondChildTest"
         ]
       },
       "data": {
@@ -505,14 +520,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public",
+          "ParentTest::SecondChildTest#test_public",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest::SecondChildTest#test_public",
           {
             "start_line": 14,
             "start_column": 4,
             "end_line": 14,
             "end_column": 24
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -537,14 +553,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public",
+          "ParentTest::SecondChildTest#test_public",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest::SecondChildTest#test_public",
           {
             "start_line": 14,
             "start_column": 4,
             "end_line": 14,
             "end_column": 24
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -569,14 +586,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public",
+          "ParentTest::SecondChildTest#test_public",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest::SecondChildTest#test_public",
           {
             "start_line": 14,
             "start_column": 4,
             "end_line": 14,
             "end_column": 24
-          }
+          },
+          "test_public"
         ]
       },
       "data": {
@@ -601,14 +619,15 @@
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public_again",
+          "ParentTest#test_public_again",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest#test_public_again",
           {
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
             "end_column": 28
-          }
+          },
+          "test_public_again"
         ]
       },
       "data": {
@@ -633,14 +652,15 @@
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public_again",
+          "ParentTest#test_public_again",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest#test_public_again",
           {
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
             "end_column": 28
-          }
+          },
+          "test_public_again"
         ]
       },
       "data": {
@@ -665,14 +685,15 @@
         "command": "rubyLsp.debugTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
-          "test_public_again",
+          "ParentTest#test_public_again",
           "bundle exec ruby -Itest /fixtures/nested_minitest_tests.rb --name ParentTest#test_public_again",
           {
             "start_line": 19,
             "start_column": 2,
             "end_line": 19,
             "end_column": 28
-          }
+          },
+          "test_public_again"
         ]
       },
       "data": {
@@ -682,5 +703,7 @@
       }
     }
   ],
-  "params": []
+  "params": [
+
+  ]
 }

--- a/test/fixtures/minitest_spec_tests.rb
+++ b/test/fixtures/minitest_spec_tests.rb
@@ -17,3 +17,13 @@ end
 describe Foo::Bar do
   it 'it_class_constant_path'
 end
+
+describe Baz do
+  describe "#foo" do
+    it "works"
+  end
+
+  describe "#bar" do
+    it "works"
+  end
+end

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -88,10 +88,10 @@ export class TestController {
     });
 
     response.forEach((res) => {
-      const [_, name, command, location] = res.command!.arguments!;
+      const [_, name, command, location, label] = res.command!.arguments!;
       const testItem: vscode.TestItem = this.testController.createTestItem(
         name,
-        name,
+        label || name,
         uri,
       );
 


### PR DESCRIPTION
### Motivation

I'd like to revive #2230 but I noticed there are a couple of small issues with the test code lenses that should be fixed before resuming work:

1. The filter patterns for minitest specs are too broad causing unintended tests to run
2. The IDs for the test items are not unique causing the wrong one to be run when they clash

| Before | After |
| - | - |
| <img width="2032" alt="Screenshot 2024-09-04 at 08 36 31" src="https://github.com/user-attachments/assets/ddcce014-9d15-497d-8045-66af64d39609"> | <img width="2032" alt="Screenshot 2024-09-04 at 08 41 30" src="https://github.com/user-attachments/assets/c1da96d5-fe7f-4003-bf0c-461d1f0e070a"> |
| Clicking "Run In Terminal" causes multiple tests to be run | Clicking "Run In Terminal" causes a single test to be run |

| Before | After |
| - | - |
| <img width="2032" alt="Screenshot 2024-09-04 at 08 39 30" src="https://github.com/user-attachments/assets/f4ca7e65-8c66-4e96-ae4b-3b5f5ade9a46"> | <img width="2032" alt="Screenshot 2024-09-04 at 08 42 19" src="https://github.com/user-attachments/assets/1aaec85e-71ec-4aee-901a-dc04d77d7673"> |
| Clicking "Run" causes the wrong test to be run | Clicking "Run" causes the correct test to be run |

These two issues can both happen at the same time, for example:

```rb
# typed: strict
# frozen_string_literal: true

require "minitest/spec"
require "minitest/autorun"

describe "a" do
  describe "b" do
    # Clicking "Run" here will incorrectly cause both tests to be run, and the result will
    # be incorrectly linked to the second test in the test explorer.
    it "works" do
      assert true
    end
  end

  describe "c" do
    it "works" do
      refute true
    end
  end
end
```

| Before | After |
| - | - |
| <img width="2032" alt="Screenshot 2024-09-04 at 08 55 31" src="https://github.com/user-attachments/assets/01ec709b-c0a7-43ec-b581-83d17f53158c"> | <img width="2032" alt="Screenshot 2024-09-04 at 08 57 33" src="https://github.com/user-attachments/assets/81473937-b262-4561-9be7-912dcc84f87c"> |
| Clicking "Run" causes multiple tests to be run and linked to the wrong item in the test explorer | Clicking "Run" causes the correct test to be run and linked to the correct item in the test explorer |

### Implementation

To fix the issue with broad filter patterns for minitests specs, I used a more specific selector based on the format minitest uses internally. It uses the `@group_stack` instance variable to capture the path leading to each example, and adds a new `@spec_id` variable that tracks how many examples are in each group. This information can be combined into a fully qualified selector like `a::b#test_0001_works`.

To fix the issue with non-unique IDs, I added a `generate_fully_qualified_id` method that does something similar to above. Instead of using just the method name, the ID will include the name of the group that it sits within.

I tried to make this work in a backwards compatible way. I would have preferred to remove `name` and replace it with `id` and `label` but plugins are currently using the (private) `add_test_code_lens` method. I also considered backwards compatibility between the extension and old versions of the LSP by making the new `label` argument optional.

### Automated Tests

I have added an expectation specifically to capture the issue with minitest specs. The other issue was already covered implicitly by various expectation tests. I also added a mechanism to update expectation snapshots because this PR involved many small changes—I can remove that if it's unwanted.

### Manual Tests

See the code example above which covers both issues. Try clicking "Run" and "Run In Terminal" for the examples in that test.
