### PR TITLE
Separate Jekyll CI from regular CI and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,3 +52,18 @@ updates:
       - "chore"
       - "dependencies"
       - "gh-actions"
+  - package-ecosystem: "bundler"
+    directory: "jekyll"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "Shopify/ruby-dev-exp"
+    labels:
+      - "dependencies"
+      - "ruby"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'jekyll/**'
+
+  pull_request:
+    paths-ignore:
+      - 'jekyll/**'
 
 jobs:
   lint_ruby:

--- a/.github/workflows/verify_docs.yml
+++ b/.github/workflows/verify_docs.yml
@@ -1,0 +1,29 @@
+name: Verify docs
+
+on:
+  push:
+    paths:
+      - 'jekyll/**'
+      - '.github/workflows/publish_docs.yml'
+
+  pull_request:
+    paths:
+      - 'jekyll/**'
+      - '.github/workflows/publish_docs.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Verify Jekyll website builds
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          working-directory: ./jekyll
+
+      - name: Generate documentation
+        working-directory: ./jekyll
+        run: bundle exec jekyll build


### PR DESCRIPTION
### Motivation

Now that we have Jekyll as a completely separate website inside the repository, we can make some adjustments to our CI. This PR:

- Stops running regular CI if only files under `jekyll` were modified
- Adds a "CI" step for when `jekyll` files are modified that just verifies the documentation builds properly
- Sets up dependabot for the separate Gemfile