### PR TITLE
Allow launching the server in debug mode

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -83,6 +83,11 @@
         "category": "Ruby LSP"
       },
       {
+        "command": "rubyLsp.startServerInDebugMode",
+        "title": "Debug the Ruby LSP server",
+        "category": "Ruby LSP"
+      },
+      {
         "command": "rubyLsp.update",
         "title": "Update language server gem",
         "category": "Ruby LSP"

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -245,6 +245,7 @@ export default class Client extends LanguageClient implements ClientInterface {
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel: WorkspaceChannel,
     isMainWorkspace = false,
+    debugMode?: boolean,
   ) {
     super(
       LSP_NAME,
@@ -256,6 +257,7 @@ export default class Client extends LanguageClient implements ClientInterface {
         ruby,
         isMainWorkspace,
       ),
+      debugMode,
     );
 
     this.workspaceOutputChannel = outputChannel;

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -27,6 +27,7 @@ export enum Command {
   RailsDestroy = "rubyLsp.railsDestroy",
   NewMinitestFile = "rubyLsp.newMinitestFile",
   CollectRubyLspInfo = "rubyLsp.collectRubyLspInfo",
+  StartServerInDebugMode = "rubyLsp.startServerInDebugMode",
 }
 
 export interface RubyInterface {

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -575,6 +575,13 @@ export class RubyLsp {
         const workspace = await this.showWorkspacePick();
         await collectRubyLspInfo(workspace);
       }),
+      vscode.commands.registerCommand(
+        Command.StartServerInDebugMode,
+        async () => {
+          const workspace = await this.showWorkspacePick();
+          await workspace?.start(true);
+        },
+      ),
     );
   }
 

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -47,7 +47,7 @@ export class Workspace implements WorkspaceInterface {
     this.registerRebaseWatcher(context);
   }
 
-  async start() {
+  async start(debugMode?: boolean) {
     await this.ruby.activateRuby();
 
     if (this.ruby.error) {
@@ -105,6 +105,7 @@ export class Workspace implements WorkspaceInterface {
       this.workspaceFolder,
       this.outputChannel,
       this.isMainWorkspace,
+      debugMode,
     );
 
     try {


### PR DESCRIPTION
### Motivation

Improves #1774

Attaching the debugger to a live Ruby LSP server is one of the quickest and most useful ways to understand what's happening. However, the fact that you need to be running the extension in development to activate the debug mode on the server really makes little sense and makes this useful functionality more difficult to use.

This PR adds a command to launch/restart the server in force debug mode.

### Notes

Why not a setting? I considered adding a setting for this, but I feel like it would be super easy to forget removing it after you're done debugging. That wouldn't be good because you'd be launching every Ruby LSP server with the debugger.

So I ended up going with a command. It launches in debug mode, but if you restart the server or close the editor, the next launch is normal. I think this is a good compromise, since you don't need debug mode every time.

### Implementation

The 4th argument of the language client constructor is the `forceDebugMode` flag, which is does what you'd expect: launches the `debug` executable instead of the `run` executable, which results in the server having the debugger available for attach.

I just added a command that passes that flag all the way down to the client.