### PR TITLE
Add support for ASDF_ENV environment variable

### DIFF
--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -29,6 +29,18 @@ export class Asdf extends VersionManager {
     const scriptName =
       path.basename(vscode.env.shell) === "fish" ? "asdf.fish" : "asdf.sh";
 
+    if (process.env['ASDF_DIR']) {
+      // Follow the ASDF_DIR if it was set up.
+      const possiblePath = vscode.Uri.joinPath(vscode.Uri.parse(process.env["ASDF_DIR"]), scriptName)
+      
+      try {
+        await vscode.workspace.fs.stat(possiblePath);
+        return possiblePath;
+      } catch (error: any) {
+        // Continue looking
+      }
+    }
+    
     // Possible ASDF installation paths as described in https://asdf-vm.com/guide/getting-started.html#_3-install-asdf.
     // In order, the methods of installation are:
     // 1. Git


### PR DESCRIPTION
### Motivation

To handle custom asdf vm installation paths.

Closes #2686

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

ASDF supports custom installation paths using the asdf_dir env var, and ruby-lsp should look for it as it already supports ASDF. Currently, it tries the default installation paths only.

### Implementation

I check if the ASDF_DIR env var do exists, and if it did, I try to find if the asdf script. Otherwise, it will follow the actual behavior. 

### Automated Tests

Since I only check if an env var exists, and didn't change the actual workflow of the extension, the current test suit should cover it up.

### Manual Tests

- I set the variable ASDF_DIR.
- Change asdf installation to a non-default folder.
- I open vscode
- Check if the extension was working
- Check if it finds the asdf.