### PR TITLE
Use code units cache API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ruby-lsp (0.19.2)
       language_server-protocol (~> 3.17.0)
-      prism (>= 1.1, < 2.0)
+      prism (>= 1.2, < 2.0)
       rbs (>= 3, < 4)
       sorbet-runtime (>= 0.5.10782)
 
@@ -39,7 +39,7 @@ GEM
       ast (~> 2.4.1)
       racc
     prettier_print (1.2.1)
-    prism (1.1.0)
+    prism (1.2.0)
     psych (5.1.2)
       stringio
     racc (1.8.1)

--- a/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
@@ -19,8 +19,12 @@ module RubyIndexer
         owner: T.nilable(Entry::Namespace),
         node: Prism::CallNode,
         file_path: String,
+        code_units_cache: T.any(
+          T.proc.params(arg0: Integer).returns(Integer),
+          Prism::CodeUnitsCache,
+        ),
       ).void
     end
-    def on_call_node(index, owner, node, file_path); end
+    def on_call_node(index, owner, node, file_path, code_units_cache); end
   end
 end

--- a/lib/ruby_indexer/lib/ruby_indexer/location.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/location.rb
@@ -8,13 +8,21 @@ module RubyIndexer
     class << self
       extend T::Sig
 
-      sig { params(prism_location: Prism::Location, encoding: Encoding).returns(T.attached_class) }
-      def from_prism_location(prism_location, encoding)
+      sig do
+        params(
+          prism_location: Prism::Location,
+          code_units_cache: T.any(
+            T.proc.params(arg0: Integer).returns(Integer),
+            Prism::CodeUnitsCache,
+          ),
+        ).returns(T.attached_class)
+      end
+      def from_prism_location(prism_location, code_units_cache)
         new(
           prism_location.start_line,
           prism_location.end_line,
-          prism_location.start_code_units_column(encoding),
-          prism_location.end_code_units_column(encoding),
+          prism_location.cached_start_code_units_column(code_units_cache),
+          prism_location.cached_end_code_units_column(code_units_cache),
         )
       end
     end

--- a/lib/ruby_indexer/test/enhancements_test.rb
+++ b/lib/ruby_indexer/test/enhancements_test.rb
@@ -9,14 +9,14 @@ module RubyIndexer
       enhancement_class = Class.new do
         include Enhancement
 
-        def on_call_node(index, owner, node, file_path)
+        def on_call_node(index, owner, node, file_path, code_units_cache)
           return unless owner
           return unless node.name == :extend
 
           arguments = node.arguments&.arguments
           return unless arguments
 
-          location = Location.from_prism_location(node.location, index.configuration.encoding)
+          location = Location.from_prism_location(node.location, code_units_cache)
 
           arguments.each do |node|
             next unless node.is_a?(Prism::ConstantReadNode) || node.is_a?(Prism::ConstantPathNode)
@@ -101,7 +101,7 @@ module RubyIndexer
       enhancement_class = Class.new do
         include Enhancement
 
-        def on_call_node(index, owner, node, file_path)
+        def on_call_node(index, owner, node, file_path, code_units_cache)
           return unless owner
 
           name = node.name
@@ -113,7 +113,7 @@ module RubyIndexer
           association_name = arguments.first
           return unless association_name.is_a?(Prism::SymbolNode)
 
-          location = Location.from_prism_location(association_name.location, index.configuration.encoding)
+          location = Location.from_prism_location(association_name.location, code_units_cache)
 
           index.add(Entry::Method.new(
             T.must(association_name.value),
@@ -164,7 +164,7 @@ module RubyIndexer
       enhancement_class = Class.new do
         include Enhancement
 
-        def on_call_node(index, owner, node, file_path)
+        def on_call_node(index, owner, node, file_path, code_units_cache)
           raise "Error"
         end
 

--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -64,6 +64,16 @@ module RubyLsp
       char && char != " "
     end
 
+    sig do
+      returns(T.any(
+        T.proc.params(arg0: Integer).returns(Integer),
+        Prism::CodeUnitsCache,
+      ))
+    end
+    def code_units_cache
+      @parse_result.code_units_cache(@encoding)
+    end
+
     class ERBScanner
       extend T::Sig
 

--- a/lib/ruby_lsp/listeners/folding_ranges.rb
+++ b/lib/ruby_lsp/listeners/folding_ranges.rb
@@ -239,10 +239,10 @@ module RubyLsp
         statements = node.statements
         return unless statements
 
-        body = statements.body
-        return if body.empty?
+        statement = statements.body.last
+        return unless statement
 
-        add_lines_range(node.location.start_line, body.last.location.end_line)
+        add_lines_range(node.location.start_line, statement.location.end_line)
       end
 
       sig { params(node: Prism::Node).void }

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -99,7 +99,13 @@ module RubyLsp
 
         # Find the closest statements node, so that we place the refactor in a valid position
         node_context = RubyDocument
-          .locate(@document.parse_result.value, start_index, node_types: [Prism::StatementsNode, Prism::BlockNode])
+          .locate(@document.parse_result.value,
+            start_index,
+            node_types: [
+              Prism::StatementsNode,
+              Prism::BlockNode,
+            ],
+            code_units_cache: @document.code_units_cache)
 
         closest_statements = node_context.node
         parent_statements = node_context.parent
@@ -196,7 +202,7 @@ module RubyLsp
           @document.parse_result.value,
           start_index,
           node_types: [Prism::DefNode],
-          encoding: @global_state.encoding,
+          code_units_cache: @document.code_units_cache,
         )
         closest_node = node_context.node
         return Error::InvalidTargetRange unless closest_node

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -57,7 +57,7 @@ module RubyLsp
             Prism::InstanceVariableTargetNode,
             Prism::InstanceVariableWriteNode,
           ],
-          encoding: global_state.encoding,
+          code_units_cache: document.code_units_cache,
         )
         @response_builder = T.let(
           ResponseBuilders::CollectionResponseBuilder[Interface::CompletionItem].new,

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -58,7 +58,7 @@ module RubyLsp
             Prism::SuperNode,
             Prism::ForwardingSuperNode,
           ],
-          encoding: global_state.encoding,
+          code_units_cache: document.code_units_cache,
         )
 
         target = node_context.node

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -28,7 +28,11 @@ module RubyLsp
         char_position = document.create_scanner.find_char_position(position)
         delegate_request_if_needed!(global_state, document, char_position)
 
-        node_context = RubyDocument.locate(document.parse_result.value, char_position, encoding: global_state.encoding)
+        node_context = RubyDocument.locate(
+          document.parse_result.value,
+          char_position,
+          code_units_cache: document.code_units_cache,
+        )
 
         @response_builder = T.let(
           ResponseBuilders::CollectionResponseBuilder[Interface::DocumentHighlight].new,

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -41,7 +41,7 @@ module RubyLsp
           document.parse_result.value,
           char_position,
           node_types: Listeners::Hover::ALLOWED_TARGETS,
-          encoding: global_state.encoding,
+          code_units_cache: document.code_units_cache,
         )
         target = node_context.node
         parent = node_context.parent

--- a/lib/ruby_lsp/requests/range_formatting.rb
+++ b/lib/ruby_lsp/requests/range_formatting.rb
@@ -34,16 +34,18 @@ module RubyLsp
         )
         return unless formatted_text
 
+        code_units_cache = @document.code_units_cache
+
         [
           Interface::TextEdit.new(
             range: Interface::Range.new(
               start: Interface::Position.new(
                 line: location.start_line - 1,
-                character: location.start_code_units_column(@document.encoding),
+                character: location.cached_start_code_units_column(code_units_cache),
               ),
               end: Interface::Position.new(
                 line: location.end_line - 1,
-                character: location.end_code_units_column(@document.encoding),
+                character: location.cached_end_code_units_column(code_units_cache),
               ),
             ),
             new_text: formatted_text.strip,

--- a/lib/ruby_lsp/requests/references.rb
+++ b/lib/ruby_lsp/requests/references.rb
@@ -42,7 +42,7 @@ module RubyLsp
             Prism::CallNode,
             Prism::DefNode,
           ],
-          encoding: @global_state.encoding,
+          code_units_cache: @document.code_units_cache,
         )
         target = node_context.node
         parent = node_context.parent

--- a/lib/ruby_lsp/requests/rename.rb
+++ b/lib/ruby_lsp/requests/rename.rb
@@ -37,7 +37,7 @@ module RubyLsp
           @document.parse_result.value,
           char_position,
           node_types: [Prism::ConstantReadNode, Prism::ConstantPathNode, Prism::ConstantPathTargetNode],
-          encoding: @global_state.encoding,
+          code_units_cache: @document.code_units_cache,
         )
         target = node_context.node
         parent = node_context.parent

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -101,7 +101,7 @@ module RubyLsp
         @range = range
         @result_id = T.let(SemanticHighlighting.next_result_id.to_s, String)
         @response_builder = T.let(
-          ResponseBuilders::SemanticHighlighting.new(global_state.encoding),
+          ResponseBuilders::SemanticHighlighting.new(document.code_units_cache),
           ResponseBuilders::SemanticHighlighting,
         )
         Listeners::SemanticHighlighting.new(dispatcher, @response_builder)

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -43,7 +43,7 @@ module RubyLsp
           document.parse_result.value,
           char_position,
           node_types: [Prism::CallNode],
-          encoding: global_state.encoding,
+          code_units_cache: document.code_units_cache,
         )
 
         target = adjust_for_nested_target(node_context.node, node_context.parent, position)

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -159,7 +159,7 @@ module RubyLsp
         def namespace_constant_name(node)
           path = node.constant_path
           case path
-          when Prism::ConstantPathNode, Prism::ConstantReadNode, Prism::ConstantPathTargetNode
+          when Prism::ConstantPathNode, Prism::ConstantReadNode
             constant_name(path)
           end
         end

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -218,5 +218,15 @@ module RubyLsp
         encoding: @encoding,
       )
     end
+
+    sig do
+      returns(T.any(
+        T.proc.params(arg0: Integer).returns(Integer),
+        Prism::CodeUnitsCache,
+      ))
+    end
+    def code_units_cache
+      @parse_result.code_units_cache(@encoding)
+    end
   end
 end

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -25,11 +25,14 @@ module RubyLsp
         params(
           node: Prism::Node,
           char_position: Integer,
+          code_units_cache: T.any(
+            T.proc.params(arg0: Integer).returns(Integer),
+            Prism::CodeUnitsCache,
+          ),
           node_types: T::Array[T.class_of(Prism::Node)],
-          encoding: Encoding,
         ).returns(NodeContext)
       end
-      def locate(node, char_position, node_types: [], encoding: Encoding::UTF_8)
+      def locate(node, char_position, code_units_cache:, node_types: [])
         queue = T.let(node.child_nodes.compact, T::Array[T.nilable(Prism::Node)])
         closest = node
         parent = T.let(nil, T.nilable(Prism::Node))
@@ -62,8 +65,8 @@ module RubyLsp
 
           # Skip if the current node doesn't cover the desired position
           loc = candidate.location
-          loc_start_offset = loc.start_code_units_offset(encoding)
-          loc_end_offset = loc.end_code_units_offset(encoding)
+          loc_start_offset = loc.cached_start_code_units_offset(code_units_cache)
+          loc_end_offset = loc.cached_end_code_units_offset(code_units_cache)
           next unless (loc_start_offset...loc_end_offset).cover?(char_position)
 
           # If the node's start character is already past the position, then we should've found the closest node
@@ -74,7 +77,7 @@ module RubyLsp
           # and need to pop the stack
           previous_level = nesting_nodes.last
           if previous_level &&
-              (loc_start_offset > previous_level.location.end_code_units_offset(encoding))
+              (loc_start_offset > previous_level.location.cached_end_code_units_offset(code_units_cache))
             nesting_nodes.pop
           end
 
@@ -89,10 +92,10 @@ module RubyLsp
           if candidate.is_a?(Prism::CallNode)
             arg_loc = candidate.arguments&.location
             blk_loc = candidate.block&.location
-            if (arg_loc && (arg_loc.start_code_units_offset(encoding)...
-                            arg_loc.end_code_units_offset(encoding)).cover?(char_position)) ||
-                (blk_loc && (blk_loc.start_code_units_offset(encoding)...
-                            blk_loc.end_code_units_offset(encoding)).cover?(char_position))
+            if (arg_loc && (arg_loc.cached_start_code_units_offset(code_units_cache)...
+                            arg_loc.cached_end_code_units_offset(code_units_cache)).cover?(char_position)) ||
+                (blk_loc && (blk_loc.cached_start_code_units_offset(code_units_cache)...
+                            blk_loc.cached_end_code_units_offset(code_units_cache)).cover?(char_position))
               call_node = candidate
             end
           end
@@ -102,8 +105,8 @@ module RubyLsp
 
           # If the current node is narrower than or equal to the previous closest node, then it is more precise
           closest_loc = closest.location
-          closest_node_start_offset = closest_loc.start_code_units_offset(encoding)
-          closest_node_end_offset = closest_loc.end_code_units_offset(encoding)
+          closest_node_start_offset = closest_loc.cached_start_code_units_offset(code_units_cache)
+          closest_node_end_offset = closest_loc.cached_end_code_units_offset(code_units_cache)
           if loc_end_offset - loc_start_offset <= closest_node_end_offset - closest_node_start_offset
             parent = closest
             closest = candidate
@@ -131,12 +134,30 @@ module RubyLsp
       end
     end
 
+    sig do
+      returns(T.any(
+        T.proc.params(arg0: Integer).returns(Integer),
+        Prism::CodeUnitsCache,
+      ))
+    end
+    attr_reader :code_units_cache
+
+    sig { params(source: String, version: Integer, uri: URI::Generic, encoding: Encoding).void }
+    def initialize(source:, version:, uri:, encoding: Encoding::UTF_8)
+      super
+      @code_units_cache = T.let(@parse_result.code_units_cache(@encoding), T.any(
+        T.proc.params(arg0: Integer).returns(Integer),
+        Prism::CodeUnitsCache,
+      ))
+    end
+
     sig { override.returns(T::Boolean) }
     def parse!
       return false unless @needs_parsing
 
       @needs_parsing = false
       @parse_result = Prism.parse(@source)
+      @code_units_cache = @parse_result.code_units_cache(@encoding)
       true
     end
 
@@ -214,19 +235,9 @@ module RubyLsp
       RubyDocument.locate(
         @parse_result.value,
         create_scanner.find_char_position(position),
+        code_units_cache: @code_units_cache,
         node_types: node_types,
-        encoding: @encoding,
       )
-    end
-
-    sig do
-      returns(T.any(
-        T.proc.params(arg0: Integer).returns(Integer),
-        Prism::CodeUnitsCache,
-      ))
-    end
-    def code_units_cache
-      @parse_result.code_units_cache(@encoding)
     end
   end
 end

--- a/lib/ruby_lsp/type_inferrer.rb
+++ b/lib/ruby_lsp/type_inferrer.rb
@@ -93,7 +93,7 @@ module RubyLsp
         raw_receiver = if receiver.is_a?(Prism::CallNode)
           receiver.message
         else
-          receiver&.slice
+          receiver.slice
         end
 
         if raw_receiver

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("language_server-protocol", "~> 3.17.0")
-  s.add_dependency("prism", ">= 1.1", "< 2.0")
+  s.add_dependency("prism", ">= 1.2", "< 2.0")
   s.add_dependency("rbs", ">= 3", "< 4")
   s.add_dependency("sorbet-runtime", ">= 0.5.10782")
 

--- a/test/expectations/semantic_highlighting/multibyte_characters.exp.json
+++ b/test/expectations/semantic_highlighting/multibyte_characters.exp.json
@@ -16,7 +16,7 @@
     },
     {
       "delta_line": 3,
-      "delta_start_char": 11,
+      "delta_start_char": 10,
       "length": 2,
       "token_type": 8,
       "token_modifiers": 0
@@ -24,7 +24,7 @@
     {
       "delta_line": 1,
       "delta_start_char": 11,
-      "length": 2,
+      "length": 1,
       "token_type": 8,
       "token_modifiers": 0
     }


### PR DESCRIPTION
### Motivation

Closes #2674, closes #2671

This PR adopts the new [code units cache API from Prism](https://github.com/ruby/prism/pull/3173), so that code unit locations can be computed faster.

### Implementation

I recommend reviewing by commit. The new API allows us to instantiate a code units cache ahead of time, which is then passed to get the code units in a more performant way. In places where we previously passed the encoding, we now pass the cache.

**Note**: this actually fixed a bug in the locations for semantic highlighting.

### Automated Tests

Existing tests cover it, but I fixed one of them which had an incorrect expectation.