### PR TITLE
Fix documentation publishing action

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'jekyll/**'
+      - '.github/workflows/publish_docs.yml'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/jekyll/.ruby-version
+++ b/jekyll/.ruby-version
@@ -1,0 +1,1 @@
+../.ruby-version


### PR DESCRIPTION
1. If we specify `working-directory` to `setup-ruby`, it also expects `.ruby-version` in that folder. So I symlinked `.ruby-version` to `jekyll/.ruby-version`
2. We need to trigger `publish_docs` when the job config itself is updated too. Additionally, I think allow it to be manually triggered can help debugging too. We can remove it later if that stops being the case.