### PR TITLE
Display add-on version in the displayAddons command

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -89,7 +89,7 @@ module RubyLsp
             id: message[:id],
             response:
               Addon.addons.map do |addon|
-                { name: addon.name, errored: addon.error? }
+                { name: addon.name, version: addon.version, errored: addon.error? }
               end,
           ),
         )

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -461,9 +461,11 @@ class ServerTest < Minitest::Test
     addons_info = @server.pop_response.response
 
     assert_equal("Foo", addons_info[0][:name])
+    assert_equal("0.1.0", addons_info[0][:version])
     refute(addons_info[0][:errored])
 
     assert_equal("Bar", addons_info[1][:name])
+    assert_equal("0.2.0", addons_info[1][:version])
     assert(addons_info[1][:errored])
   ensure
     RubyLsp::Addon.addons.clear
@@ -722,7 +724,7 @@ class ServerTest < Minitest::Test
       def deactivate; end
 
       def version
-        "0.1.0"
+        "0.2.0"
       end
     end
   end

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -39,6 +39,8 @@ export interface RubyInterface {
 export interface Addon {
   name: string;
   errored: boolean;
+  // Older versions of ruby-lsp don't return version for add-ons requests
+  version?: string;
 }
 
 export interface ClientInterface {

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -286,7 +286,7 @@ export class RubyLsp {
           .map((addon) => {
             const icon = addon.errored ? "$(error)" : "$(pass)";
             return {
-              label: `${icon} ${addon.name}`,
+              label: `${icon} ${addon.name} ${addon.version ? `v${addon.version}` : ""}`,
             };
           });
 


### PR DESCRIPTION
### Motivation

Since add-ons now can specify their versions, we can also display them in VS Code.

### Implementation

- Add `version` to `rubyLsp/workspace/addons`'s response
- Add a nullable `version` attribute to the `Addon` extension class as older versions of `ruby-lsp` don't return it
- Add `version` information to `displayAddon` command's output:

<img width="40%" alt="Screenshot 2024-10-03 at 14 51 59" src="https://github.com/user-attachments/assets/0615d594-f09e-4904-8edb-6b3c6be743fd">


### Automated Tests

Updated an existing case for it.

### Manual Tests

1. Run Ruby LSP extension with this branch
2. Use the latest `ruby-lsp-rails` as the development host
3. Update `ruby-lsp-rails`'s Gemfile to use this branch of `ruby-lsp`
    - `gem "ruby-lsp", github: "Shopify/ruby-lsp", branch: "display-add-on-version"`
    - Run `bundle update`
4. After Ruby LSP is initialized, run `Ruby LSP: Display addons` command in VS Code's command palette 
