### PR TITLE
Add feature flag support to GlobalState

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -53,6 +53,7 @@ module RubyLsp
         T::Boolean,
       )
       @client_capabilities = T.let(ClientCapabilities.new, ClientCapabilities)
+      @enabled_feature_flags = T.let({}, T::Hash[Symbol, T::Boolean])
     end
 
     sig { params(addon_name: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -139,7 +140,15 @@ module RubyLsp
         @addon_settings.merge!(addon_settings)
       end
 
+      enabled_flags = options.dig(:initializationOptions, :enabledFeatureFlags)
+      @enabled_feature_flags = enabled_flags if enabled_flags
+
       notifications
+    end
+
+    sig { params(flag: Symbol).returns(T.nilable(T::Boolean)) }
+    def enabled_feature?(flag)
+      @enabled_feature_flags[flag]
     end
 
     sig { returns(String) }

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -229,6 +229,23 @@ module RubyLsp
       global_state.supports_watching_files
     end
 
+    def test_feature_flags_are_processed_by_apply_options
+      state = GlobalState.new
+
+      state.apply_options({
+        initializationOptions: {
+          enabledFeatureFlags: {
+            semantic_highlighting: true,
+            code_lens: false,
+          },
+        },
+      })
+
+      assert(state.enabled_feature?(:semantic_highlighting))
+      refute(state.enabled_feature?(:code_lens))
+      assert_nil(state.enabled_feature?(:unknown_flag))
+    end
+
     private
 
     def stub_direct_dependencies(dependencies)

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -35,6 +35,8 @@ import {
   ClientInterface,
   Addon,
   SUPPORTED_LANGUAGE_IDS,
+  FEATURE_FLAGS,
+  featureEnabled,
 } from "./common";
 import { Ruby } from "./ruby";
 import { WorkspaceChannel } from "./workspaceChannel";
@@ -49,6 +51,14 @@ interface ServerErrorTelemetryEvent {
 }
 
 type ServerTelemetryEvent = ServerErrorTelemetryEvent;
+
+function enabledFeatureFlags() {
+  const allKeys = Object.keys(FEATURE_FLAGS) as (keyof typeof FEATURE_FLAGS)[];
+
+  return allKeys.map((key) => {
+    return { [key]: featureEnabled(key) };
+  });
+}
 
 // Get the executables to start the server based on the user's configuration
 function getLspExecutables(
@@ -216,6 +226,7 @@ function collectClientOptions(
       linters: configuration.get("linters"),
       indexing: configuration.get("indexing"),
       addonSettings: configuration.get("addonSettings"),
+      enabledFeatureFlags: enabledFeatureFlags(),
     },
   };
 }


### PR DESCRIPTION
### Motivation

This PR starts passing the enabled feature flags to the server and storing it in the global state. That way the Ruby LSP and its add-ons can check for specific feature flags. This also allows users of other editors to opt into features through `initializationOptions`.

### Implementation

- Started passing all enabled flag information to the server
- Started storing this information in the global state

### Automated Tests

Added unit tests to verify feature flag processing and retrieval functionality.