### PR TITLE
Fix inference for compact namespace declarations

### DIFF
--- a/lib/ruby_lsp/type_inferrer.rb
+++ b/lib/ruby_lsp/type_inferrer.rb
@@ -121,8 +121,12 @@ module RubyLsp
       return Type.new(node_context.fully_qualified_name) if node_context.surrounding_method
 
       # If we're not inside a method, then we're inside the body of a class or module, which is a singleton
-      # context
-      Type.new("#{nesting.join("::")}::<Class:#{nesting.last}>")
+      # context.
+      #
+      # If the class/module definition is using compact style (e.g.: `class Foo::Bar`), then we need to split the name
+      # into its individual parts to build the correct singleton name
+      parts = nesting.flat_map { |part| part.split("::") }
+      Type.new("#{parts.join("::")}::<Class:#{parts.last}>")
     end
 
     sig do

--- a/test/type_inferrer_test.rb
+++ b/test/type_inferrer_test.rb
@@ -358,6 +358,40 @@ module RubyLsp
       assert_equal("Proc", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
+    def test_infer_self_type_for_compact_namespace
+      node_context = index_and_locate(<<~RUBY, { line: 1, character: 3 })
+        class Admin::User
+          validates
+        end
+      RUBY
+
+      assert_equal("Admin::User::<Class:User>", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_self_type_for_compact_namespace_inside_method
+      node_context = index_and_locate(<<~RUBY, { line: 2, character: 4 })
+        class Admin::User
+          def foo
+            hello
+          end
+        end
+      RUBY
+
+      assert_equal("Admin::User", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_self_type_for_compact_namespace_inside_singleton_method
+      node_context = index_and_locate(<<~RUBY, { line: 2, character: 4 })
+        class Admin::User
+          def self.foo
+            hello
+          end
+        end
+      RUBY
+
+      assert_equal("Admin::User::<Class:User>", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
     private
 
     def index_and_locate(source, position)


### PR DESCRIPTION
### Motivation

Closes #2568

We weren't splitting the name parts from the nesting, which caused us to produce the incorrect type name `Admin::User::<Class:Admin::User>` as opposed to the correct singleton name `Admin::User::<Class:User>`.

That caused inference for `self` when invoking singleton methods on compact namespaces to be incorrect, which then makes completion, definition, hover and signature help not work.

### Implementation

We just need to ensure that we're working with the individual name parts, so I just flat mapped the split.

### Automated Tests

Added a few tests to ensure we don't regress.