### PR TITLE
Prevent accessing rootUri if there's no git repository

### DIFF
--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -59,7 +59,10 @@ export class Workspace implements WorkspaceInterface {
     if (gitExtension) {
       const api = gitExtension.exports.getAPI(1);
       const repository = await api.openRepository(this.workspaceFolder.uri);
-      rootGitUri = repository.rootUri;
+
+      if (repository) {
+        rootGitUri = repository.rootUri;
+      }
     }
 
     this.registerCreateDeleteWatcher(


### PR DESCRIPTION
### Motivation

Closes #2725

If the user is developing on a repository not tracked by git, then `api.openRepository` returns `null` and the line immediately after fails when trying to access `rootUri`.

### Implementation

We need to check that there is indeed a git repository before trying to read the root URI.