### PR TITLE
Only require RuboCop diagnostic inside the formatter

### DIFF
--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -47,7 +47,6 @@ require "ruby_lsp/response_builders/semantic_highlighting"
 require "ruby_lsp/response_builders/signature_help"
 
 # Request support
-require "ruby_lsp/requests/support/rubocop_diagnostic"
 require "ruby_lsp/requests/support/selection_range"
 require "ruby_lsp/requests/support/annotation"
 require "ruby_lsp/requests/support/sorbet"

--- a/lib/ruby_lsp/requests/support/rubocop_formatter.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_formatter.rb
@@ -3,6 +3,8 @@
 
 return unless defined?(RubyLsp::Requests::Support::RuboCopRunner)
 
+require "ruby_lsp/requests/support/rubocop_diagnostic"
+
 module RubyLsp
   module Requests
     module Support


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

The RuboCop diagnostic class should only be required if RuboCop is present. In #2589, I mistakenly moved the require to `internal.rb`, but trying to require it when RuboCop is not present fails.

### Implementation

Moved the require inside the class that needs the diagnostic class. That require will only occur if RuboCop is present.

### Manual tests

1. Remove all rubocop related gems and syntax tree from the Gemfile
2. Reload VS Code
3. Verify it doesn't crash