### PR TITLE
Test for presence of shadowenv binary before running Shadowenv suite

### DIFF
--- a/vscode/src/test/suite/ruby/shadowenv.test.ts
+++ b/vscode/src/test/suite/ruby/shadowenv.test.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import assert from "assert";
 import path from "path";
 import os from "os";
+import { execSync } from "child_process";
 
 import { beforeEach, afterEach } from "mocha";
 import * as vscode from "vscode";
@@ -18,6 +19,14 @@ suite("Shadowenv", () => {
   if (os.platform() === "win32") {
     // eslint-disable-next-line no-console
     console.log("Skipping Shadowenv tests on Windows");
+    return;
+  }
+
+  try {
+    execSync("shadowenv --version >/dev/null 2>&1");
+  } catch {
+    // eslint-disable-next-line no-console
+    console.log("Skipping Shadowenv tests because no `shadowenv` found");
     return;
   }
 


### PR DESCRIPTION
Not all non-Shopify developer environments have a version of shadowenv installed. In those circumstances, skip the suite with a console warning.

Part of #2877