### PR TITLE
Look for Shadowenv in specific Homebrew path and check for untrusted workspace explicitly

### DIFF
--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -22,9 +22,11 @@ export class Shadowenv extends VersionManager {
       );
     }
 
+    const shadowenvExec = await this.findShadowenvExec();
+
     try {
       const parsedResult = await this.runEnvActivationScript(
-        "shadowenv exec -- ruby",
+        `${shadowenvExec} exec -- ruby`,
       );
 
       return {
@@ -68,5 +70,25 @@ export class Shadowenv extends VersionManager {
         "Cannot activate Ruby environment in an untrusted workspace",
       );
     }
+  }
+
+  // Tries to find the Shadowenv executable either directly in known paths or in the PATH
+  async findShadowenvExec() {
+    // If we can find the Shadowenv executable in the Homebrew installation path, then prefer it over relying on the
+    // executable being available in the PATH. Sometimes, users might have shell scripts or other extensions that can
+    // mess up the PATH and then we can't find the Shadowenv executable
+    const possibleUris = [vscode.Uri.file("/opt/homebrew/bin/shadowenv")];
+
+    for (const uri of possibleUris) {
+      try {
+        await vscode.workspace.fs.stat(uri);
+        this.outputChannel.info(`Found Shadowenv executable at ${uri.fsPath}`);
+        return uri.fsPath;
+      } catch (error: any) {
+        // continue searching
+      }
+    }
+
+    return "shadowenv";
   }
 }

--- a/vscode/src/test/suite/ruby/shadowenv.test.ts
+++ b/vscode/src/test/suite/ruby/shadowenv.test.ts
@@ -212,23 +212,12 @@ suite("Shadowenv", () => {
       .onFirstCall()
       .rejects(new Error("shadowenv: command not found"))
       .onSecondCall()
-      .resolves({ stdout: "", stderr: "" });
-
-    const windowStub = sinon
-      .stub(vscode.window, "showErrorMessage")
-      .resolves("Cancel" as any);
+      .rejects(new Error("shadowenv: command not found"));
 
     await assert.rejects(async () => {
       await shadowenv.activate();
     });
 
-    assert.ok(
-      windowStub.calledOnceWith(
-        "Couldn't find shadowenv executable. Double-check that it's installed and that it's in your PATH.",
-      ),
-    );
-
     execStub.restore();
-    windowStub.restore();
   });
 });


### PR DESCRIPTION
### Motivation

We're seeing some errors related to the Shadowenv integration that we should try to address for a smoother experience.

The first part is that we're seeing more devs with the error of not having `shadowenv` in their `PATH`. This error is still a bit obscure. Every time I paired with someone it turned out they had too many shell plugins and extension and couldn't tell what was causing the integration to break.

The second part is that we're not being very precise when detecting that a workspace is untrusted and that is putting unrelated errors in the same bucket.

### Implementation

I split the fixes in two commits:

1. Started searching for the Shadowenv executable in the Homebrew installation path first. That way, even if the `$PATH` got mutated or couldn't be setup for whatever reason, we should still find the executable
2. Shadowenv emits a specific error message if the workspace is untrusted. We should look for that specifically so that we can avoid putting unrelated errors in the same group

### Automated Tests

Made small adjustments to the tests.