### PR TITLE
Reduce noise from "This file is too long" warning

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -320,7 +320,7 @@ module RubyLsp
           language_id: language_id,
         )
 
-        if document.past_expensive_limit?
+        if document.past_expensive_limit? && text_document[:uri].scheme == "file"
           log_message = <<~MESSAGE
             The file #{text_document[:uri].path} is too long. For performance reasons, semantic highlighting and
             diagnostics will be disabled.


### PR DESCRIPTION
### Motivation

Resolves #2550 

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Frequent notifications for large files are disruptive. Refactoring the files isn't always feasible, so a better solution is needed to reduce the noise.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

- **Log Only for File Scheme**: Notifications will now only log if the scheme is a file, preventing unnecessary alerts for other URI types.
- **Output Tab Logging**: Notifications will be printed to the output tab instead of showing a popup, reducing interruptions.

