### PR TITLE
Print Bundler progress to stderr when invoking CLI directly

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -32,6 +32,7 @@ module RubyLsp
       @project_path = project_path
       @branch = T.let(options[:branch], T.nilable(String))
       @launcher = T.let(options[:launcher], T.nilable(T::Boolean))
+      patch_thor_to_print_progress_to_stderr! if @launcher
 
       # Regular bundle paths
       @gemfile = T.let(
@@ -399,6 +400,22 @@ module RubyLsp
       end
 
       "bundle"
+    end
+
+    sig { void }
+    def patch_thor_to_print_progress_to_stderr!
+      return unless defined?(Bundler::Thor::Shell::Basic)
+
+      Bundler::Thor::Shell::Basic.prepend(Module.new do
+        extend T::Sig
+
+        sig { returns(IO) }
+        def stdout
+          $stderr
+        end
+      end)
+
+      Bundler.ui.level = :info
     end
   end
 end

--- a/project-words
+++ b/project-words
@@ -27,6 +27,7 @@ FIXEDENCODING
 Floo
 fnmatch
 fooo
+gemname
 hostedtoolcache
 importmap
 indexables

--- a/sorbet/rbi/shims/bundler.rbi
+++ b/sorbet/rbi/shims/bundler.rbi
@@ -23,4 +23,10 @@ module Bundler
       def run; end
     end
   end
+
+  module Thor # rubocop:disable Style/ClassAndModuleChildren
+    module Shell
+      class Basic; end
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

In launcher mode #2778, we don't see the Bundler output printed because we're setting the UI to silent. If we make the Thor shell used by Bundler print to stderr instead of stdout, then we can see the output normally.

### Implementation

Started prepending a patch to the Thor shell to guarantee we can only print to stderr. This is only used in launch mode.

### Automated Tests

Added a test.