### PR TITLE
Only reindex documents if declarations are being modified

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -64,7 +64,6 @@ module RubyIndexer
         :on_constant_path_or_write_node_enter,
         :on_constant_path_operator_write_node_enter,
         :on_constant_path_and_write_node_enter,
-        :on_constant_or_write_node_enter,
         :on_constant_write_node_enter,
         :on_constant_or_write_node_enter,
         :on_constant_and_write_node_enter,

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -8,6 +8,22 @@ module RubyLsp
 
     ParseResultType = type_member { { fixed: Prism::ParseResult } }
 
+    METHODS_THAT_CHANGE_DECLARATIONS = [
+      :private_constant,
+      :attr_reader,
+      :attr_writer,
+      :attr_accessor,
+      :alias_method,
+      :include,
+      :prepend,
+      :extend,
+      :public,
+      :protected,
+      :private,
+      :module_function,
+      :private_class_method,
+    ].freeze
+
     class SorbetLevel < T::Enum
       enums do
         None = new("none")
@@ -239,6 +255,58 @@ module RubyLsp
         code_units_cache: @code_units_cache,
         node_types: node_types,
       )
+    end
+
+    sig { returns(T::Boolean) }
+    def last_edit_may_change_declarations?
+      # This method controls when we should index documents. If there's no recent edit and the document has just been
+      # opened, we need to index it
+      return true unless @last_edit
+
+      case @last_edit
+      when Delete
+        # Not optimized yet. It's not trivial to identify that a declaration has been removed since the source is no
+        # longer there and we don't remember the deleted text
+        true
+      when Insert, Replace
+        position_may_impact_declarations?(@last_edit.range[:start])
+      else
+        false
+      end
+    end
+
+    private
+
+    sig { params(position: T::Hash[Symbol, Integer]).returns(T::Boolean) }
+    def position_may_impact_declarations?(position)
+      node_context = locate_node(position)
+      node_at_edit = node_context.node
+
+      # Adjust to the parent when editing the constant of a class/module declaration
+      if node_at_edit.is_a?(Prism::ConstantReadNode) || node_at_edit.is_a?(Prism::ConstantPathNode)
+        node_at_edit = node_context.parent
+      end
+
+      case node_at_edit
+      when Prism::ClassNode, Prism::ModuleNode, Prism::SingletonClassNode, Prism::DefNode,
+          Prism::ConstantPathWriteNode, Prism::ConstantPathOrWriteNode, Prism::ConstantPathOperatorWriteNode,
+          Prism::ConstantPathAndWriteNode, Prism::ConstantOrWriteNode, Prism::ConstantWriteNode,
+          Prism::ConstantAndWriteNode, Prism::ConstantOperatorWriteNode, Prism::GlobalVariableAndWriteNode,
+          Prism::GlobalVariableOperatorWriteNode, Prism::GlobalVariableOrWriteNode, Prism::GlobalVariableTargetNode,
+          Prism::GlobalVariableWriteNode, Prism::InstanceVariableWriteNode, Prism::InstanceVariableAndWriteNode,
+          Prism::InstanceVariableOperatorWriteNode, Prism::InstanceVariableOrWriteNode,
+          Prism::InstanceVariableTargetNode, Prism::AliasMethodNode
+        true
+      when Prism::MultiWriteNode
+        [*node_at_edit.lefts, *node_at_edit.rest, *node_at_edit.rights].any? do |node|
+          node.is_a?(Prism::ConstantTargetNode) || node.is_a?(Prism::ConstantPathTargetNode)
+        end
+      when Prism::CallNode
+        receiver = node_at_edit.receiver
+        (!receiver || receiver.is_a?(Prism::SelfNode)) && METHODS_THAT_CHANGE_DECLARATIONS.include?(node_at_edit.name)
+      else
+        false
+      end
     end
   end
 end

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -203,6 +203,9 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
           params: { textDocument: { uri: uri }, position: { line: 1, character: 2 } },
         })
 
+        # Pop the re-indexing notification
+        server.pop_response
+
         result = server.pop_response
         assert_instance_of(RubyLsp::Result, result)
 

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -89,6 +89,10 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
           method: "textDocument/documentSymbol",
           params: { textDocument: { uri: uri } },
         })
+
+        # Pop the re-indexing notification
+        server.pop_response
+
         result = server.pop_response
         assert_instance_of(RubyLsp::Result, result)
 

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -805,6 +805,73 @@ class RubyDocumentTest < Minitest::Test
     MESSAGE
   end
 
+  def test_document_tracks_latest_edit_context
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
+      class Foo
+
+      end
+    RUBY
+
+    # Insert
+    range = { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } }
+    document.push_edits([{ range: range, text: "d" }], version: 2)
+
+    last_edit = T.must(document.last_edit)
+    assert_instance_of(RubyLsp::Document::Insert, last_edit)
+    assert_equal(range, last_edit.range)
+
+    # Replace
+    range = { start: { line: 1, character: 0 }, end: { line: 1, character: 1 } }
+    document.push_edits([{ range: range, text: "def" }], version: 3)
+
+    last_edit = T.must(document.last_edit)
+    assert_instance_of(RubyLsp::Document::Replace, last_edit)
+    assert_equal(range, last_edit.range)
+
+    # Delete
+    range = { start: { line: 1, character: 0 }, end: { line: 1, character: 3 } }
+    document.push_edits([{ range: range, text: "" }], version: 4)
+
+    last_edit = T.must(document.last_edit)
+    assert_instance_of(RubyLsp::Document::Delete, last_edit)
+    assert_equal(range, last_edit.range)
+
+    assert_equal(<<~RUBY, document.source)
+      class Foo
+
+      end
+    RUBY
+  end
+
+  def test_last_edit_may_change_declarations_for_inserts
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
+      class Foo
+      end
+    RUBY
+    assert_predicate(document, :last_edit_may_change_declarations?)
+
+    range = { start: { line: 0, character: 9 }, end: { line: 0, character: 9 } }
+    document.push_edits([{ range: range, text: "t" }], version: 2)
+
+    assert_instance_of(RubyLsp::Document::Insert, document.last_edit)
+    assert_predicate(document, :last_edit_may_change_declarations?)
+  end
+
+  def test_last_edit_may_change_declarations_for_replaces
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
+      class Foo
+      end
+    RUBY
+
+    assert_predicate(document, :last_edit_may_change_declarations?)
+
+    range = { start: { line: 0, character: 6 }, end: { line: 0, character: 9 } }
+    document.push_edits([{ range: range, text: "Bar" }], version: 2)
+
+    assert_instance_of(RubyLsp::Document::Replace, document.last_edit)
+    assert_predicate(document, :last_edit_may_change_declarations?)
+  end
+
   private
 
   def assert_error_edit(actual, error_range)


### PR DESCRIPTION
### Motivation

This PR tries to limit the amount of times we pay the price of reindexing the current document being modified by analyzing the context behind the last edit made to it.

### Implementation

The idea of this approach is to remember the position of the last edit made to a document and the nature of the edit (insert, replace or delete).

Then, depending on the type of edit and what nodes exist under the position where the edit was made, we decide if reindexing is relevant or not.

To determine that, we look at the node under the cursor and, if it matches a node we use for indexing in the `DeclarationListener`, then we consider that we need to reindex.

It's not perfect, so let me know if you have other ideas on how to determine this in a way that is:

1. Fast
2. Accurate

Necessarily in this order because the whole point is to reduce the performance impact of having to reindex. If detecting whether we need to do it or not is equally as slow, then there's no point in doing it.

### Automated Tests

Added some tests, but we should probably add more.