### PR TITLE
Delete comment prefix when lazy fetching

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -98,8 +98,13 @@ module RubyIndexer
         # object is dropped, so this will not prevent updates
         if correct_group
           correct_group.filter_map do |comment|
-            content = comment.slice
-            content if content.valid_encoding?
+            content = comment.slice.chomp
+
+            if content.valid_encoding?
+              content.delete_prefix!("#")
+              content.delete_prefix!(" ")
+              content
+            end
           end.join("\n")
         else
           ""

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -605,5 +605,19 @@ module RubyIndexer
       assert_entry("Foo::Bar", Entry::Class, "/fake/path/foo.rb:2-4:3-7")
       assert_entry("Qux", Entry::Class, "/fake/path/foo.rb:5-4:6-7")
     end
+
+    def test_lazy_comment_fetching_uses_correct_line_breaks_for_rendering
+      path = "lib/ruby_lsp/node_context.rb"
+      indexable = IndexablePath.new("#{Dir.pwd}/lib", path)
+
+      @index.index_single(indexable, collect_comments: false)
+
+      entry = @index["RubyLsp::NodeContext"].first
+
+      assert_equal(<<~COMMENTS.chomp, entry.comments)
+        This class allows listeners to access contextual information about a node in the AST, such as its parent,
+        its namespace nesting, and the surrounding CallNode (e.g. a method call).
+      COMMENTS
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Closes #2582

I forgot to delete the leading `#` and possible blank space when we're fetching comments lazily. Since the documentation is rendered as markdown, it makes everything appear as `h1` tags, which are huge.

### Implementation

Just added the prefix delete, exactly like we do in eager comment fetching.

### Automated Tests

Added a test to ensure we don't regress.