### PR TITLE
Fix glob typo for indexing config

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -469,10 +469,9 @@ To configure indexing, pass a JSON hash as part of the Ruby LSP configuration, f
 // PROJECT/.vscode/settings.json
 {
   "rubyLsp.indexing": {
-    "excludedPatterns": ["**/test/**.rb"],
-    "includedPatterns": ["**/bin/**"],
+    "excludedPatterns": ["**/test/**/*.rb"],
+    "includedPatterns": ["**/bin/**/*"],
     "excludedGems": ["rubocop", "rubocop-performance"],
-    "includedPatterns": ["rake"],
     "excludedMagicComments": ["compiled:true"],
   },
 }


### PR DESCRIPTION
### Motivation

The typo results in a glob pattern that doesn't work like expected since it's checking for directories.
