### PR TITLE
Allow declaration of project addons

### DIFF
--- a/jekyll/add-ons.markdown
+++ b/jekyll/add-ons.markdown
@@ -61,6 +61,10 @@ The Ruby LSP discovers add-ons based on the existence of an `addon.rb` file plac
 example, `my_gem/lib/ruby_lsp/my_gem/addon.rb`. This file must declare the add-on class, which can be used to perform any
 necessary activation when the server starts.
 
+{: .note }
+Projects can also define their own private add-ons for functionality that only applies to a particular application. As
+long as a file matching `ruby_lsp/**/addon.rb` exists inside of the workspace (not necessarily at the root), it will be
+loaded by the Ruby LSP.
 
 ```ruby
 # frozen_string_literal: true

--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -239,6 +239,8 @@ module RubyIndexer
 
       excluded.uniq!
       excluded.map(&:name)
+    rescue Bundler::GemfileNotFound
+      []
     end
   end
 end

--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -54,14 +54,24 @@ module RubyLsp
       end
 
       # Discovers and loads all add-ons. Returns a list of errors when trying to require add-ons
-      sig { params(global_state: GlobalState, outgoing_queue: Thread::Queue).returns(T::Array[StandardError]) }
-      def load_addons(global_state, outgoing_queue)
+      sig do
+        params(
+          global_state: GlobalState,
+          outgoing_queue: Thread::Queue,
+          include_project_addons: T::Boolean,
+        ).returns(T::Array[StandardError])
+      end
+      def load_addons(global_state, outgoing_queue, include_project_addons: true)
         # Require all add-ons entry points, which should be placed under
         # `some_gem/lib/ruby_lsp/your_gem_name/addon.rb` or in the workspace under
         # `your_project/ruby_lsp/project_name/addon.rb`
-        errors = Gem.find_files("ruby_lsp/**/addon.rb")
-          .concat(Dir.glob(File.join(global_state.workspace_path, "**", "ruby_lsp/**/addon.rb")))
-          .filter_map do |addon_path|
+        addon_files = Gem.find_files("ruby_lsp/**/addon.rb")
+
+        if include_project_addons
+          addon_files.concat(Dir.glob(File.join(global_state.workspace_path, "**", "ruby_lsp/**/addon.rb")))
+        end
+
+        errors = addon_files.filter_map do |addon_path|
           # Avoid requiring this file twice. This may happen if you're working on the Ruby LSP itself and at the same
           # time have `ruby-lsp` installed as a vendored gem
           next if File.basename(File.dirname(addon_path)) == "ruby_lsp"

--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -54,14 +54,19 @@ module RubyLsp
       end
 
       # Discovers and loads all add-ons. Returns a list of errors when trying to require add-ons
-      sig do
-        params(global_state: GlobalState, outgoing_queue: Thread::Queue).returns(T::Array[StandardError])
-      end
+      sig { params(global_state: GlobalState, outgoing_queue: Thread::Queue).returns(T::Array[StandardError]) }
       def load_addons(global_state, outgoing_queue)
         # Require all add-ons entry points, which should be placed under
-        # `some_gem/lib/ruby_lsp/your_gem_name/addon.rb`
-        errors = Gem.find_files("ruby_lsp/**/addon.rb").filter_map do |addon|
-          require File.expand_path(addon)
+        # `some_gem/lib/ruby_lsp/your_gem_name/addon.rb` or in the workspace under
+        # `your_project/ruby_lsp/project_name/addon.rb`
+        errors = Gem.find_files("ruby_lsp/**/addon.rb")
+          .concat(Dir.glob(File.join(global_state.workspace_path, "**", "ruby_lsp/**/addon.rb")))
+          .filter_map do |addon_path|
+          # Avoid requiring this file twice. This may happen if you're working on the Ruby LSP itself and at the same
+          # time have `ruby-lsp` installed as a vendored gem
+          next if File.basename(File.dirname(addon_path)) == "ruby_lsp"
+
+          require File.expand_path(addon_path)
           nil
         rescue => e
           e
@@ -90,6 +95,10 @@ module RubyLsp
       # the responsibility of the add-ons using this API to handle these errors appropriately.
       sig { params(addon_name: String, version_constraints: String).returns(Addon) }
       def get(addon_name, *version_constraints)
+        if version_constraints.empty?
+          raise IncompatibleApiError, "Must specify version constraints when accessing other add-ons"
+        end
+
         addon = addons.find { |addon| addon.name == addon_name }
         raise AddonNotFoundError, "Could not find add-on '#{addon_name}'" unless addon
 

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -123,9 +123,9 @@ module RubyLsp
       send_log_message("Error processing #{message[:method]}: #{e.full_message}", type: Constant::MessageType::ERROR)
     end
 
-    sig { void }
-    def load_addons
-      errors = Addon.load_addons(@global_state, @outgoing_queue)
+    sig { params(include_project_addons: T::Boolean).void }
+    def load_addons(include_project_addons: true)
+      errors = Addon.load_addons(@global_state, @outgoing_queue, include_project_addons: include_project_addons)
 
       if errors.any?
         send_log_message(

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -42,7 +42,7 @@ module RubyLsp
         RubyIndexer::IndexablePath.new(nil, T.must(uri.to_standardized_path)),
         source,
       )
-      server.load_addons if load_addons
+      server.load_addons(include_project_addons: false) if load_addons
       block.call(server, uri)
     ensure
       if load_addons


### PR DESCRIPTION
### Motivation

Users may want to define project-specific addons for behaviour that only applies to a particular application. Supporting it is quite straight forward, so I think we should move forward and allow it.

### Implementation

All of the mechanism to load the addons is already in place, the only limitation is that `Gem.find_files` won't find files that aren't in gems.

We just need to run a glob pattern on the workspace path to find project specific ones.

### Automated Tests

Added a test.