### PR TITLE
Add some necessary guards for operating with a partial bundle

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -1,16 +1,26 @@
 # typed: strict
 # frozen_string_literal: true
 
+# If there's no top level Gemfile, don't load RuboCop from a global installation
+begin
+  Bundler.with_original_env { Bundler.default_gemfile }
+rescue Bundler::GemfileNotFound
+  return
+end
+
+# Ensure that RuboCop is available
 begin
   require "rubocop"
 rescue LoadError
   return
 end
 
+# Ensure that RuboCop is at least version 1.4.0
 begin
   gem("rubocop", ">= 1.4.0")
 rescue LoadError
-  raise StandardError, "Incompatible RuboCop version. Ruby LSP requires >= 1.4.0"
+  $stderr.puts "Incompatible RuboCop version. Ruby LSP requires >= 1.4.0"
+  return
 end
 
 if RuboCop.const_defined?(:LSP) # This condition will be removed when requiring RuboCop >= 1.61.

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1029,7 +1029,7 @@ module RubyLsp
 
     sig { params(message: T::Hash[Symbol, T.untyped]).void }
     def workspace_dependencies(message)
-      response = begin
+      response = if @global_state.top_level_bundle
         Bundler.with_original_env do
           definition = Bundler.definition
           dep_keys = definition.locked_deps.keys.to_set
@@ -1043,7 +1043,7 @@ module RubyLsp
             }
           end
         end
-      rescue Bundler::GemfileNotFound, Bundler::GitError
+      else
         []
       end
 


### PR DESCRIPTION
### Motivation

For launcher mode #2774, we will need to add some necessary guards for operating with a partial bundle. For example, if `Bundler.setup` fails, then the load path is not going to be configured and we cannot try to load RuboCop.

Similarly, since we will start allowing running the server even the top level bundle isn't locked yet, we need to protect requests like workspace dependencies.

### Implementation

Just added a few necessary guards to prevent breaking under failure scenarios.