### PR TITLE
Handle multibyte characters in RubyDocument

### DIFF
--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -50,7 +50,12 @@ module RubyLsp
       ).returns(NodeContext)
     end
     def locate_node(position, node_types: [])
-      RubyDocument.locate(@parse_result.value, create_scanner.find_char_position(position), node_types: node_types)
+      RubyDocument.locate(
+        @parse_result.value,
+        create_scanner.find_char_position(position),
+        node_types: node_types,
+        encoding: @encoding,
+      )
     end
 
     sig { params(char_position: Integer).returns(T.nilable(T::Boolean)) }

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -23,10 +23,11 @@ module RubyLsp
         end
       end
 
-      sig { params(document: RubyDocument, code_action: T::Hash[Symbol, T.untyped]).void }
-      def initialize(document, code_action)
+      sig { params(document: RubyDocument, global_state: GlobalState, code_action: T::Hash[Symbol, T.untyped]).void }
+      def initialize(document, global_state, code_action)
         super()
         @document = document
+        @global_state = global_state
         @code_action = code_action
       end
 
@@ -191,7 +192,12 @@ module RubyLsp
         extracted_source = T.must(@document.source[start_index...end_index])
 
         # Find the closest method declaration node, so that we place the refactor in a valid position
-        node_context = RubyDocument.locate(@document.parse_result.value, start_index, node_types: [Prism::DefNode])
+        node_context = RubyDocument.locate(
+          @document.parse_result.value,
+          start_index,
+          node_types: [Prism::DefNode],
+          encoding: @global_state.encoding,
+        )
         closest_node = node_context.node
         return Error::InvalidTargetRange unless closest_node
 

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -57,6 +57,7 @@ module RubyLsp
             Prism::InstanceVariableTargetNode,
             Prism::InstanceVariableWriteNode,
           ],
+          encoding: global_state.encoding,
         )
         @response_builder = T.let(
           ResponseBuilders::CollectionResponseBuilder[Interface::CompletionItem].new,

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -57,6 +57,7 @@ module RubyLsp
             Prism::SuperNode,
             Prism::ForwardingSuperNode,
           ],
+          encoding: global_state.encoding,
         )
 
         target = node_context.node

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -28,7 +28,7 @@ module RubyLsp
         char_position = document.create_scanner.find_char_position(position)
         delegate_request_if_needed!(global_state, document, char_position)
 
-        node_context = RubyDocument.locate(document.parse_result.value, char_position)
+        node_context = RubyDocument.locate(document.parse_result.value, char_position, encoding: global_state.encoding)
 
         @response_builder = T.let(
           ResponseBuilders::CollectionResponseBuilder[Interface::DocumentHighlight].new,

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -41,6 +41,7 @@ module RubyLsp
           document.parse_result.value,
           char_position,
           node_types: Listeners::Hover::ALLOWED_TARGETS,
+          encoding: global_state.encoding,
         )
         target = node_context.node
         parent = node_context.parent

--- a/lib/ruby_lsp/requests/references.rb
+++ b/lib/ruby_lsp/requests/references.rb
@@ -36,6 +36,7 @@ module RubyLsp
           @document.parse_result.value,
           char_position,
           node_types: [Prism::ConstantReadNode, Prism::ConstantPathNode, Prism::ConstantPathTargetNode],
+          encoding: @global_state.encoding,
         )
         target = node_context.node
         parent = node_context.parent

--- a/lib/ruby_lsp/requests/rename.rb
+++ b/lib/ruby_lsp/requests/rename.rb
@@ -37,6 +37,7 @@ module RubyLsp
           @document.parse_result.value,
           char_position,
           node_types: [Prism::ConstantReadNode, Prism::ConstantPathNode, Prism::ConstantPathTargetNode],
+          encoding: @global_state.encoding,
         )
         target = node_context.node
         parent = node_context.parent

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -39,7 +39,12 @@ module RubyLsp
         char_position = document.create_scanner.find_char_position(position)
         delegate_request_if_needed!(global_state, document, char_position)
 
-        node_context = RubyDocument.locate(document.parse_result.value, char_position, node_types: [Prism::CallNode])
+        node_context = RubyDocument.locate(
+          document.parse_result.value,
+          char_position,
+          node_types: [Prism::CallNode],
+          encoding: global_state.encoding,
+        )
 
         target = adjust_for_nested_target(node_context.node, node_context.parent, position)
 

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -772,7 +772,7 @@ module RubyLsp
         return
       end
 
-      result = Requests::CodeActionResolve.new(document, params).perform
+      result = Requests::CodeActionResolve.new(document, @global_state, params).perform
 
       case result
       when Requests::CodeActionResolve::Error::EmptySelection

--- a/test/requests/code_action_resolve_expectations_test.rb
+++ b/test/requests/code_action_resolve_expectations_test.rb
@@ -7,11 +7,15 @@ require_relative "support/expectations_test_runner"
 class CodeActionResolveExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeActionResolve, "code_action_resolve"
 
+  def setup
+    @global_state = RubyLsp::GlobalState.new
+  end
+
   def run_expectations(source)
     params = @__params&.any? ? @__params : default_args
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
 
-    RubyLsp::Requests::CodeActionResolve.new(document, params).perform
+    RubyLsp::Requests::CodeActionResolve.new(document, @global_state, params).perform
   end
 
   def assert_expectations(source, expected)

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -558,6 +558,26 @@ class RubyDocumentTest < Minitest::Test
     assert_equal(["Foo", "Bar"], node_context.nesting)
   end
 
+  def test_locate_returns_correct_nesting_when_contains_multibyte_characters
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///foo/bar.rb"))
+      module A動物
+        class Bねこ
+          def C鳴く
+            "にゃー"
+          end
+        end
+      end
+    RUBY
+
+    node_context = document.locate_node(
+      { line: 2, character: 8 },
+      node_types: [Prism::DefNode],
+    )
+    found = node_context.node
+    assert_equal(:C鳴く, T.cast(found, Prism::DefNode).name)
+    assert_equal(["A動物", "Bねこ"], node_context.nesting)
+  end
+
   def test_reparsing_without_new_edits_does_nothing
     text = "def foo; end"
 


### PR DESCRIPTION
### Motivation

<!-- Closes # -->
Close https://github.com/Shopify/ruby-lsp/issues/1251

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

In [Shopify/ruby-lsp#2619](https://github.com/Shopify/ruby-lsp/pull/2619), we modified the Index creation to handle multibyte characters. However, when processing requests from the LSP to calculate the target node, the character positions are calculated based on the PrismResult rather than the Index, so adjustments are needed in this part of the code as well.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This Pull Request updates the `locate` function in RubyDocument to handle multibyte characters .

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

I added simple test cases for it and the definition request.


### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

I have tested this on multiple projects (including those with Japanese) and confirmed that the definition jump and hover functions work as intended.
