### PR TITLE
Fix activation on files that were previously opened

### DIFF
--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -142,9 +142,14 @@ export class RubyLsp {
       const workspaceFolder = vscode.workspace.getWorkspaceFolder(
         activeDocument.uri,
       );
+      if (workspaceFolder) {
+        const existingWorkspace = this.workspaces.get(
+          workspaceFolder.uri.toString(),
+        );
 
-      if (workspaceFolder && workspaceFolder !== firstWorkspace) {
-        await this.activateWorkspace(workspaceFolder, true);
+        if (workspaceFolder && !existingWorkspace) {
+          await this.activateWorkspace(workspaceFolder, false);
+        }
       }
     }
 


### PR DESCRIPTION
If you close VS Code with a Ruby file opened and then reopen it, workspace activation would only happen when you open a different file (or close and reopen the same one). This should fix the problem.