### PR TITLE
Fix body line height for code

### DIFF
--- a/jekyll/_sass/custom/_custom.scss
+++ b/jekyll/_sass/custom/_custom.scss
@@ -1,0 +1,3 @@
+pre.highlight {
+  line-height: 1;
+}


### PR DESCRIPTION
By default, the just-the-docs theme sets the line height for code to match that of the body, resulting in some odd-looking gaps.

See https://github.com/just-the-docs/just-the-docs/discussions/932

Before:

<img width="765" alt="Screenshot 2024-09-23 at 1 10 10 PM" src="https://github.com/user-attachments/assets/8975799c-5d71-431b-a0bd-033ccc76407b">

After:

<img width="769" alt="Screenshot 2024-09-23 at 1 09 56 PM" src="https://github.com/user-attachments/assets/c28943df-4516-4da4-8f71-21519ccc7fb9">
