### PR TITLE
Use separator for activation script result

### DIFF
--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -13,14 +13,9 @@ import { VersionManager, ActivationResult } from "./versionManager";
 export class Asdf extends VersionManager {
   async activate(): Promise<ActivationResult> {
     const asdfUri = await this.findAsdfInstallation();
-    const activationScript =
-      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
-
-    const result = await this.runScript(
-      `. ${asdfUri.fsPath} && asdf exec ruby -W0 -rjson -e '${activationScript}'`,
+    const parsedResult = await this.runEnvActivationScript(
+      `. ${asdfUri.fsPath} && asdf exec ruby`,
     );
-
-    const parsedResult = this.parseWithErrorHandling(result.stderr);
 
     return {
       env: { ...process.env, ...parsedResult.env },

--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -6,14 +6,16 @@ import * as vscode from "vscode";
 
 import { WorkspaceChannel } from "../workspaceChannel";
 
-import { ActivationResult, VersionManager } from "./versionManager";
+import {
+  ActivationResult,
+  VersionManager,
+  ACTIVATION_SEPARATOR,
+} from "./versionManager";
 
 interface RubyVersion {
   engine?: string;
   version: string;
 }
-
-const ACTIVATION_SEPARATOR = "ACTIVATION_SEPARATOR";
 
 // A tool to change the current Ruby version
 // Learn more: https://github.com/postmodern/chruby

--- a/vscode/src/ruby/custom.ts
+++ b/vscode/src/ruby/custom.ts
@@ -10,14 +10,10 @@ import { VersionManager, ActivationResult } from "./versionManager";
 // GEM_HOME and GEM_PATH as needed to find the correct Ruby runtime.
 export class Custom extends VersionManager {
   async activate(): Promise<ActivationResult> {
-    const activationScript =
-      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
-
-    const result = await this.runScript(
-      `${this.customCommand()} && ruby -W0 -rjson -e '${activationScript}'`,
+    const parsedResult = await this.runEnvActivationScript(
+      `${this.customCommand()} && ruby`,
     );
 
-    const parsedResult = this.parseWithErrorHandling(result.stderr);
     return {
       env: { ...process.env, ...parsedResult.env },
       yjit: parsedResult.yjit,

--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -12,15 +12,11 @@ export class Mise extends VersionManager {
   async activate(): Promise<ActivationResult> {
     const miseUri = await this.findMiseUri();
 
-    const activationScript =
-      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
-
     // The exec command in Mise is called `x`
-    const result = await this.runScript(
-      `${miseUri.fsPath} x -- ruby -W0 -rjson -e '${activationScript}'`,
+    const parsedResult = await this.runEnvActivationScript(
+      `${miseUri.fsPath} x -- ruby`,
     );
 
-    const parsedResult = this.parseWithErrorHandling(result.stderr);
     return {
       env: { ...process.env, ...parsedResult.env },
       yjit: parsedResult.yjit,

--- a/vscode/src/ruby/none.ts
+++ b/vscode/src/ruby/none.ts
@@ -26,14 +26,8 @@ export class None extends VersionManager {
   }
 
   async activate(): Promise<ActivationResult> {
-    const activationScript =
-      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
+    const parsedResult = await this.runEnvActivationScript(this.rubyPath);
 
-    const result = await this.runScript(
-      `${this.rubyPath} -W0 -rjson -e '${activationScript}'`,
-    );
-
-    const parsedResult = this.parseWithErrorHandling(result.stderr);
     return {
       env: { ...process.env, ...parsedResult.env },
       yjit: parsedResult.yjit,

--- a/vscode/src/ruby/rbenv.ts
+++ b/vscode/src/ruby/rbenv.ts
@@ -7,14 +7,7 @@ import { VersionManager, ActivationResult } from "./versionManager";
 // Learn more: https://github.com/rbenv/rbenv
 export class Rbenv extends VersionManager {
   async activate(): Promise<ActivationResult> {
-    const activationScript =
-      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
-
-    const result = await this.runScript(
-      `rbenv exec ruby -W0 -rjson -e '${activationScript}'`,
-    );
-
-    const parsedResult = this.parseWithErrorHandling(result.stderr);
+    const parsedResult = await this.runEnvActivationScript("rbenv exec ruby");
 
     return {
       env: { ...process.env, ...parsedResult.env },

--- a/vscode/src/ruby/rvm.ts
+++ b/vscode/src/ruby/rvm.ts
@@ -11,15 +11,11 @@ import { ActivationResult, VersionManager } from "./versionManager";
 // - https://rvm.io
 export class Rvm extends VersionManager {
   async activate(): Promise<ActivationResult> {
-    const activationScript =
-      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
-
     const installationPath = await this.findRvmInstallation();
-    const result = await this.runScript(
-      `${installationPath.fsPath} -W0 -rjson -e '${activationScript}'`,
+    const parsedResult = await this.runEnvActivationScript(
+      installationPath.fsPath,
     );
 
-    const parsedResult = this.parseWithErrorHandling(result.stderr);
     const activatedKeys = Object.entries(parsedResult.env)
       .map(([key, value]) => `${key}=${value}`)
       .join(" ");

--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -22,15 +22,11 @@ export class Shadowenv extends VersionManager {
       );
     }
 
-    const activationScript =
-      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
-
     try {
-      const result = await this.runScript(
-        `shadowenv exec -- ruby -W0 -rjson -e '${activationScript}'`,
+      const parsedResult = await this.runEnvActivationScript(
+        "shadowenv exec -- ruby",
       );
 
-      const parsedResult = this.parseWithErrorHandling(result.stderr);
       return {
         env: { ...process.env, ...parsedResult.env },
         yjit: parsedResult.yjit,

--- a/vscode/src/test/suite/ruby/asdf.test.ts
+++ b/vscode/src/test/suite/ruby/asdf.test.ts
@@ -8,6 +8,7 @@ import sinon from "sinon";
 import { Asdf } from "../../../ruby/asdf";
 import { WorkspaceChannel } from "../../../workspaceChannel";
 import * as common from "../../../common";
+import { ACTIVATION_SEPARATOR } from "../../../ruby/versionManager";
 
 suite("Asdf", () => {
   if (os.platform() === "win32") {
@@ -26,16 +27,15 @@ suite("Asdf", () => {
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
     const asdf = new Asdf(workspaceFolder, outputChannel);
-    const activationScript =
-      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
+    const envStub = {
+      env: { ANY: "true" },
+      yjit: true,
+      version: "3.0.0",
+    };
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
-      stderr: JSON.stringify({
-        env: { ANY: "true" },
-        yjit: true,
-        version: "3.0.0",
-      }),
+      stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
     });
 
     const findInstallationStub = sinon
@@ -47,7 +47,7 @@ suite("Asdf", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `. ${os.homedir()}/.asdf/asdf.sh && asdf exec ruby -W0 -rjson -e '${activationScript}'`,
+        `. ${os.homedir()}/.asdf/asdf.sh && asdf exec ruby -W0 -rjson -e '${asdf.activationScript}'`,
         {
           cwd: workspacePath,
           shell: "/bin/bash",
@@ -76,16 +76,15 @@ suite("Asdf", () => {
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
     const asdf = new Asdf(workspaceFolder, outputChannel);
-    const activationScript =
-      "STDERR.print({env: ENV.to_h,yjit:!!defined?(RubyVM::YJIT),version:RUBY_VERSION}.to_json)";
+    const envStub = {
+      env: { ANY: "true" },
+      yjit: true,
+      version: "3.0.0",
+    };
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
-      stderr: JSON.stringify({
-        env: { ANY: "true" },
-        yjit: true,
-        version: "3.0.0",
-      }),
+      stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
     });
 
     const findInstallationStub = sinon
@@ -99,7 +98,7 @@ suite("Asdf", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `. ${os.homedir()}/.asdf/asdf.fish && asdf exec ruby -W0 -rjson -e '${activationScript}'`,
+        `. ${os.homedir()}/.asdf/asdf.fish && asdf exec ruby -W0 -rjson -e '${asdf.activationScript}'`,
         {
           cwd: workspacePath,
           shell: "/opt/homebrew/bin/fish",

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -9,6 +9,7 @@ import sinon from "sinon";
 import { Mise } from "../../../ruby/mise";
 import { WorkspaceChannel } from "../../../workspaceChannel";
 import * as common from "../../../common";
+import { ACTIVATION_SEPARATOR } from "../../../ruby/versionManager";
 
 suite("Mise", () => {
   if (os.platform() === "win32") {
@@ -28,16 +29,15 @@ suite("Mise", () => {
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
     const mise = new Mise(workspaceFolder, outputChannel);
 
-    const activationScript =
-      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
+    const envStub = {
+      env: { ANY: "true" },
+      yjit: true,
+      version: "3.0.0",
+    };
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
-      stderr: JSON.stringify({
-        env: { ANY: "true" },
-        yjit: true,
-        version: "3.0.0",
-      }),
+      stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
     });
     const findStub = sinon
       .stub(mise, "findMiseUri")
@@ -54,7 +54,7 @@ suite("Mise", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `${os.homedir()}/.local/bin/mise x -- ruby -W0 -rjson -e '${activationScript}'`,
+        `${os.homedir()}/.local/bin/mise x -- ruby -W0 -rjson -e '${mise.activationScript}'`,
         {
           cwd: workspacePath,
           shell: vscode.env.shell,
@@ -84,17 +84,17 @@ suite("Mise", () => {
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
     const mise = new Mise(workspaceFolder, outputChannel);
 
-    const activationScript =
-      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
+    const envStub = {
+      env: { ANY: "true" },
+      yjit: true,
+      version: "3.0.0",
+    };
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
-      stderr: JSON.stringify({
-        env: { ANY: "true" },
-        yjit: true,
-        version: "3.0.0",
-      }),
+      stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
     });
+
     const misePath = path.join(workspacePath, "mise");
     fs.writeFileSync(misePath, "fakeMiseBinary");
 
@@ -113,7 +113,7 @@ suite("Mise", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `${misePath} x -- ruby -W0 -rjson -e '${activationScript}'`,
+        `${misePath} x -- ruby -W0 -rjson -e '${mise.activationScript}'`,
         {
           cwd: workspacePath,
           shell: vscode.env.shell,

--- a/vscode/src/test/suite/ruby/none.test.ts
+++ b/vscode/src/test/suite/ruby/none.test.ts
@@ -9,6 +9,7 @@ import sinon from "sinon";
 import { None } from "../../../ruby/none";
 import { WorkspaceChannel } from "../../../workspaceChannel";
 import * as common from "../../../common";
+import { ACTIVATION_SEPARATOR } from "../../../ruby/versionManager";
 
 suite("None", () => {
   test("Invokes Ruby directly", async () => {
@@ -24,22 +25,22 @@ suite("None", () => {
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
     const none = new None(workspaceFolder, outputChannel);
 
-    const activationScript =
-      "STDERR.print({ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION }.to_json)";
+    const envStub = {
+      env: { ANY: "true" },
+      yjit: true,
+      version: "3.0.0",
+    };
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
-      stderr: JSON.stringify({
-        env: { ANY: "true" },
-        yjit: true,
-        version: "3.0.0",
-      }),
+      stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
     });
+
     const { env, version, yjit } = await none.activate();
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `ruby -W0 -rjson -e '${activationScript}'`,
+        `ruby -W0 -rjson -e '${none.activationScript}'`,
         {
           cwd: uri.fsPath,
           shell: vscode.env.shell,

--- a/vscode/src/test/suite/ruby/rubyInstaller.test.ts
+++ b/vscode/src/test/suite/ruby/rubyInstaller.test.ts
@@ -12,6 +12,7 @@ import { RubyInstaller } from "../../../ruby/rubyInstaller";
 import { WorkspaceChannel } from "../../../workspaceChannel";
 import { LOG_CHANNEL } from "../../../common";
 import { RUBY_VERSION } from "../../rubyVersion";
+import { ACTIVATION_SEPARATOR } from "../../../ruby/versionManager";
 
 suite("RubyInstaller", () => {
   if (os.platform() !== "win32") {
@@ -121,7 +122,7 @@ suite("RubyInstaller", () => {
 
     const windows = new RubyInstaller(workspaceFolder, outputChannel);
     const result = ["/fake/dir", "/other/fake/dir", true, RUBY_VERSION].join(
-      "ACTIVATION_SEPARATOR",
+      ACTIVATION_SEPARATOR,
     );
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",


### PR DESCRIPTION
### Motivation

Closes #2370

Some users seem to have issues with their shells printing extra output when being invoked by NodeJS. This leads to an invalid JSON being returned by the activation script, which we fail to parse.

I believe we can make the activation more robust if we just print the activated JSON between two separators so that we can automatically ignore any extra output.

### Implementation

I noticed that, with the exception of `chruby`, all activation scripts are almost identical. So I extract a good part of the logic to the parent class, so that we can more easily share with all manager integrations.

Then I started printing the environment between two separators and we look for those before parsing the result.

### Automated Tests

Had to updated the stubs on all tests to match the new behaviour.

### Manual Tests

Since version manager integrations are always critical, I would like to make a preview release to verify if everything is fixed and works as expected after this PR is approved, but before shipping.