### PR TITLE
Fix a typo in the activation script

### DIFF
--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -19,7 +19,7 @@ export const ACTIVATION_SEPARATOR = "RUBY_LSP_ACTIVATION_SEPARATOR";
 export abstract class VersionManager {
   public activationScript = [
     `STDERR.print("${ACTIVATION_SEPARATOR}" + `,
-    "{ env: ENV.to_h, yjit: !!defined?(RubyVM:: YJIT), version: RUBY_VERSION, gemPath: Gem.path }.to_json + ",
+    "{ env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION, gemPath: Gem.path }.to_json + ",
     `"${ACTIVATION_SEPARATOR}")`,
   ].join("");
 


### PR DESCRIPTION
I for sure thought it would change meaning but turns out this space doesn't matter and the ast is the same.