### PR TITLE
Ensure all `ruby-lsp` dependencies are installed before launch

### DIFF
--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.executables = ["ruby-lsp", "ruby-lsp-check"]
   s.require_paths = ["lib"]
 
+  # Dependencies must be kept in sync with the checks in the extension side on workspace.ts
   s.add_dependency("language_server-protocol", "~> 3.17.0")
   s.add_dependency("prism", ">= 1.2", "< 2.0")
   s.add_dependency("rbs", ">= 3", "< 4")


### PR DESCRIPTION
### Motivation

One way launching the server may fail is if the user decided to uninstall one of our required dependencies for any reason.

For example, if you run `gem uninstall prism` and delete all installations, launching the language server will fail because rubygems will raise saying not all dependencies are satisfied.

### Implementation

Our previous check was a bit too simple. We just verified if the `ruby-lsp` was present, but in fact we need to verify that all dependencies are installed or else launching will fail.