### PR TITLE
Remove version manager setting migration code

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -8,8 +8,6 @@ import { LOG_CHANNEL } from "./common";
 let extension: RubyLsp;
 
 export async function activate(context: vscode.ExtensionContext) {
-  await migrateManagerConfigurations();
-
   if (!vscode.workspace.workspaceFolders) {
     // We currently don't support usage without any workspace folders opened. Here we warn the user, point to the issue
     // and offer to open a folder instead
@@ -36,38 +34,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate(): Promise<void> {
   await extension.deactivate();
-}
-
-type InspectKeys =
-  | "globalValue"
-  | "workspaceValue"
-  | "workspaceFolderValue"
-  | "globalLanguageValue"
-  | "workspaceLanguageValue"
-  | "workspaceFolderLanguageValue";
-// Function to migrate the old version manager configuration to the new format. Remove this after a few months
-async function migrateManagerConfigurations() {
-  const configuration = vscode.workspace.getConfiguration("rubyLsp");
-  const currentManagerSettings =
-    configuration.inspect<string>("rubyVersionManager")!;
-  let identifier: string | undefined;
-
-  const targetMap: Record<InspectKeys, vscode.ConfigurationTarget> = {
-    globalValue: vscode.ConfigurationTarget.Global,
-    globalLanguageValue: vscode.ConfigurationTarget.Global,
-    workspaceFolderLanguageValue: vscode.ConfigurationTarget.WorkspaceFolder,
-    workspaceFolderValue: vscode.ConfigurationTarget.WorkspaceFolder,
-    workspaceLanguageValue: vscode.ConfigurationTarget.Workspace,
-    workspaceValue: vscode.ConfigurationTarget.Workspace,
-  };
-
-  for (const [key, target] of Object.entries(targetMap)) {
-    identifier = currentManagerSettings[key as InspectKeys];
-
-    if (identifier && typeof identifier === "string") {
-      await configuration.update("rubyVersionManager", { identifier }, target);
-    }
-  }
 }
 
 async function createLogger(context: vscode.ExtensionContext) {


### PR DESCRIPTION
### Motivation

In #1831, we refactored version manager settings and code to automatically fix users configurations. It's been quite a few months since then, so I think we can remove the migration code already.

### Implementation

Just removed the migration code.