### PR TITLE
Extract progress notifications to helpers

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1111,52 +1111,21 @@ module RubyLsp
         params: Interface::WorkDoneProgressCreateParams.new(token: id),
       ))
 
-      send_message(Notification.new(
-        method: "$/progress",
-        params: Interface::ProgressParams.new(
-          token: id,
-          value: Interface::WorkDoneProgressBegin.new(
-            kind: "begin",
-            title: title,
-            percentage: percentage,
-            message: "#{percentage}% completed",
-          ),
-        ),
-      ))
+      send_message(Notification.progress_begin(id, title, percentage: percentage, message: "#{percentage}% completed"))
     end
 
     sig { params(id: String, percentage: Integer).void }
     def progress(id, percentage)
       return unless @global_state.client_capabilities.supports_progress
 
-      send_message(
-        Notification.new(
-          method: "$/progress",
-          params: Interface::ProgressParams.new(
-            token: id,
-            value: Interface::WorkDoneProgressReport.new(
-              kind: "report",
-              percentage: percentage,
-              message: "#{percentage}% completed",
-            ),
-          ),
-        ),
-      )
+      send_message(Notification.progress_report(id, percentage: percentage, message: "#{percentage}% completed"))
     end
 
     sig { params(id: String).void }
     def end_progress(id)
       return unless @global_state.client_capabilities.supports_progress
 
-      send_message(
-        Notification.new(
-          method: "$/progress",
-          params: Interface::ProgressParams.new(
-            token: id,
-            value: Interface::WorkDoneProgressEnd.new(kind: "end"),
-          ),
-        ),
-      )
+      send_message(Notification.progress_end(id))
     rescue ClosedQueueError
       # If the server was killed and the message queue is already closed, there's no way to end the progress
       # notification

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -87,6 +87,61 @@ module RubyLsp
           params: data,
         )
       end
+
+      sig do
+        params(
+          id: String,
+          title: String,
+          percentage: T.nilable(Integer),
+          message: T.nilable(String),
+        ).returns(Notification)
+      end
+      def progress_begin(id, title, percentage: nil, message: nil)
+        new(
+          method: "$/progress",
+          params: Interface::ProgressParams.new(
+            token: id,
+            value: Interface::WorkDoneProgressBegin.new(
+              kind: "begin",
+              title: title,
+              percentage: percentage,
+              message: message,
+            ),
+          ),
+        )
+      end
+
+      sig do
+        params(
+          id: String,
+          percentage: T.nilable(Integer),
+          message: T.nilable(String),
+        ).returns(Notification)
+      end
+      def progress_report(id, percentage: nil, message: nil)
+        new(
+          method: "$/progress",
+          params: Interface::ProgressParams.new(
+            token: id,
+            value: Interface::WorkDoneProgressReport.new(
+              kind: "report",
+              percentage: percentage,
+              message: message,
+            ),
+          ),
+        )
+      end
+
+      sig { params(id: String).returns(Notification) }
+      def progress_end(id)
+        Notification.new(
+          method: "$/progress",
+          params: Interface::ProgressParams.new(
+            token: id,
+            value: Interface::WorkDoneProgressEnd.new(kind: "end"),
+          ),
+        )
+      end
     end
 
     extend T::Sig


### PR DESCRIPTION
### Motivation

This PR extracts progress related notifications to helpers, to make it easier for add-ons (and the LSP itself) use progress more often.

### Implementation

Essentially just make some factory methods like we do for other notifications.

### Automated Tests

Existing tests cover it.