### PR TITLE
Report Ruby activation errors to telemetry

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -51,15 +51,18 @@ export class Ruby implements RubyInterface {
   private readonly context: vscode.ExtensionContext;
   private readonly customBundleGemfile?: string;
   private readonly outputChannel: WorkspaceChannel;
+  private readonly telemetry: vscode.TelemetryLogger;
 
   constructor(
     context: vscode.ExtensionContext,
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel: WorkspaceChannel,
+    telemetry: vscode.TelemetryLogger,
   ) {
     this.context = context;
     this.workspaceFolder = workspaceFolder;
     this.outputChannel = outputChannel;
+    this.telemetry = telemetry;
 
     const customBundleGemfile: string = vscode.workspace
       .getConfiguration("rubyLsp")
@@ -125,6 +128,10 @@ export class Ruby implements RubyInterface {
       try {
         await this.runManagerActivation();
       } catch (error: any) {
+        this.telemetry.logError(error, {
+          versionManager: this.versionManager.identifier,
+        });
+
         // If an error occurred and a global Ruby path is configured, then we can try to fallback to that
         const globalRubyPath = vscode.workspace
           .getConfiguration("rubyLsp")

--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -138,7 +138,12 @@ async function launchClient(workspaceUri: vscode.Uri) {
     }
   }
 
-  const ruby = new Ruby(context, workspaceFolder, outputChannel);
+  const ruby = new Ruby(
+    context,
+    workspaceFolder,
+    outputChannel,
+    FAKE_TELEMETRY,
+  );
   await ruby.activateRuby();
   ruby.env.RUBY_LSP_BYPASS_TYPECHECKER = "true";
 

--- a/vscode/src/test/suite/debugger.test.ts
+++ b/vscode/src/test/suite/debugger.test.ts
@@ -13,6 +13,8 @@ import { WorkspaceChannel } from "../../workspaceChannel";
 import { LOG_CHANNEL, asyncExec } from "../../common";
 import { RUBY_VERSION } from "../rubyVersion";
 
+import { FAKE_TELEMETRY } from "./fakeTelemetry";
+
 suite("Debugger", () => {
   test("Provide debug configurations returns the default configs", () => {
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
@@ -203,7 +205,12 @@ suite("Debugger", () => {
       name: path.basename(tmpPath),
       index: 0,
     };
-    const ruby = new Ruby(context, workspaceFolder, outputChannel);
+    const ruby = new Ruby(
+      context,
+      workspaceFolder,
+      outputChannel,
+      FAKE_TELEMETRY,
+    );
     await ruby.activateRuby();
 
     try {

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -11,6 +11,8 @@ import { LOG_CHANNEL } from "../../common";
 import * as common from "../../common";
 import { ACTIVATION_SEPARATOR } from "../../ruby/versionManager";
 
+import { FAKE_TELEMETRY } from "./fakeTelemetry";
+
 suite("Ruby environment activation", () => {
   const workspacePath = path.dirname(
     path.dirname(path.dirname(path.dirname(__dirname))),
@@ -48,7 +50,12 @@ suite("Ruby environment activation", () => {
         },
       } as unknown as vscode.WorkspaceConfiguration);
 
-    const ruby = new Ruby(context, workspaceFolder, outputChannel);
+    const ruby = new Ruby(
+      context,
+      workspaceFolder,
+      outputChannel,
+      FAKE_TELEMETRY,
+    );
     await ruby.activateRuby();
 
     assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
@@ -80,7 +87,12 @@ suite("Ruby environment activation", () => {
         },
       } as unknown as vscode.WorkspaceConfiguration);
 
-    const ruby = new Ruby(context, workspaceFolder, outputChannel);
+    const ruby = new Ruby(
+      context,
+      workspaceFolder,
+      outputChannel,
+      FAKE_TELEMETRY,
+    );
 
     process.env.VERBOSE = "1";
     process.env.DEBUG = "WARN";
@@ -123,7 +135,12 @@ suite("Ruby environment activation", () => {
       stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
     });
 
-    const ruby = new Ruby(context, workspaceFolder, outputChannel);
+    const ruby = new Ruby(
+      context,
+      workspaceFolder,
+      outputChannel,
+      FAKE_TELEMETRY,
+    );
     await ruby.activateRuby();
     execStub.restore();
     configStub.restore();

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -44,7 +44,12 @@ export class Workspace implements WorkspaceInterface {
       LOG_CHANNEL,
     );
     this.telemetry = telemetry;
-    this.ruby = new Ruby(context, workspaceFolder, this.outputChannel);
+    this.ruby = new Ruby(
+      context,
+      workspaceFolder,
+      this.outputChannel,
+      telemetry,
+    );
     this.createTestItems = createTestItems;
     this.isMainWorkspace = isMainWorkspace;
     this.virtualDocuments = virtualDocuments;


### PR DESCRIPTION
### Motivation

Let's add error telemetry for Ruby activation failures so that we can better understand under which situations this most commonly happens. We can then aim to add helpers and special integrations to reduce user's frustrations.

### Implementation

Started requiring the telemetry object for instantiating Ruby and started reporting the errors including the version manager identifier.

### Automated Tests

Adapted existing tests.