### PR TITLE
Turn on semantic highlighting for ERB

### DIFF
--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -39,7 +39,7 @@ module RubyLsp
         sig { returns(Interface::SemanticTokensRegistrationOptions) }
         def provider
           Interface::SemanticTokensRegistrationOptions.new(
-            document_selector: [{ language: "ruby" }],
+            document_selector: [{ language: "ruby" }, { language: "erb" }],
             legend: Interface::SemanticTokensLegend.new(
               token_types: ResponseBuilders::SemanticHighlighting::TOKEN_TYPES.keys,
               token_modifiers: ResponseBuilders::SemanticHighlighting::TOKEN_MODIFIERS.keys,


### PR DESCRIPTION
### Motivation

I noticed semantic highlighting was turned off for ERB files. We should turn it on to get proper highlighting, especially in blocks with arguments.

For example, the `user` usage below was not properly highlighted, but after this change it is.

```erb
<% @users.each do |user| %>
  <%= user.name %>
<% end %>
```