### PR TITLE
Move `supports_progress` to global state

### DIFF
--- a/lib/ruby_lsp/client_capabilities.rb
+++ b/lib/ruby_lsp/client_capabilities.rb
@@ -10,7 +10,8 @@ module RubyLsp
     sig { returns(T::Boolean) }
     attr_reader :supports_watching_files,
       :supports_request_delegation,
-      :window_show_message_supports_extra_properties
+      :window_show_message_supports_extra_properties,
+      :supports_progress
 
     sig { void }
     def initialize
@@ -28,6 +29,9 @@ module RubyLsp
 
       # Which resource operations the editor supports, like renaming files
       @supported_resource_operations = T.let([], T::Array[String])
+
+      # The editor supports displaying progress requests
+      @supports_progress = T.let(false, T::Boolean)
     end
 
     sig { params(capabilities: T::Hash[Symbol, T.untyped]).void }
@@ -50,6 +54,9 @@ module RubyLsp
         :additionalPropertiesSupport,
       )
       @window_show_message_supports_extra_properties = supports_additional_properties || false
+
+      progress = capabilities.dig(:window, :workDoneProgress)
+      @supports_progress = progress if progress
     end
 
     sig { returns(T::Boolean) }

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -188,8 +188,6 @@ module RubyLsp
       client_name = options.dig(:clientInfo, :name)
       @store.client_name = client_name if client_name
 
-      progress = options.dig(:capabilities, :window, :workDoneProgress)
-      @store.supports_progress = progress.nil? ? true : progress
       configured_features = options.dig(:initializationOptions, :enabledFeatures)
 
       configured_hints = options.dig(:initializationOptions, :featuresConfiguration, :inlayHint)
@@ -1105,7 +1103,7 @@ module RubyLsp
 
     sig { params(id: String, title: String, percentage: Integer).void }
     def begin_progress(id, title, percentage: 0)
-      return unless @store.supports_progress
+      return unless @global_state.client_capabilities.supports_progress
 
       send_message(Request.new(
         id: @current_request_id,
@@ -1129,7 +1127,7 @@ module RubyLsp
 
     sig { params(id: String, percentage: Integer).void }
     def progress(id, percentage)
-      return unless @store.supports_progress
+      return unless @global_state.client_capabilities.supports_progress
 
       send_message(
         Notification.new(
@@ -1148,7 +1146,7 @@ module RubyLsp
 
     sig { params(id: String).void }
     def end_progress(id)
-      return unless @store.supports_progress
+      return unless @global_state.client_capabilities.supports_progress
 
       send_message(
         Notification.new(

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -7,9 +7,6 @@ module RubyLsp
 
     class NonExistingDocumentError < StandardError; end
 
-    sig { returns(T::Boolean) }
-    attr_accessor :supports_progress
-
     sig { returns(T::Hash[Symbol, RequestConfig]) }
     attr_accessor :features_configuration
 
@@ -19,7 +16,6 @@ module RubyLsp
     sig { void }
     def initialize
       @state = T.let({}, T::Hash[String, Document[T.untyped]])
-      @supports_progress = T.let(true, T::Boolean)
       @features_configuration = T.let(
         {
           inlayHint: RequestConfig.new({

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -165,19 +165,6 @@ class ServerTest < Minitest::Test
     assert_equal("rubocop", hash.dig("formatter"))
   end
 
-  def test_initialized_populates_index
-    capture_subprocess_io do
-      @server.process_message({ method: "initialized" })
-
-      assert_equal("$/progress", @server.pop_response.method)
-      assert_equal("$/progress", @server.pop_response.method)
-      assert_equal("$/progress", @server.pop_response.method)
-      assert_equal("$/progress", @server.pop_response.method)
-
-      refute_empty(@server.global_state.index)
-    end
-  end
-
   def test_initialized_recovers_from_indexing_failures
     @server.global_state.index.expects(:index_all).once.raises(StandardError, "boom!")
     capture_subprocess_io do


### PR DESCRIPTION
### Motivation

We want to allow add-ons to show progress bars if the editor supports it. However, whether it supports it or not is currently a state of `Store`, which add-ons don't have access to. We need to put that in the global state.

### Implementation

Moved `supports_progress` to the global state.

### Automated Tests

I got rid of a test that wasn't very useful and that was difficult to avoid flakiness after this change.