### PR TITLE
Move `defined?` check out of `process_overload`

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -5,6 +5,8 @@ module RubyIndexer
   class RBSIndexer
     extend T::Sig
 
+    HAS_UNTYPED_FUNCTION = T.let(!!defined?(RBS::Types::UntypedFunction), T::Boolean)
+
     sig { params(index: Index).void }
     def initialize(index)
       @index = index
@@ -161,7 +163,7 @@ module RubyIndexer
 
       # Untyped functions are a new RBS feature (since v3.6.0) to declare methods that accept any parameters. For our
       # purposes, accepting any argument is equivalent to `...`
-      if defined?(RBS::Types::UntypedFunction) && function.is_a?(RBS::Types::UntypedFunction)
+      if HAS_UNTYPED_FUNCTION && function.is_a?(RBS::Types::UntypedFunction)
         [Entry::ForwardingParameter.new]
       else
         []


### PR DESCRIPTION
Since the result of `defined?(RBS::Types::UntypedFunction)` doesn't change and `process_overload` is going to be called many times, I think we should extract it outside of the method to avoid unnecessary computation.