### PR TITLE
Add version constraint for add-ons

### DIFF
--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -244,6 +244,10 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
       def deactivate; end
 
       def name; end
+
+      def version
+        "0.1.0"
+      end
     end
   end
 

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1520,6 +1520,10 @@ class CompletionTest < Minitest::Test
       def name
         "Foo"
       end
+
+      def version
+        "0.1.0"
+      end
     end
   end
 end

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -1027,6 +1027,10 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       def deactivate; end
 
       def name; end
+
+      def version
+        "0.1.0"
+      end
     end
   end
 end

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -78,6 +78,10 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
 
       def deactivate; end
 
+      def version
+        "0.1.0"
+      end
+
       def create_document_symbol_listener(response_builder, dispatcher)
         klass = Class.new do
           include RubyLsp::Requests::Support::Common

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -744,6 +744,10 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
       def deactivate; end
 
+      def version
+        "0.1.0"
+      end
+
       def create_hover_listener(response_builder, nesting, dispatcher)
         klass = Class.new do
           def initialize(response_builder, dispatcher)

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -108,6 +108,10 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
       def deactivate; end
 
       def name; end
+
+      def version
+        "0.1.0"
+      end
     end
   end
 

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -699,6 +699,10 @@ class ServerTest < Minitest::Test
       end
 
       def deactivate; end
+
+      def version
+        "0.1.0"
+      end
     end
 
     Class.new(RubyLsp::Addon) do
@@ -712,6 +716,10 @@ class ServerTest < Minitest::Test
       end
 
       def deactivate; end
+
+      def version
+        "0.1.0"
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation

This PR proposes an API for add-ons to declare version dependencies for the Ruby LSP and for other add-ons.

If the proposed API is accepted, I will add it to our add-ons documentation page.

### Implementation

There are two API changes here.

The new `depend_on!` method declares a dependency on the Ruby LSP. This should be invoked at the top level, so that we skip requiring the add-on completely if it's depends on a version that cannot be satisfied by the current API. This method is only intended to be invoked by add-ons that are defined in gems that do not depend on the `ruby-lsp` explicitly.

The second change is requiring the version constraint as part of `Addon.get`. This ensures that add-ons depending on other add-ons have to "declare" which version constraint they are comfortable depending on, so that if a breaking change happens they can handle accordingly and run in partial support mode.

### Example

```ruby

RubyLsp::Addon.depend_on!(">= 0.18.0", "< 0.19.0")

# ... requires


module RubyLsp
  module MyGem
    class Addon < ::RubyLsp::Addon
      def activate(global_state, outgoing_queue)
        rails_addon = ::RubyLsp::Addon.get("Ruby LSP Rails", "> 0.3.0", "< 1.0.0")
      rescue RubyLsp::Addon::IncompatibleApiError
        # decide how to provide partial support
      end
    end
  end
end
```

### Automated Tests

Added test.