### PR TITLE
Fix `ruby-lsp-check` raising when server message itself is an error

### DIFF
--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -32,7 +32,7 @@ files.each_with_index do |file, index|
   })
 
   result = server.pop_response
-  errors[file] = result.message if result.is_a?(RubyLsp::Error)
+  errors[file] = result if result.is_a?(RubyLsp::Error)
 ensure
   server.process_message({ method: "textDocument/didClose", params: { textDocument: { uri: uri } } })
   server.pop_response


### PR DESCRIPTION
### Motivation

<details><summary>Stacktrace</summary>
<p>

```rb
$ bundle exec ruby-lsp-check
/home/earlopain/.rbenv/versions/3.3.5/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Verifying that all automatic LSP requests execute successfully. This may take a while...
Completed 136/136
Verifying that indexing executes successfully. This may take a while...
Indexed 2015/2015
/home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/ruby-lsp-0.19.0/exe/ruby-lsp-check:66:in `block in <top (required)>': undefined method `message' for an instance of String (NoMethodError)

  #{errors.map { |file, error| "#{file}: #{error.message}" }.join("\n")}
                                                ^^^^^^^^
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/ruby-lsp-0.19.0/exe/ruby-lsp-check:66:in `each'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/ruby-lsp-0.19.0/exe/ruby-lsp-check:66:in `map'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/ruby-lsp-0.19.0/exe/ruby-lsp-check:66:in `<top (required)>'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bin/ruby-lsp-check:25:in `load'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bin/ruby-lsp-check:25:in `<top (required)>'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:58:in `load'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:58:in `kernel_load'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/cli/exec.rb:23:in `run'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/cli.rb:455:in `exec'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/cli.rb:35:in `dispatch'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/cli.rb:29:in `start'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.20/exe/bundle:28:in `block in <top (required)>'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/site_ruby/3.3.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/bundler-2.5.20/exe/bundle:20:in `<top (required)>'
        from /home/earlopain/.rbenv/versions/3.3.5/bin/bundle:25:in `load'
        from /home/earlopain/.rbenv/versions/3.3.5/bin/bundle:25:in `<main>'
```

</p>
</details> 

### Implementation

The hash must be`String => StandardError` since at the end it calls `message` on it already.

### Automated Tests

Seems hard since this should never fail anyways

### Manual Tests

Not sure, still looking into the failure myself. But at least the troubleshooting works with this (:. I guess you can make the server raise one manually if you want to check it out.