### PR TITLE
Add method support to References request

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
@@ -11,27 +11,27 @@ module RubyIndexer
     class ConstTarget < Target
       extend T::Sig
 
+      sig { returns(String) }
+      attr_reader :fully_qualified_name
+
       sig { params(fully_qualified_name: String).void }
       def initialize(fully_qualified_name)
         super()
         @fully_qualified_name = fully_qualified_name
       end
-
-      sig { returns(String) }
-      attr_reader :fully_qualified_name
     end
 
     class MethodTarget < Target
       extend T::Sig
+
+      sig { returns(String) }
+      attr_reader :method_name
 
       sig { params(method_name: String).void }
       def initialize(method_name)
         super()
         @method_name = method_name
       end
-
-      sig { returns(String) }
-      attr_reader :method_name
     end
 
     class Reference

--- a/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
@@ -6,8 +6,6 @@ module RubyIndexer
     extend T::Sig
 
     class Target
-      # def initialize
-      # end
     end
 
     class ConstTarget < Target

--- a/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
@@ -6,6 +6,9 @@ module RubyIndexer
     extend T::Sig
 
     class Target
+      extend T::Helpers
+
+      abstract!
     end
 
     class ConstTarget < Target

--- a/lib/ruby_indexer/test/reference_finder_test.rb
+++ b/lib/ruby_indexer/test/reference_finder_test.rb
@@ -29,7 +29,8 @@ module RubyIndexer
     end
 
     def test_finds_constant_references_inside_singleton_contexts
-      refs = find_references("Foo::<Class:Foo>::Bar", <<~RUBY)
+      target = ReferenceFinder::ConstTarget.new("Foo::<Class:Foo>::Bar")
+      refs = find_references(target, <<~RUBY)
         class Foo
           class << self
             class Bar
@@ -48,7 +49,8 @@ module RubyIndexer
     end
 
     def test_finds_top_level_constant_references
-      refs = find_references("Bar", <<~RUBY)
+      target = ReferenceFinder::ConstTarget.new("Bar")
+      refs = find_references(target, <<~RUBY)
         class Bar
         end
 
@@ -126,7 +128,7 @@ module RubyIndexer
       index.index_single(IndexablePath.new(nil, file_path), source)
       parse_result = Prism.parse(source)
       dispatcher = Prism::Dispatcher.new
-      finder = ReferenceFinder.new(target, index, dispatcher, parse_result) # parse_result used?
+      finder = ReferenceFinder.new(target, index, dispatcher)
       dispatcher.visit(parse_result.value)
       finder.references
     end

--- a/lib/ruby_indexer/test/reference_finder_test.rb
+++ b/lib/ruby_indexer/test/reference_finder_test.rb
@@ -108,6 +108,7 @@ module RubyIndexer
         end
       RUBY
 
+      # We want to match `foo` but not `foo=`
       assert_equal(2, refs.size)
 
       assert_equal("foo", refs[0].name)

--- a/lib/ruby_indexer/test/reference_finder_test.rb
+++ b/lib/ruby_indexer/test/reference_finder_test.rb
@@ -6,7 +6,8 @@ require "test_helper"
 module RubyIndexer
   class ReferenceFinderTest < Minitest::Test
     def test_finds_constant_references
-      refs = find_references("Foo::Bar", <<~RUBY)
+      target = ReferenceFinder::ConstTarget.new("Foo::Bar")
+      refs = find_references(target, <<~RUBY)
         module Foo
           class Bar
           end
@@ -70,15 +71,61 @@ module RubyIndexer
       assert_equal(8, refs[2].location.start_line)
     end
 
+    def test_finds_method_references
+      target = ReferenceFinder::MethodTarget.new("foo")
+      refs = find_references(target, <<~RUBY)
+        class Bar
+          def foo
+          end
+
+          def baz
+            foo
+          end
+        end
+      RUBY
+
+      assert_equal("foo", refs[0].name)
+      assert_equal(2, refs[0].location.start_line)
+
+      assert_equal("foo", refs[1].name)
+      assert_equal(6, refs[1].location.start_line)
+    end
+
+    def test_does_not_mismatch_on_attrs_readers_and_writers
+      target = ReferenceFinder::MethodTarget.new("foo")
+      refs = find_references(target, <<~RUBY)
+        class Bar
+          def foo
+          end
+
+          def foo=(value)
+          end
+
+          def baz
+            self.foo = 1
+            self.foo
+          end
+        end
+      RUBY
+
+      assert_equal(2, refs.size)
+
+      assert_equal("foo", refs[0].name)
+      assert_equal(2, refs[0].location.start_line)
+
+      assert_equal("foo", refs[1].name)
+      assert_equal(10, refs[1].location.start_line)
+    end
+
     private
 
-    def find_references(fully_qualified_name, source)
+    def find_references(target, source)
       file_path = "/fake.rb"
       index = Index.new
       index.index_single(IndexablePath.new(nil, file_path), source)
       parse_result = Prism.parse(source)
       dispatcher = Prism::Dispatcher.new
-      finder = ReferenceFinder.new(fully_qualified_name, index, dispatcher)
+      finder = ReferenceFinder.new(target, index, dispatcher, parse_result) # parse_result used?
       dispatcher.visit(parse_result.value)
       finder.references
     end

--- a/lib/ruby_indexer/test/reference_finder_test.rb
+++ b/lib/ruby_indexer/test/reference_finder_test.rb
@@ -91,7 +91,7 @@ module RubyIndexer
       assert_equal(6, refs[1].location.start_line)
     end
 
-    def test_does_not_mismatch_on_attrs_readers_and_writers
+    def test_does_not_mismatch_on_readers_and_writers
       refs = find_method_references("foo", <<~RUBY)
         class Bar
           def foo
@@ -115,6 +115,32 @@ module RubyIndexer
 
       assert_equal("foo", refs[1].name)
       assert_equal(10, refs[1].location.start_line)
+    end
+
+    def test_matches_writers
+      refs = find_method_references("foo=", <<~RUBY)
+        class Bar
+          def foo
+          end
+
+          def foo=(value)
+          end
+
+          def baz
+            self.foo = 1
+            self.foo
+          end
+        end
+      RUBY
+
+      # We want to match `foo=` but not `foo`
+      assert_equal(2, refs.size)
+
+      assert_equal("foo=", refs[0].name)
+      assert_equal(5, refs[0].location.start_line)
+
+      assert_equal("foo=", refs[1].name)
+      assert_equal(9, refs[1].location.start_line)
     end
 
     private

--- a/lib/ruby_lsp/requests/references.rb
+++ b/lib/ruby_lsp/requests/references.rb
@@ -90,7 +90,7 @@ module RubyLsp
 
       sig do
         params(
-          target: T.any(
+          target_node: T.any(
             Prism::ConstantReadNode,
             Prism::ConstantPathNode,
             Prism::ConstantPathTargetNode,
@@ -100,10 +100,10 @@ module RubyLsp
           node_context: NodeContext,
         ).returns(T.nilable(RubyIndexer::ReferenceFinder::Target))
       end
-      def create_reference_target(target, node_context)
-        case target
+      def create_reference_target(target_node, node_context)
+        case target_node
         when Prism::ConstantReadNode, Prism::ConstantPathNode, Prism::ConstantPathTargetNode
-          name = constant_name(target)
+          name = constant_name(target_node)
           return unless name
 
           entries = @global_state.index.resolve(name, node_context.nesting)
@@ -112,7 +112,7 @@ module RubyLsp
           fully_qualified_name = T.must(entries.first).name
           RubyIndexer::ReferenceFinder::ConstTarget.new(fully_qualified_name)
         when Prism::CallNode, Prism::DefNode
-          RubyIndexer::ReferenceFinder::MethodTarget.new(target.name.to_s)
+          RubyIndexer::ReferenceFinder::MethodTarget.new(target_node.name.to_s)
         end
       end
 

--- a/lib/ruby_lsp/requests/references.rb
+++ b/lib/ruby_lsp/requests/references.rb
@@ -35,7 +35,13 @@ module RubyLsp
         node_context = RubyDocument.locate(
           @document.parse_result.value,
           char_position,
-          node_types: [Prism::ConstantReadNode, Prism::ConstantPathNode, Prism::ConstantPathTargetNode],
+          node_types: [
+            Prism::ConstantReadNode,
+            Prism::ConstantPathNode,
+            Prism::ConstantPathTargetNode,
+            Prism::CallNode,
+            Prism::DefNode,
+          ],
         )
         target = node_context.node
         parent = node_context.parent
@@ -51,16 +57,17 @@ module RubyLsp
 
         target = T.cast(
           target,
-          T.any(Prism::ConstantReadNode, Prism::ConstantPathNode, Prism::ConstantPathTargetNode),
+          T.any(
+            Prism::ConstantReadNode,
+            Prism::ConstantPathNode,
+            Prism::ConstantPathTargetNode,
+            Prism::CallNode,
+            Prism::DefNode,
+          ),
         )
 
-        name = constant_name(target)
-        return @locations unless name
-
-        entries = @global_state.index.resolve(name, node_context.nesting)
-        return @locations unless entries
-
-        fully_qualified_name = T.must(entries.first).name
+        reference_target = create_reference_target(target, node_context)
+        return @locations unless reference_target
 
         Dir.glob(File.join(@global_state.workspace_path, "**/*.rb")).each do |path|
           uri = URI::Generic.from_path(path: path)
@@ -69,11 +76,11 @@ module RubyLsp
           next if @store.key?(uri)
 
           parse_result = Prism.parse_file(path)
-          collect_references(fully_qualified_name, parse_result, uri)
+          collect_references(reference_target, parse_result, uri)
         end
 
         @store.each do |_uri, document|
-          collect_references(fully_qualified_name, document.parse_result, document.uri)
+          collect_references(reference_target, document.parse_result, document.uri)
         end
 
         @locations
@@ -83,15 +90,43 @@ module RubyLsp
 
       sig do
         params(
-          fully_qualified_name: String,
+          target: T.any(
+            Prism::ConstantReadNode,
+            Prism::ConstantPathNode,
+            Prism::ConstantPathTargetNode,
+            Prism::CallNode,
+            Prism::DefNode,
+          ),
+          node_context: NodeContext,
+        ).returns(T.nilable(RubyIndexer::ReferenceFinder::Target))
+      end
+      def create_reference_target(target, node_context)
+        case target
+        when Prism::ConstantReadNode, Prism::ConstantPathNode, Prism::ConstantPathTargetNode
+          name = constant_name(target)
+          return unless name
+
+          entries = @global_state.index.resolve(name, node_context.nesting)
+          return unless entries
+
+          fully_qualified_name = T.must(entries.first).name
+          RubyIndexer::ReferenceFinder::ConstTarget.new(fully_qualified_name)
+        when Prism::CallNode, Prism::DefNode
+          RubyIndexer::ReferenceFinder::MethodTarget.new(target.name.to_s)
+        end
+      end
+
+      sig do
+        params(
+          target: RubyIndexer::ReferenceFinder::Target,
           parse_result: Prism::ParseResult,
           uri: URI::Generic,
         ).void
       end
-      def collect_references(fully_qualified_name, parse_result, uri)
+      def collect_references(target, parse_result, uri)
         dispatcher = Prism::Dispatcher.new
         finder = RubyIndexer::ReferenceFinder.new(
-          fully_qualified_name,
+          target,
           @global_state.index,
           dispatcher,
           include_declarations: @params.dig(:context, :includeDeclaration) || true,

--- a/lib/ruby_lsp/requests/rename.rb
+++ b/lib/ruby_lsp/requests/rename.rb
@@ -166,11 +166,7 @@ module RubyLsp
       end
       def collect_changes(target, parse_result, name, uri)
         dispatcher = Prism::Dispatcher.new
-        finder = RubyIndexer::ReferenceFinder.new(
-          target,
-          @global_state.index,
-          dispatcher,
-        )
+        finder = RubyIndexer::ReferenceFinder.new(target, @global_state.index, dispatcher)
         dispatcher.visit(parse_result.value)
 
         finder.references.map do |reference|

--- a/lib/ruby_lsp/requests/rename.rb
+++ b/lib/ruby_lsp/requests/rename.rb
@@ -66,7 +66,8 @@ module RubyLsp
         end
 
         fully_qualified_name = T.must(entries.first).name
-        changes = collect_text_edits(fully_qualified_name, name)
+        reference_target = RubyIndexer::ReferenceFinder::ConstTarget.new(fully_qualified_name)
+        changes = collect_text_edits(reference_target, name)
 
         # If the client doesn't support resource operations, such as renaming files, then we can only return the basic
         # text changes
@@ -127,8 +128,13 @@ module RubyLsp
         end
       end
 
-      sig { params(fully_qualified_name: String, name: String).returns(T::Hash[String, T::Array[Interface::TextEdit]]) }
-      def collect_text_edits(fully_qualified_name, name)
+      sig do
+        params(
+          target: RubyIndexer::ReferenceFinder::Target,
+          name: String,
+        ).returns(T::Hash[String, T::Array[Interface::TextEdit]])
+      end
+      def collect_text_edits(target, name)
         changes = {}
 
         Dir.glob(File.join(@global_state.workspace_path, "**/*.rb")).each do |path|
@@ -138,12 +144,12 @@ module RubyLsp
           next if @store.key?(uri)
 
           parse_result = Prism.parse_file(path)
-          edits = collect_changes(fully_qualified_name, parse_result, name, uri)
+          edits = collect_changes(target, parse_result, name, uri)
           changes[uri.to_s] = edits unless edits.empty?
         end
 
         @store.each do |uri, document|
-          edits = collect_changes(fully_qualified_name, document.parse_result, name, document.uri)
+          edits = collect_changes(target, document.parse_result, name, document.uri)
           changes[uri] = edits unless edits.empty?
         end
 
@@ -152,15 +158,19 @@ module RubyLsp
 
       sig do
         params(
-          fully_qualified_name: String,
+          target: RubyIndexer::ReferenceFinder::Target,
           parse_result: Prism::ParseResult,
           name: String,
           uri: URI::Generic,
         ).returns(T::Array[Interface::TextEdit])
       end
-      def collect_changes(fully_qualified_name, parse_result, name, uri)
+      def collect_changes(target, parse_result, name, uri)
         dispatcher = Prism::Dispatcher.new
-        finder = RubyIndexer::ReferenceFinder.new(fully_qualified_name, @global_state.index, dispatcher)
+        finder = RubyIndexer::ReferenceFinder.new(
+          target,
+          @global_state.index,
+          dispatcher,
+        )
         dispatcher.visit(parse_result.value)
 
         finder.references.map do |reference|


### PR DESCRIPTION
This allows the use of Find All References for methods.

As discussed in https://github.com/Shopify/ruby-lsp/issues/2640, we cannot have _full_ confidence in the matches due the lack of a type system.

Note: In VS Code, Rename Symbol will show as available for methods, but isn't yet implemented.

Co-authored with @vinistock 

Closes https://github.com/Shopify/ruby-lsp/issues/2640