### PR TITLE
Allow opting into specific feature flags

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -126,7 +126,7 @@ export function featureEnabled(feature: keyof typeof FEATURE_FLAGS): boolean {
   }
 
   // If the user opted-in to all features, return true
-  if (flagConfiguration.all) {
+  if (flagConfiguration.all || flagConfiguration[feature]) {
     return true;
   }
 

--- a/vscode/src/test/suite/common.test.ts
+++ b/vscode/src/test/suite/common.test.ts
@@ -96,4 +96,18 @@ suite("Common", () => {
     stub.restore();
     assert.strictEqual(result, true);
   });
+
+  test("returns true if user opted in to a specific feature", () => {
+    (FEATURE_FLAGS as any).fakeFeature = 0.02;
+
+    const stub = sandbox.stub(vscode.workspace, "getConfiguration").returns({
+      get: () => {
+        return { fakeFeature: true };
+      },
+    } as any);
+
+    const result = featureEnabled("fakeFeature" as any);
+    stub.restore();
+    assert.strictEqual(result, true);
+  });
 });


### PR DESCRIPTION
### Motivation

In the implementation of feature flags, I forgot to check if the user opted into a specific flag. Currently, the code doesn't check for that, which means you can only opt into all of them.

### Implementation

We just need to check if the user opted into that specific flag.

### Automated Tests

Added a test.