### PR TITLE
Turn Bundler settings into execution environment

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -64,15 +64,12 @@ if ENV["BUNDLE_GEMFILE"].nil?
   require_relative "../lib/ruby_lsp/setup_bundler"
 
   begin
-    bundle_gemfile, bundle_path, bundle_app_config = RubyLsp::SetupBundler.new(Dir.pwd, **options).setup!
+    env = RubyLsp::SetupBundler.new(Dir.pwd, **options).setup!
   rescue RubyLsp::SetupBundler::BundleNotLocked
     warn("Project contains a Gemfile, but no Gemfile.lock. Run `bundle install` to lock gems and restart the server")
     exit(78)
   end
 
-  env = { "BUNDLE_GEMFILE" => bundle_gemfile }
-  env["BUNDLE_PATH"] = bundle_path if bundle_path
-  env["BUNDLE_APP_CONFIG"] = bundle_app_config if bundle_app_config
   exit exec(env, "bundle exec ruby-lsp #{original_args.join(" ")}")
 end
 

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -56,7 +56,7 @@ module RubyLsp
 
     # Sets up the custom bundle and returns the `BUNDLE_GEMFILE`, `BUNDLE_PATH` and `BUNDLE_APP_CONFIG` that should be
     # used for running the server
-    sig { returns([String, T.nilable(String), T.nilable(String)]) }
+    sig { returns(T::Hash[String, String]) }
     def setup!
       raise BundleNotLocked if @gemfile&.exist? && !@lockfile&.exist?
 
@@ -176,22 +176,18 @@ module RubyLsp
       dependencies
     end
 
-    sig { params(bundle_gemfile: T.nilable(Pathname)).returns([String, T.nilable(String), T.nilable(String)]) }
+    sig { params(bundle_gemfile: T.nilable(Pathname)).returns(T::Hash[String, String]) }
     def run_bundle_install(bundle_gemfile = @gemfile)
+      env = bundler_settings_as_env
+      env["BUNDLE_GEMFILE"] = bundle_gemfile.to_s
+
       # If the user has a custom bundle path configured, we need to ensure that we will use the absolute and not
       # relative version of it when running `bundle install`. This is necessary to avoid installing the gems under the
       # `.ruby-lsp` folder, which is not the user's intention. For example, if the path is configured as `vendor`, we
       # want to install it in the top level `vendor` and not `.ruby-lsp/vendor`
-      path = Bundler.settings["path"]
-      expanded_path = File.expand_path(path, @project_path) if path
-
-      # Use the absolute `BUNDLE_PATH` to prevent accidentally creating unwanted folders under `.ruby-lsp`
-      env = {}
-      env["BUNDLE_GEMFILE"] = bundle_gemfile.to_s
-      env["BUNDLE_PATH"] = expanded_path if expanded_path
-
-      local_config_path = File.join(@project_path, ".bundle")
-      env["BUNDLE_APP_CONFIG"] = local_config_path if Dir.exist?(local_config_path)
+      if env["BUNDLE_PATH"]
+        env["BUNDLE_PATH"] = File.expand_path(env["BUNDLE_PATH"], @project_path)
+      end
 
       # If `ruby-lsp` and `debug` (and potentially `ruby-lsp-rails`) are already in the Gemfile, then we shouldn't try
       # to upgrade them or else we'll produce undesired source control changes. If the custom bundle was just created
@@ -238,7 +234,29 @@ module RubyLsp
         return setup!
       end
 
-      [bundle_gemfile.to_s, expanded_path, env["BUNDLE_APP_CONFIG"]]
+      env
+    end
+
+    # Gather all Bundler settings (global and local) and return them as a hash that can be used as the environment
+    sig { returns(T::Hash[String, String]) }
+    def bundler_settings_as_env
+      local_config_path = File.join(@project_path, ".bundle")
+
+      # If there's no Gemfile or if the local config path does not exist, we return an empty setting set (which has the
+      # global settings included). Otherwise, we also load the local settings
+      settings = begin
+        Dir.exist?(local_config_path) ? Bundler::Settings.new(local_config_path) : Bundler::Settings.new
+      rescue Bundler::GemfileNotFound
+        Bundler::Settings.new
+      end
+
+      # Map all settings to their environment variable names with `key_for` and their values. For example, the if the
+      # setting name `e` is `path` with a value of `vendor/bundle`, then it will return `"BUNDLE_PATH" =>
+      # "vendor/bundle"`
+      settings.all.to_h do |e|
+        key = Bundler::Settings.key_for(e)
+        [key, settings[e].to_s]
+      end
     end
 
     sig { returns(T::Boolean) }

--- a/sorbet/rbi/shims/bundler.rbi
+++ b/sorbet/rbi/shims/bundler.rbi
@@ -1,0 +1,6 @@
+# typed: true
+
+class Bundler::Settings
+  sig { params(name: String).returns(String) }
+  def self.key_for(name); end
+end


### PR DESCRIPTION
### Motivation

Closes #2531, closes #2519

The issue reported is that if `BUNDLE_PATH` is set using project level Bundler configs (`project/.bundle/config`), then our attempts to make `BUNDLE_PATH` absolute fail because Bundler will give precedence to the one set in local config.

For example, for these configs

```
# project/.bundle/config
"BUNDLE_PATH": "vendor/bundle" 
```

Even if we set `env["BUNDLE_PATH"]` to an absolute path, Bundler will still use `vendor/bundle` because we're passing `BUNDLE_APP_CONFIG` and it's loading it directly from the local configs, which override `env["BUNDLE_PATH"]`.

Thinking about it more generally, I actually believe we weren't handling Bundler settings properly and could potentially have been missing some.

### Implementation

The changes consist of:

1. Reading all settings (global + local) using the Bundler API. This means that we should respect whatever precedence Bundler uses
2. Then we use the Bundler API to turn the settings into their environment variable equivalents (e.g.: `path` -> `BUNDLE_PATH`)
3. Finally, we enforce that `BUNDLE_PATH` is absolute if it is set

This should also load any tokens for private gem repositories, which I believe had been an issue reported in the past.

### Automated Tests

Added a test that reproduces the issue. I also made changes to the tests so that our stubbing is a bit easier to use.