### PR TITLE
Prevent full indexing (`index_all`) from being called multiple times

### DIFF
--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -2023,5 +2023,12 @@ module RubyIndexer
         ),
       )
     end
+
+    def test_prevents_multiple_calls_to_index_all
+      # For this test class, `index_all` is already called once in `setup`.
+      assert_raises(Index::IndexNotEmptyError) do
+        @index.index_all
+      end
+    end
   end
 end


### PR DESCRIPTION
During the RubyConf 2024 hackday, while exploring some indexing behaviour using `irb`, there was some confusion because the index was referring to code that had been deleted.

In this PR, I've added a check that raises on attempting to called `index_all` if it already contains entries.

We _could_ use a more technical approach such as adding a `reindex` method, or clearing the index each time when calling `index_all`. But since this is a relative rare usage, I think this protection is enough for the time being.