### PR TITLE
Fix global variable indexing rebase conflict

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -469,9 +469,8 @@ module RubyIndexer
       @index.add(Entry::GlobalVariable.new(
         name,
         @file_path,
-        loc,
+        Location.from_prism_location(loc, @encoding),
         comments,
-        @index.configuration.encoding,
       ))
     end
 


### PR DESCRIPTION
### Motivation

The global variable PR and the change for creating entries had a conflict because of the change in the API.