### PR TITLE
Ensure absolute lockfile remotes for gems nested inside project

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -7,6 +7,7 @@ require "fileutils"
 require "pathname"
 require "digest"
 require "time"
+require "uri"
 
 # This file is a script that will configure a custom bundle for the Ruby LSP. The custom bundle allows developers to use
 # the Ruby LSP without including the gem in their application's Gemfile while at the same time giving us access to the
@@ -300,7 +301,7 @@ module RubyLsp
 
         # We should only apply the correction if the remote is a relative path. It might also be a URI, like
         # `https://rubygems.org` or an absolute path, in which case we shouldn't do anything
-        if path&.start_with?(".")
+        if path && !URI(path).scheme
           "remote: #{File.expand_path(path, T.must(@gemfile).dirname)}"
         else
           match


### PR DESCRIPTION
### Motivation

I discovered this problem while working on #2774 and I frankly don't understand how it wasn't surfaced before.

We were checking for a leading dot to perform remote relative path correction, but when you have gems nested inside a project, the relative path may not necessarily begin with a dot.

For example, if you have this in your Gemfile

```ruby
gem "nested", path: "gems/nested"
```

Then the remote won't necessarily be `../gems/nested`. It might just be `gems/nested`, which is also a relative path. We need to convert those into absolute paths too, otherwise setting up the composed bundle fails.

### Implementation

I started using `URI` to check if the remote has a scheme. If it has a scheme, like `http`, then we don't want to perform any corrections.

If it has no scheme, then it's a file path and we can turn it into absolute.

### Automated Tests

Added a test that doesn't pass before the fix.