### PR TITLE
Only include workspace name as part of telemetry

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -498,7 +498,7 @@ export default class Client extends LanguageClient implements ClientInterface {
                 ...error.data,
                 serverVersion: this.serverVersion,
                 workspace: new vscode.TelemetryTrustedValue(
-                  this.workingDirectory,
+                  path.basename(this.workingDirectory),
                 ),
               },
             );


### PR DESCRIPTION
### Motivation

I made a mistake when adding the workspace as part of the telemetry. I thought it was the workspace name, but it's actually the path to the workspace, which may include things like `/Users/name/...`.

Let's return only the workspace name to fully anonymize the telemetry.