### PR TITLE
Find git root through the git extension API

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -26,6 +26,9 @@
     "workspaceContains:gems.locked",
     "onView:dependencies"
   ],
+  "extensionDependencies": [
+    "vscode.git"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "chatParticipants": [

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -218,6 +218,7 @@ export class RubyLsp {
     );
     this.workspaces.set(workspaceFolder.uri.toString(), workspace);
 
+    await workspace.activate();
     await workspace.start();
     this.context.subscriptions.push(workspace);
 


### PR DESCRIPTION
### Motivation

To create the restart watchers for git operations like rebase and bisect, we were using the workspace URI or the parent directory. That's not always correct and we should instead rely on the git extension to tell us where the repository exists.

### Implementation

I followed the [documentation](https://github.com/microsoft/vscode/tree/main/extensions/git#git-integration-for-visual-studio-code) for the git extension's public API.

Essentially, we use the `openRepository` API to find where the git root exists and then we create the restart watcher using that, with a fallback to the workspace URI.