### PR TITLE
Prevent passing version to `bin/bundle`

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -84,7 +84,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
     "bundle"
   end
 
-  exit exec(env, "#{base_bundle} exec ruby-lsp #{original_args.join(" ")}")
+  exit exec(env, "#{base_bundle} exec ruby-lsp #{original_args.join(" ")}".strip)
 end
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))

--- a/project-words
+++ b/project-words
@@ -8,6 +8,7 @@ binread
 Bizt
 Bizw
 bufnr
+binstub
 byteslice
 codepoint
 codepoints

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -4,11 +4,9 @@
 require "test_helper"
 
 class IntegrationTest < Minitest::Test
-  def setup
-    skip("CI only") unless ENV["CI"]
-  end
-
   def test_ruby_lsp_doctor_works
+    skip("CI only") unless ENV["CI"]
+
     in_isolation do
       system("bundle exec ruby-lsp --doctor")
       assert_equal(0, $CHILD_STATUS)
@@ -16,36 +14,100 @@ class IntegrationTest < Minitest::Test
   end
 
   def test_ruby_lsp_check_works
+    skip("CI only") unless ENV["CI"]
+
     in_isolation do
       system("bundle exec ruby-lsp-check")
       assert_equal(0, $CHILD_STATUS)
     end
   end
 
+  def test_adds_bundler_version_as_part_of_exec_command
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+        source "https://rubygems.org"
+        gem "ruby-lsp", path: "#{Bundler.root}"
+      GEMFILE
+
+      Bundler.with_unbundled_env do
+        capture_subprocess_io do
+          system("bundle install")
+
+          Object.any_instance.expects(:exec).with do |env, command|
+            env.key?("BUNDLE_GEMFILE") &&
+              env.key?("BUNDLER_VERSION") &&
+              /bundle _[\d\.]+_ exec ruby-lsp/.match?(command)
+          end.once.raises(StandardError.new("stop"))
+
+          # We raise intentionally to avoid continuing running the executable
+          assert_raises(StandardError) do
+            load(Gem.bin_path("ruby-lsp", "ruby-lsp"))
+          end
+        end
+      end
+    end
+  end
+
+  def test_avoids_bundler_version_if_local_bin_is_in_path
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+        source "https://rubygems.org"
+        gem "ruby-lsp", path: "#{Bundler.root}"
+      GEMFILE
+
+      FileUtils.mkdir(File.join(dir, "bin"))
+      FileUtils.touch(File.join(dir, "bin", "bundle"))
+
+      Bundler.with_unbundled_env do
+        capture_subprocess_io do
+          system("bundle install")
+
+          Object.any_instance.expects(:exec).with do |env, command|
+            env.key?("BUNDLE_GEMFILE") &&
+              !env.key?("BUNDLER_VERSION") &&
+              "bundle exec ruby-lsp" == command
+          end.once.raises(StandardError.new("stop"))
+
+          ENV["PATH"] = "./bin#{File::PATH_SEPARATOR}#{ENV["PATH"]}"
+          # We raise intentionally to avoid continuing running the executable
+          assert_raises(StandardError) do
+            load(Gem.bin_path("ruby-lsp", "ruby-lsp"))
+          end
+        end
+      end
+    end
+  end
+
   private
+
+  def in_temp_dir
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        yield(dir)
+      end
+    end
+  end
 
   def in_isolation(&block)
     gem_path = Bundler.root
-    Dir.mktmpdir do |dir|
-      Dir.chdir(dir) do
-        File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
-          source "https://rubygems.org"
-          gem "ruby-lsp", path: "#{gem_path}"
-        GEMFILE
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+        source "https://rubygems.org"
+        gem "ruby-lsp", path: "#{gem_path}"
+      GEMFILE
 
-        Bundler.with_unbundled_env do
-          capture_subprocess_io do
-            system("bundle install")
+      Bundler.with_unbundled_env do
+        capture_subprocess_io do
+          system("bundle install")
 
-            # Only do this after `bundle install` as to not change the lockfile
-            File.write(File.join(dir, "Gemfile"), <<~GEMFILE, mode: "a+")
-              # This causes ruby-lsp to run in its own directory without
-              # all the supplementary gems like rubocop
-              Dir.chdir("#{gem_path}")
-            GEMFILE
+          # Only do this after `bundle install` as to not change the lockfile
+          File.write(File.join(dir, "Gemfile"), <<~GEMFILE, mode: "a+")
+            # This causes ruby-lsp to run in its own directory without
+            # all the supplementary gems like rubocop
+            Dir.chdir("#{gem_path}")
+          GEMFILE
 
-            yield
-          end
+          yield
         end
       end
     end


### PR DESCRIPTION
### Motivation

Closes #2731

If the user has their local `bin` directory as part of the `PATH` and a `bin/bundle` binstub exists, we accidentally invoke the binstub rather than invoking `bundle exec`.

This is problematic because the binstub doesn't accept the same arguments as the bundle executable. Namely, we can't pass the version using `_2.5.12_` to ensure that the locked Bundler version is used and no restarts happen.

I'd argue that overriding the `bundle` executable with something that doesn't support the same arguments is not great as it prevents any tools from invoking Bundler directly, which is what they may legitimately want to do (this is the Ruby LSP's case).

However, it appears that this affects a considerable number of users, so let's put in a fix to prevent this error from happening.

### Implementation

If there's a `bin/bundle` and any parts of the path are pointing to the local `bin` directory, then we favour using the binstub with no version.

Otherwise, we continue doing the same as before. I'm hesitant to expand this to always use the binstub if present since people could have modified their binstubs and that may lead to other errors.

### Automated Tests

I added two new tests.