### PR TITLE
Allow env variables in bundleGemfile vscode plugin config

### DIFF
--- a/vscode/src/bundleGemfileHelper.ts
+++ b/vscode/src/bundleGemfileHelper.ts
@@ -1,0 +1,25 @@
+import path from "path";
+import * as vscode from "vscode";
+
+function expandEnvVariables(filepath: string): string {
+  return filepath.replace(/\$\{(\w+)\}|\$(\w+)/g, (match: string, p1: string, p2: string): string => {
+    const envVar = p1 || p2; // Use either ${VAR} or $VAR syntax
+    return process.env[envVar] || match; // Replace with env var if it exists, else keep original
+  });
+}
+
+
+export function getCustomBundleGemfile(workspaceFolder: vscode.WorkspaceFolder): string | undefined {
+  const customBundleGemfile: string = vscode.workspace
+    .getConfiguration("rubyLsp")
+    .get("bundleGemfile")!;
+
+  const expandedPath = expandEnvVariables(customBundleGemfile);
+
+  if (expandedPath.length > 0) {
+    return path.isAbsolute(expandedPath)
+      ? expandedPath
+      : path.resolve(path.join(workspaceFolder.uri.fsPath, expandedPath));
+  }
+  return undefined;
+}

--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-process-env */
-import path from "path";
 import os from "os";
 
 import * as vscode from "vscode";
@@ -16,6 +15,7 @@ import { Rvm } from "./ruby/rvm";
 import { None } from "./ruby/none";
 import { Custom } from "./ruby/custom";
 import { Asdf } from "./ruby/asdf";
+import { getCustomBundleGemfile } from "./bundleGemfileHelper";
 
 export enum ManagerIdentifier {
   Asdf = "asdf",
@@ -59,18 +59,7 @@ export class Ruby implements RubyInterface {
     this.context = context;
     this.workspaceFolder = workspaceFolder;
     this.outputChannel = outputChannel;
-
-    const customBundleGemfile: string = vscode.workspace
-      .getConfiguration("rubyLsp")
-      .get("bundleGemfile")!;
-
-    if (customBundleGemfile.length > 0) {
-      this.customBundleGemfile = path.isAbsolute(customBundleGemfile)
-        ? customBundleGemfile
-        : path.resolve(
-            path.join(this.workspaceFolder.uri.fsPath, customBundleGemfile),
-          );
-    }
+    this.customBundleGemfile = getCustomBundleGemfile(this.workspaceFolder);
   }
 
   get versionManager(): ManagerConfiguration {

--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 
 import { WorkspaceChannel } from "../workspaceChannel";
 import { asyncExec } from "../common";
+import { getCustomBundleGemfile } from "../bundleGemfileHelper";
 
 export interface ActivationResult {
   env: NodeJS.ProcessEnv;
@@ -24,17 +25,7 @@ export abstract class VersionManager {
   ) {
     this.workspaceFolder = workspaceFolder;
     this.outputChannel = outputChannel;
-    const customBundleGemfile: string = vscode.workspace
-      .getConfiguration("rubyLsp")
-      .get("bundleGemfile")!;
-
-    if (customBundleGemfile.length > 0) {
-      this.customBundleGemfile = path.isAbsolute(customBundleGemfile)
-        ? customBundleGemfile
-        : path.resolve(
-            path.join(this.workspaceFolder.uri.fsPath, customBundleGemfile),
-          );
-    }
+    this.customBundleGemfile = getCustomBundleGemfile(this.workspaceFolder);
 
     this.bundleUri = this.customBundleGemfile
       ? vscode.Uri.file(path.dirname(this.customBundleGemfile))


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
```
{
  "rubyLsp.bundleGemfile": "../../path/to/the/directory/Gemfile",
}
```
Didn't accept env variables like

```
{
  "rubyLsp.bundleGemfile": "${HOME}/$CUSTOM/Gemfile",
}
```

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Didn't find from node core function for this. Created a new one in vscode/src/bundleGemfileHelper.ts
Also extracted same code logic from versionManager.ts and ruby.ts to use this shared helper.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

I didn't. I have too restricted environment at the moment to be able to run tests that uses window managers (I think this is the reason why yarn run test fails)

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

I updated my remote extension folder with extesion.js file after running yarm run package and tested env variables are expanded as expected.
