### PR TITLE
Make sure `.ruby-lsp` directory always exists

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -61,6 +61,11 @@ module RubyLsp
     def setup!
       raise BundleNotLocked if @gemfile&.exist? && !@lockfile&.exist?
 
+      # Automatically create and ignore the .ruby-lsp folder for users
+      @custom_dir.mkpath unless @custom_dir.exist?
+      ignore_file = @custom_dir + ".gitignore"
+      ignore_file.write("*") unless ignore_file.exist?
+
       # Do not set up a custom bundle if LSP dependencies are already in the Gemfile
       if @dependencies["ruby-lsp"] &&
           @dependencies["debug"] &&
@@ -69,18 +74,8 @@ module RubyLsp
           "Ruby LSP> Skipping custom bundle setup since LSP dependencies are already in #{@gemfile}",
         )
 
-        # If the user decided to add `ruby-lsp` and `debug` (and potentially `ruby-lsp-rails`) to their Gemfile after
-        # having already run the Ruby LSP, then we need to remove the `.ruby-lsp` folder, otherwise we will run `bundle
-        # install` for the top level and try to execute the Ruby LSP using the custom bundle, which will fail since the
-        # gems are not installed there
-        @custom_dir.rmtree if @custom_dir.exist?
         return run_bundle_install
       end
-
-      # Automatically create and ignore the .ruby-lsp folder for users
-      @custom_dir.mkpath unless @custom_dir.exist?
-      ignore_file = @custom_dir + ".gitignore"
-      ignore_file.write("*") unless ignore_file.exist?
 
       write_custom_gemfile
 

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -5,14 +5,14 @@ require "test_helper"
 require "ruby_lsp/setup_bundler"
 
 class SetupBundlerTest < Minitest::Test
-  def test_does_nothing_if_both_ruby_lsp_and_debug_are_in_the_bundle
+  def test_does_not_create_composed_gemfile_if_ruby_lsp_and_debug_are_in_the_bundle
     stub_bundle_with_env(bundle_env)
     Bundler::LockfileParser.any_instance.expects(:dependencies).returns({ "ruby-lsp" => true, "debug" => true })
     run_script
-    refute_path_exists(".ruby-lsp")
+    refute_path_exists(".ruby-lsp/Gemfile")
   end
 
-  def test_does_nothing_if_both_ruby_lsp_and_debug_are_in_the_bundle2
+  def test_does_not_create_composed_gemfile_if_all_gems_are_in_the_bundle_for_rails_apps
     stub_bundle_with_env(bundle_env)
     Bundler::LockfileParser.any_instance.expects(:dependencies).returns({
       "ruby-lsp" => true,
@@ -21,28 +21,7 @@ class SetupBundlerTest < Minitest::Test
       "debug" => true,
     })
     run_script
-    refute_path_exists(".ruby-lsp")
-  end
-
-  def test_removes_ruby_lsp_folder_if_both_gems_were_added_to_the_bundle
-    stub_bundle_with_env(bundle_env)
-    Bundler::LockfileParser.any_instance.expects(:dependencies).returns({ "ruby-lsp" => true, "debug" => true })
-    FileUtils.mkdir(".ruby-lsp")
-    run_script
-    refute_path_exists(".ruby-lsp")
-  ensure
-    FileUtils.rm_r(".ruby-lsp") if Dir.exist?(".ruby-lsp")
-  end
-
-  def test_in_a_rails_app_removes_ruby_lsp_folder_if_all_gems_were_added_to_the_bundle
-    stub_bundle_with_env(bundle_env)
-    Bundler::LockfileParser.any_instance.expects(:dependencies)
-      .returns({ "ruby-lsp" => true, "ruby-lsp-rails" => true, "debug" => true })
-    FileUtils.mkdir(".ruby-lsp")
-    run_script
-    refute_path_exists(".ruby-lsp")
-  ensure
-    FileUtils.rm_r(".ruby-lsp") if Dir.exist?(".ruby-lsp")
+    refute_path_exists(".ruby-lsp/Gemfile")
   end
 
   def test_creates_custom_bundle
@@ -241,7 +220,7 @@ class SetupBundlerTest < Minitest::Test
     end
   end
 
-  def test_does_nothing_if_both_ruby_lsp_and_debug_are_gemspec_dependencies
+  def test_does_not_create_composed_gemfile_if_both_ruby_lsp_and_debug_are_gemspec_dependencies
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         # Write a fake Gemfile and gemspec
@@ -279,7 +258,7 @@ class SetupBundlerTest < Minitest::Test
           run_script(dir)
         end
 
-        refute_path_exists(".ruby-lsp")
+        refute_path_exists(".ruby-lsp/Gemfile")
       end
     end
   end


### PR DESCRIPTION
### Motivation

Another change aimed at the new launcher strategy. We will need to write the path to the Gemfile that needs to be used to setup Bundler to a file on every activation. That means, we will need the `.ruby-lsp` directory even when all gems are present in the bundle.

### Implementation

This PR ensures that the directory is always available.

### Automated Tests

Modified existing tests. Removed the ones that aren't relevant anymore.