### PR TITLE
Support module_function in the indexer

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -780,11 +780,12 @@ module RubyIndexer
           entry.visibility = Entry::Visibility::PRIVATE
 
           singleton = @index.existing_or_new_singleton_class(entry_owner_name)
+          location = Location.from_prism_location(argument.location, @code_units_cache)
           @index.add(Entry::Method.new(
             method_name,
             @file_path,
-            Location.from_prism_location(node.location, @code_units_cache),
-            Location.from_prism_location(T.must(node.message_loc), @code_units_cache),
+            location,
+            location,
             collect_comments(node),
             entry.signatures,
             Entry::Visibility::PUBLIC,

--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -313,28 +313,7 @@ module RubyIndexer
       when :private
         @visibility_stack.push(Entry::Visibility::PRIVATE)
       when :module_function
-        name_argument = node.arguments.arguments.first
-        return unless name_argument
-
-        entries = @index.resolve_method(name_argument.value, @owner_stack.last.name)
-        return unless entries
-
-        entries.each do |e|
-          e.visibility = Entry::Visibility::PRIVATE
-
-          singleton = @index.existing_or_new_singleton_class(e.owner.name)
-
-          @index.add(Entry::Method.new(
-            name_argument.value,
-            @file_path,
-            Location.from_prism_location(node.location, @code_units_cache),
-            Location.from_prism_location(node.message_loc, @code_units_cache),
-            collect_comments(node),
-            [],
-            Entry::Visibility::PUBLIC,
-            singleton,
-          ))
-        end
+        handle_module_function(node)
       end
 
       @enhancements.each do |enhancement|
@@ -771,6 +750,41 @@ module RubyIndexer
       rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError,
              Prism::ConstantPathNode::MissingNodesInConstantPathError
         # Do nothing
+      end
+    end
+
+    sig { params(node: Prism::CallNode).void }
+    def handle_module_function(node)
+      arguments_node = node.arguments
+      return unless arguments_node
+
+      name_argument = arguments_node.arguments.first
+      return unless name_argument.is_a?(Prism::SymbolNode)
+
+      method_name = name_argument.value.to_s
+      owner_name = @owner_stack.last&.name
+      return unless owner_name
+
+      entries = @index.resolve_method(method_name, owner_name)
+      return unless entries
+
+      entries.each do |entry|
+        entry_owner_name = entry.owner&.name
+        next unless entry_owner_name
+
+        entry.visibility = Entry::Visibility::PRIVATE
+
+        singleton = @index.existing_or_new_singleton_class(entry_owner_name)
+        @index.add(Entry::Method.new(
+          method_name,
+          @file_path,
+          Location.from_prism_location(node.location, @code_units_cache),
+          Location.from_prism_location(T.must(node.message_loc), @code_units_cache),
+          collect_comments(node),
+          [],
+          Entry::Visibility::PUBLIC,
+          singleton,
+        ))
       end
     end
 

--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -786,7 +786,7 @@ module RubyIndexer
             @file_path,
             location,
             location,
-            collect_comments(node),
+            collect_comments(node)&.concat(entry.comments),
             entry.signatures,
             Entry::Visibility::PUBLIC,
             singleton,

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -123,6 +123,34 @@ module RubyIndexer
       assert_entry("baz", Entry::Method, "/fake/path/foo.rb:9-2:9-14", visibility: Entry::Visibility::PRIVATE)
     end
 
+    def test_visibility_tracking_with_module_function
+      index(<<~RUBY)
+        module Foo
+          def foo; end
+          module_function :foo
+        end
+
+        class Bar
+          include Foo
+        end
+      RUBY
+
+      entries = T.must(@index["foo"])
+      # receive two entries because module_function creates a singleton method
+      # for the Foo module and a private method for classes include Foo module
+      assert_equal(entries.size, 2)
+      # The first entry points to the location of the module_function call
+      first_entry = entries.first
+      assert_equal("Foo", first_entry.owner.name)
+      assert_instance_of(Entry::Module, first_entry.owner)
+      assert_equal(Entry::Visibility::PRIVATE, first_entry.visibility)
+      # The second entry points to the public singleton method
+      second_entry = entries.last
+      assert_equal("Foo::<Class:Foo>", second_entry.owner.name)
+      assert_instance_of(Entry::SingletonClass, second_entry.owner)
+      assert_equal(Entry::Visibility::PUBLIC, second_entry.visibility)
+    end
+
     def test_method_with_parameters
       index(<<~RUBY)
         class Foo

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -139,13 +139,12 @@ module RubyIndexer
       # receive two entries because module_function creates a singleton method
       # for the Foo module and a private method for classes include Foo module
       assert_equal(entries.size, 2)
+      first_entry, second_entry = *entries
       # The first entry points to the location of the module_function call
-      first_entry = entries.first
       assert_equal("Foo", first_entry.owner.name)
       assert_instance_of(Entry::Module, first_entry.owner)
       assert_equal(Entry::Visibility::PRIVATE, first_entry.visibility)
       # The second entry points to the public singleton method
-      second_entry = entries.last
       assert_equal("Foo::<Class:Foo>", second_entry.owner.name)
       assert_instance_of(Entry::SingletonClass, second_entry.owner)
       assert_equal(Entry::Visibility::PUBLIC, second_entry.visibility)


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/2653 

The `module_function` invocation creates both a singleton method and a private method when using `include` in a class. The indexer needs to account for this behavior by mutating the method's visibility and handling both method types.

### Implementation

When the indexer encounters a `module_function`, it updates the corresponding method entry:
  - Changes the instance method’s visibility to private.
  - Adds the singleton method to the indexer (public).
  
### Automated Tests

Add a new test
