### PR TITLE
Chruby test suite looks for ruby binary in multiple locations

### DIFF
--- a/vscode/src/test/suite/ruby/chruby.test.ts
+++ b/vscode/src/test/suite/ruby/chruby.test.ts
@@ -29,7 +29,19 @@ function createRubySymlinks(destination: string) {
       destination,
     );
   } else {
-    fs.symlinkSync(`/opt/rubies/${RUBY_VERSION}/bin/ruby`, destination);
+    const possibleLocations = [
+      `${os.homedir()}/.rubies/${RUBY_VERSION}/bin/ruby`,
+      `${os.homedir()}/.rubies/ruby-${RUBY_VERSION}/bin/ruby`,
+      `/opt/rubies/${RUBY_VERSION}/bin/ruby`,
+      `/opt/rubies/ruby-${RUBY_VERSION}/bin/ruby`,
+    ];
+
+    for (const location of possibleLocations) {
+      if (fs.existsSync(location)) {
+        fs.symlinkSync(location, destination);
+        break;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Support both `/opt/rubies` and `~/.rubies` for installation paths, checking both the `engine-version` and `version` formats.

Part of #2877