### PR TITLE
Add `coding-terms` to dictionaries list

### DIFF
--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -33,5 +33,5 @@
       "coverage/**",
       "test/fixtures/",
     ],
-    "dictionaries": ["ruby", "en_US", "shell", "file-types", "project-words", "companies", "softwareTerms", "misc"]
+    "dictionaries": ["ruby", "en_US", "shell", "file-types", "project-words", "companies", "softwareTerms", "misc", "coding-terms"]
   }


### PR DESCRIPTION
This should help cut down on the amount of custom words we need to add.

https://github.com/streetsidesoftware/cspell-dicts/blob/main/dictionaries/software-terms/src/coding-terms.txt

(long term I'm considering how we might package up this behavior and make it easy for other teams to adopt, so this is part of that exploration).