### PR TITLE
Build locations before creating entries

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -33,6 +33,7 @@ module RubyIndexer
         T::Hash[Integer, Prism::Comment],
       )
       @inside_def = T.let(false, T::Boolean)
+      @encoding = T.let(@index.configuration.encoding, Encoding)
 
       # The nesting stack we're currently inside. Used to determine the fully qualified name of constants, but only
       # stored by unresolved aliases which need the original nesting to be lazily resolved
@@ -106,10 +107,9 @@ module RubyIndexer
       entry = Entry::Class.new(
         nesting,
         @file_path,
-        node.location,
-        constant_path.location,
+        Location.from_prism_location(node.location, @encoding),
+        Location.from_prism_location(constant_path.location, @encoding),
         comments,
-        @index.configuration.encoding,
         parent_class,
       )
 
@@ -136,10 +136,9 @@ module RubyIndexer
       entry = Entry::Module.new(
         actual_nesting(name),
         @file_path,
-        node.location,
-        constant_path.location,
+        Location.from_prism_location(node.location, @encoding),
+        Location.from_prism_location(constant_path.location, @encoding),
         comments,
-        @index.configuration.encoding,
       )
 
       @owner_stack << entry
@@ -170,19 +169,17 @@ module RubyIndexer
         if existing_entries
           entry = T.must(existing_entries.first)
           entry.update_singleton_information(
-            node.location,
-            expression.location,
+            Location.from_prism_location(node.location, @encoding),
+            Location.from_prism_location(expression.location, @encoding),
             collect_comments(node),
-            @index.configuration.encoding,
           )
         else
           entry = Entry::SingletonClass.new(
             real_nesting,
             @file_path,
-            node.location,
-            expression.location,
+            Location.from_prism_location(node.location, @encoding),
+            Location.from_prism_location(expression.location, @encoding),
             collect_comments(node),
-            @index.configuration.encoding,
             nil,
           )
           @index.add(entry, skip_prefix_tree: true)
@@ -340,10 +337,9 @@ module RubyIndexer
         @index.add(Entry::Method.new(
           method_name,
           @file_path,
-          node.location,
-          node.name_loc,
+          Location.from_prism_location(node.location, @encoding),
+          Location.from_prism_location(node.name_loc, @encoding),
           comments,
-          @index.configuration.encoding,
           [Entry::Signature.new(list_params(node.parameters))],
           current_visibility,
           @owner_stack.last,
@@ -357,10 +353,9 @@ module RubyIndexer
           @index.add(Entry::Method.new(
             method_name,
             @file_path,
-            node.location,
-            node.name_loc,
+            Location.from_prism_location(node.location, @encoding),
+            Location.from_prism_location(node.name_loc, @encoding),
             comments,
-            @index.configuration.encoding,
             [Entry::Signature.new(list_params(node.parameters))],
             current_visibility,
             singleton,
@@ -417,9 +412,8 @@ module RubyIndexer
           node.old_name.slice,
           @owner_stack.last,
           @file_path,
-          node.new_name.location,
+          Location.from_prism_location(node.new_name.location, @encoding),
           comments,
-          @index.configuration.encoding,
         ),
       )
     end
@@ -453,9 +447,8 @@ module RubyIndexer
       @index.add(Entry::InstanceVariable.new(
         name,
         @file_path,
-        loc,
+        Location.from_prism_location(loc, @encoding),
         collect_comments(node),
-        @index.configuration.encoding,
         owner,
       ))
     end
@@ -518,9 +511,8 @@ module RubyIndexer
           old_name_value,
           @owner_stack.last,
           @file_path,
-          new_name.location,
+          Location.from_prism_location(new_name.location, @encoding),
           comments,
-          @index.configuration.encoding,
         ),
       )
     end
@@ -555,9 +547,8 @@ module RubyIndexer
             @stack.dup,
             name,
             @file_path,
-            node.location,
+            Location.from_prism_location(node.location, @encoding),
             comments,
-            @index.configuration.encoding,
           )
         when Prism::ConstantWriteNode, Prism::ConstantAndWriteNode, Prism::ConstantOrWriteNode,
         Prism::ConstantOperatorWriteNode
@@ -569,9 +560,8 @@ module RubyIndexer
             @stack.dup,
             name,
             @file_path,
-            node.location,
+            Location.from_prism_location(node.location, @encoding),
             comments,
-            @index.configuration.encoding,
           )
         when Prism::ConstantPathWriteNode, Prism::ConstantPathOrWriteNode, Prism::ConstantPathOperatorWriteNode,
         Prism::ConstantPathAndWriteNode
@@ -581,12 +571,16 @@ module RubyIndexer
             @stack.dup,
             name,
             @file_path,
-            node.location,
+            Location.from_prism_location(node.location, @encoding),
             comments,
-            @index.configuration.encoding,
           )
         else
-          Entry::Constant.new(name, @file_path, node.location, comments, @index.configuration.encoding)
+          Entry::Constant.new(
+            name,
+            @file_path,
+            Location.from_prism_location(node.location, @encoding),
+            comments,
+          )
         end,
       )
     end
@@ -652,9 +646,8 @@ module RubyIndexer
           @index.add(Entry::Accessor.new(
             name,
             @file_path,
-            loc,
+            Location.from_prism_location(loc, @encoding),
             comments,
-            @index.configuration.encoding,
             current_visibility,
             @owner_stack.last,
           ))
@@ -665,9 +658,8 @@ module RubyIndexer
         @index.add(Entry::Accessor.new(
           "#{name}=",
           @file_path,
-          loc,
+          Location.from_prism_location(loc, @encoding),
           comments,
-          @index.configuration.encoding,
           current_visibility,
           @owner_stack.last,
         ))

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -31,30 +31,16 @@ module RubyIndexer
       params(
         name: String,
         file_path: String,
-        location: T.any(Prism::Location, RubyIndexer::Location),
+        location: Location,
         comments: T.nilable(String),
-        encoding: Encoding,
       ).void
     end
-    def initialize(name, file_path, location, comments, encoding)
+    def initialize(name, file_path, location, comments)
       @name = name
       @file_path = file_path
       @comments = comments
       @visibility = T.let(Visibility::PUBLIC, Visibility)
-
-      @location = T.let(
-        if location.is_a?(Prism::Location)
-          Location.new(
-            location.start_line,
-            location.end_line,
-            location.start_code_units_column(encoding),
-            location.end_code_units_column(encoding),
-          )
-        else
-          location
-        end,
-        RubyIndexer::Location,
-      )
+      @location = location
     end
 
     sig { returns(T::Boolean) }
@@ -152,32 +138,19 @@ module RubyIndexer
         params(
           nesting: T::Array[String],
           file_path: String,
-          location: T.any(Prism::Location, RubyIndexer::Location),
-          name_location: T.any(Prism::Location, Location),
+          location: Location,
+          name_location: Location,
           comments: T.nilable(String),
-          encoding: Encoding,
         ).void
       end
-      def initialize(nesting, file_path, location, name_location, comments, encoding) # rubocop:disable Metrics/ParameterLists
+      def initialize(nesting, file_path, location, name_location, comments)
         @name = T.let(nesting.join("::"), String)
         # The original nesting where this namespace was discovered
         @nesting = nesting
 
-        super(@name, file_path, location, comments, encoding)
+        super(@name, file_path, location, comments)
 
-        @name_location = T.let(
-          if name_location.is_a?(Prism::Location)
-            Location.new(
-              name_location.start_line,
-              name_location.end_line,
-              name_location.start_code_units_column(encoding),
-              name_location.end_code_units_column(encoding),
-            )
-          else
-            name_location
-          end,
-          RubyIndexer::Location,
-        )
+        @name_location = name_location
       end
 
       sig { returns(T::Array[String]) }
@@ -214,15 +187,14 @@ module RubyIndexer
         params(
           nesting: T::Array[String],
           file_path: String,
-          location: T.any(Prism::Location, RubyIndexer::Location),
-          name_location: T.any(Prism::Location, Location),
+          location: Location,
+          name_location:  Location,
           comments: T.nilable(String),
-          encoding: Encoding,
           parent_class: T.nilable(String),
         ).void
       end
-      def initialize(nesting, file_path, location, name_location, comments, encoding, parent_class) # rubocop:disable Metrics/ParameterLists
-        super(nesting, file_path, location, name_location, comments, encoding)
+      def initialize(nesting, file_path, location, name_location, comments, parent_class) # rubocop:disable Metrics/ParameterLists
+        super(nesting, file_path, location, name_location, comments)
         @parent_class = parent_class
       end
 
@@ -237,26 +209,14 @@ module RubyIndexer
 
       sig do
         params(
-          location: Prism::Location,
-          name_location: Prism::Location,
+          location: Location,
+          name_location: Location,
           comments: T.nilable(String),
-          encoding: Encoding,
         ).void
       end
-      def update_singleton_information(location, name_location, comments, encoding)
-        # Create a new RubyIndexer::Location object from the Prism location
-        @location = Location.new(
-          location.start_line,
-          location.end_line,
-          location.start_code_units_column(encoding),
-          location.end_code_units_column(encoding),
-        )
-        @name_location = Location.new(
-          name_location.start_line,
-          name_location.end_line,
-          name_location.start_code_units_column(encoding),
-          name_location.end_code_units_column(encoding),
-        )
+      def update_singleton_information(location, name_location, comments)
+        @location = location
+        @name_location = name_location
         (@comments ||= +"") << comments if comments
       end
     end
@@ -373,15 +333,14 @@ module RubyIndexer
         params(
           name: String,
           file_path: String,
-          location: T.any(Prism::Location, RubyIndexer::Location),
+          location: Location,
           comments: T.nilable(String),
-          encoding: Encoding,
           visibility: Visibility,
           owner: T.nilable(Entry::Namespace),
         ).void
       end
-      def initialize(name, file_path, location, comments, encoding, visibility, owner) # rubocop:disable Metrics/ParameterLists
-        super(name, file_path, location, comments, encoding)
+      def initialize(name, file_path, location, comments, visibility, owner) # rubocop:disable Metrics/ParameterLists
+        super(name, file_path, location, comments)
         @visibility = visibility
         @owner = owner
       end
@@ -441,31 +400,18 @@ module RubyIndexer
         params(
           name: String,
           file_path: String,
-          location: T.any(Prism::Location, RubyIndexer::Location),
-          name_location: T.any(Prism::Location, Location),
+          location: Location,
+          name_location: Location,
           comments: T.nilable(String),
-          encoding: Encoding,
           signatures: T::Array[Signature],
           visibility: Visibility,
           owner: T.nilable(Entry::Namespace),
         ).void
       end
-      def initialize(name, file_path, location, name_location, comments, encoding, signatures, visibility, owner) # rubocop:disable Metrics/ParameterLists
-        super(name, file_path, location, comments, encoding, visibility, owner)
+      def initialize(name, file_path, location, name_location, comments, signatures, visibility, owner) # rubocop:disable Metrics/ParameterLists
+        super(name, file_path, location, comments, visibility, owner)
         @signatures = signatures
-        @name_location = T.let(
-          if name_location.is_a?(Prism::Location)
-            Location.new(
-              name_location.start_line,
-              name_location.end_line,
-              name_location.start_code_units_column(encoding),
-              name_location.end_code_units_column(encoding),
-            )
-          else
-            name_location
-          end,
-          RubyIndexer::Location,
-        )
+        @name_location = name_location
       end
     end
 
@@ -494,13 +440,12 @@ module RubyIndexer
           nesting: T::Array[String],
           name: String,
           file_path: String,
-          location: T.any(Prism::Location, RubyIndexer::Location),
+          location: Location,
           comments: T.nilable(String),
-          encoding: Encoding,
         ).void
       end
-      def initialize(target, nesting, name, file_path, location, comments, encoding) # rubocop:disable Metrics/ParameterLists
-        super(name, file_path, location, comments, encoding)
+      def initialize(target, nesting, name, file_path, location, comments) # rubocop:disable Metrics/ParameterLists
+        super(name, file_path, location, comments)
 
         @target = target
         @nesting = nesting
@@ -514,14 +459,13 @@ module RubyIndexer
       sig { returns(String) }
       attr_reader :target
 
-      sig { params(target: String, unresolved_alias: UnresolvedConstantAlias, encoding: Encoding).void }
-      def initialize(target, unresolved_alias, encoding)
+      sig { params(target: String, unresolved_alias: UnresolvedConstantAlias).void }
+      def initialize(target, unresolved_alias)
         super(
           unresolved_alias.name,
           unresolved_alias.file_path,
           unresolved_alias.location,
           unresolved_alias.comments,
-          encoding
         )
 
         @visibility = unresolved_alias.visibility
@@ -541,14 +485,13 @@ module RubyIndexer
         params(
           name: String,
           file_path: String,
-          location: T.any(Prism::Location, RubyIndexer::Location),
+          location: Location,
           comments: T.nilable(String),
-          encoding: Encoding,
           owner: T.nilable(Entry::Namespace),
         ).void
       end
-      def initialize(name, file_path, location, comments, encoding, owner) # rubocop:disable Metrics/ParameterLists
-        super(name, file_path, location, comments, encoding)
+      def initialize(name, file_path, location, comments, owner)
+        super(name, file_path, location, comments)
         @owner = owner
       end
     end
@@ -571,13 +514,12 @@ module RubyIndexer
           old_name: String,
           owner: T.nilable(Entry::Namespace),
           file_path: String,
-          location: T.any(Prism::Location, RubyIndexer::Location),
+          location: Location,
           comments: T.nilable(String),
-          encoding: Encoding,
         ).void
       end
-      def initialize(new_name, old_name, owner, file_path, location, comments, encoding) # rubocop:disable Metrics/ParameterLists
-        super(new_name, file_path, location, comments, encoding)
+      def initialize(new_name, old_name, owner, file_path, location, comments) # rubocop:disable Metrics/ParameterLists
+        super(new_name, file_path, location, comments)
 
         @new_name = new_name
         @old_name = old_name
@@ -596,9 +538,9 @@ module RubyIndexer
       attr_reader :owner
 
       sig do
-        params(target: T.any(Member, MethodAlias), unresolved_alias: UnresolvedMethodAlias, encoding: Encoding).void
+        params(target: T.any(Member, MethodAlias), unresolved_alias: UnresolvedMethodAlias).void
       end
-      def initialize(target, unresolved_alias, encoding)
+      def initialize(target, unresolved_alias)
         full_comments = +"Alias for #{target.name}\n"
         full_comments << "#{unresolved_alias.comments}\n"
         full_comments << target.comments
@@ -608,7 +550,6 @@ module RubyIndexer
           unresolved_alias.file_path,
           unresolved_alias.location,
           full_comments,
-          encoding
         )
 
         @target = target

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -665,7 +665,6 @@ module RubyIndexer
           attached_ancestor.location,
           attached_ancestor.name_location,
           nil,
-          @configuration.encoding,
           nil,
         )
         add(singleton, skip_prefix_tree: true)
@@ -859,7 +858,7 @@ module RubyIndexer
       return entry unless target
 
       target_name = T.must(target.first).name
-      resolved_alias = Entry::ConstantAlias.new(target_name, entry, @configuration.encoding)
+      resolved_alias = Entry::ConstantAlias.new(target_name, entry)
 
       # Replace the UnresolvedAlias by a resolved one so that we don't have to do this again later
       original_entries = T.must(@entries[alias_name])
@@ -1050,7 +1049,7 @@ module RubyIndexer
       target_method_entries = resolve_method(entry.old_name, receiver_name, seen_names)
       return entry unless target_method_entries
 
-      resolved_alias = Entry::MethodAlias.new(T.must(target_method_entries.first), entry, @configuration.encoding)
+      resolved_alias = Entry::MethodAlias.new(T.must(target_method_entries.first), entry)
       original_entries = T.must(@entries[new_name])
       original_entries.delete(entry)
       original_entries << resolved_alias

--- a/lib/ruby_indexer/lib/ruby_indexer/location.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/location.rb
@@ -5,6 +5,20 @@ module RubyIndexer
   class Location
     extend T::Sig
 
+    class << self
+      extend T::Sig
+
+      sig { params(prism_location: Prism::Location, encoding: Encoding).returns(T.attached_class) }
+      def from_prism_location(prism_location, encoding)
+        new(
+          prism_location.start_line,
+          prism_location.end_line,
+          prism_location.start_code_units_column(encoding),
+          prism_location.end_code_units_column(encoding),
+        )
+      end
+    end
+
     sig { returns(Integer) }
     attr_reader :start_line, :end_line, :start_column, :end_column
 

--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -61,9 +61,9 @@ module RubyIndexer
       comments = comments_to_string(declaration)
       entry = if declaration.is_a?(RBS::AST::Declarations::Class)
         parent_class = declaration.super_class&.name&.name&.to_s
-        Entry::Class.new(nesting, file_path, location, location, comments, @index.configuration.encoding, parent_class)
+        Entry::Class.new(nesting, file_path, location, location, comments, parent_class)
       else
-        Entry::Module.new(nesting, file_path, location, location, comments, @index.configuration.encoding)
+        Entry::Module.new(nesting, file_path, location, location, comments)
       end
       add_declaration_mixins_to_entry(declaration, entry)
       @index.add(entry)
@@ -136,7 +136,6 @@ module RubyIndexer
         location,
         location,
         comments,
-        @index.configuration.encoding,
         signatures,
         visibility,
         real_owner,
@@ -269,7 +268,6 @@ module RubyIndexer
         file_path,
         to_ruby_indexer_location(declaration.location),
         comments_to_string(declaration),
-        @index.configuration.encoding,
       ))
     end
 
@@ -279,14 +277,12 @@ module RubyIndexer
       file_path = pathname.to_s
       location = to_ruby_indexer_location(declaration.location)
       comments = comments_to_string(declaration)
-      encoding = @index.configuration.encoding
 
       @index.add(Entry::GlobalVariable.new(
         name,
         file_path,
         location,
         comments,
-        encoding,
       ))
     end
 
@@ -302,7 +298,6 @@ module RubyIndexer
         file_path,
         to_ruby_indexer_location(member.location),
         comments,
-        @index.configuration.encoding,
       )
 
       @index.add(entry)

--- a/lib/ruby_indexer/test/enhancements_test.rb
+++ b/lib/ruby_indexer/test/enhancements_test.rb
@@ -16,7 +16,7 @@ module RubyIndexer
           arguments = node.arguments&.arguments
           return unless arguments
 
-          location = node.location
+          location = Location.from_prism_location(node.location, index.configuration.encoding)
 
           arguments.each do |node|
             next unless node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
@@ -39,7 +39,6 @@ module RubyIndexer
               location,
               location,
               nil,
-              index.configuration.encoding,
               [Entry::Signature.new([Entry::RequiredParameter.new(name: :a)])],
               Entry::Visibility::PUBLIC,
               owner,
@@ -114,7 +113,7 @@ module RubyIndexer
           association_name = arguments.first
           return unless association_name.is_a?(Prism::SymbolNode)
 
-          location = association_name.location
+          location = Location.from_prism_location(association_name.location, index.configuration.encoding)
 
           index.add(Entry::Method.new(
             T.must(association_name.value),
@@ -122,7 +121,6 @@ module RubyIndexer
             location,
             location,
             nil,
-            index.configuration.encoding,
             [],
             Entry::Visibility::PUBLIC,
             owner,


### PR DESCRIPTION
### Motivation

Currently, our index entries accept either a `Prism::Location` or a `RubyIndexer::Location`. This is causing some weird patterns, like the need to pass the encoding everywhere even after the initial indexing has been performed.

Prism is about to ship a new [code units cache concept](https://github.com/ruby/prism/pull/3173), which will hopefully solve the performance degradation we've been seeing, but it will also make our current design even more difficult to deal with.

This PR forces us to build locations outside of entries, which prevents the coupling with the encoding and makes the changes required much more straight forward.

### Implementation

Every entry only accepts a `RubyIndexer::Location` now. I added a helper method to build them from a `Prism::Location`, so that the transition to use the code units cache is easier.

### Automated Tests

Existing tests should cover it.