### PR TITLE
Avoid excluding transitive dependencies of default dependencies

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -273,6 +273,9 @@ module RubyIndexer
       end
 
       others.concat(this_gem.to_spec.dependencies) if this_gem
+      others.concat(others.filter_map { |d| d.to_spec&.dependencies }.flatten)
+      others.uniq!
+      others.map!(&:name)
 
       excluded.each do |dependency|
         next unless dependency.runtime?
@@ -281,12 +284,7 @@ module RubyIndexer
         next unless spec
 
         spec.dependencies.each do |transitive_dependency|
-          # If the transitive dependency is included in other groups, skip it
-          next if others.any? { |d| d.name == transitive_dependency.name }
-
-          # If the transitive dependency is included as a transitive dependency of a gem outside of the development
-          # group, skip it
-          next if others.any? { |d| d.to_spec&.dependencies&.include?(transitive_dependency) }
+          next if others.include?(transitive_dependency.name)
 
           excluded << transitive_dependency
         end

--- a/project-words
+++ b/project-words
@@ -67,6 +67,7 @@ rhtml
 rindex
 rjson
 rmtree
+rruby
 rubyfmt
 rubylibdir
 rubylibprefix


### PR DESCRIPTION
### Motivation

I noticed that we were incorrectly excluding dependencies if they were transitive to both the `development` and the default groups. For example:

```ruby
gem "irb"

group :development do
  gem "debug"
end
```

In this case, both `debug` and `irb` depend on `reline`. Since `irb` is a part of the default group, we should not exclude `reline`. The bug is that we weren't taking the transitive dependencies of the default group into account and so when we saw that `debug` was in the development group, we excluded it.

### Implementation

Started concatenating the transitive dependencies that cannot be excluded into the list.

### Automated Tests

Added a test that fails before the fix.