### PR TITLE
Declare type in initializer for `RubyIndexer::Enhancement`

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
@@ -33,7 +33,7 @@ module RubyIndexer
 
     sig { params(listener: DeclarationListener).void }
     def initialize(listener)
-      @listener = listener
+      @listener = T.let(listener, RubyIndexer::DeclarationListener)
     end
 
     # The `on_extend` indexing enhancement is invoked whenever an extend is encountered in the code. It can be used to


### PR DESCRIPTION
This will allow us to remove the shim from addons which use Sorbet, such as ruby-lsp-rails.