### PR TITLE
Show that server is running on degraded mode

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -259,6 +259,7 @@ module RubyLsp
           version: VERSION,
         },
         formatter: @global_state.formatter,
+        degraded_mode: !!(@install_error || @setup_error),
       }
 
       send_message(Result.new(id: message[:id], response: response))

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -279,6 +279,7 @@ export default class Client extends LanguageClient implements ClientInterface {
   public readonly ruby: Ruby;
   public serverVersion?: string;
   public addons?: Addon[];
+  public degraded = false;
   private readonly workingDirectory: string;
   private readonly telemetry: vscode.TelemetryLogger;
   private readonly createTestItems: (response: CodeLens[]) => void;
@@ -355,6 +356,11 @@ export default class Client extends LanguageClient implements ClientInterface {
   async afterStart() {
     this.#formatter = this.initializeResult?.formatter;
     this.serverVersion = this.initializeResult?.serverInfo?.version;
+
+    if (this.initializeResult?.degraded_mode) {
+      this.degraded = this.initializeResult?.degraded_mode;
+    }
+
     await this.fetchAddons();
   }
 

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -48,6 +48,7 @@ export interface ClientInterface {
   formatter: string;
   addons?: Addon[];
   serverVersion?: string;
+  degraded: boolean;
   sendRequest<T>(
     method: string,
     param: any,

--- a/vscode/src/status.ts
+++ b/vscode/src/status.ts
@@ -92,8 +92,15 @@ export class ServerStatus extends StatusItem {
         this.item.text = workspace.lspClient.serverVersion
           ? `Ruby LSP v${workspace.lspClient.serverVersion}: Running`
           : "Ruby LSP: Running";
+
+        if (workspace.lspClient.degraded) {
+          this.item.text += " (degraded)";
+          this.item.severity = vscode.LanguageStatusSeverity.Warning;
+        } else {
+          this.item.severity = vscode.LanguageStatusSeverity.Information;
+        }
+
         this.item.command!.arguments = [STARTED_SERVER_OPTIONS];
-        this.item.severity = vscode.LanguageStatusSeverity.Information;
         break;
       }
       case State.Starting: {

--- a/vscode/src/test/suite/status.test.ts
+++ b/vscode/src/test/suite/status.test.ts
@@ -41,6 +41,7 @@ suite("StatusItems", () => {
           formatter: "none",
           serverVersion: "1.0.0",
           sendRequest: <T>() => Promise.resolve([] as T),
+          degraded: false,
         },
         error: false,
       };
@@ -78,6 +79,7 @@ suite("StatusItems", () => {
           formatter: "none",
           serverVersion: "1.0.0",
           sendRequest: <T>() => Promise.resolve([] as T),
+          degraded: false,
         },
         error: false,
       };
@@ -128,6 +130,19 @@ suite("StatusItems", () => {
       );
       assert.strictEqual(status.item.name, "Ruby LSP Server Status");
     });
+
+    test("Refresh when server is in degraded mode", () => {
+      workspace.lspClient!.degraded = true;
+      status.refresh(workspace);
+      assert.strictEqual(
+        status.item.text,
+        "Ruby LSP v1.0.0: Running (degraded)",
+      );
+      assert.strictEqual(
+        status.item.severity,
+        vscode.LanguageStatusSeverity.Warning,
+      );
+    });
   });
 
   suite("ExperimentalFeaturesStatus", () => {
@@ -141,6 +156,7 @@ suite("StatusItems", () => {
           formatter,
           serverVersion: "1.0.0",
           sendRequest: <T>() => Promise.resolve([] as T),
+          degraded: false,
         },
         error: false,
       };
@@ -170,6 +186,7 @@ suite("StatusItems", () => {
           formatter: "none",
           serverVersion: "1.0.0",
           sendRequest: <T>() => Promise.resolve([] as T),
+          degraded: false,
         },
         error: false,
       };
@@ -258,6 +275,7 @@ suite("StatusItems", () => {
           state: State.Running,
           formatter: "auto",
           serverVersion: "1.0.0",
+          degraded: false,
           sendRequest: <T>() => Promise.resolve([] as T),
         },
         error: false,
@@ -283,6 +301,7 @@ suite("StatusItems", () => {
           addons: undefined,
           state: State.Running,
           formatter: "auto",
+          degraded: false,
           serverVersion: "1.0.0",
           sendRequest: <T>() => Promise.resolve([] as T),
         },


### PR DESCRIPTION
### Motivation

Let's show in the language status item if the server is running in degraded mode, so that it's easier to realize why full functionality may not be available.

### Implementation

In essence, if there was an install or a setup error, then we are in degraded mode. We return that as part of the initialize result and use that to change the status entry message.

### Automated Tests

Added a test.