### PR TITLE
Check target precision for call node in hover and definition

### DIFF
--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -118,6 +118,8 @@ module RubyLsp
           Prism::InstanceVariableWriteNode
 
           !covers_position?(target.name_loc, position)
+        when Prism::CallNode
+          !covers_position?(target.message_loc, position)
         else
           false
         end

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -103,6 +103,8 @@ module RubyLsp
           Prism::GlobalVariableOrWriteNode,
           Prism::GlobalVariableWriteNode
           !covers_position?(target.name_loc, position)
+        when Prism::CallNode
+          !covers_position?(target.message_loc, position)
         else
           false
         end

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -1097,6 +1097,40 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_definition_call_node_precision
+    source = <<~RUBY
+      class Foo
+        def message
+          "hello!"
+        end
+      end
+
+      class Bar
+        def with_foo(foo)
+          @foo_message = foo.message
+        end
+      end
+    RUBY
+
+    with_server(source) do |server, uri|
+      # On the `foo` receiver, we should not show any results
+      server.process_message(
+        id: 1,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 19, line: 8 } },
+      )
+      assert_empty(server.pop_response.response)
+
+      # On `message`, we should
+      server.process_message(
+        id: 2,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 23, line: 8 } },
+      )
+      refute_empty(server.pop_response.response)
+    end
+  end
+
   private
 
   def create_definition_addon


### PR DESCRIPTION
### Motivation

Closes #2846

We had a regression in our call node target precisions. Essentially, the call node covers both the receiver and the message, but we only want to make the call node the target is the position covers the message location exactly.

### Implementation

Added another branch to the checks for whether the position is covered or not.

### Automated Tests

Added tests to ensure we don't regress.