### PR TITLE
Fix bundler env

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -255,7 +255,9 @@ module RubyLsp
       # "vendor/bundle"`
       settings.all.to_h do |e|
         key = Bundler::Settings.key_for(e)
-        [key, settings[e].to_s]
+        value = Array(settings[e]).join(":").tr(" ", ":")
+
+        [key, value]
       end
     end
 

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -600,6 +600,31 @@ class SetupBundlerTest < Minitest::Test
     end
   end
 
+  def test_uses_correct_bundler_env_when_there_is_bundle_config
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+          source "https://rubygems.org"
+          gem "irb"
+        GEMFILE
+
+        Bundler.with_unbundled_env do
+          system("bundle config set --local with production staging")
+
+          assert_path_exists(File.join(dir, ".bundle", "config"))
+
+          capture_subprocess_io do
+            system("bundle install")
+
+            env = run_script(dir)
+
+            assert_equal("production:staging", env["BUNDLE_WITH"])
+          end
+        end
+      end
+    end
+  end
+
   private
 
   def with_default_external_encoding(encoding, &block)
@@ -629,12 +654,15 @@ class SetupBundlerTest < Minitest::Test
   # This method runs the script and then immediately unloads it. This allows us to make assertions against the effects
   # of running the script multiple times
   def run_script(path = Dir.pwd, expected_path: nil, **options)
+    env = T.let({}, T::Hash[String, String])
+
     stdout, _stderr = capture_subprocess_io do
       env = RubyLsp::SetupBundler.new(path, **options).setup!
       assert_equal(expected_path, env["BUNDLE_PATH"]) if expected_path
     end
 
     assert_empty(stdout)
+    env
   end
 
   # This method needs to be called inside the `Bundler.with_unbundled_env` block IF the command you want to test is
@@ -658,7 +686,9 @@ class SetupBundlerTest < Minitest::Test
 
     env = settings.all.to_h do |e|
       key = Bundler::Settings.key_for(e)
-      [key, settings[e].to_s]
+      value = Array(settings[e]).join(":").tr(" ", ":")
+
+      [key, value]
     end
 
     if env["BUNDLE_PATH"]


### PR DESCRIPTION
### Motivation

Bundler has [array configs](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/settings.rb#L73) like `BUNDLE_WITHOUT` and `settings[e]` [returns array](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/settings.rb#L438) that later converted to string incorrectly (e.g. `'[:development, :test]'`, but must be `'development:test'`). Because of that bundler tries to install all gems in Gemfile, when `ruby-lsp` is not included in your application's Gemfile

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

Couldn't find any related tests, so tests are missing.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

You need to have a group of gems in your Gemfile. Then you should run `bundle config set without 'YOUR_GROUP'`. And you should not have gems in this group installed after the LSP server starts
