### PR TITLE
Avoid showing private methods for external references

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -440,8 +440,11 @@ module RubyLsp
         return unless range
 
         guessed_type = type.is_a?(TypeInferrer::GuessedType) && type.name
+        external_references = @node_context.fully_qualified_name != type.name
 
         @index.method_completion_candidates(method_name, type.name).each do |entry|
+          next if entry.visibility != RubyIndexer::Entry::Visibility::PUBLIC && external_references
+
           entry_name = entry.name
           owner_name = entry.owner&.name
 


### PR DESCRIPTION
### Motivation

I noticed that we were suggesting private methods even if the reference would be invalid. This PR fixes that.

### Implementation

You can only call a private method from within the namespace where it is defined, so we can just check if the resolved type is the same as the current nesting.

### Automated Tests

Added a test that reproduces the issue and doesn't pass before the fix.