### PR TITLE
Fix rescue token without explicit class

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -142,7 +142,7 @@
           "name": "variable.ruby"
         }
       },
-      "match": "^\\s*([a-z]([A-Za-z0-9_])*)\\s*=[^=]",
+      "match": "^\\s*([a-z]([A-Za-z0-9_])*)\\s*=[^=>]",
       "comment": "A local variable assignment"
     },
     {

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -325,6 +325,20 @@ suite("Grammars", () => {
       });
     });
 
+    suite("Local variables", () => {
+      test("rescue is not confused", () => {
+        const ruby = "rescue => e";
+        const expectedTokens = [
+          ["rescue", ["source.ruby", "keyword.control.ruby"]],
+          [" ", ["source.ruby"]],
+          ["=>", ["source.ruby", "punctuation.separator.key-value"]],
+          [" e", ["source.ruby"]],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+    });
+
     function tokenizeRuby(ruby: string): [string, string[]][] {
       if (!rubyGrammar) {
         throw new Error("Ruby grammar not loaded");


### PR DESCRIPTION
### Motivation

I noticed that `rescue => e` was marking `rescue` as a local variable, which isn't correct. The reason is because we weren't taking the `>` into account for making the regex fail.

### Implementation

Started considering `>` in the regex.

### Automated Tests

Added a test.