### PR TITLE
Downgrade engine to v1.91

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "icon": "icon.png",
   "engines": {
-    "vscode": "^1.92.0"
+    "vscode": "^1.91.0"
   },
   "categories": [
     "Programming Languages",
@@ -704,7 +704,7 @@
     "@types/mocha": "^10.0.7",
     "@types/node": "22.x",
     "@types/sinon": "^17.0.3",
-    "@types/vscode": "^1.92.0",
+    "@types/vscode": "^1.91.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@vscode/test-electron": "^2.4.1",

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -720,7 +720,7 @@
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz#5fd3592ff10c1e9695d377020c033116cc2889f2"
   integrity sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==
 
-"@types/vscode@^1.92.0":
+"@types/vscode@^1.91.0":
   version "1.92.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.92.0.tgz#b4d6bc180e7206defe643a1a5f38a1367947d418"
   integrity sha512-DcZoCj17RXlzB4XJ7IfKdPTcTGDLYvTOcTNkvtjXWF+K2TlKzHHkBEXNWQRpBIXixNEUgx39cQeTFunY0E2msw==


### PR DESCRIPTION
### Motivation

I just realized that we don't need v1.92 for the chat functionality. v1.91 already has what we need.
