### PR TITLE
Start returning composed bundle environment from initialize request

### DIFF
--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -74,9 +74,6 @@ rescue StandardError => e
   # If Bundler.setup fails, we need to restore the original $LOAD_PATH so that we can still require the Ruby LSP server
   # in degraded mode
   $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
-ensure
-  require "fileutils"
-  FileUtils.rm(bundle_env_path) if File.exist?(bundle_env_path)
 end
 
 error_path = File.join(".ruby-lsp", "install_error")

--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -21,6 +21,7 @@ require "prism"
 require "prism/visitor"
 require "language_server-protocol"
 require "rbs"
+require "fileutils"
 
 require "ruby-lsp"
 require "ruby_lsp/base_server"

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -216,6 +216,13 @@ module RubyLsp
         Hash.new(true)
       end
 
+      bundle_env_path = File.join(".ruby-lsp", "bundle_env")
+      bundle_env = if File.exist?(bundle_env_path)
+        env = File.readlines(bundle_env_path).to_h { |line| T.cast(line.chomp.split("=", 2), [String, String]) }
+        FileUtils.rm(bundle_env_path)
+        env
+      end
+
       document_symbol_provider = Requests::DocumentSymbol.provider if enabled_features["documentSymbols"]
       document_link_provider = Requests::DocumentLink.provider if enabled_features["documentLink"]
       code_lens_provider = Requests::CodeLens.provider if enabled_features["codeLens"]
@@ -269,6 +276,7 @@ module RubyLsp
         },
         formatter: @global_state.formatter,
         degraded_mode: !!(@install_error || @setup_error),
+        bundle_env: bundle_env,
       }
 
       send_message(Result.new(id: message[:id], response: response))

--- a/project-words
+++ b/project-words
@@ -58,6 +58,7 @@ quxx
 quux
 qorge
 rdbg
+readlines
 realpath
 reparsing
 requireds


### PR DESCRIPTION
### Motivation

Currently, we are always spawning the debug client with the incorrect environment. The reason is because the composed bundle process does a lot of heavy lifting to determine the exact environment variables that need to be set to apply an accurate Bundler configuration.

We need the debug client to have access to the composed environment if we want to be able to launch the debugger properly for all scenarios.

### Implementation

Started reading the bundle env and returning it as part of the initialize request.

### Automated Tests

Added a test to verify that we're returning the environment.