### PR TITLE
Add go-to-definition for global variables

### DIFF
--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -46,6 +46,7 @@ module RubyLsp
             Prism::ConstantReadNode,
             Prism::ConstantPathNode,
             Prism::BlockArgumentNode,
+            Prism::GlobalVariableReadNode,
             Prism::InstanceVariableReadNode,
             Prism::InstanceVariableAndWriteNode,
             Prism::InstanceVariableOperatorWriteNode,


### PR DESCRIPTION
### Motivation

Iteration of https://github.com/Shopify/ruby-lsp/issues/2644

Handle global variables in definition request.

### Implementation

Follow existing pattern, first listen `on_global_variable_read_node_enter`, then search for entries in index with variable name, finally push each entry location in response.

### Automated Tests

I added a basic test, not sure if indexing RBS for the test case is really needed here, happy to have feedback on it. 

### Manual Tests

Write $DEBUG within a file, then cmd + click on it, you must be redirected to RBS declaration.

https://github.com/user-attachments/assets/61e53250-7f5d-4a5a-9a49-f6ea82f2c517