### PR TITLE
Remove --experimental flag

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -29,13 +29,6 @@ parser = OptionParser.new do |opts|
     options[:branch] = branch
   end
 
-  opts.on(
-    "--experimental",
-    "Run pre-release versions of the Ruby LSP",
-  ) do
-    options[:experimental] = true
-  end
-
   opts.on("--doctor", "Run troubleshooting steps") do
     options[:doctor] = true
   end

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -27,7 +27,6 @@ module RubyLsp
     def initialize(project_path, **options)
       @project_path = project_path
       @branch = T.let(options[:branch], T.nilable(String))
-      @experimental = T.let(options[:experimental], T.nilable(T::Boolean))
 
       # Regular bundle paths
       @gemfile = T.let(
@@ -207,7 +206,6 @@ module RubyLsp
         command << "ruby-lsp " unless @dependencies["ruby-lsp"]
         command << "debug " unless @dependencies["debug"]
         command << "ruby-lsp-rails " if @rails_app && !@dependencies["ruby-lsp-rails"]
-        command << "--pre" if @experimental
         command.delete_suffix!(" ")
         command << ")"
 

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -301,38 +301,6 @@ class SetupBundlerTest < Minitest::Test
     end
   end
 
-  def test_install_prerelease_versions_if_experimental_is_true
-    Dir.mktmpdir do |dir|
-      Dir.chdir(dir) do
-        File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
-          source "https://rubygems.org"
-          gem "rdoc"
-        GEMFILE
-
-        capture_subprocess_io do
-          Bundler.with_unbundled_env do
-            # Run bundle install to generate the lockfile
-            system("bundle install")
-
-            # Run the script once to generate a custom bundle
-            run_script(dir)
-          end
-        end
-
-        capture_subprocess_io do
-          Bundler.with_unbundled_env do
-            stub_bundle_with_env(
-              bundle_env(dir, ".ruby-lsp/Gemfile"),
-              "((bundle check && bundle update ruby-lsp debug --pre) || bundle install) 1>&2",
-            )
-
-            run_script(dir, experimental: true)
-          end
-        end
-      end
-    end
-  end
-
   def test_returns_bundle_app_config_if_there_is_local_config
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do


### PR DESCRIPTION
### Motivation

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
This PR removes the `--experimental` flag and closes #2549.

Introduced in #1126, this flag was intended to allow users to enable experimental server features and install beta/release candidate versions. However, it was never used, and it posed a risk of upgrading transitive dependencies unintentionally. Therefore, we have decided to remove it.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Removed all references to the `--experimental` flag from the codebase, including related tests.
