### PR TITLE
Handle method aliases in completion resolve

### DIFF
--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -46,8 +46,8 @@ module RubyLsp
 
         if owner_name
           entries = entries.select do |entry|
-            (entry.is_a?(RubyIndexer::Entry::Member) || entry.is_a?(RubyIndexer::Entry::InstanceVariable)) &&
-              entry.owner&.name == owner_name
+            (entry.is_a?(RubyIndexer::Entry::Member) || entry.is_a?(RubyIndexer::Entry::InstanceVariable) ||
+            entry.is_a?(RubyIndexer::Entry::MethodAlias)) && entry.owner&.name == owner_name
           end
         end
 


### PR DESCRIPTION
### Motivation

We weren't handling method aliases in completion resolve, which meant that trying to invoke one (like `Kernel#kind_of?`) would show empty documentation.

### Implementation

We just need to include `MethodAlias` in the filter.

### Automated Tests

Added a test.