### PR TITLE
Ensure top level scripts are indexed

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -109,6 +109,12 @@ module RubyIndexer
 
       indexables = T.let([], T::Array[IndexablePath])
 
+      # Handle top level files separately. The path below is an optimization to prevent descending down directories that
+      # are going to be excluded anyway, so we need to handle top level scripts separately
+      Dir.glob(File.join(@workspace_path, "*.rb"), flags).each do |path|
+        indexables << IndexablePath.new(nil, path)
+      end
+
       # Add user specified patterns
       @included_patterns.each do |pattern|
         load_path_entry = T.let(nil, T.nilable(String))

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -160,5 +160,15 @@ module RubyIndexer
         )
       end
     end
+
+    def test_includes_top_level_files
+      Dir.mktmpdir do |dir|
+        FileUtils.touch(File.join(dir, "find_me.rb"))
+        @config.workspace_path = dir
+
+        indexables = @config.indexables
+        assert(indexables.find { |i| File.basename(i.full_path) == "find_me.rb" })
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation

With the optimizations to prevent descending into directories that we know are going to be excluded, we accidentally stopped indexing top level scripts.

### Implementation

Since the code now lists directories to eagerly exclude them, we need a separate path for the top level scripts.

### Automated Tests

Added a test that reproduces the issue.