### PR TITLE
Start accepting any URI scheme in the index

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -140,8 +140,8 @@ if options[:doctor]
   puts "Globbing for indexable files"
 
   index.configuration.indexable_uris.each do |uri|
-    puts "indexing: #{uri.full_path}"
-    index.index_single(uri)
+    puts "indexing: #{uri}"
+    index.index_file(uri)
   end
   return
 end

--- a/exe/ruby-lsp-check
+++ b/exe/ruby-lsp-check
@@ -47,7 +47,7 @@ index = RubyIndexer::Index.new
 uris = index.configuration.indexable_uris
 
 uris.each_with_index do |uri, i|
-  index.index_single(uri)
+  index.index_file(uri)
 rescue => e
   errors[uri.full_path] = e
 ensure

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -60,19 +60,24 @@ module RubyIndexer
 
     sig { returns(String) }
     def file_name
-      File.basename(file_path)
+      if @uri.scheme == "untitled"
+        T.must(@uri.opaque)
+      else
+        File.basename(T.must(file_path))
+      end
     end
 
-    sig { returns(String) }
+    sig { returns(T.nilable(String)) }
     def file_path
-      T.must(@uri.full_path)
+      @uri.full_path
     end
 
     sig { returns(String) }
     def comments
       @comments ||= begin
         # Parse only the comments based on the file path, which is much faster than parsing the entire file
-        parsed_comments = Prism.parse_file_comments(file_path)
+        path = file_path
+        parsed_comments = path ? Prism.parse_file_comments(path) : []
 
         # Group comments based on whether they belong to a single block of comments
         grouped = parsed_comments.slice_when do |left, right|

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -623,7 +623,7 @@ module RubyIndexer
         path: "#{Dir.pwd}/lib/ruby_lsp/node_context.rb",
       )
 
-      @index.index_single(uri, collect_comments: false)
+      @index.index_file(uri, collect_comments: false)
 
       entry = @index["RubyLsp::NodeContext"].first
 

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -13,8 +13,8 @@ module RubyIndexer
 
     private
 
-    def index(source)
-      @index.index_single(URI::Generic.from_path(path: "/fake/path/foo.rb"), source)
+    def index(source, uri: URI::Generic.from_path(path: "/fake/path/foo.rb"))
+      @index.index_single(uri, source)
     end
 
     def assert_entry(expected_name, type, expected_location, visibility: nil)

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1004,11 +1004,13 @@ module RubyLsp
         load_path_entry = $LOAD_PATH.find { |load_path| file_path.start_with?(load_path) }
         uri.add_require_path_from_load_entry(load_path_entry) if load_path_entry
 
+        content = File.read(file_path)
+
         case change[:type]
         when Constant::FileChangeType::CREATED
-          index.index_single(uri)
+          index.index_single(uri, content)
         when Constant::FileChangeType::CHANGED
-          index.handle_change(uri)
+          index.handle_change(uri, content)
         when Constant::FileChangeType::DELETED
           index.delete(uri)
         end

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -36,20 +36,21 @@ module RubyLsp
             },
           },
         })
+
+        server.global_state.index.index_single(uri, source)
       end
 
-      server.global_state.index.index_single(
-        URI::Generic.from_path(path: T.must(uri.to_standardized_path)),
-        source,
-      )
       server.load_addons(include_project_addons: false) if load_addons
-      block.call(server, uri)
-    ensure
-      if load_addons
-        RubyLsp::Addon.addons.each(&:deactivate)
-        RubyLsp::Addon.addons.clear
+
+      begin
+        block.call(server, uri)
+      ensure
+        if load_addons
+          RubyLsp::Addon.addons.each(&:deactivate)
+          RubyLsp::Addon.addons.clear
+        end
+        server.run_shutdown
       end
-      T.must(server).run_shutdown
     end
   end
 end

--- a/rakelib/index.rake
+++ b/rakelib/index.rake
@@ -84,8 +84,7 @@ task "index:topgems": ["download:topgems"] do
 
     errors = Dir[File.join(directory, "**", "*.rb")].filter_map do |filepath|
       print(".")
-      code = File.read(filepath)
-      index.index_single(URI::Generic.from_path(path: filepath), code)
+      index.index_file(URI::Generic.from_path(path: filepath))
       nil
     rescue => e
       errors << { message: e.message, file: filepath }

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1600,7 +1600,7 @@ class CompletionTest < Minitest::Test
         URI::Generic.from_path(load_path_entry: tmpdir, path: path)
       end
 
-      uris.each { |uri| index.index_single(uri) }
+      uris.each { |uri| index.index_file(uri) }
       block.call(tmpdir)
     ensure
       $LOAD_PATH.delete(tmpdir)

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -14,7 +14,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
 
       index = server.global_state.index
 
-      index.index_single(
+      index.index_file(
         URI::Generic.from_path(
           load_path_entry: "#{Dir.pwd}/lib",
           path: File.expand_path(
@@ -23,7 +23,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
           ),
         ),
       )
-      index.index_single(
+      index.index_file(
         URI::Generic.from_path(
           path: File.expand_path(
             "../../test/fixtures/constant_reference_target.rb",
@@ -31,7 +31,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
           ),
         ),
       )
-      index.index_single(
+      index.index_file(
         URI::Generic.from_path(
           load_path_entry: "#{Dir.pwd}/lib",
           path: File.expand_path(
@@ -75,7 +75,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
   def test_jumping_to_default_gems
     with_server("Pathname") do |server, uri|
       index = server.global_state.index
-      index.index_single(URI::Generic.from_path(path: "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb"))
+      index.index_file(URI::Generic.from_path(path: "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb"))
       server.process_message(
         id: 1,
         method: "textDocument/definition",
@@ -163,10 +163,10 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
         path: "#{RbConfig::CONFIG["rubylibdir"]}/bundler.rb",
         load_path_entry: RbConfig::CONFIG["rubylibdir"],
       )
-      index.index_single(bundler_uri)
+      index.index_file(bundler_uri)
 
       Dir.glob("#{RbConfig::CONFIG["rubylibdir"]}/bundler/*.rb").each do |path|
-        index.index_single(URI::Generic.from_path(load_path_entry: RbConfig::CONFIG["rubylibdir"], path: path))
+        index.index_file(URI::Generic.from_path(load_path_entry: RbConfig::CONFIG["rubylibdir"], path: path))
       end
 
       server.process_message(
@@ -230,7 +230,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       create_definition_addon
 
       with_server(source, stub_no_typechecker: true) do |server, uri|
-        server.global_state.index.index_single(
+        server.global_state.index.index_file(
           URI::Generic.from_path(
             load_path_entry: "#{Dir.pwd}/lib",
             path: File.expand_path(

--- a/test/requests/workspace_symbol_test.rb
+++ b/test/requests/workspace_symbol_test.rb
@@ -66,7 +66,7 @@ class WorkspaceSymbolTest < Minitest::Test
   end
 
   def test_does_not_include_symbols_from_dependencies
-    @index.index_single(URI::Generic.from_path(path: "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb"))
+    @index.index_file(URI::Generic.from_path(path: "#{RbConfig::CONFIG["rubylibdir"]}/pathname.rb"))
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "Pathname").perform
     assert_empty(result)

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -439,6 +439,7 @@ class ServerTest < Minitest::Test
   end
 
   def test_changed_file_only_indexes_ruby
+    File.expects(:read).with("/foo.rb").returns("class Foo\nend")
     @server.global_state.index.expects(:index_single).once.with do |uri|
       uri.full_path == "/foo.rb"
     end


### PR DESCRIPTION
### Motivation

Another step towards #1908

After the recent changes, we can now make the index treat entries coming from any URIs appropriately.

### Implementation

The main aspect of change is changing the `@files_to_entries` variable into `@uris_to_entries`. Since entries can now be discovered in URIs not backed by a file on disk, we need to be able to add, remove and handle changes based on URIs.

Additionally, for synchronizing changes in the index, we need to accept the source now, which will be kept in memory for unsaved files.

**Note**: this is a breaking change because it means that the `entries_for` API now _needs_ to accept a URI instead of a file path.

### Automated Tests

Added a test that verifies all of the important functionality for entries discovered in unsaved URIs.