### PR TITLE
Delegate all possible features for ERB

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -18,8 +18,7 @@ commands:
     aliases: ["tc"]
     run: "bundle exec srb tc"
   ci:
-    run: "bundle exec rake ruby_lsp:check_docs &&
-      bundle exec srb tc &&
+    run: "bundle exec srb tc &&
       bin/rubocop &&
       bin/test &&
       bundle exec exe/ruby-lsp-check"

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -17,7 +17,7 @@ module RubyLsp
         def provider
           Interface::CompletionOptions.new(
             resolve_provider: true,
-            trigger_characters: ["/", "\"", "'", ":", "@", "."],
+            trigger_characters: ["/", "\"", "'", ":", "@", ".", "=", "<"],
             completion_item: {
               labelDetailsSupport: true,
             },

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -35,8 +35,12 @@ module RubyLsp
         )
         @dispatcher = dispatcher
 
-        node_context = document.locate_node(
-          position,
+        char_position = document.create_scanner.find_char_position(position)
+        delegate_request_if_needed!(global_state, document, char_position)
+
+        node_context = RubyDocument.locate(
+          document.parse_result.value,
+          char_position,
           node_types: [
             Prism::CallNode,
             Prism::ConstantReadNode,

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -17,14 +17,19 @@ module RubyLsp
 
       sig do
         params(
+          global_state: GlobalState,
           document: T.any(RubyDocument, ERBDocument),
           position: T::Hash[Symbol, T.untyped],
           dispatcher: Prism::Dispatcher,
         ).void
       end
-      def initialize(document, position, dispatcher)
+      def initialize(global_state, document, position, dispatcher)
         super()
-        node_context = document.locate_node(position)
+        char_position = document.create_scanner.find_char_position(position)
+        delegate_request_if_needed!(global_state, document, char_position)
+
+        node_context = RubyDocument.locate(document.parse_result.value, char_position)
+
         @response_builder = T.let(
           ResponseBuilders::CollectionResponseBuilder[Interface::DocumentHighlight].new,
           ResponseBuilders::CollectionResponseBuilder[Interface::DocumentHighlight],

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -33,7 +33,15 @@ module RubyLsp
       end
       def initialize(document, global_state, position, dispatcher, sorbet_level)
         super()
-        node_context = document.locate_node(position, node_types: Listeners::Hover::ALLOWED_TARGETS)
+
+        char_position = document.create_scanner.find_char_position(position)
+        delegate_request_if_needed!(global_state, document, char_position)
+
+        node_context = RubyDocument.locate(
+          document.parse_result.value,
+          char_position,
+          node_types: Listeners::Hover::ALLOWED_TARGETS,
+        )
         target = node_context.node
         parent = node_context.parent
 

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -35,10 +35,11 @@ module RubyLsp
       end
       def initialize(document, global_state, position, context, dispatcher, sorbet_level) # rubocop:disable Metrics/ParameterLists
         super()
-        node_context = document.locate_node(
-          { line: position[:line], character: position[:character] },
-          node_types: [Prism::CallNode],
-        )
+
+        char_position = document.create_scanner.find_char_position(position)
+        delegate_request_if_needed!(global_state, document, char_position)
+
+        node_context = RubyDocument.locate(document.parse_result.value, char_position, node_types: [Prism::CallNode])
 
         target = adjust_for_nested_target(node_context.node, node_context.parent, position)
 

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -547,7 +547,7 @@ module RubyLsp
         return
       end
 
-      request = Requests::DocumentHighlight.new(document, params[:position], dispatcher)
+      request = Requests::DocumentHighlight.new(@global_state, document, params[:position], dispatcher)
       dispatcher.dispatch(document.parse_result.value)
       send_message(Result.new(id: message[:id], response: request.perform))
     end

--- a/test/requests/document_highlight_expectations_test.rb
+++ b/test/requests/document_highlight_expectations_test.rb
@@ -12,8 +12,9 @@ class DocumentHighlightExpectationsTest < ExpectationsTestRunner
     params = @__params&.any? ? @__params : default_args
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
 
+    global_state = RubyLsp::GlobalState.new
     dispatcher = Prism::Dispatcher.new
-    listener = RubyLsp::Requests::DocumentHighlight.new(document, params.first, dispatcher)
+    listener = RubyLsp::Requests::DocumentHighlight.new(global_state, document, params.first, dispatcher)
     dispatcher.dispatch(document.parse_result.value)
     listener.perform
   end

--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -788,4 +788,225 @@ suite("Client", () => {
       ),
     );
   }).timeout(20000);
+
+  test("delegate hover", async () => {
+    await client.sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri: documentUri.toString(),
+        version: 1,
+        text: "",
+      },
+    });
+
+    const text = ["<% @users.each do |user| %>", "  <di", "<% end %>"].join(
+      "\n",
+    );
+    const uri = vscode.Uri.joinPath(
+      workspaceUri,
+      "lib",
+      "ruby_lsp",
+      "index.html.erb",
+    ).toString();
+
+    await client.sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        version: 1,
+        text,
+        languageId: "erb",
+      },
+    });
+
+    const stub = sinon
+      .stub(vscode.commands, "executeCommand")
+      .resolves({ contents: { kind: "markdown", value: "Hello!" } });
+
+    await client.sendRequest("textDocument/hover", {
+      textDocument: {
+        uri,
+      },
+      position: { line: 1, character: 5 },
+    });
+    stub.restore();
+
+    await client.sendNotification("textDocument/didClose", {
+      textDocument: { uri },
+    });
+
+    assert.ok(
+      stub.calledWithExactly(
+        "vscode.executeHoverProvider",
+        vscode.Uri.parse(
+          `embedded-content://html/${encodeURIComponent(uri)}.html`,
+        ),
+        { line: 1, character: 5 },
+      ),
+    );
+  }).timeout(20000);
+
+  test("delegate definition", async () => {
+    await client.sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri: documentUri.toString(),
+        version: 1,
+        text: "",
+      },
+    });
+
+    const text = ["<% @users.each do |user| %>", "  <di", "<% end %>"].join(
+      "\n",
+    );
+    const uri = vscode.Uri.joinPath(
+      workspaceUri,
+      "lib",
+      "ruby_lsp",
+      "index.html.erb",
+    ).toString();
+
+    await client.sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        version: 1,
+        text,
+        languageId: "erb",
+      },
+    });
+
+    const stub = sinon.stub(vscode.commands, "executeCommand").resolves(null);
+
+    await client.sendRequest("textDocument/definition", {
+      textDocument: {
+        uri,
+      },
+      position: { line: 1, character: 5 },
+    });
+    stub.restore();
+
+    await client.sendNotification("textDocument/didClose", {
+      textDocument: { uri },
+    });
+
+    assert.ok(
+      stub.calledWithExactly(
+        "vscode.executeDefinitionProvider",
+        vscode.Uri.parse(
+          `embedded-content://html/${encodeURIComponent(uri)}.html`,
+        ),
+        { line: 1, character: 5 },
+      ),
+    );
+  }).timeout(20000);
+
+  test("delegate signature help", async () => {
+    await client.sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri: documentUri.toString(),
+        version: 1,
+        text: "",
+      },
+    });
+
+    const text = [
+      "<% @users.each do |user| %>",
+      "  <div onclick='alert(;'>",
+      "<% end %>",
+    ].join("\n");
+    const uri = vscode.Uri.joinPath(
+      workspaceUri,
+      "lib",
+      "ruby_lsp",
+      "index.html.erb",
+    ).toString();
+
+    await client.sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        version: 1,
+        text,
+        languageId: "erb",
+      },
+    });
+
+    const stub = sinon.stub(vscode.commands, "executeCommand").resolves(null);
+
+    await client.sendRequest("textDocument/signatureHelp", {
+      textDocument: {
+        uri,
+      },
+      position: { line: 1, character: 23 },
+      context: {},
+    });
+    stub.restore();
+
+    await client.sendNotification("textDocument/didClose", {
+      textDocument: { uri },
+    });
+
+    assert.ok(
+      stub.calledWithExactly(
+        "vscode.executeSignatureHelpProvider",
+        vscode.Uri.parse(
+          `embedded-content://html/${encodeURIComponent(uri)}.html`,
+        ),
+        { line: 1, character: 23 },
+        undefined,
+      ),
+    );
+  }).timeout(20000);
+
+  test("delegate document highlight", async () => {
+    await client.sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri: documentUri.toString(),
+        version: 1,
+        text: "",
+      },
+    });
+
+    const text = [
+      "<% @users.each do |user| %>",
+      "  <div></div>",
+      "<% end %>",
+    ].join("\n");
+    const uri = vscode.Uri.joinPath(
+      workspaceUri,
+      "lib",
+      "ruby_lsp",
+      "index.html.erb",
+    ).toString();
+
+    await client.sendNotification("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        version: 1,
+        text,
+        languageId: "erb",
+      },
+    });
+
+    const stub = sinon.stub(vscode.commands, "executeCommand").resolves(null);
+
+    await client.sendRequest("textDocument/documentHighlight", {
+      textDocument: {
+        uri,
+      },
+      position: { line: 1, character: 4 },
+      context: {},
+    });
+    stub.restore();
+
+    await client.sendNotification("textDocument/didClose", {
+      textDocument: { uri },
+    });
+
+    assert.ok(
+      stub.calledWithExactly(
+        "vscode.executeDocumentHighlights",
+        vscode.Uri.parse(
+          `embedded-content://html/${encodeURIComponent(uri)}.html`,
+        ),
+        { line: 1, character: 4 },
+      ),
+    );
+  }).timeout(20000);
 });


### PR DESCRIPTION
### Motivation

Closes #2529

This PR starts delegating the remaining features that occur in the host language part of an ERB file to the appropriate language services.

The features that will be available for the host languages are now: definition, hover, signature help, document highlight, folding range and document link.

### Caveats

#### JavaScript embedded in HTML in embedded Ruby

When using ERB in an HTML template, there's double delegation happening if the user is writing CSS or JavaScript. For example, consider this ERB template:

```erb
<% @users.each do |user| %>
  <button onclick="document."></button>
<% end %>
```

When typing the dot inside the `onclick` attribute, the HTML language server is in JavaScript mode, delegating all requests to the JS service.

This is currently working, but I noticed that when the double-delegation is in place the completion results for JavaScript are not exactly the same as when you use a regular HTML file. I created a [discussion](https://github.com/microsoft/vscode-discussions/discussions/1628) for this because I'm not sure if this is an issue with our implementation, with VS Code or with the `html-language-features` extension.

After #2561 goes in, I can add some documentation highlighting that this is a current limitation.

#### Semantic highlighting

The only missing feature that the Ruby LSP does implement is semantic highlighting. It is possible to support delegation for it by firing two requests and then concatenating the responses, but that requires that the Ruby LSP server stops encoding the tokens for ERB documents, so that they can be concatenated, ordered and only then encoded in the client.

It's not very trivial and I'm not sure how semantic tokens delta would work in this case. We would probably need to re-implement delta on the client so that we could compute deltas between fully merged semantic token responses. For now, I'm going to skip semantic highlighting due to the complexity.

#### Other features

Request delegation can only work for features that are supported by the Ruby LSP, so references and rename support are currently missing.

### Implementation

For position based requests, we just followed the exactly same approach as we did for completion. For full document requests, we need to delegate the request, run the real request on the server and merge the responses.

This allows you to get features for the mixed document, like being able to fold both the Ruby and the HTML code in an ERB template at the right places.

### Automated Tests

Added tests.