### PR TITLE
Ensure default gem path is also in document selector

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -148,17 +148,27 @@ function collectClientOptions(
     });
   }
 
-  // Because of how default gems are installed, the entry in the `GEM_PATH` is actually not exactly where the files
-  // are located. With the regex, we are correcting the default gem path from this (where the files are not located)
-  // /opt/rubies/3.3.1/lib/ruby/gems/3.3.0
-  //
-  // to this (where the files are actually stored)
-  // /opt/rubies/3.3.1/lib/ruby/3.3.0
   ruby.gemPath.forEach((gemPath) => {
     documentSelector.push({
       language: "ruby",
-      pattern: `${gemPath.replace(/lib\/ruby\/gems\/(?=\d)/, "lib/ruby/")}/**/*`,
+      pattern: `${gemPath}/**/*`,
     });
+
+    // Because of how default gems are installed, the gemPath location is actually not exactly where the files are
+    // located. With the regex, we are correcting the default gem path from this (where the files are not located)
+    // /opt/rubies/3.3.1/lib/ruby/gems/3.3.0
+    //
+    // to this (where the files are actually stored)
+    // /opt/rubies/3.3.1/lib/ruby/3.3.0
+    //
+    // Notice that we still need to add the regular path to the selector because some version managers will install gems
+    // under the non-corrected path
+    if (/lib\/ruby\/gems\/(?=\d)/.test(gemPath)) {
+      documentSelector.push({
+        language: "ruby",
+        pattern: `${gemPath.replace(/lib\/ruby\/gems\/(?=\d)/, "lib/ruby/")}/**/*`,
+      });
+    }
   });
 
   // This is a temporary solution as an escape hatch for users who cannot upgrade the `ruby-lsp` gem to a version that

--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -674,6 +674,7 @@ suite("Client", () => {
       workspaceRubyFilter,
       workspaceERBFilter,
       bundledGemsFilter,
+      defaultPathFilter,
       defaultGemsFilter,
     ] = client.clientOptions.documentSelector!;
 
@@ -700,6 +701,11 @@ suite("Client", () => {
     assert.match(
       (bundledGemsFilter as TextDocumentFilter).pattern!,
       new RegExp(`ruby\\/\\d\\.\\d\\.\\d\\/\\*\\*\\/\\*`),
+    );
+
+    assert.match(
+      (defaultPathFilter as TextDocumentFilter).pattern!,
+      /lib\/ruby\/gems\/\d\.\d\.\d\/\*\*\/\*/,
     );
 
     assert.match(


### PR DESCRIPTION
### Motivation

See https://github.com/Shopify/ruby-lsp/issues/2709#issuecomment-2422674648

The default gem path is `~/rubies/3.3.1/lib/ruby/gems/3.3.0`. We were correcting this to be `~/rubies/3.3.1/lib/ruby/3.3.0` because that's where default gems are installed.

However, some version managers still install gems under the non corrected path `~/rubies/3.3.1/lib/ruby/gems/3.3.0`.

### Implementation

We need to include both paths in the document selector. The normal path will account for version managers that install gems under the default directory and the corrected one will guarantee we handle requests for default gems.