### PR TITLE
Fallback to latest known Ruby if no .ruby-version is found

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -173,7 +173,7 @@ export class Ruby implements RubyInterface {
 
   async manuallySelectRuby() {
     const manualSelection = await vscode.window.showInformationMessage(
-      "Configure global fallback or workspace specific Ruby?",
+      "Configure global or workspace specific fallback for the Ruby LSP?",
       "global",
       "workspace",
       "clear previous workspace selection",


### PR DESCRIPTION
### Motivation

Completes a significant part of handling missing `.ruby-version` for #2793

If the user doesn't have a `.ruby-version` in their project or in any parent directories, then we can try to fallback to the latest known Ruby available.

**Note**: this PR doesn't handle the aspect of having a `.ruby-version` configured to a Ruby that's not installed. I'll follow up with that later.

### Implementation

To avoid having this behaviour be surprising, I used a progress notification with a 5 second delay warning the user that we are going to try falling back to the latest known Ruby. If they don't do anything, we search for the Ruby installation and launch.

If the user clicks cancel, then we stop everything and offer them 3 options:

1. Create a `.ruby-version` file in a parent directory. Here we use a quick pick to list all known rubies and create the file for them using what they select
2. Manually configure a global fallback Ruby installation for the LSP
3. Shutdown

### Automated Tests

Added automated tests for two scenarios. I haven't figured out if it's possible to trigger the cancellation in a test even with a stub, so I failed to create tests for those cases.

If you have an idea about how to fake the cancellation of the progress notification, please let me know!