### PR TITLE
Disable compile cache for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         name: Use Node.js 18.x
+        env:
+          DISABLE_V8_COMPILE_CACHE: "1"
         with:
           node-version: "20.9"
           cache: "yarn"


### PR DESCRIPTION
### Motivation

Our publish action is sometimes failing on that V8 compile cache crash. Let's disable it so that publishing stops failing randomly.
