### PR TITLE
Allow custom gemfile for debug

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -390,6 +390,11 @@
           "type": "string",
           "default": ""
         },
+        "rubyLsp.debugGemfile": {
+          "description": "Relative or absolute path to the Gemfile to use when running debug.  If unset, the Gemfile used for the Ruby LSP server will be used",
+          "type": "string",
+          "default": ""
+        },
         "rubyLsp.testTimeout": {
           "description": "The amount of time in seconds to wait for a test to finish before timing out. Only used when running tests from the test explorer",
           "type": "integer",

--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -1,12 +1,12 @@
 import net from "net";
 import os from "os";
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import path from "path";
 
 import * as vscode from "vscode";
 
 import { LOG_CHANNEL, asyncExec } from "./common";
 import { Workspace } from "./workspace";
-import path from "path";
 
 class TerminalLogger {
   append(message: string) {
@@ -137,9 +137,11 @@ export class Debugger
     // allow user to override the default of using the RubyLsp Gemfile
     // when debugging
     if (customDebugGemfile.length > 0) {
-      debugConfiguration.env.BUNDLE_GEMFILE = path.isAbsolute(customDebugGemfile)
-          ? customDebugGemfile
-          : path.resolve(path.join(workspaceUri.fsPath, customDebugGemfile),);
+      debugConfiguration.env.BUNDLE_GEMFILE = path.isAbsolute(
+        customDebugGemfile,
+      )
+        ? customDebugGemfile
+        : path.resolve(path.join(workspaceUri.fsPath, customDebugGemfile));
       return debugConfiguration;
     }
 

--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -6,6 +6,7 @@ import * as vscode from "vscode";
 
 import { LOG_CHANNEL, asyncExec } from "./common";
 import { Workspace } from "./workspace";
+import path from "path";
 
 class TerminalLogger {
   append(message: string) {
@@ -128,6 +129,19 @@ export class Debugger
     };
 
     const customBundleUri = vscode.Uri.joinPath(workspaceUri, ".ruby-lsp");
+
+    const customDebugGemfile: string = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get("debugGemfile")!;
+
+    // allow user to override the default of using the RubyLsp Gemfile
+    // when debugging
+    if (customDebugGemfile.length > 0) {
+      debugConfiguration.env.BUNDLE_GEMFILE = path.isAbsolute(customDebugGemfile)
+          ? customDebugGemfile
+          : path.resolve(path.join(workspaceUri.fsPath, customDebugGemfile),);
+      return debugConfiguration;
+    }
 
     return vscode.workspace.fs.readDirectory(customBundleUri).then(
       (value) => {


### PR DESCRIPTION
### Motivation

Potentially closes:
https://github.com/Shopify/ruby-lsp/issues/1767
https://github.com/st0012/ruby-lsp-rspec/issues/33

When triggering debug (run and debug) from the editor, this extension was setting the env BUNDLE_GEMFILE to be the RubyLsp generated one, not the workspaces one.

### Implementation

I added a new setting, `rubyLsp.debugGemfile`, allowing users to specify the Gemfile to use for debug runs.  This way, no users are affected by this change unless they opt in.

### Automated Tests

When I try and run the tests, I get this error.  So I haven't bothered to write one for this change. 

`AssertionError [ERR_ASSERTION]: Ruby bin path does not exist /opt/rubies/3.3.4/bin`

### Manual Tests

You can see this test in action by triggering debug runs from the editor.  If you set the setting, you should see the value of the BUNDLE_GEMFILE change in the output of RubyLsp when it dumps all the envs into the output.
