### PR TITLE
Ignore `.vscode-tests` for eslint

### DIFF
--- a/vscode/eslint.config.mjs
+++ b/vscode/eslint.config.mjs
@@ -46,6 +46,11 @@ const config = [
         }
       ]
     }
+  },
+  {
+    ignores: [
+      ".vscode-test/*",
+    ],
   }
 ]
 


### PR DESCRIPTION
https://eslint.org/docs/latest/use/configure/ignore#ignoring-files

> In your eslint.config.js file, if an ignores key is used without any other keys in the configuration object, then the patterns act as global ignores.

Before:
```
$ yarn run lint
yarn run v1.22.22
$ eslint '**/*.ts' && prettier '**/*.{json,md,yaml,yml}' --check

/home/earlopain/Documents/ruby-lsp/vscode/.vscode-test/vscode-linux-x64-1.35.0/resources/app/extensions/html-language-features/server/lib/jquery.d.ts
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/.vscode-test/vscode-linux-x64-1.35.0/resources/app/extensions/html-language-features/server/lib/jquery.d.ts` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/troubleshooting/typed-linting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file

/home/earlopain/Documents/ruby-lsp/vscode/.vscode-test/vscode-linux-x64-1.35.0/resources/app/out/vs/vscode.d.ts
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/.vscode-test/vscode-linux-x64-1.35.0/resources/app/out/vs/vscode.d.ts` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/troubleshooting/typed-linting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file

/home/earlopain/Documents/ruby-lsp/vscode/.vscode-test/vscode-linux-x64-1.91.0/resources/app/extensions/html-language-features/server/lib/jquery.d.ts
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/.vscode-test/vscode-linux-x64-1.91.0/resources/app/extensions/html-language-features/server/lib/jquery.d.ts` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/troubleshooting/typed-linting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file

/home/earlopain/Documents/ruby-lsp/vscode/.vscode-test/vscode-linux-x64-1.91.0/resources/app/extensions/markdown-language-features/types/previewMessaging.d.ts
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/.vscode-test/vscode-linux-x64-1.91.0/resources/app/extensions/markdown-language-features/types/previewMessaging.d.ts` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/troubleshooting/typed-linting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file

/home/earlopain/Documents/ruby-lsp/vscode/.vscode-test/vscode-linux-x64-1.91.0/resources/app/out/vscode-dts/vscode.d.ts
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/.vscode-test/vscode-linux-x64-1.91.0/resources/app/out/vscode-dts/vscode.d.ts` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/troubleshooting/typed-linting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file

✖ 5 problems (5 errors, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After:
```
$ yarn run lint
yarn run v1.22.22
$ eslint '**/*.ts' && prettier '**/*.{json,md,yaml,yml}' --check
Checking formatting...
All matched files use Prettier code style!
Done in 4.38s.
```