### PR TITLE
Use Bundler CLI directly and send errors to telemetry

### DIFF
--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -16,58 +16,78 @@ headers = $stdin.gets("\r\n\r\n")
 content_length = headers[/Content-Length: (\d+)/i, 1].to_i
 raw_initialize = $stdin.read(content_length)
 
-bundle_gemfile_file = File.join(".ruby-lsp", "bundle_gemfile")
-locked_bundler_version_file = File.join(".ruby-lsp", "locked_bundler_version")
-
 # Compose the Ruby LSP bundle in a forked process so that we can require gems without polluting the main process
 # `$LOAD_PATH` and `Gem.loaded_specs`. Windows doesn't support forking, so we need a separate path to support it
 pid = if Gem.win_platform?
-  spawn(Gem.ruby, File.expand_path("../lib/ruby_lsp/scripts/compose_bundle_windows.rb", __dir__), raw_initialize)
+  # Since we can't fork on Windows and spawn won't carry over the existing load paths, we need to explicitly pass that
+  # down to the child process or else requiring gems during composing the bundle will fail
+  load_path = $LOAD_PATH.flat_map do |path|
+    ["-I", File.expand_path(path)]
+  end
+
+  Process.spawn(
+    Gem.ruby,
+    *load_path,
+    File.expand_path("../lib/ruby_lsp/scripts/compose_bundle_windows.rb", __dir__),
+    raw_initialize,
+  )
 else
   fork do
-    $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
-    require "ruby_lsp/scripts/compose_bundle"
+    require_relative "../lib/ruby_lsp/scripts/compose_bundle"
     compose(raw_initialize)
   end
 end
 
-# Wait until the composed Bundle is finished
-Process.wait(pid)
+begin
+  # Wait until the composed Bundle is finished
+  Process.wait(pid)
+rescue Errno::ECHILD
+  # In theory, the child process can finish before we even get to the wait call, but that is not an error
+end
 
 begin
+  bundle_env_path = File.join(".ruby-lsp", "bundle_env")
   # We can't require `bundler/setup` because that file prematurely exits the process if setup fails. However, we can't
   # simply require bundler either because the version required might conflict with the one locked in the composed
   # bundle. We need the composed bundle sub-process to inform us of the locked Bundler version, so that we can then
   # activate the right spec and require the exact Bundler version required by the app
-  if File.exist?(locked_bundler_version_file)
-    locked_bundler_version = File.read(locked_bundler_version_file)
-    Gem::Specification.find_by_name("bundler", locked_bundler_version).activate
-  end
+  if File.exist?(bundle_env_path)
+    env = File.readlines(bundle_env_path).to_h { |line| line.chomp.split("=", 2) }
+    ENV.merge!(env)
 
-  require "bundler"
-  Bundler.ui.level = :silent
+    if env["BUNDLER_VERSION"]
+      Gem::Specification.find_by_name("bundler", env["BUNDLER_VERSION"]).activate
+    end
 
-  # The composed bundle logic informs the main process about which Gemfile to setup Bundler with
-  if File.exist?(bundle_gemfile_file)
-    ENV["BUNDLE_GEMFILE"] = File.read(bundle_gemfile_file)
+    require "bundler"
+    Bundler.ui.level = :silent
     Bundler.setup
+    $stderr.puts("Composed Bundle set up successfully")
   end
 rescue StandardError => e
   # If installing gems failed for any reason, we don't want to exit the process prematurely. We can still provide most
   # features in a degraded mode. We simply save the error so that we can report to the user that certain gems might be
   # missing, but we respect the LSP life cycle
   setup_error = e
+  $stderr.puts("Failed to set up composed Bundle\n#{e.full_message}")
 
-  # If we failed to set up the bundle, the minimum we need is to have our own dependencies activated so that we can
-  # require the gems the LSP depends on. If even that fails, then there's no way we can continue to run the language
-  # server
-  Gem::Specification.find_by_name("ruby-lsp").activate
+  # If Bundler.setup fails, we need to restore the original $LOAD_PATH so that we can still require the Ruby LSP server
+  # in degraded mode
+  $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+ensure
+  require "fileutils"
+  FileUtils.rm(bundle_env_path) if File.exist?(bundle_env_path)
 end
 
-# Now that the bundle is set up, we can begin actually launching the server
+error_path = File.join(".ruby-lsp", "install_error")
 
-$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+install_error = if File.exist?(error_path)
+  Marshal.load(File.read(error_path))
+end
 
+# Now that the bundle is set up, we can begin actually launching the server. Note that `Bundler.setup` will have already
+# configured the load path using the version of the Ruby LSP present in the composed bundle. Do not push any Ruby LSP
+# paths into the load path manually or we may end up requiring the wrong version of the gem
 require "ruby_lsp/load_sorbet"
 require "ruby_lsp/internal"
 
@@ -91,7 +111,17 @@ $> = $stderr
 
 initialize_request = JSON.parse(raw_initialize, symbolize_names: true) if raw_initialize
 
-RubyLsp::Server.new(
-  setup_error: setup_error,
-  initialize_request: initialize_request,
-).start
+begin
+  RubyLsp::Server.new(
+    install_error: install_error,
+    setup_error: setup_error,
+    initialize_request: initialize_request,
+  ).start
+rescue ArgumentError
+  # If the launcher is booting an outdated version of the server, then the initializer doesn't accept a keyword splat
+  # and we already read the initialize request from the stdin pipe. In this case, we need to process the initialize
+  # request manually and then start the main loop
+  server = RubyLsp::Server.new
+  server.process_message(initialize_request)
+  server.start
+end

--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -12,6 +12,7 @@ module RubyLsp
     def initialize(**options)
       @test_mode = T.let(options[:test_mode], T.nilable(T::Boolean))
       @setup_error = T.let(options[:setup_error], T.nilable(StandardError))
+      @install_error = T.let(options[:install_error], T.nilable(StandardError))
       @writer = T.let(Transport::Stdio::Writer.new, Transport::Stdio::Writer)
       @reader = T.let(Transport::Stdio::Reader.new, Transport::Stdio::Reader)
       @incoming_queue = T.let(Thread::Queue.new, Thread::Queue)

--- a/lib/ruby_lsp/scripts/compose_bundle.rb
+++ b/lib/ruby_lsp/scripts/compose_bundle.rb
@@ -2,10 +2,10 @@
 # frozen_string_literal: true
 
 def compose(raw_initialize)
-  require "ruby_lsp/setup_bundler"
+  require_relative "../setup_bundler"
   require "json"
   require "uri"
-  require "core_ext/uri"
+  require_relative "../../core_ext/uri"
 
   initialize_request = JSON.parse(raw_initialize, symbolize_names: true)
   workspace_uri = initialize_request.dig(:params, :workspaceFolders, 0, :uri)
@@ -13,6 +13,8 @@ def compose(raw_initialize)
   workspace_path ||= Dir.pwd
 
   env = RubyLsp::SetupBundler.new(workspace_path, launcher: true).setup!
-  File.write(File.join(".ruby-lsp", "bundle_gemfile"), env["BUNDLE_GEMFILE"])
-  File.write(File.join(".ruby-lsp", "locked_bundler_version"), env["BUNDLER_VERSION"]) if env["BUNDLER_VERSION"]
+  File.write(
+    File.join(".ruby-lsp", "bundle_env"),
+    env.map { |k, v| "#{k}=#{v}" }.join("\n"),
+  )
 end

--- a/lib/ruby_lsp/scripts/compose_bundle_windows.rb
+++ b/lib/ruby_lsp/scripts/compose_bundle_windows.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.expand_path("../../../lib", __dir__))
 require_relative "compose_bundle"
 
 # When this is invoked on Windows, we pass the raw initialize as an argument to this script. On other platforms, we

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -79,6 +79,14 @@ module RubyLsp
           params: Interface::LogMessageParams.new(type: type, message: message),
         )
       end
+
+      sig { params(data: T::Hash[Symbol, T.untyped]).returns(Notification) }
+      def telemetry(data)
+        new(
+          method: "telemetry/event",
+          params: data,
+        )
+      end
     end
 
     extend T::Sig

--- a/sorbet/rbi/shims/bundler.rbi
+++ b/sorbet/rbi/shims/bundler.rbi
@@ -1,6 +1,26 @@
 # typed: true
 
-class Bundler::Settings
-  sig { params(name: String).returns(String) }
-  def self.key_for(name); end
+module Bundler
+  class Settings
+    sig { params(name: String).returns(String) }
+    def self.key_for(name); end
+  end
+
+  module CLI
+    class Install
+      sig { params(options: T::Hash[String, T.untyped]).void }
+      def initialize(options); end
+
+      sig { void }
+      def run; end
+    end
+
+    class Update
+      sig { params(options: T::Hash[String, T.untyped], gems: T::Array[String]).void }
+      def initialize(options, gems); end
+
+      sig { void }
+      def run; end
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

This PR starts invoking the Bundler CLI objects for install and update directly on the new launcher strategy instead of shelling out.

This will provide us with two benefits: one is performance since we don't have to start a whole new process to start running Bundler commands. The second is that we can now rescue the errors and send them to telemetry, so that we can understand what are the common failures to bundle install and start making it more robust.

### Implementation

The idea is to invoke `Bundler::CLI::{Install,Update}` as needed, rescue errors and report them to the editor as telemetry.

I'm also enabling YJIT in the child process that sets up the composed bundle, since it speeds up both install and update.

### Automated Tests

Added tests.