### PR TITLE
Inhibit restart while git operation in progress

### DIFF
--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -85,7 +85,7 @@ export class Workspace implements WorkspaceInterface {
 
     this.registerCreateDeleteWatcher(
       rootGitUri,
-      ".git/{rebase-merge,rebase-apply,BISECT_START,CHERRY_PICK_HEAD}",
+      ".git/{rebase-merge,rebase-apply,BISECT_START,CHERRY_PICK_HEAD,index.lock}",
     );
 
     this.registerRestarts();


### PR DESCRIPTION
I need to test, but I think this would help reduces errors causes by unwanted restarts, e.g. while pulling updates from the git remote. Worth considering?

Idea is from https://stackoverflow.com/questions/47901986/how-to-tell-if-a-git-operation-is-in-progress