### PR TITLE
Fix documentation reference when methods are too close

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -660,10 +660,21 @@ module RubyIndexer
 
       comments = +""
 
-      start_line = node.location.start_line - 1
-      start_line -= 1 unless @comments_by_line.key?(start_line)
+      comment_lines = [node.location.start_line - 1, node.location.start_line - 2]
 
+      comment_lines.each do |line_number|
+        collect_comment_lines(line_number, comments)
+      end
+
+      comments.chomp!
+      comments
+    end
+
+    sig { params(start_line: Integer, comments: String).void }
+    def collect_comment_lines(start_line, comments)
       start_line.downto(1) do |line|
+        break if line < 1
+
         comment = @comments_by_line[line]
         break unless comment
 
@@ -677,10 +688,9 @@ module RubyIndexer
         comment_content.delete_prefix!("#")
         comment_content.delete_prefix!(" ")
         comments.prepend("#{comment_content}\n")
-      end
 
-      comments.chomp!
-      comments
+        @comments_by_line.delete(line)
+      end
     end
 
     sig { params(name: String).returns(String) }

--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -663,23 +663,7 @@ module RubyIndexer
 
       start_line = node.location.start_line - 1
       start_line -= 1 unless comment_exists_at?(start_line)
-
-      append_comment_lines(start_line, comments)
-
-      comments.chomp!
-      comments
-    end
-
-    sig { params(line: Integer).returns(T::Boolean) }
-    def comment_exists_at?(line)
-      @comments_by_line.key?(line) || !@source_lines[line - 1].to_s.strip.empty?
-    end
-
-    sig { params(start_line: Integer, comments: String).void }
-    def append_comment_lines(start_line, comments)
       start_line.downto(1) do |line|
-        break if line < 1
-
         comment = @comments_by_line[line]
         break unless comment
 
@@ -694,6 +678,14 @@ module RubyIndexer
         comment_content.delete_prefix!(" ")
         comments.prepend("#{comment_content}\n")
       end
+
+      comments.chomp!
+      comments
+    end
+
+    sig { params(line: Integer).returns(T::Boolean) }
+    def comment_exists_at?(line)
+      @comments_by_line.key?(line) || !@source_lines[line - 1].to_s.strip.empty?
     end
 
     sig { params(name: String).returns(String) }

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -149,6 +149,39 @@ module RubyIndexer
       end
     end
 
+    def test_comments_documentation
+      index(<<~RUBY)
+        # Documentation for Foo
+
+        class Foo
+          # ####################
+          # Documentation for bar
+          # ####################
+          #
+          def bar
+          end
+
+          # test
+
+          # Documentation for baz
+          def baz; end
+          def ban; end
+        end
+      RUBY
+
+      foo_comment = @index["Foo"].first.comments
+      assert_equal("Documentation for Foo", foo_comment)
+
+      bar_comment = @index["bar"].first.comments
+      assert_equal("####################\nDocumentation for bar\n####################\n", bar_comment)
+
+      baz_comment = @index["baz"].first.comments
+      assert_equal("Documentation for baz", baz_comment)
+
+      ban_comment = @index["ban"].first.comments
+      assert_equal("", ban_comment)
+    end
+
     def test_method_with_parameters
       index(<<~RUBY)
         class Foo

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -179,7 +179,7 @@ module RubyIndexer
       assert_equal("Documentation for baz", baz_comment)
 
       ban_comment = @index["ban"].first.comments
-      assert_equal("", ban_comment)
+      assert_empty(ban_comment)
     end
 
     def test_method_with_parameters

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -50,8 +50,8 @@ class CompletionResolveTest < Minitest::Test
       end
 
       class Foo
-        # Foo!
         def initialize
+          # Foo!
           @a = 1
         end
       end


### PR DESCRIPTION
### Motivation

Closes #2786

Fix incorrect documentation references when methods are too close.

### Implementation

Add `comment_exists_at?` to check for a comment at the `start_line`. If there is, it returns true. Otherwise, it returns false (there is no comment at the `start_line`, and it's an empty line). 

### Automated Tests

Add a new test
