### PR TITLE
Index all missing global variable nodes

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -65,6 +65,11 @@ module RubyIndexer
         :on_constant_or_write_node_enter,
         :on_constant_and_write_node_enter,
         :on_constant_operator_write_node_enter,
+        :on_global_variable_and_write_node_enter,
+        :on_global_variable_operator_write_node_enter,
+        :on_global_variable_or_write_node_enter,
+        :on_global_variable_target_node_enter,
+        :on_global_variable_write_node_enter,
         :on_instance_variable_write_node_enter,
         :on_instance_variable_and_write_node_enter,
         :on_instance_variable_operator_write_node_enter,
@@ -382,6 +387,31 @@ module RubyIndexer
       end
     end
 
+    sig { params(node: Prism::GlobalVariableAndWriteNode).void }
+    def on_global_variable_and_write_node_enter(node)
+      handle_global_variable(node, node.name_loc)
+    end
+
+    sig { params(node: Prism::GlobalVariableOperatorWriteNode).void }
+    def on_global_variable_operator_write_node_enter(node)
+      handle_global_variable(node, node.name_loc)
+    end
+
+    sig { params(node: Prism::GlobalVariableOrWriteNode).void }
+    def on_global_variable_or_write_node_enter(node)
+      handle_global_variable(node, node.name_loc)
+    end
+
+    sig { params(node: Prism::GlobalVariableTargetNode).void }
+    def on_global_variable_target_node_enter(node)
+      handle_global_variable(node, node.location)
+    end
+
+    sig { params(node: Prism::GlobalVariableWriteNode).void }
+    def on_global_variable_write_node_enter(node)
+      handle_global_variable(node, node.name_loc)
+    end
+
     sig { params(node: Prism::InstanceVariableWriteNode).void }
     def on_instance_variable_write_node_enter(node)
       handle_instance_variable(node, node.name_loc)
@@ -425,6 +455,31 @@ module RubyIndexer
     end
 
     private
+
+    sig do
+      params(
+        node: T.any(
+          Prism::GlobalVariableAndWriteNode,
+          Prism::GlobalVariableOperatorWriteNode,
+          Prism::GlobalVariableOrWriteNode,
+          Prism::GlobalVariableTargetNode,
+          Prism::GlobalVariableWriteNode,
+        ),
+        loc: Prism::Location,
+      ).void
+    end
+    def handle_global_variable(node, loc)
+      name = node.name.to_s
+      comments = collect_comments(node)
+
+      @index.add(Entry::GlobalVariable.new(
+        name,
+        @file_path,
+        loc,
+        comments,
+        @index.configuration.encoding,
+      ))
+    end
 
     sig do
       params(

--- a/lib/ruby_indexer/test/global_variable_test.rb
+++ b/lib/ruby_indexer/test/global_variable_test.rb
@@ -1,0 +1,49 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module RubyIndexer
+  class GlobalVariableTest < TestCase
+    def test_global_variable_and_write
+      index(<<~RUBY)
+        $foo &&= 1
+      RUBY
+
+      assert_entry("$foo", Entry::GlobalVariable, "/fake/path/foo.rb:0-0:0-4")
+    end
+
+    def test_global_variable_operator_write
+      index(<<~RUBY)
+        $foo += 1
+      RUBY
+
+      assert_entry("$foo", Entry::GlobalVariable, "/fake/path/foo.rb:0-0:0-4")
+    end
+
+    def test_global_variable_or_write
+      index(<<~RUBY)
+        $foo ||= 1
+      RUBY
+
+      assert_entry("$foo", Entry::GlobalVariable, "/fake/path/foo.rb:0-0:0-4")
+    end
+
+    def test_global_variable_target_node
+      index(<<~RUBY)
+        $foo, $bar = 1
+      RUBY
+
+      assert_entry("$foo", Entry::GlobalVariable, "/fake/path/foo.rb:0-0:0-4")
+      assert_entry("$bar", Entry::GlobalVariable, "/fake/path/foo.rb:0-6:0-10")
+    end
+
+    def test_global_variable_write
+      index(<<~RUBY)
+        $foo = 1
+      RUBY
+
+      assert_entry("$foo", Entry::GlobalVariable, "/fake/path/foo.rb:0-0:0-4")
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
Iteration of https://github.com/Shopify/ruby-lsp/issues/2644  
The first PR to index global variables (https://github.com/Shopify/ruby-lsp/pull/2656) focused only on RBS declarations. This covers only partial use cases, as it is possible for a user to define their own global variables.

### Implementation
From [prism/config.yml](https://github.com/ruby/prism/blob/d6e9b8de36b4d18debfe36e4545116539964ceeb/config.yml#L2110), listen to all kinds of global variable writing nodes, and push `GlobalVariable` entries into the index.

### Automated Tests
Added a new file with all kinds of global variable writing.

### Manual Tests
Because I have already merged go-to-definition changes for global variables, we can already check that it's working.

https://github.com/user-attachments/assets/70245e1d-7778-4c2e-b733-d565e60a69e1