### PR TITLE
Log when trying to format files outside of workspace

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -604,6 +604,11 @@ module RubyLsp
       # don't want to format it
       path = uri.to_standardized_path
       unless path.nil? || path.start_with?(@global_state.workspace_path)
+        send_log_message(<<~MESSAGE)
+          Ignoring formatting request for file outside of the workspace.
+          Workspace path was set by editor as #{@global_state.workspace_path}.
+          File path requested for formatting was #{path}
+        MESSAGE
         send_empty_response(message[:id])
         return
       end


### PR DESCRIPTION
### Motivation

We were having trouble figuring out why formatting wasn't working properly for some Emacs users. It turns out that Emacs wasn't setting the workspace URI, which makes us consider every file as external and thus we don't format them (to prevent accidentally formatting gems for example).

Let's log when this is happening so that understanding the situation is easier.