### PR TITLE
Add supports_watching_files to GlobalState

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -159,6 +159,11 @@ module RubyLsp
       end
     end
 
+    sig { returns(T::Boolean) }
+    def supports_watching_files
+      @client_capabilities.supports_watching_files
+    end
+
     private
 
     sig { params(direct_dependencies: T::Array[String], all_dependencies: T::Array[String]).returns(String) }

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -223,6 +223,12 @@ module RubyLsp
       assert_equal({ runtimeServerEnabled: false }, global_state.settings_for_addon("Ruby LSP Rails"))
     end
 
+    def test_delegates_supports_watching_files_to_client_capabilities
+      global_state = GlobalState.new
+      global_state.client_capabilities.expects(:supports_watching_files).returns(true)
+      global_state.supports_watching_files
+    end
+
     private
 
     def stub_direct_dependencies(dependencies)


### PR DESCRIPTION
### Motivation

To prevent breaking the activation of the Standard add-on, which relies on the old API and doesn't declare version constraints using our new depends_on API.

### Implementation

Added the method they rely back, delegating to client capabilities.

### Automated Tests

Added a test.