### PR TITLE
Use `rbenv` executable directly if available

### DIFF
--- a/vscode/src/ruby/rbenv.ts
+++ b/vscode/src/ruby/rbenv.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-process-env */
+import * as vscode from "vscode";
 
 import { VersionManager, ActivationResult } from "./versionManager";
 
@@ -7,7 +8,14 @@ import { VersionManager, ActivationResult } from "./versionManager";
 // Learn more: https://github.com/rbenv/rbenv
 export class Rbenv extends VersionManager {
   async activate(): Promise<ActivationResult> {
-    const parsedResult = await this.runEnvActivationScript("rbenv exec ruby");
+    const rbenvExec = await this.findExec(
+      [vscode.Uri.file("/opt/homebrew/bin"), vscode.Uri.file("/usr/local/bin")],
+      "rbenv",
+    );
+
+    const parsedResult = await this.runEnvActivationScript(
+      `${rbenvExec} exec ruby`,
+    );
 
     return {
       env: { ...process.env, ...parsedResult.env },

--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -22,7 +22,10 @@ export class Shadowenv extends VersionManager {
       );
     }
 
-    const shadowenvExec = await this.findShadowenvExec();
+    const shadowenvExec = await this.findExec(
+      [vscode.Uri.file("/opt/homebrew/bin")],
+      "shadowenv",
+    );
 
     try {
       const parsedResult = await this.runEnvActivationScript(
@@ -70,25 +73,5 @@ export class Shadowenv extends VersionManager {
         `Failed to activate Ruby environment with Shadowenv: ${error.message}`,
       );
     }
-  }
-
-  // Tries to find the Shadowenv executable either directly in known paths or in the PATH
-  async findShadowenvExec() {
-    // If we can find the Shadowenv executable in the Homebrew installation path, then prefer it over relying on the
-    // executable being available in the PATH. Sometimes, users might have shell scripts or other extensions that can
-    // mess up the PATH and then we can't find the Shadowenv executable
-    const possibleUris = [vscode.Uri.file("/opt/homebrew/bin/shadowenv")];
-
-    for (const uri of possibleUris) {
-      try {
-        await vscode.workspace.fs.stat(uri);
-        this.outputChannel.info(`Found Shadowenv executable at ${uri.fsPath}`);
-        return uri.fsPath;
-      } catch (error: any) {
-        // continue searching
-      }
-    }
-
-    return "shadowenv";
   }
 }

--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -105,4 +105,23 @@ export abstract class VersionManager {
       env: process.env,
     });
   }
+
+  // Tries to find `execName` within the given directories. Prefers the executables found in the given directories over
+  // finding the executable in the PATH
+  protected async findExec(directories: vscode.Uri[], execName: string) {
+    for (const uri of directories) {
+      try {
+        const fullUri = vscode.Uri.joinPath(uri, execName);
+        await vscode.workspace.fs.stat(fullUri);
+        this.outputChannel.info(
+          `Found ${execName} executable at ${uri.fsPath}`,
+        );
+        return fullUri.fsPath;
+      } catch (error: any) {
+        // continue searching
+      }
+    }
+
+    return execName;
+  }
 }


### PR DESCRIPTION
### Motivation

Closes #2822

I believe the issue the users are facing is similar to #2791, where sourcing shell scripts may fail, then Homebrew paths are never properly set up and we can't find the executable.

Let's check for known paths first and prefer those over just the executable name, since this seemed to improve the situation for Shadowenv.

### Implementation

I extracted a more generic implementation to the parent class and started using it for both Shadowenv and rbenv. If the executables exist in known paths, we use those directly without counting that they will be available in the PATH.