### PR TITLE
Add debugger integration test for project with local Bundler settings

### DIFF
--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -34,12 +34,15 @@ export class Debugger
     uri: vscode.Uri | undefined,
   ) => Workspace | undefined;
 
+  private readonly context: vscode.ExtensionContext;
+
   constructor(
     context: vscode.ExtensionContext,
     workspaceResolver: (uri: vscode.Uri | undefined) => Workspace | undefined,
   ) {
     this.workspaceResolver = workspaceResolver;
 
+    this.context = context;
     context.subscriptions.push(
       vscode.debug.registerDebugConfigurationProvider("ruby_lsp", this),
       vscode.debug.registerDebugAdapterDescriptorFactory("ruby_lsp", this),
@@ -258,9 +261,6 @@ export class Debugger
 
       this.logDebuggerMessage(`Spawning debugger in directory ${cwd}`);
       this.logDebuggerMessage(`   Command bundle ${args.join(" ")}`);
-      this.logDebuggerMessage(
-        `   Environment ${JSON.stringify(configuration.env)}`,
-      );
 
       this.debugProcess = spawn("bundle", args, {
         shell: true,
@@ -354,5 +354,10 @@ export class Debugger
     // Log to Debug Console: Unlike Output panel, this needs explicit newlines
     // so we preserve the original message format including any newlines
     this.console.append(message);
+
+    if (this.context.extensionMode === vscode.ExtensionMode.Test) {
+      // eslint-disable-next-line no-console
+      console.log(message);
+    }
   }
 }

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -23,7 +23,8 @@ import { collectRubyLspInfo } from "./infoCollector";
 // activation event. One instance of this class controls all of the existing workspaces, telemetry and handles all
 // commands
 export class RubyLsp {
-  private readonly workspaces: Map<string, Workspace> = new Map();
+  // Only public for testing
+  public readonly workspaces: Map<string, Workspace> = new Map();
   private readonly context: vscode.ExtensionContext;
   private readonly statusItems: StatusItems;
   private readonly testController: TestController;
@@ -119,10 +120,10 @@ export class RubyLsp {
 
   // Activate the extension. This method should perform all actions necessary to start the extension, such as booting
   // all language servers for each existing workspace
-  async activate() {
-    await vscode.commands.executeCommand("testing.clearTestResults");
-
-    const firstWorkspace = vscode.workspace.workspaceFolders?.[0];
+  async activate(firstWorkspace = vscode.workspace.workspaceFolders?.[0]) {
+    if (this.context.extensionMode !== vscode.ExtensionMode.Test) {
+      await vscode.commands.executeCommand("testing.clearTestResults");
+    }
 
     // We only activate the first workspace eagerly to avoid running into performance and memory issues. Having too many
     // workspaces spawning the Ruby LSP server and indexing can grind the editor to a halt. All other workspaces are

--- a/vscode/src/test/suite/rubyLsp.test.ts
+++ b/vscode/src/test/suite/rubyLsp.test.ts
@@ -1,0 +1,162 @@
+import path from "path";
+import assert from "assert";
+import fs from "fs";
+import os from "os";
+
+import sinon from "sinon";
+import * as vscode from "vscode";
+import { beforeEach, afterEach, before, after } from "mocha";
+import { State } from "vscode-languageclient";
+
+import { RubyLsp } from "../../rubyLsp";
+import { RUBY_VERSION } from "../rubyVersion";
+
+import { FAKE_TELEMETRY } from "./fakeTelemetry";
+import { ensureRubyInstallationPaths } from "./testHelpers";
+
+suite("Ruby LSP", () => {
+  const context = {
+    extensionMode: vscode.ExtensionMode.Test,
+    subscriptions: [],
+    workspaceState: {
+      get: (_name: string) => undefined,
+      update: (_name: string, _value: any) => Promise.resolve(),
+    },
+    extensionUri: vscode.Uri.file(
+      path.dirname(path.dirname(path.dirname(__dirname))),
+    ),
+  } as unknown as vscode.ExtensionContext;
+  let workspacePath: string;
+  let workspaceUri: vscode.Uri;
+  let workspaceFolder: vscode.WorkspaceFolder;
+  const originalSaveBeforeStart = vscode.workspace
+    .getConfiguration("debug")
+    .get("saveBeforeStart");
+
+  before(async () => {
+    await vscode.workspace
+      .getConfiguration("debug")
+      .update("saveBeforeStart", "none", true);
+  });
+
+  after(async () => {
+    await vscode.workspace
+      .getConfiguration("debug")
+      .update("saveBeforeStart", originalSaveBeforeStart, true);
+  });
+
+  beforeEach(() => {
+    workspacePath = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ruby-lsp-integration-test-"),
+    );
+    workspaceUri = vscode.Uri.file(workspacePath);
+    workspaceFolder = {
+      uri: workspaceUri,
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspacePath, { recursive: true, force: true });
+  });
+
+  test("launching debugger in a project with local Bundler settings and composed bundle", async () => {
+    fs.writeFileSync(path.join(workspacePath, "test.rb"), "1 + 1");
+    fs.writeFileSync(path.join(workspacePath, ".ruby-version"), RUBY_VERSION);
+    fs.writeFileSync(
+      path.join(workspacePath, "Gemfile"),
+      'source "https://rubygems.org"\n',
+    );
+    fs.writeFileSync(
+      path.join(workspacePath, "Gemfile.lock"),
+      [
+        "GEM",
+        "  remote: https://rubygems.org/",
+        "  specs:",
+        "",
+        "PLATFORMS",
+        "  arm64-darwin-23",
+        "  ruby",
+        "",
+        "DEPENDENCIES",
+        "",
+        "BUNDLED WITH",
+        "  2.5.16",
+      ].join("\n"),
+    );
+    fs.mkdirSync(path.join(workspacePath, ".bundle"));
+    fs.writeFileSync(
+      path.join(workspacePath, ".bundle", "config"),
+      `BUNDLE_PATH: ${path.join("vendor", "bundle")}`,
+    );
+
+    await ensureRubyInstallationPaths();
+
+    const rubyLsp = new RubyLsp(context, FAKE_TELEMETRY);
+
+    try {
+      await rubyLsp.activate(workspaceFolder);
+
+      const client = rubyLsp.workspaces.get(
+        workspaceFolder.uri.toString(),
+      )!.lspClient!;
+
+      if (client.state !== State.Running) {
+        await new Promise<void>((resolve) => {
+          const callback = client.onDidChangeState(() => {
+            if (client.state === State.Running) {
+              callback.dispose();
+              resolve();
+            }
+          });
+        });
+      }
+    } catch (error: any) {
+      assert.fail(
+        `Failed to activate Ruby LSP: ${error.message}\n\n${error.stack}`,
+      );
+    }
+
+    const stub = sinon.stub(vscode.window, "activeTextEditor").get(() => {
+      return {
+        document: {
+          uri: vscode.Uri.file(path.join(workspacePath, "test.rb")),
+        },
+      } as vscode.TextEditor;
+    });
+
+    const getWorkspaceStub = sinon
+      .stub(vscode.workspace, "getWorkspaceFolder")
+      .returns(workspaceFolder);
+
+    try {
+      await vscode.debug.startDebugging(workspaceFolder, {
+        type: "ruby_lsp",
+        name: "Debug",
+        request: "launch",
+        program: `ruby ${path.join(workspacePath, "test.rb")}`,
+      });
+    } catch (error: any) {
+      assert.fail(`Failed to launch debugger: ${error.message}`);
+    }
+
+    // The debugger might take a bit of time to disconnect from the editor. We need to perform cleanup when we receive
+    // the termination callback or else we try to dispose of the debugger client too early, but we need to wait for that
+    // so that we can clean up stubs otherwise they leak into other tests.
+    await new Promise<void>((resolve) => {
+      vscode.debug.onDidTerminateDebugSession((_session) => {
+        stub.restore();
+        getWorkspaceStub.restore();
+
+        context.subscriptions.forEach((subscription) => {
+          if (!("logLevel" in subscription)) {
+            subscription.dispose();
+          }
+        });
+
+        resolve();
+      });
+    });
+  }).timeout(90000);
+});

--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 
 import * as vscode from "vscode";
 import { CodeLens } from "vscode-languageclient/node";
+import { afterEach } from "mocha";
 
 import { TestController } from "../../testController";
 import { Command } from "../../common";
@@ -17,6 +18,10 @@ suite("TestController", () => {
       update: (_name: string, _value: any) => Promise.resolve(),
     },
   } as unknown as vscode.ExtensionContext;
+
+  afterEach(() => {
+    context.subscriptions.forEach((subscription) => subscription.dispose());
+  });
 
   test("createTestItems doesn't break when there's a missing group", () => {
     const controller = new TestController(

--- a/vscode/src/test/suite/testHelpers.ts
+++ b/vscode/src/test/suite/testHelpers.ts
@@ -1,0 +1,66 @@
+/* eslint-disable no-process-env */
+
+import os from "os";
+import fs from "fs";
+import path from "path";
+
+import * as vscode from "vscode";
+
+import { ManagerIdentifier } from "../../ruby";
+import { RUBY_VERSION } from "../rubyVersion";
+
+export async function ensureRubyInstallationPaths() {
+  const [major, minor, _patch] = RUBY_VERSION.split(".");
+  // Ensure that we're activating the correct Ruby version on CI
+  if (process.env.CI) {
+    if (os.platform() === "linux") {
+      await vscode.workspace
+        .getConfiguration("rubyLsp")
+        .update(
+          "rubyVersionManager",
+          { identifier: ManagerIdentifier.Chruby },
+          true,
+        );
+
+      fs.mkdirSync(path.join(os.homedir(), ".rubies"), { recursive: true });
+      fs.symlinkSync(
+        `/opt/hostedtoolcache/Ruby/${RUBY_VERSION}/x64`,
+        path.join(os.homedir(), ".rubies", RUBY_VERSION),
+      );
+    } else if (os.platform() === "darwin") {
+      await vscode.workspace
+        .getConfiguration("rubyLsp")
+        .update(
+          "rubyVersionManager",
+          { identifier: ManagerIdentifier.Chruby },
+          true,
+        );
+
+      fs.mkdirSync(path.join(os.homedir(), ".rubies"), { recursive: true });
+      fs.symlinkSync(
+        `/Users/runner/hostedtoolcache/Ruby/${RUBY_VERSION}/arm64`,
+        path.join(os.homedir(), ".rubies", RUBY_VERSION),
+      );
+    } else {
+      await vscode.workspace
+        .getConfiguration("rubyLsp")
+        .update(
+          "rubyVersionManager",
+          { identifier: ManagerIdentifier.RubyInstaller },
+          true,
+        );
+
+      fs.symlinkSync(
+        path.join(
+          "C:",
+          "hostedtoolcache",
+          "windows",
+          "Ruby",
+          RUBY_VERSION,
+          "x64",
+        ),
+        path.join("C:", `Ruby${major}${minor}-${os.arch()}`),
+      );
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

This PR adds an integration test to verify that we can launch the debugger properly for a project with Bundler settings.

This test fails in versions previous than v0.22.0 because we weren't returning the composed bundle env back to the extension, with the same failure reported in https://github.com/Shopify/ruby-lsp/issues/1767 and https://github.com/Shopify/ruby-lsp/issues/1785.