### PR TITLE
Adopt tests to Ruby 3.4

### DIFF
--- a/test/expectations/document_link/source_comment.exp.json
+++ b/test/expectations/document_link/source_comment.exp.json
@@ -22,11 +22,11 @@
                 },
                 "end": {
                     "line": 4,
-                    "character": 32
+                    "character": 24
                 }
             },
-            "target": "file://RUBY_ROOT/mutex_m.rb#1",
-            "tooltip": "Jump to RUBY_ROOT/mutex_m.rb#1"
+            "target": "file://RUBY_ROOT/erb.rb#1",
+            "tooltip": "Jump to RUBY_ROOT/erb.rb#1"
         },
         {
             "range": {

--- a/test/fixtures/source_comment.rb
+++ b/test/fixtures/source_comment.rb
@@ -2,7 +2,7 @@
 def foo
 end
 
-# source://mutex_m//mutex_m.rb#1
+# source://erb//erb.rb#1
 def bar
 end
 

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -421,7 +421,11 @@ class ServerTest < Minitest::Test
     content = log.params.message
 
     assert_match(/boom/, content)
-    assert_match(%r{ruby-lsp/lib/ruby_lsp/server\.rb:\d+:in `process_message'}, content)
+    if RUBY_VERSION >= "3.4"
+      assert_match(%r{ruby-lsp/lib/ruby_lsp/server\.rb:\d+:in 'RubyLsp::Server#process_message'}, content)
+    else
+      assert_match(%r{ruby-lsp/lib/ruby_lsp/server\.rb:\d+:in `process_message'}, content)
+    end
   end
 
   def test_changed_file_only_indexes_ruby

--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -375,7 +375,7 @@ suite("Client", () => {
   }).timeout(20000);
 
   test("document link", async () => {
-    const text = "# source://mutex_m//mutex_m.rb#1\ndef foo\nend";
+    const text = "# source://erb//erb.rb#1\ndef foo\nend";
 
     await client.sendNotification("textDocument/didOpen", {
       textDocument: {
@@ -394,7 +394,7 @@ suite("Client", () => {
     );
 
     assert.strictEqual(response.length, 1);
-    assert.match(response[0].target!, /mutex_m\.rb/);
+    assert.match(response[0].target!, /erb\.rb/);
   }).timeout(20000);
 
   test("workspace symbol", async () => {


### PR DESCRIPTION
### Motivation

<details><summary>Test failures</summary>
<p>

```
Failure:
DocumentLinkExpectationsTest#test_document_link__source_comment [/home/earlopain/Documents/ruby-lsp/test/requests/support/expectations_test_runner.rb:60]
Minitest::Assertion: --- expected
+++ actual
@@ -5,12 +5,6 @@
   "tooltip"=>
    "Jump to /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/syntax_tree-6.2.0/lib/syntax_tree.rb#39"},
  {"range"=>
-   {"start"=>{"line"=>4, "character"=>0}, "end"=>{"line"=>4, "character"=>32}},
-  "target"=>
-   "file:///home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/3.4.0+0/mutex_m.rb#1",
-  "tooltip"=>
-   "Jump to /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/3.4.0+0/mutex_m.rb#1"},
- {"range"=>
    {"start"=>{"line"=>8, "character"=>0}, "end"=>{"line"=>8, "character"=>45}},
   "target"=>
    "file:///home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/syntax_tree-6.2.0/lib/syntax_tree.rb#39",

Failure:
ServerTest#test_backtrace_is_printed_to_stderr_on_exceptions [/home/earlopain/Documents/ruby-lsp/test/server_test.rb:424]
Minitest::Assertion: Expected /ruby-lsp\/lib\/ruby_lsp\/server\.rb:\d+:in `process_message'/
 to match "Error processing rubyLsp/workspace/dependencies: /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/mocha-2.4.5/lib/mocha/exception_raiser.rb:11:in 'Mocha::ExceptionRaiser#evaluate': boom (StandardError)\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/mocha-2.4.5/lib/mocha/return_values.rb:18:in 'Mocha::ReturnValues#next'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/mocha-2.4.5/lib/mocha/invocation.rb:26:in 'Mocha::Invocation#call'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/mocha-2.4.5/lib/mocha/expectation.rb:665:in 'Mocha::Expectation#invoke'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/mocha-2.4.5/lib/mocha/mock.rb:325:in 'Mocha::Mock#handle_method_call'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/mocha-2.4.5/lib/mocha/stubbed_method.rb:47:in 'block in define_new_method'\n" +
"\tfrom /home/earlopain/Documents/ruby-lsp/lib/ruby_lsp/server.rb:81:in 'RubyLsp::Server#process_message'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/sorbet-runtime-0.5.11577/lib/types/private/methods/call_validation_2_7.rb:1547:in 'UnboundMethod#bind_call'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/sorbet-runtime-0.5.11577/lib/types/private/methods/call_validation_2_7.rb:1547:in 'block in RubyLsp::Server#create_validator_procedure_medium1'\n" +
"\tfrom /home/earlopain/Documents/ruby-lsp/test/server_test.rb:413:in 'block in ServerTest#test_backtrace_is_printed_to_stderr_on_exceptions'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest/assertions.rb:546:in 'block in Minitest::Assertions#capture_io'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest/assertions.rb:182:in 'Minitest::Assertions#_synchronize'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest/assertions.rb:539:in 'Minitest::Assertions#capture_io'\n" +
"\tfrom /home/earlopain/Documents/ruby-lsp/test/server_test.rb:412:in 'ServerTest#test_backtrace_is_printed_to_stderr_on_exceptions'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest/test.rb:94:in 'block (2 levels) in Minitest::Test#run'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest/test.rb:190:in 'Minitest::Test#capture_exceptions'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest/test.rb:89:in 'block in Minitest::Test#run'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:367:in 'Minitest::Runnable#time_it'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest/test.rb:88:in 'Minitest::Test#run'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-reporters-1.7.1/lib/minitest/reporters.rb:48:in 'Minitest::Test#run_with_hooks'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:1207:in 'Minitest.run_one_method'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:446:in 'Minitest::Runnable.run_one_method'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:433:in 'block (2 levels) in Minitest::Runnable.run'\n" +
"\tfrom <internal:array>:42:in 'Array#each'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:429:in 'block in Minitest::Runnable.run'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:471:in 'Minitest::Runnable.on_signal'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:458:in 'Minitest::Runnable.with_info_handler'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:428:in 'Minitest::Runnable.run'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:331:in 'block in Minitest.__run'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:331:in 'Array#map'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:331:in 'Minitest.__run'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:287:in 'Minitest.run'\n" +
"\tfrom /home/earlopain/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest.rb:85:in 'block in Minitest.autorun'\n"
.
```

</p>
</details> 

### Implementation

* `mutex_m` is gone, use another default gem
* changes to the backtrace format:
  https://bugs.ruby-lang.org/issues/16495
  https://bugs.ruby-lang.org/issues/19117

### Automated Tests

Just changed the two tests to pass on 3.4-dev

### Manual Tests

Install 3.4-dev (for example with `rbenv install 3.4-dev`), and run tests with that version
