### PR TITLE
Use correct error response for cancellations

### DIFF
--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -173,6 +173,9 @@ module RubyLsp
     sig { returns(String) }
     attr_reader :message
 
+    sig { returns(Integer) }
+    attr_reader :code
+
     sig { params(id: Integer, code: Integer, message: String, data: T.nilable(T::Hash[Symbol, T.untyped])).void }
     def initialize(id:, code:, message:, data: nil)
       @id = id


### PR DESCRIPTION
### Motivation

While working on #2938, I noticed that our request cancellation response was incorrect. The spec determines that requests that got cancelled by the client need to return an error using the code for request cancelled ([see here](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#cancelRequest) and see `RequestCancelled` [here](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes)).

### Implementation

Started returning an error with the right code, rather than a response with a `nil` body.

I also started running cancel notifications directly in the main thread without pushing it to the queue, which was another mistake. If we put that notification in the queue, then we're guaranteed to only process them **after** we finish running requests, which is useless. We need the ability to process them as soon as we receive the notification, so that we have enough time to cancel the requests.

### Automated Tests

Added a test to verify this.