### PR TITLE
Allow individual version managers to trigger manual Ruby selection

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -114,7 +114,12 @@ export class Ruby implements RubyInterface {
     if (workspaceRubyPath) {
       // If a workspace specific Ruby path is configured, then we use that to activate the environment
       await this.runActivation(
-        new None(this.workspaceFolder, this.outputChannel, workspaceRubyPath),
+        new None(
+          this.workspaceFolder,
+          this.outputChannel,
+          this.manuallySelectRuby.bind(this),
+          workspaceRubyPath,
+        ),
       );
     } else {
       // If the version manager is auto, discover the actual manager before trying to activate anything
@@ -139,7 +144,12 @@ export class Ruby implements RubyInterface {
 
         if (globalRubyPath) {
           await this.runActivation(
-            new None(this.workspaceFolder, this.outputChannel, globalRubyPath),
+            new None(
+              this.workspaceFolder,
+              this.outputChannel,
+              this.manuallySelectRuby.bind(this),
+              globalRubyPath,
+            ),
           );
         } else {
           this._error = true;
@@ -266,47 +276,83 @@ export class Ruby implements RubyInterface {
     switch (this.versionManager.identifier) {
       case ManagerIdentifier.Asdf:
         await this.runActivation(
-          new Asdf(this.workspaceFolder, this.outputChannel),
+          new Asdf(
+            this.workspaceFolder,
+            this.outputChannel,
+            this.manuallySelectRuby.bind(this),
+          ),
         );
         break;
       case ManagerIdentifier.Chruby:
         await this.runActivation(
-          new Chruby(this.workspaceFolder, this.outputChannel),
+          new Chruby(
+            this.workspaceFolder,
+            this.outputChannel,
+            this.manuallySelectRuby.bind(this),
+          ),
         );
         break;
       case ManagerIdentifier.Rbenv:
         await this.runActivation(
-          new Rbenv(this.workspaceFolder, this.outputChannel),
+          new Rbenv(
+            this.workspaceFolder,
+            this.outputChannel,
+            this.manuallySelectRuby.bind(this),
+          ),
         );
         break;
       case ManagerIdentifier.Rvm:
         await this.runActivation(
-          new Rvm(this.workspaceFolder, this.outputChannel),
+          new Rvm(
+            this.workspaceFolder,
+            this.outputChannel,
+            this.manuallySelectRuby.bind(this),
+          ),
         );
         break;
       case ManagerIdentifier.Mise:
         await this.runActivation(
-          new Mise(this.workspaceFolder, this.outputChannel),
+          new Mise(
+            this.workspaceFolder,
+            this.outputChannel,
+            this.manuallySelectRuby.bind(this),
+          ),
         );
         break;
       case ManagerIdentifier.RubyInstaller:
         await this.runActivation(
-          new RubyInstaller(this.workspaceFolder, this.outputChannel),
+          new RubyInstaller(
+            this.workspaceFolder,
+            this.outputChannel,
+            this.manuallySelectRuby.bind(this),
+          ),
         );
         break;
       case ManagerIdentifier.Custom:
         await this.runActivation(
-          new Custom(this.workspaceFolder, this.outputChannel),
+          new Custom(
+            this.workspaceFolder,
+            this.outputChannel,
+            this.manuallySelectRuby.bind(this),
+          ),
         );
         break;
       case ManagerIdentifier.None:
         await this.runActivation(
-          new None(this.workspaceFolder, this.outputChannel),
+          new None(
+            this.workspaceFolder,
+            this.outputChannel,
+            this.manuallySelectRuby.bind(this),
+          ),
         );
         break;
       default:
         await this.runActivation(
-          new Shadowenv(this.workspaceFolder, this.outputChannel),
+          new Shadowenv(
+            this.workspaceFolder,
+            this.outputChannel,
+            this.manuallySelectRuby.bind(this),
+          ),
         );
         break;
     }

--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -29,8 +29,9 @@ export class Chruby extends VersionManager {
   constructor(
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel: WorkspaceChannel,
+    manuallySelectRuby: () => Promise<void>,
   ) {
-    super(workspaceFolder, outputChannel);
+    super(workspaceFolder, outputChannel, manuallySelectRuby);
 
     const configuredRubies = vscode.workspace
       .getConfiguration("rubyLsp")

--- a/vscode/src/ruby/none.ts
+++ b/vscode/src/ruby/none.ts
@@ -19,9 +19,10 @@ export class None extends VersionManager {
   constructor(
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel: WorkspaceChannel,
+    manuallySelectRuby: () => Promise<void>,
     rubyPath?: string,
   ) {
-    super(workspaceFolder, outputChannel);
+    super(workspaceFolder, outputChannel, manuallySelectRuby);
     this.rubyPath = rubyPath ?? "ruby";
   }
 

--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -26,15 +26,18 @@ export abstract class VersionManager {
   protected readonly outputChannel: WorkspaceChannel;
   protected readonly workspaceFolder: vscode.WorkspaceFolder;
   protected readonly bundleUri: vscode.Uri;
+  protected readonly manuallySelectRuby: () => Promise<void>;
 
   private readonly customBundleGemfile?: string;
 
   constructor(
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel: WorkspaceChannel,
+    manuallySelectRuby: () => Promise<void>,
   ) {
     this.workspaceFolder = workspaceFolder;
     this.outputChannel = outputChannel;
+    this.manuallySelectRuby = manuallySelectRuby;
     const customBundleGemfile: string = vscode.workspace
       .getConfiguration("rubyLsp")
       .get("bundleGemfile")!;

--- a/vscode/src/test/suite/ruby/asdf.test.ts
+++ b/vscode/src/test/suite/ruby/asdf.test.ts
@@ -26,7 +26,7 @@ suite("Asdf", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const asdf = new Asdf(workspaceFolder, outputChannel);
+    const asdf = new Asdf(workspaceFolder, outputChannel, async () => {});
     const envStub = {
       env: { ANY: "true" },
       yjit: true,
@@ -75,7 +75,7 @@ suite("Asdf", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const asdf = new Asdf(workspaceFolder, outputChannel);
+    const asdf = new Asdf(workspaceFolder, outputChannel, async () => {});
     const envStub = {
       env: { ANY: "true" },
       yjit: true,

--- a/vscode/src/test/suite/ruby/chruby.test.ts
+++ b/vscode/src/test/suite/ruby/chruby.test.ts
@@ -74,7 +74,7 @@ suite("Chruby", () => {
   test("Finds Ruby when .ruby-version is inside workspace", async () => {
     fs.writeFileSync(path.join(workspacePath, ".ruby-version"), RUBY_VERSION);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel);
+    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -90,7 +90,7 @@ suite("Chruby", () => {
   test("Finds Ruby when .ruby-version is inside on parent directories", async () => {
     fs.writeFileSync(path.join(rootPath, ".ruby-version"), RUBY_VERSION);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel);
+    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -126,7 +126,7 @@ suite("Chruby", () => {
 
     fs.writeFileSync(path.join(rootPath, ".ruby-version"), RUBY_VERSION);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel);
+    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -171,7 +171,7 @@ suite("Chruby", () => {
       `${RUBY_VERSION}-rc1`,
     );
 
-    const chruby = new Chruby(workspaceFolder, outputChannel);
+    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -201,7 +201,7 @@ suite("Chruby", () => {
 
     fs.writeFileSync(path.join(rootPath, ".ruby-version"), RUBY_VERSION);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel);
+    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
     chruby.rubyInstallationUris = [vscode.Uri.file(rubyHome)];
 
     const { env, version, yjit } = await chruby.activate();
@@ -223,7 +223,7 @@ suite("Chruby", () => {
             : "",
       } as any);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel);
+    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
     configStub.restore();
 
     const { env, version, yjit } = await chruby.activate();
@@ -247,7 +247,7 @@ suite("Chruby", () => {
       `${major}.${minor}`,
     );
 
-    const chruby = new Chruby(workspaceFolder, outputChannel);
+    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -278,7 +278,7 @@ suite("Chruby", () => {
       `${major}.${minor}`,
     );
 
-    const chruby = new Chruby(workspaceFolder, outputChannel);
+    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, ".rubies")),
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),

--- a/vscode/src/test/suite/ruby/custom.test.ts
+++ b/vscode/src/test/suite/ruby/custom.test.ts
@@ -23,7 +23,7 @@ suite("Custom", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const custom = new Custom(workspaceFolder, outputChannel);
+    const custom = new Custom(workspaceFolder, outputChannel, async () => {});
 
     const envStub = {
       env: { ANY: "true" },

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -27,7 +27,7 @@ suite("Mise", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const mise = new Mise(workspaceFolder, outputChannel);
+    const mise = new Mise(workspaceFolder, outputChannel, async () => {});
 
     const envStub = {
       env: { ANY: "true" },
@@ -82,7 +82,7 @@ suite("Mise", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const mise = new Mise(workspaceFolder, outputChannel);
+    const mise = new Mise(workspaceFolder, outputChannel, async () => {});
 
     const envStub = {
       env: { ANY: "true" },

--- a/vscode/src/test/suite/ruby/none.test.ts
+++ b/vscode/src/test/suite/ruby/none.test.ts
@@ -23,7 +23,7 @@ suite("None", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const none = new None(workspaceFolder, outputChannel);
+    const none = new None(workspaceFolder, outputChannel, async () => {});
 
     const envStub = {
       env: { ANY: "true" },

--- a/vscode/src/test/suite/ruby/rbenv.test.ts
+++ b/vscode/src/test/suite/ruby/rbenv.test.ts
@@ -27,7 +27,7 @@ suite("Rbenv", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const rbenv = new Rbenv(workspaceFolder, outputChannel);
+    const rbenv = new Rbenv(workspaceFolder, outputChannel, async () => {});
 
     const envStub = {
       env: { ANY: "true" },
@@ -70,7 +70,7 @@ suite("Rbenv", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const rbenv = new Rbenv(workspaceFolder, outputChannel);
+    const rbenv = new Rbenv(workspaceFolder, outputChannel, async () => {});
 
     const envStub = {
       env: { ANY: "true" },
@@ -129,7 +129,7 @@ suite("Rbenv", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const rbenv = new Rbenv(workspaceFolder, outputChannel);
+    const rbenv = new Rbenv(workspaceFolder, outputChannel, async () => {});
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",

--- a/vscode/src/test/suite/ruby/rubyInstaller.test.ts
+++ b/vscode/src/test/suite/ruby/rubyInstaller.test.ts
@@ -60,7 +60,11 @@ suite("RubyInstaller", () => {
 
     fs.writeFileSync(path.join(workspacePath, ".ruby-version"), RUBY_VERSION);
 
-    const windows = new RubyInstaller(workspaceFolder, outputChannel);
+    const windows = new RubyInstaller(
+      workspaceFolder,
+      outputChannel,
+      async () => {},
+    );
     const { env, version, yjit } = await windows.activate();
 
     assert.match(env.GEM_PATH!, /ruby\/3\.3\.0/);
@@ -90,7 +94,11 @@ suite("RubyInstaller", () => {
 
     fs.writeFileSync(path.join(workspacePath, ".ruby-version"), RUBY_VERSION);
 
-    const windows = new RubyInstaller(workspaceFolder, outputChannel);
+    const windows = new RubyInstaller(
+      workspaceFolder,
+      outputChannel,
+      async () => {},
+    );
     const { env, version, yjit } = await windows.activate();
 
     assert.match(env.GEM_PATH!, /ruby\/3\.3\.0/);
@@ -120,7 +128,11 @@ suite("RubyInstaller", () => {
 
     fs.writeFileSync(path.join(workspacePath, ".ruby-version"), RUBY_VERSION);
 
-    const windows = new RubyInstaller(workspaceFolder, outputChannel);
+    const windows = new RubyInstaller(
+      workspaceFolder,
+      outputChannel,
+      async () => {},
+    );
     const result = ["/fake/dir", "/other/fake/dir", true, RUBY_VERSION].join(
       ACTIVATION_SEPARATOR,
     );

--- a/vscode/src/test/suite/ruby/rvm.test.ts
+++ b/vscode/src/test/suite/ruby/rvm.test.ts
@@ -26,7 +26,7 @@ suite("RVM", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const rvm = new Rvm(workspaceFolder, outputChannel);
+    const rvm = new Rvm(workspaceFolder, outputChannel, async () => {});
 
     const installationPathStub = sinon
       .stub(rvm, "findRvmInstallation")

--- a/vscode/src/test/suite/ruby/shadowenv.test.ts
+++ b/vscode/src/test/suite/ruby/shadowenv.test.ts
@@ -121,7 +121,11 @@ suite("Shadowenv", () => {
       `(env/prepend-to-pathlist "PATH" "${rubyBinPath}")`,
     );
 
-    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+    const shadowenv = new Shadowenv(
+      workspaceFolder,
+      outputChannel,
+      async () => {},
+    );
     const { env, version, yjit } = await shadowenv.activate();
 
     assert.match(env.PATH!, new RegExp(rubyBinPath));
@@ -137,7 +141,11 @@ suite("Shadowenv", () => {
       shadowLispFile,
     );
 
-    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+    const shadowenv = new Shadowenv(
+      workspaceFolder,
+      outputChannel,
+      async () => {},
+    );
     const { env, version, yjit } = await shadowenv.activate();
 
     assert.match(env.PATH!, new RegExp(rubyBinPath));
@@ -159,7 +167,11 @@ suite("Shadowenv", () => {
       .stub(vscode.window, "showErrorMessage")
       .resolves("Trust workspace" as any);
 
-    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+    const shadowenv = new Shadowenv(
+      workspaceFolder,
+      outputChannel,
+      async () => {},
+    );
     const { env, version, yjit } = await shadowenv.activate();
 
     assert.match(env.PATH!, new RegExp(rubyBinPath));
@@ -185,7 +197,11 @@ suite("Shadowenv", () => {
       .stub(vscode.window, "showErrorMessage")
       .resolves("Cancel" as any);
 
-    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+    const shadowenv = new Shadowenv(
+      workspaceFolder,
+      outputChannel,
+      async () => {},
+    );
 
     await assert.rejects(async () => {
       await shadowenv.activate();
@@ -204,7 +220,11 @@ suite("Shadowenv", () => {
       shadowLispFile,
     );
 
-    const shadowenv = new Shadowenv(workspaceFolder, outputChannel);
+    const shadowenv = new Shadowenv(
+      workspaceFolder,
+      outputChannel,
+      async () => {},
+    );
 
     // First, reject the call to `shadowenv exec`. Then resolve the call to `which shadowenv` to return nothing
     const execStub = sinon


### PR DESCRIPTION
### Motivation

First step for #2793

This PR passes down the `manuallySelectRuby` function to version managers in order to allow specific version managers to offer configuring fallbacks under certain situations.

### Implementation

This PR only starts passing the function down to managers. The next PR in the stack starts using it.

### Automated Tests

Updated existing tests.