### PR TITLE
Merge composed bundle environment into Ruby object

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -389,6 +389,10 @@ export default class Client extends LanguageClient implements ClientInterface {
       this.degraded = this.initializeResult?.degraded_mode;
     }
 
+    if (this.initializeResult?.bundle_env) {
+      this.ruby.mergeComposedEnvironment(this.initializeResult.bundle_env);
+    }
+
     await this.fetchAddons();
   }
 

--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -127,6 +127,12 @@ export class Debugger
       name: workspace.workspaceFolder.name,
     };
 
+    // In newer versions of the server, the composed bundle environment is merged directly into the Ruby object and no
+    // adjustments have to be made here
+    if (debugConfiguration.env.BUNDLE_GEMFILE) {
+      return debugConfiguration;
+    }
+
     const customBundleUri = vscode.Uri.joinPath(workspaceUri, ".ruby-lsp");
 
     return vscode.workspace.fs.readDirectory(customBundleUri).then(

--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -218,6 +218,10 @@ export class Ruby implements RubyInterface {
     return this.activateRuby();
   }
 
+  mergeComposedEnvironment(env: Record<string, string>) {
+    this._env = { ...this._env, ...env };
+  }
+
   private async runActivation(manager: VersionManager) {
     const { env, version, yjit, gemPath } = await manager.activate();
     const [major, minor, _patch] = version.split(".").map(Number);

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -150,4 +150,21 @@ suite("Ruby environment activation", () => {
       "/opt/rubies/3.3.5/lib/ruby/gems/3.3.0",
     ]);
   });
+
+  test("mergeComposedEnv merges environment variables", () => {
+    const ruby = new Ruby(
+      context,
+      workspaceFolder,
+      outputChannel,
+      FAKE_TELEMETRY,
+    );
+
+    assert.deepStrictEqual(ruby.env, {});
+
+    ruby.mergeComposedEnvironment({
+      BUNDLE_GEMFILE: ".ruby-lsp/Gemfile",
+    });
+
+    assert.deepStrictEqual(ruby.env, { BUNDLE_GEMFILE: ".ruby-lsp/Gemfile" });
+  });
 });


### PR DESCRIPTION
### Motivation

Closes #1767, closes #1785

Merge the composed bundle environment into the workspace's Ruby object. The language server sets up the composed bundle environment, returns it, and then we merge that into the Ruby object to ensure that any other parts of the extension are using the exact same environment.

This fixes a few issues people have been experiencing with the debug client.

### Implementation

Started merging the composed environment into the Ruby object and then started relying on that for the debug client.

### Automated Tests

Added some tests. I will follow up with another PR that creates an integration test for a scenario that currently fails.