### PR TITLE
Add support for delegating completion requests for ERB files

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -59,7 +59,7 @@ module RubyLsp
                 # If the client supports request delegation and we're working with an ERB document and there was
                 # something to parse, then we have to maintain the client updated about the virtual state of the host
                 # language source
-                if document.parse && @global_state.supports_request_delegation && document.is_a?(ERBDocument)
+                if document.parse! && @global_state.supports_request_delegation && document.is_a?(ERBDocument)
                   send_message(
                     Notification.new(
                       method: "delegate/textDocument/virtualState",

--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -31,6 +31,7 @@ module RubyLsp
         Thread,
       )
 
+      @global_state = T.let(GlobalState.new, GlobalState)
       Thread.main.priority = 1
     end
 
@@ -52,7 +53,26 @@ module RubyLsp
               message[:params][:textDocument][:uri] = parsed_uri
 
               # We don't want to try to parse documents on text synchronization notifications
-              @store.get(parsed_uri).parse unless method.start_with?("textDocument/did")
+              unless method.start_with?("textDocument/did")
+                document = @store.get(parsed_uri)
+
+                # If the client supports request delegation and we're working with an ERB document and there was
+                # something to parse, then we have to maintain the client updated about the virtual state of the host
+                # language source
+                if document.parse && @global_state.supports_request_delegation && document.is_a?(ERBDocument)
+                  send_message(
+                    Notification.new(
+                      method: "delegate/textDocument/virtualState",
+                      params: {
+                        textDocument: {
+                          uri: uri,
+                          text: document.host_language_source,
+                        },
+                      },
+                    ),
+                  )
+                end
+              end
             rescue Store::NonExistingDocumentError
               # If we receive a request for a file that no longer exists, we don't want to fail
             end

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -52,7 +52,7 @@ module RubyLsp
       @uri = T.let(uri, URI::Generic)
       @needs_parsing = T.let(true, T::Boolean)
       @parse_result = T.let(T.unsafe(nil), ParseResultType)
-      parse
+      parse!
     end
 
     sig { params(other: Document[T.untyped]).returns(T::Boolean) }
@@ -109,7 +109,7 @@ module RubyLsp
 
     # Returns `true` if the document was parsed and `false` if nothing needed parsing
     sig { abstract.returns(T::Boolean) }
-    def parse; end
+    def parse!; end
 
     sig { abstract.returns(T::Boolean) }
     def syntax_error?; end

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -51,7 +51,8 @@ module RubyLsp
       @version = T.let(version, Integer)
       @uri = T.let(uri, URI::Generic)
       @needs_parsing = T.let(true, T::Boolean)
-      @parse_result = T.let(parse, ParseResultType)
+      @parse_result = T.let(T.unsafe(nil), ParseResultType)
+      parse
     end
 
     sig { params(other: Document[T.untyped]).returns(T::Boolean) }
@@ -106,7 +107,8 @@ module RubyLsp
       @cache.clear
     end
 
-    sig { abstract.returns(ParseResultType) }
+    # Returns `true` if the document was parsed and `false` if nothing needed parsing
+    sig { abstract.returns(T::Boolean) }
     def parse; end
 
     sig { abstract.returns(T::Boolean) }

--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -20,7 +20,7 @@ module RubyLsp
     end
 
     sig { override.returns(T::Boolean) }
-    def parse
+    def parse!
       return false unless @needs_parsing
 
       @needs_parsing = false

--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -6,17 +6,30 @@ module RubyLsp
     extend T::Sig
     extend T::Generic
 
+    sig { returns(String) }
+    attr_reader :host_language_source
+
     ParseResultType = type_member { { fixed: Prism::ParseResult } }
 
-    sig { override.returns(ParseResultType) }
+    sig { params(source: String, version: Integer, uri: URI::Generic, encoding: Encoding).void }
+    def initialize(source:, version:, uri:, encoding: Encoding::UTF_8)
+      # This has to be initialized before calling super because we call `parse` in the parent constructor, which
+      # overrides this with the proper virtual host language source
+      @host_language_source = T.let("", String)
+      super
+    end
+
+    sig { override.returns(T::Boolean) }
     def parse
-      return @parse_result unless @needs_parsing
+      return false unless @needs_parsing
 
       @needs_parsing = false
       scanner = ERBScanner.new(@source)
       scanner.scan
+      @host_language_source = scanner.host_language
       # assigning empty scopes to turn Prism into eval mode
       @parse_result = Prism.parse(scanner.ruby, scopes: [[]])
+      true
     end
 
     sig { override.returns(T::Boolean) }
@@ -39,16 +52,22 @@ module RubyLsp
       RubyDocument.locate(@parse_result.value, create_scanner.find_char_position(position), node_types: node_types)
     end
 
+    sig { params(char_position: Integer).returns(T.nilable(T::Boolean)) }
+    def inside_host_language?(char_position)
+      char = @host_language_source[char_position]
+      char && char != " "
+    end
+
     class ERBScanner
       extend T::Sig
 
       sig { returns(String) }
-      attr_reader :ruby, :html
+      attr_reader :ruby, :host_language
 
       sig { params(source: String).void }
       def initialize(source)
         @source = source
-        @html = T.let(+"", String)
+        @host_language = T.let(+"", String)
         @ruby = T.let(+"", String)
         @current_pos = T.let(0, Integer)
         @inside_ruby = T.let(false, T::Boolean)
@@ -104,16 +123,16 @@ module RubyLsp
           end
         when "\r"
           @ruby << char
-          @html << char
+          @host_language << char
 
           if next_char == "\n"
             @ruby << next_char
-            @html << next_char
+            @host_language << next_char
             @current_pos += 1
           end
         when "\n"
           @ruby << char
-          @html << char
+          @host_language << char
         else
           push_char(T.must(char))
         end
@@ -123,10 +142,10 @@ module RubyLsp
       def push_char(char)
         if @inside_ruby
           @ruby << char
-          @html << " " * char.length
+          @host_language << " " * char.length
         else
           @ruby << " " * char.length
-          @html << char
+          @host_language << char
         end
       end
 

--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -21,7 +21,7 @@ module RubyLsp
     attr_reader :encoding
 
     sig { returns(T::Boolean) }
-    attr_reader :supports_watching_files, :experimental_features
+    attr_reader :supports_watching_files, :experimental_features, :supports_request_delegation
 
     sig { returns(TypeInferrer) }
     attr_reader :type_inferrer
@@ -41,6 +41,7 @@ module RubyLsp
       @experimental_features = T.let(false, T::Boolean)
       @type_inferrer = T.let(TypeInferrer.new(@index, @experimental_features), TypeInferrer)
       @addon_settings = T.let({}, T::Hash[String, T.untyped])
+      @supports_request_delegation = T.let(false, T::Boolean)
     end
 
     sig { params(addon_name: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -131,6 +132,7 @@ module RubyLsp
         @addon_settings.merge!(addon_settings)
       end
 
+      @supports_request_delegation = options.dig(:capabilities, :experimental, :requestDelegation) || false
       notifications
     end
 

--- a/lib/ruby_lsp/rbs_document.rb
+++ b/lib/ruby_lsp/rbs_document.rb
@@ -14,18 +14,19 @@ module RubyLsp
       super
     end
 
-    sig { override.returns(ParseResultType) }
+    sig { override.returns(T::Boolean) }
     def parse
-      return @parse_result unless @needs_parsing
+      return false unless @needs_parsing
 
       @needs_parsing = false
 
       _, _, declarations = RBS::Parser.parse_signature(@source)
       @syntax_error = false
       @parse_result = declarations
+      true
     rescue RBS::ParsingError
       @syntax_error = true
-      @parse_result
+      true
     end
 
     sig { override.returns(T::Boolean) }

--- a/lib/ruby_lsp/rbs_document.rb
+++ b/lib/ruby_lsp/rbs_document.rb
@@ -15,7 +15,7 @@ module RubyLsp
     end
 
     sig { override.returns(T::Boolean) }
-    def parse
+    def parse!
       return false unless @needs_parsing
 
       @needs_parsing = false

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -60,6 +60,8 @@ module RubyLsp
         # Completion always receives the position immediately after the character that was just typed. Here we adjust it
         # back by 1, so that we find the right node
         char_position = document.create_scanner.find_char_position(params[:position]) - 1
+        delegate_request_if_needed!(global_state, document, char_position)
+
         node_context = RubyDocument.locate(
           document.parse_result.value,
           char_position,

--- a/lib/ruby_lsp/requests/request.rb
+++ b/lib/ruby_lsp/requests/request.rb
@@ -17,6 +17,23 @@ module RubyLsp
 
       private
 
+      # Signals to the client that the request should be delegated to the language server server for the host language
+      # in ERB files
+      sig do
+        params(
+          global_state: GlobalState,
+          document: Document[T.untyped],
+          char_position: Integer,
+        ).void
+      end
+      def delegate_request_if_needed!(global_state, document, char_position)
+        if global_state.supports_request_delegation &&
+            document.is_a?(ERBDocument) &&
+            document.inside_host_language?(char_position)
+          raise DelegateRequestError
+        end
+      end
+
       # Checks if a location covers a position
       sig { params(location: Prism::Location, position: T.untyped).returns(T::Boolean) }
       def cover?(location, position)

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -122,7 +122,7 @@ module RubyLsp
     end
 
     sig { override.returns(T::Boolean) }
-    def parse
+    def parse!
       return false unless @needs_parsing
 
       @needs_parsing = false

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -121,12 +121,13 @@ module RubyLsp
       end
     end
 
-    sig { override.returns(ParseResultType) }
+    sig { override.returns(T::Boolean) }
     def parse
-      return @parse_result unless @needs_parsing
+      return false unless @needs_parsing
 
       @needs_parsing = false
       @parse_result = Prism.parse(@source)
+      true
     end
 
     sig { override.returns(T::Boolean) }

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -27,6 +27,16 @@ module RubyLsp
   )
   GUESSED_TYPES_URL = "https://github.com/Shopify/ruby-lsp/blob/main/DESIGN_AND_ROADMAP.md#guessed-types"
 
+  # Request delegation for embedded languages is not yet standardized into the language server specification. Here we
+  # use this custom error class as a way to return a signal to the client that the request should be delegated to the
+  # language server for the host language. The support for delegation is custom built on the client side, so each editor
+  # needs to implement their own until this becomes a part of the spec
+  class DelegateRequestError < StandardError
+    # A custom error code that clients can use to handle delegate requests. This is past the range of error codes listed
+    # by the specification to avoid conflicting with other error types
+    CODE = -32900
+  end
+
   # A notification to be sent to the client
   class Message
     extend T::Sig

--- a/test/erb_document_test.rb
+++ b/test/erb_document_test.rb
@@ -14,7 +14,7 @@ class ERBDocumentTest < Minitest::Test
       </ul>
     ERB
 
-    document.parse
+    document.parse!
 
     refute_predicate(document, :syntax_error?)
     assert_equal(
@@ -35,7 +35,7 @@ class ERBDocumentTest < Minitest::Test
       </html>
     ERB
 
-    document.parse
+    document.parse!
 
     refute_predicate(document, :syntax_error?)
     assert_equal(
@@ -46,7 +46,7 @@ class ERBDocumentTest < Minitest::Test
 
   def test_erb_document_handles_windows_newlines
     document = RubyLsp::ERBDocument.new(source: "<%=\r\nbar %>", version: 1, uri: URI("file:///foo.erb"))
-    document.parse
+    document.parse!
 
     refute_predicate(document, :syntax_error?)
     assert_equal("   \r\nbar   ", document.parse_result.source.source)
@@ -62,7 +62,7 @@ class ERBDocumentTest < Minitest::Test
       "<%= foo %\n<%= bar %>",
     ].each do |source|
       document = RubyLsp::ERBDocument.new(source: source, version: 1, uri: URI("file:///foo.erb"))
-      document.parse
+      document.parse!
     end
   end
 

--- a/test/erb_document_test.rb
+++ b/test/erb_document_test.rb
@@ -106,4 +106,20 @@ class ERBDocumentTest < Minitest::Test
     assert_equal(value, document.cache_set("textDocument/semanticHighlighting", value))
     assert_equal(value, document.cache_get("textDocument/semanticHighlighting"))
   end
+
+  def test_keeps_track_of_virtual_host_language_source
+    document = RubyLsp::ERBDocument.new(source: +<<~ERB, version: 1, uri: URI("file:///foo.erb"))
+      <ul>
+        <li><%= foo %><li>
+        <li><%= end %><li>
+      </ul>
+    ERB
+
+    assert_equal(<<~HTML, document.host_language_source)
+      <ul>
+        <li>          <li>
+        <li>          <li>
+      </ul>
+    HTML
+  end
 end

--- a/test/rbs_document_test.rb
+++ b/test/rbs_document_test.rb
@@ -29,7 +29,7 @@ class RBSDocumentTest < Minitest::Test
       [{ range: { start: { line: 1, character: 15 }, end: { line: 1, character: 15 } }, text: ">" }],
       version: 2,
     )
-    document.parse
+    document.parse!
     refute_predicate(document, :syntax_error?)
   end
 end

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -14,7 +14,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -49,7 +49,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -80,7 +80,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -111,7 +111,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -132,7 +132,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     document.push_edits(
       [{
@@ -198,7 +198,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     document.push_edits(
       [{
@@ -236,7 +236,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -263,7 +263,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -286,7 +286,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -316,7 +316,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -343,7 +343,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -379,7 +379,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -400,7 +400,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -545,7 +545,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -632,7 +632,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -663,7 +663,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -698,7 +698,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -720,7 +720,7 @@ class OnTypeFormattingTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -339,7 +339,7 @@ class RubyDocumentTest < Minitest::Test
       version: 2,
     )
 
-    document.parse
+    document.parse!
 
     assert_equal(<<~RUBY, document.source)
       class Foo
@@ -384,7 +384,7 @@ class RubyDocumentTest < Minitest::Test
       version: 11,
     )
 
-    document.parse
+    document.parse!
 
     assert_equal(<<~RUBY, document.source)
       class Foo
@@ -409,7 +409,7 @@ class RubyDocumentTest < Minitest::Test
       }],
       version: 2,
     )
-    document.parse
+    document.parse!
 
     assert_predicate(document, :syntax_error?)
   end
@@ -571,11 +571,11 @@ class RubyDocumentTest < Minitest::Test
 
     # When there's a new edit, we parse it the first `parse` invocation
     Prism.expects(:parse).with(document.source).once.returns(parse_result)
-    document.parse
+    document.parse!
 
     # If there are no new edits, we don't do anything
     Prism.expects(:parse).never
-    document.parse
+    document.parse!
 
     document.push_edits(
       [{ range: { start: { line: 0, character: 12 }, end: { line: 0, character: 12 } }, text: "\ndef bar; end" }],
@@ -584,7 +584,7 @@ class RubyDocumentTest < Minitest::Test
 
     # If there's another edit, we parse it once again
     Prism.expects(:parse).with(document.source).once.returns(parse_result)
-    document.parse
+    document.parse!
   end
 
   def test_cache_set_and_get

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -22,6 +22,11 @@ import {
   CloseAction,
   State,
   DocumentFilter,
+  CompletionList,
+  StaticFeature,
+  ClientCapabilities,
+  FeatureState,
+  ServerCapabilities,
 } from "vscode-languageclient/node";
 
 import {
@@ -224,6 +229,25 @@ class ClientErrorHandler implements ErrorHandler {
   }
 }
 
+class ExperimentalCapabilities implements StaticFeature {
+  fillClientCapabilities(capabilities: ClientCapabilities): void {
+    capabilities.experimental = {
+      requestDelegation: true,
+    };
+  }
+
+  initialize(
+    _capabilities: ServerCapabilities,
+    _documentSelector: DocumentSelector | undefined,
+  ): void {}
+
+  getState(): FeatureState {
+    return { kind: "static" };
+  }
+
+  clear(): void {}
+}
+
 export default class Client extends LanguageClient implements ClientInterface {
   public readonly ruby: Ruby;
   public serverVersion?: string;
@@ -233,6 +257,7 @@ export default class Client extends LanguageClient implements ClientInterface {
   private readonly createTestItems: (response: CodeLens[]) => void;
   private readonly baseFolder;
   private readonly workspaceOutputChannel: WorkspaceChannel;
+  private readonly virtualDocuments = new Map<string, string>();
 
   #context: vscode.ExtensionContext;
   #formatter: string;
@@ -244,6 +269,7 @@ export default class Client extends LanguageClient implements ClientInterface {
     createTestItems: (response: CodeLens[]) => void,
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel: WorkspaceChannel,
+    virtualDocuments: Map<string, string>,
     isMainWorkspace = false,
     debugMode?: boolean,
   ) {
@@ -260,7 +286,9 @@ export default class Client extends LanguageClient implements ClientInterface {
       debugMode,
     );
 
+    this.registerFeature(new ExperimentalCapabilities());
     this.workspaceOutputChannel = outputChannel;
+    this.virtualDocuments = virtualDocuments;
 
     // Middleware are part of client options, but because they must reference `this`, we cannot make it a part of the
     // `super` call (TypeScript does not allow accessing `this` before invoking `super`)
@@ -273,6 +301,13 @@ export default class Client extends LanguageClient implements ClientInterface {
     this.#context = context;
     this.ruby = ruby;
     this.#formatter = "";
+
+    this.onNotification("delegate/textDocument/virtualState", (params) => {
+      this.virtualDocuments.set(
+        params.textDocument.uri,
+        params.textDocument.text,
+      );
+    });
   }
 
   async afterStart() {
@@ -317,7 +352,7 @@ export default class Client extends LanguageClient implements ClientInterface {
 
   private async benchmarkMiddleware<T>(
     type: string | MessageSignature,
-    _params: any,
+    params: any,
     runRequest: () => Promise<T>,
   ): Promise<T> {
     if (this.state !== State.Running) {
@@ -341,6 +376,12 @@ export default class Client extends LanguageClient implements ClientInterface {
       this.logResponseTime(bench.duration, request);
       return result;
     } catch (error: any) {
+      // We use a special error code to indicate delegated requests. This is not actually an error, it's a signal that
+      // the client needs to invoke the appropriate language service for this request
+      if (error.code === -32900) {
+        return this.executeDelegateRequest(type, params);
+      }
+
       if (error.data) {
         if (
           this.baseFolder === "ruby-lsp" ||
@@ -376,6 +417,58 @@ export default class Client extends LanguageClient implements ClientInterface {
       }
 
       throw error;
+    }
+  }
+
+  private async executeDelegateRequest(
+    type: string | MessageSignature,
+    params: any,
+  ): Promise<any> {
+    const request = typeof type === "string" ? type : type.method;
+    const originalUri = params.textDocument.uri;
+
+    // Delegating requests only makes sense for text document requests, where a URI is available
+    if (!originalUri) {
+      return null;
+    }
+
+    const hostLanguage = /\.([^.]+)\.erb$/.exec(originalUri)?.[1] || "html";
+    const vdocUriString = `embedded-content://${hostLanguage}/${encodeURIComponent(
+      originalUri,
+    )}.${hostLanguage}`;
+
+    if (request === "textDocument/completion") {
+      return vscode.commands
+        .executeCommand<CompletionList>(
+          "vscode.executeCompletionItemProvider",
+          vscode.Uri.parse(vdocUriString),
+          params.position,
+          params.context.triggerCharacter,
+        )
+        .then((response) => {
+          // We need to tell the server that the completion item is being delegated, so that when it receives the
+          // `completionItem/resolve`, we can delegate that too
+          response.items.forEach((item) => {
+            // For whatever reason, HTML completion items don't include the `kind` and that causes a failure in the
+            // editor. It might be a mistake in the delegation
+            if (
+              item.documentation &&
+              typeof item.documentation !== "string" &&
+              "value" in item.documentation
+            ) {
+              item.documentation.kind = "markdown";
+            }
+
+            item.data = { ...item.data, delegateCompletion: true };
+          });
+
+          return response;
+        });
+    } else {
+      this.workspaceOutputChannel.warn(
+        `Attempted to delegate unsupported request ${request}`,
+      );
+      return null;
     }
   }
 

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -21,6 +21,7 @@ export class Workspace implements WorkspaceInterface {
   private readonly context: vscode.ExtensionContext;
   private readonly isMainWorkspace: boolean;
   private readonly telemetry: vscode.TelemetryLogger;
+  private readonly virtualDocuments = new Map<string, string>();
   private needsRestart = false;
   #inhibitRestart = false;
   #error = false;
@@ -30,6 +31,7 @@ export class Workspace implements WorkspaceInterface {
     workspaceFolder: vscode.WorkspaceFolder,
     telemetry: vscode.TelemetryLogger,
     createTestItems: (response: CodeLens[]) => void,
+    virtualDocuments: Map<string, string>,
     isMainWorkspace = false,
   ) {
     this.context = context;
@@ -42,6 +44,7 @@ export class Workspace implements WorkspaceInterface {
     this.ruby = new Ruby(context, workspaceFolder, this.outputChannel);
     this.createTestItems = createTestItems;
     this.isMainWorkspace = isMainWorkspace;
+    this.virtualDocuments = virtualDocuments;
 
     this.registerRestarts(context);
     this.registerCreateDeleteWatcher(
@@ -109,6 +112,7 @@ export class Workspace implements WorkspaceInterface {
       this.createTestItems,
       this.workspaceFolder,
       this.outputChannel,
+      this.virtualDocuments,
       this.isMainWorkspace,
       debugMode,
     );


### PR DESCRIPTION
### Motivation

Implements the majority of what's needed for #2529. This PR only adds completion support, but it implements all of the building blocks necessary and adding the other features should be relatively straight forward after this.

This PR makes the Ruby LSP capable of delegating requests that occur in the host language of an ERB template to the appropriate language service. Before this PR, we only serve Ruby related features for the ERB files.

After this PR, we continue to serve all features for the embedded Ruby portion of the documents, but if a request is triggered for the host language (like inside the HTML part of the code), then the Ruby LSP server will signal to the client that it needs to delegate the request to the appropriate language service.

The result is that users get features for both the embedded Ruby part and the host language (provided they have a language service registered to handle the features for the host language). Since most of the time ERB is used with HTML, this should work by default in VS Code.

I will follow up adding the remaining features, which are `hover`, `definition`, `signature help` and `document highlight`.

**Note**: the HTML language server also supports references and rename, but it's not possible to delegate a request that the Ruby LSP itself doesn't implement yet, so those will have to wait.

### Important note

This implementation is heavily based on the [sample for request delegation](https://github.com/microsoft/vscode-extension-samples/tree/main/lsp-embedded-request-forwarding). However, request delegation is not yet standardized into the LSP specification, which means this needs custom implementation in the client and will only work for VS Code.

Other editors will need to implement the custom delegation too if they wish to support this feature - at least until this becomes a part of the spec.

### Implementation

Here's the flow of delegation:

1. Someone edits an ERB file
2. The server receive requests for it
3. If the document had anything new to be parsed, if it's an ERB document and the client advertised that it supports request delegation, then we notify the client with the state of the virtual host language source, so that it can be used during delegation
4. Then if we receive a completion request and the position is inside the host language, we raise a custom error to signal that the request is being delegated
5. The client then catches the error and delegates using VS Code's completion provider

It's essentially the same implementation as the sample, but instead of detecting the virtual host language source directly in the client, we use the server since that's where the ERB scanner is.

I will add comments to explain the specific changes inline.

### Automated Tests

Added tests.

### Manual Tests

https://github.com/user-attachments/assets/7e073aa8-446c-4f0f-8b10-187b9a71a438