### PR TITLE
Use Entry#uri where possible instead of file path

### DIFF
--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -223,7 +223,7 @@ module RubyLsp
           location = entry.location
 
           @response_builder << Interface::Location.new(
-            uri: URI::Generic.from_path(path: entry.file_path).to_s,
+            uri: entry.uri.to_s,
             range: Interface::Range.new(
               start: Interface::Position.new(line: location.start_line - 1, character: location.start_column),
               end: Interface::Position.new(line: location.end_line - 1, character: location.end_column),
@@ -248,7 +248,7 @@ module RubyLsp
           location = entry.location
 
           @response_builder << Interface::Location.new(
-            uri: URI::Generic.from_path(path: entry.file_path).to_s,
+            uri: entry.uri.to_s,
             range: Interface::Range.new(
               start: Interface::Position.new(line: location.start_line - 1, character: location.start_column),
               end: Interface::Position.new(line: location.end_line - 1, character: location.end_column),
@@ -275,11 +275,11 @@ module RubyLsp
         return unless methods
 
         methods.each do |target_method|
-          file_path = target_method.file_path
-          next if sorbet_level_true_or_higher?(@sorbet_level) && not_in_dependencies?(file_path)
+          uri = target_method.uri
+          next if sorbet_level_true_or_higher?(@sorbet_level) && not_in_dependencies?(T.must(uri.full_path))
 
           @response_builder << Interface::LocationLink.new(
-            target_uri: URI::Generic.from_path(path: file_path).to_s,
+            target_uri: uri.to_s,
             target_range: range_from_location(target_method.location),
             target_selection_range: range_from_location(target_method.name_location),
           )
@@ -348,11 +348,11 @@ module RubyLsp
           # If the project has Sorbet, then we only want to handle go to definition for constants defined in gems, as an
           # additional behavior on top of jumping to RBIs. The only sigil where Sorbet cannot handle constants is typed
           # ignore
-          file_path = entry.file_path
-          next if @sorbet_level != RubyDocument::SorbetLevel::Ignore && not_in_dependencies?(file_path)
+          uri = entry.uri
+          next if @sorbet_level != RubyDocument::SorbetLevel::Ignore && not_in_dependencies?(T.must(uri.full_path))
 
           @response_builder << Interface::LocationLink.new(
-            target_uri: URI::Generic.from_path(path: file_path).to_s,
+            target_uri: uri.to_s,
             target_range: range_from_location(entry.location),
             target_selection_range: range_from_location(entry.name_location),
           )

--- a/lib/ruby_lsp/requests/prepare_type_hierarchy.rb
+++ b/lib/ruby_lsp/requests/prepare_type_hierarchy.rb
@@ -66,7 +66,7 @@ module RubyLsp
           Interface::TypeHierarchyItem.new(
             name: first_entry.name,
             kind: kind_for_entry(first_entry),
-            uri: URI::Generic.from_path(path: first_entry.file_path).to_s,
+            uri: first_entry.uri.to_s,
             range: range,
             selection_range: range,
           ),

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -93,11 +93,7 @@ module RubyLsp
             # based, which is why instead of the usual subtraction of 1 to line numbers, we are actually adding 1 to
             # columns. The format for VS Code file URIs is
             # `file:///path/to/file.rb#Lstart_line,start_column-end_line,end_column`
-            uri = URI::Generic.from_path(
-              path: entry.file_path,
-              fragment: "L#{loc.start_line},#{loc.start_column + 1}-#{loc.end_line},#{loc.end_column + 1}",
-            )
-
+            uri = "#{entry.uri}#L#{loc.start_line},#{loc.start_column + 1}-#{loc.end_line},#{loc.end_column + 1}"
             definitions << "[#{entry.file_name}](#{uri})"
             content << "\n\n#{entry.comments}" unless entry.comments.empty?
           end

--- a/lib/ruby_lsp/requests/type_hierarchy_supertypes.rb
+++ b/lib/ruby_lsp/requests/type_hierarchy_supertypes.rb
@@ -65,7 +65,7 @@ module RubyLsp
         Interface::TypeHierarchyItem.new(
           name: entry.name,
           kind: kind_for_entry(entry),
-          uri: URI::Generic.from_path(path: entry.file_path).to_s,
+          uri: entry.uri.to_s,
           range: range_from_location(entry.location),
           selection_range: range_from_location(entry.name_location),
           detail: entry.file_name,

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -21,7 +21,8 @@ module RubyLsp
       sig { override.returns(T::Array[Interface::WorkspaceSymbol]) }
       def perform
         @index.fuzzy_search(@query).filter_map do |entry|
-          file_path = entry.file_path
+          uri = entry.uri
+          file_path = T.must(uri.full_path)
 
           # We only show symbols declared in the workspace
           in_dependencies = !not_in_dependencies?(file_path)
@@ -43,7 +44,7 @@ module RubyLsp
             container_name: container.join("::"),
             kind: kind,
             location: Interface::Location.new(
-              uri: URI::Generic.from_path(path: file_path).to_s,
+              uri: uri.to_s,
               range:  Interface::Range.new(
                 start: Interface::Position.new(line: loc.start_line - 1, character: loc.start_column),
                 end: Interface::Position.new(line: loc.end_line - 1, character: loc.end_column),


### PR DESCRIPTION
### Motivation

Another step towards #1908

This PR starts using the entry's URI directly instead of rebuilding them from the file paths. This allows us to do less work, but is also an important step so that features will actually work once we index unsaved files.

### Implementation

Started using the entry's URI for building responses, like definition locations.