### PR TITLE
Limit supported client schemes to file and git

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -153,6 +153,7 @@ function collectClientOptions(
 
   const features: EnabledFeatures = configuration.get("enabledFeatures")!;
   const enabledFeatures = Object.keys(features).filter((key) => features[key]);
+  const supportedSchemes = ["file", "git"];
 
   const fsPath = workspaceFolder.uri.fsPath.replace(/\/$/, "");
 
@@ -160,9 +161,11 @@ function collectClientOptions(
   // 1. Files inside of the workspace itself
   // 2. Bundled gems
   // 3. Default gems
-  let documentSelector: DocumentSelector = SUPPORTED_LANGUAGE_IDS.map(
+  let documentSelector: DocumentSelector = SUPPORTED_LANGUAGE_IDS.flatMap(
     (language) => {
-      return { language, pattern: `${fsPath}/**/*` };
+      return supportedSchemes.map((scheme) => {
+        return { scheme, language, pattern: `${fsPath}/**/*` };
+      });
     },
   );
 
@@ -178,26 +181,30 @@ function collectClientOptions(
   }
 
   ruby.gemPath.forEach((gemPath) => {
-    documentSelector.push({
-      language: "ruby",
-      pattern: `${gemPath}/**/*`,
-    });
-
-    // Because of how default gems are installed, the gemPath location is actually not exactly where the files are
-    // located. With the regex, we are correcting the default gem path from this (where the files are not located)
-    // /opt/rubies/3.3.1/lib/ruby/gems/3.3.0
-    //
-    // to this (where the files are actually stored)
-    // /opt/rubies/3.3.1/lib/ruby/3.3.0
-    //
-    // Notice that we still need to add the regular path to the selector because some version managers will install gems
-    // under the non-corrected path
-    if (/lib\/ruby\/gems\/(?=\d)/.test(gemPath)) {
+    supportedSchemes.forEach((scheme) => {
       documentSelector.push({
+        scheme,
         language: "ruby",
-        pattern: `${gemPath.replace(/lib\/ruby\/gems\/(?=\d)/, "lib/ruby/")}/**/*`,
+        pattern: `${gemPath}/**/*`,
       });
-    }
+
+      // Because of how default gems are installed, the gemPath location is actually not exactly where the files are
+      // located. With the regex, we are correcting the default gem path from this (where the files are not located)
+      // /opt/rubies/3.3.1/lib/ruby/gems/3.3.0
+      //
+      // to this (where the files are actually stored)
+      // /opt/rubies/3.3.1/lib/ruby/3.3.0
+      //
+      // Notice that we still need to add the regular path to the selector because some version managers will install
+      // gems under the non-corrected path
+      if (/lib\/ruby\/gems\/(?=\d)/.test(gemPath)) {
+        documentSelector.push({
+          scheme,
+          language: "ruby",
+          pattern: `${gemPath.replace(/lib\/ruby\/gems\/(?=\d)/, "lib/ruby/")}/**/*`,
+        });
+      }
+    });
   });
 
   // This is a temporary solution as an escape hatch for users who cannot upgrade the `ruby-lsp` gem to a version that


### PR DESCRIPTION
### Motivation

With the new AI developments for editors, the LSP receives a lot of unnecessary requests coming from "ghost" schemes. They are usually some sort of resource URI related to the chat or something happening in the background, but it's not actually relevant for the user.

In addition to leading to extra work in the server that is completely unnecessary, it also often confuses users because some of these resources don't send a `textDocument/didOpen` notification before starting to request for other features, which leads to the non existing document error and then people think something is broken, when in reality it's not.

### Implementation

Let's limit the schemes we handle to `file` and `git`.

### Automated Tests

Updated existing tests.