### PR TITLE
Avoid directly calling version to avoid Sorbet error

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -89,7 +89,16 @@ module RubyLsp
             id: message[:id],
             response:
               Addon.addons.map do |addon|
-                { name: addon.name, version: addon.version, errored: addon.error? }
+                version_method = addon.method(:version)
+
+                # If the add-on doesn't define a `version` method, we'd be calling the abstract method defined by
+                # Sorbet, which would raise an error.
+                # Therefore, we only call the method if it's defined by the add-on itself
+                if version_method.owner != Addon
+                  version = addon.version
+                end
+
+                { name: addon.name, version: version, errored: addon.error? }
               end,
           ),
         )

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -465,7 +465,8 @@ class ServerTest < Minitest::Test
     refute(addons_info[0][:errored])
 
     assert_equal("Bar", addons_info[1][:name])
-    assert_equal("0.2.0", addons_info[1][:version])
+    # It doesn't define a `version` method
+    assert_nil(addons_info[1][:version])
     assert(addons_info[1][:errored])
   ensure
     RubyLsp::Addon.addons.clear
@@ -722,10 +723,6 @@ class ServerTest < Minitest::Test
       end
 
       def deactivate; end
-
-      def version
-        "0.2.0"
-      end
     end
   end
 


### PR DESCRIPTION
### Motivation

This will avoid breaking add-ons that don't define a `version` method and doesn't require `ruby-lsp` as a dependency when displaying the add-ons in the UI.

### Implementation

Checks if the `version` method's owner if `Addon`. If it is, calling it would cause Sorbet to raise error so we avoid it. But if it's not, we call it to get the version.

### Automated Tests

Updated existing test to cover both cases (defined and not defined).

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
