### PR TITLE
Guess types for chained invocations

### DIFF
--- a/lib/ruby_lsp/type_inferrer.rb
+++ b/lib/ruby_lsp/type_inferrer.rb
@@ -89,7 +89,12 @@ module RubyLsp
 
         Type.new("#{parts.join("::")}::#{last}::<Class:#{last}>")
       else
-        raw_receiver = node.receiver&.slice
+
+        raw_receiver = if receiver.is_a?(Prism::CallNode)
+          receiver.message
+        else
+          receiver&.slice
+        end
 
         if raw_receiver
           guessed_name = raw_receiver

--- a/test/type_inferrer_test.rb
+++ b/test/type_inferrer_test.rb
@@ -197,6 +197,17 @@ module RubyLsp
       assert_equal("User", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
+    def test_infer_guessed_types_for_chained_method_calls
+      node_context = index_and_locate(<<~RUBY, { line: 3, character: 15 })
+        class User
+        end
+
+        something.user.name
+      RUBY
+
+      assert_equal("User", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
     def test_infer_guessed_types_for_instance_variable_receiver
       node_context = index_and_locate(<<~RUBY, { line: 4, character: 6 })
         class User


### PR DESCRIPTION
### Motivation

I noticed that guessed types were not being used on chain method invocations even when the last identifier is known. The reason is because we were only looking at the slice, but we need to get the message name if the receiver is another call node.

### Implementation

Started checking if the receiver is a call node and then we take the message.

### Automated Tests

Added a test.