### PR TITLE
Highlight definition and control block structures

### DIFF
--- a/test/expectations/document_highlight/class_declaration.exp.json
+++ b/test/expectations/document_highlight/class_declaration.exp.json
@@ -1,9 +1,36 @@
 {
   "params": [
     {
-      "line": 1,
+      "line": 0,
       "character": 2
     }
   ],
-  "result": []
+  "result": [
+    {
+      "range": {
+        "start": {
+          "line": 4,
+          "character": 0
+        },
+        "end": {
+          "line": 4,
+          "character": 3
+        }
+      },
+      "kind": 1
+    },
+    {
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 0
+        },
+        "end": {
+          "line": 0,
+          "character": 5
+        }
+      },
+      "kind": 1
+    }
+  ]
 }


### PR DESCRIPTION
### Motivation

Closes #2494

### Implementation

If the cursor is on a definition or control node, both the start and end of the node will be highlighted.

### Automated Tests

Amended existing test case.

### Manual Tests

Place the cursor on one of the definition or control nodes.

[Screencast from 25-10-24 08:44:06 AM IST.webm](https://github.com/user-attachments/assets/e7899805-0244-4853-ae31-587236463691)

