### PR TITLE
Ensure we're handling client responses for window show message

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -81,8 +81,6 @@ module RubyLsp
         workspace_did_change_watched_files(message)
       when "workspace/symbol"
         workspace_symbol(message)
-      when "window/showMessageRequest"
-        window_show_message_request(message)
       when "rubyLsp/textDocument/showSyntaxTree"
         text_document_show_syntax_tree(message)
       when "rubyLsp/workspace/dependencies"
@@ -108,6 +106,8 @@ module RubyLsp
         )
       when "$/cancelRequest"
         @mutex.synchronize { @cancelled_requests << message[:params][:id] }
+      when nil
+        process_response(message) if message[:result]
       end
     rescue DelegateRequestError
       send_message(Error.new(id: message[:id], code: DelegateRequestError::CODE, message: "DELEGATE_REQUEST"))
@@ -138,6 +138,15 @@ module RubyLsp
       end
 
       send_log_message("Error processing #{message[:method]}: #{e.full_message}", type: Constant::MessageType::ERROR)
+    end
+
+    # Process responses to requests that were sent to the client
+    sig { params(message: T::Hash[Symbol, T.untyped]).void }
+    def process_response(message)
+      case message.dig(:result, :method)
+      when "window/showMessageRequest"
+        window_show_message_request(message)
+      end
     end
 
     sig { params(include_project_addons: T::Boolean).void }
@@ -1226,11 +1235,14 @@ module RubyLsp
 
     sig { params(message: T::Hash[Symbol, T.untyped]).void }
     def window_show_message_request(message)
-      addon_name = message[:addon_name]
+      result = message[:result]
+      return unless result
+
+      addon_name = result[:addon_name]
       addon = Addon.addons.find { |addon| addon.name == addon_name }
       return unless addon
 
-      addon.handle_window_show_message_response(message[:title])
+      addon.handle_window_show_message_response(result[:title])
     end
   end
 end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -696,7 +696,7 @@ class ServerTest < Minitest::Test
       addon = RubyLsp::Addon.addons.find { |a| a.is_a?(klass) }
       addon.expects(:handle_window_show_message_response).with("hello")
 
-      @server.process_message(method: "window/showMessageRequest", title: "hello", addon_name: "My Add-on")
+      @server.process_message(result: { method: "window/showMessageRequest", title: "hello", addon_name: "My Add-on" })
     ensure
       RubyLsp::Addon.addons.clear
       RubyLsp::Addon.addon_classes.clear


### PR DESCRIPTION
### Motivation

When the server makes a request to the client, the response doesn't include the requested method by default. We can make it so that add-ons need to include it as part of the message properties, but normally only the ID can be used to reconcile request and response.

We need to let add-ons include the method name as part of the properties so that we can delegate appropriately.

### Implementation

Our regular `process_message` would just ignore any responses because `message[:method]` is always `nil` in a response. We need to extract it from `result` and define that add-ons must include the `method` as part of it.

### Automated Tests

Adapted the test.