### PR TITLE
Add Social Media Preview Image for Ruby LSP Docs

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -4,6 +4,13 @@ description: >-
 baseurl: "/ruby-lsp"
 url: "https://shopify.github.io"
 github_username: shopify
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: /icon.png
+
 aux_links:
   "Ruby DX Slack":
     - "https://join.slack.com/t/ruby-dx/shared_invite/zt-2c8zjlir6-uUDJl8oIwcen_FS_aA~b6Q"
@@ -19,6 +26,7 @@ nav_external_links:
 theme: just-the-docs
 plugins:
   - jekyll-feed
+  - jekyll-seo-tag
 destination: ../docs
 
 # Copied from just-the-docs's _config.yml


### PR DESCRIPTION
This PR adds social media previews for the Ruby LSP documentation by setting a default image in Jekyll's configuration file.

### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Currently, there is no image preview when sharing the docs on social media. By adding a default image, we can enhance the appearance and engagement of shared links.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Added the Ruby LSP icon as the default image to `jekyll/_config.yml`. The `jekyll-seo-tag` dependency, which is already included in the `just-the-docs` theme, was used to handle this. I followed the instructions from the [jekyll-seo-tag documentation](https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/advanced-usage.md#setting-a-default-image) to set up the default image.