### PR TITLE
Only retry building composed bundle if there's a custom Gemfile

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -233,7 +233,7 @@ module RubyLsp
       # Try to run the bundle install or update command. If that fails, it normally means that the custom lockfile is in
       # a bad state that no longer reflects the top level one. In that case, we can remove the whole directory, try
       # another time and give up if it fails again
-      if !system(env, command) && !@retry && @custom_dir.exist?
+      if !system(env, command) && !@retry && @custom_gemfile.exist?
         @retry = true
         @custom_dir.rmtree
         $stderr.puts("Ruby LSP> Running bundle install failed. Trying to re-generate the custom bundle from scratch")


### PR DESCRIPTION
### Motivation

I missed this in #2747. Now, the composed bundle directory will always exist, so we need to check for the existence of the custom Gemfile to decide whether to retry building it from scratch or not.