### PR TITLE
Handle server error telemetry events

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -41,6 +41,15 @@ import { WorkspaceChannel } from "./workspaceChannel";
 
 type EnabledFeatures = Record<string, boolean>;
 
+interface ServerErrorTelemetryEvent {
+  type: "error";
+  errorMessage: string;
+  errorClass: string;
+  stack: string;
+}
+
+type ServerTelemetryEvent = ServerErrorTelemetryEvent;
+
 // Get the executables to start the server based on the user's configuration
 function getLspExecutables(
   workspaceFolder: vscode.WorkspaceFolder,
@@ -318,6 +327,19 @@ export default class Client extends LanguageClient implements ClientInterface {
         params.textDocument.uri,
         params.textDocument.text,
       );
+    });
+
+    this.onTelemetry((event: ServerTelemetryEvent) => {
+      if (event.type === "error") {
+        this.telemetry.logError(
+          {
+            message: event.errorMessage,
+            name: event.errorClass,
+            stack: event.stack,
+          },
+          { serverVersion: this.serverVersion },
+        );
+      }
     });
   }
 


### PR DESCRIPTION
### Motivation

We need to be able to report errors from the server without having it be associated with any requests, so that we can get better insights into what causes initialization to fail.

### Implementation

Started handling the [telemetry/event](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#telemetry_event) notifications and redirecting it to the telemetry logger.