### PR TITLE
Make `enabled_feature?` return true when all flags are enabled

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -146,7 +146,7 @@ module RubyLsp
 
     sig { params(flag: Symbol).returns(T.nilable(T::Boolean)) }
     def enabled_feature?(flag)
-      @enabled_feature_flags[flag]
+      @enabled_feature_flags[:all] || @enabled_feature_flags[flag]
     end
 
     sig { returns(String) }

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -235,6 +235,20 @@ module RubyLsp
       assert_nil(state.enabled_feature?(:unknown_flag))
     end
 
+    def test_enabled_feature_always_returns_true_if_all_are_enabled
+      state = GlobalState.new
+
+      state.apply_options({
+        initializationOptions: {
+          enabledFeatureFlags: {
+            all: true,
+          },
+        },
+      })
+
+      assert(state.enabled_feature?(:whatever))
+    end
+
     private
 
     def stub_direct_dependencies(dependencies)


### PR DESCRIPTION
### Motivation

When fixing the mistake on the feature flags object composition, I also noticed that the global state wouldn't return `true` if the user had their configuration set as

```json
{
  "rubyLsp.featureFlags": {
    "all": true
  }
}
```

which is not correct. If they enabled all flags, then checking with `enabled_feature?` should return `true`.

### Implementation

Started returning `true` if `all` is enabled.

### Automated Tests

Added a test.