### PR TITLE
Handle responses for show window request and delegate to add-ons

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -194,6 +194,13 @@ module RubyLsp
     sig { abstract.returns(String) }
     def version; end
 
+    # Handle a response from a window/showMessageRequest request. Add-ons must include the addon_name as part of the
+    # original request so that the response is delegated to the correct add-on and must override this method to handle
+    # the response
+    # https://microsoft.github.io/language-server-protocol/specification#window_showMessageRequest
+    sig { overridable.params(title: String).void }
+    def handle_window_show_message_response(title); end
+
     # Creates a new CodeLens listener. This method is invoked on every CodeLens request
     sig do
       overridable.params(

--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -21,7 +21,11 @@ module RubyLsp
     attr_reader :encoding
 
     sig { returns(T::Boolean) }
-    attr_reader :supports_watching_files, :experimental_features, :supports_request_delegation, :top_level_bundle
+    attr_reader :supports_watching_files,
+      :experimental_features,
+      :supports_request_delegation,
+      :top_level_bundle,
+      :window_show_message_supports_extra_properties
 
     sig { returns(T::Array[String]) }
     attr_reader :supported_resource_operations
@@ -55,6 +59,7 @@ module RubyLsp
         end,
         T::Boolean,
       )
+      @window_show_message_supports_extra_properties = T.let(false, T::Boolean)
     end
 
     sig { params(addon_name: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -148,6 +153,15 @@ module RubyLsp
       @supports_request_delegation = options.dig(:capabilities, :experimental, :requestDelegation) || false
       supported_resource_operations = options.dig(:capabilities, :workspace, :workspaceEdit, :resourceOperations)
       @supported_resource_operations = supported_resource_operations if supported_resource_operations
+
+      supports_additional_properties = options.dig(
+        :capabilities,
+        :window,
+        :showMessage,
+        :messageActionItem,
+        :additionalPropertiesSupport,
+      )
+      @window_show_message_supports_extra_properties = supports_additional_properties || false
 
       notifications
     end

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -81,6 +81,8 @@ module RubyLsp
         workspace_did_change_watched_files(message)
       when "workspace/symbol"
         workspace_symbol(message)
+      when "window/showMessageRequest"
+        window_show_message_request(message)
       when "rubyLsp/textDocument/showSyntaxTree"
         text_document_show_syntax_tree(message)
       when "rubyLsp/workspace/dependencies"
@@ -1219,6 +1221,15 @@ module RubyLsp
       configuration.workspace_path = @global_state.workspace_path
       # The index expects snake case configurations, but VS Code standardizes on camel case settings
       configuration.apply_config(indexing_options.transform_keys { |key| key.to_s.gsub(/([A-Z])/, "_\\1").downcase })
+    end
+
+    sig { params(message: T::Hash[Symbol, T.untyped]).void }
+    def window_show_message_request(message)
+      addon_name = message[:addon_name]
+      addon = Addon.addons.find { |addon| addon.name == addon_name }
+      return unless addon
+
+      addon.handle_window_show_message_response(message[:title])
     end
   end
 end


### PR DESCRIPTION
### Motivation

Add-ons won't have a lot of flexibility when it comes to UI elements since the LSP specification doesn't prescribe that. However, we can still allow for a certain degree of interactions by delegating responses of the `window/showMessageRequest` request.

This request made by the server allows LSPs to show a dialog with buttons to the user. The response includes which button was clicked and any other attributes (as long as the client supports additional properties).

We can use this to allow for more interactivity for add-ons. The current use case we will use this for is letting the Rails add-on inform the user there's a pending migration with a button to run it.

### Implementation

Started handling responses for `window/showMessageRequest`. We enforce the add-ons must provide their name as part of the original request in order to receive the response delegated appropriately.

Also, started remembering if the client supports additional properties. Add-ons can only use this mechanism in such cases because otherwise they don't have the means to inform us of their name for delegation.

### Automated Tests

Added a test.