### PR TITLE
Include workspace name in error telemetry

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -451,7 +451,13 @@ export default class Client extends LanguageClient implements ClientInterface {
                 name: errorClass,
                 stack,
               },
-              { ...error.data, serverVersion: this.serverVersion },
+              {
+                ...error.data,
+                serverVersion: this.serverVersion,
+                workspace: new vscode.TelemetryTrustedValue(
+                  this.workingDirectory,
+                ),
+              },
             );
           }
         }


### PR DESCRIPTION
### Motivation

Some errors can be quite challenging to figure out without knowing which project they are happening on. Let's include the workspace name as part of the error telemetry so that we can better investigate.

### Implementation

Just added the workspace name as a part of the error telemetry.