### PR TITLE
Raise if scanner cannot find requested position

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -109,6 +109,14 @@ module RubyLsp
       end
     rescue DelegateRequestError
       send_message(Error.new(id: message[:id], code: DelegateRequestError::CODE, message: "DELEGATE_REQUEST"))
+    rescue Document::Scanner::PositionNotFoundError => e
+      send_message(Notification.window_log_message(e.full_message, type: Constant::MessageType::ERROR))
+
+      send_message(Error.new(
+        id: message[:id],
+        code: Constant::ErrorCodes::INTERNAL_ERROR,
+        message: "Failed to find position",
+      ))
     rescue StandardError, LoadError => e
       # If an error occurred in a request, we have to return an error response or else the editor will hang
       if message[:id]

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -750,6 +750,17 @@ class RubyDocumentTest < Minitest::Test
     assert_nil(document.cache_get("textDocument/codeLens"))
   end
 
+  def test_searching_for_non_existing_line
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
+      class Foo
+      end
+    RUBY
+
+    assert_raises(RubyLsp::Document::Scanner::PositionNotFoundError) do
+      document.create_scanner.find_char_position({ line: 3, character: 0 })
+    end
+  end
+
   private
 
   def assert_error_edit(actual, error_range)


### PR DESCRIPTION
### Motivation

Trying to understand #2446

This PR starts raising if the document scanner cannot find the requested position. It prints both the document state and the requested position, so that we can understand if the document state got corrupted or if the requested position doesn't make sense.

### Implementation

If we exceed the search loop, but the request line is still different than the one we found, then we couldn't find the correct position and we can raise.

This is not the solution for the problem, it's just a way to diagnose it.

### Automated Tests

Added a test.