### PR TITLE
VSCode extension checks multiple install locations for `mise` binary

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -17,6 +17,24 @@ import { None } from "./ruby/none";
 import { Custom } from "./ruby/custom";
 import { Asdf } from "./ruby/asdf";
 
+async function detectMise() {
+  const possiblePaths = [
+    vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin", "mise"),
+    vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin", "mise"),
+  ];
+
+  for (const possiblePath of possiblePaths) {
+    try {
+      await vscode.workspace.fs.stat(possiblePath);
+      return true;
+    } catch (error: any) {
+      // Continue looking
+    }
+  }
+
+  return false;
+}
+
 export enum ManagerIdentifier {
   Asdf = "asdf",
   Auto = "auto",
@@ -408,19 +426,9 @@ export class Ruby implements RubyInterface {
       }
     }
 
-    try {
-      await vscode.workspace.fs.stat(
-        vscode.Uri.joinPath(
-          vscode.Uri.file(os.homedir()),
-          ".local",
-          "bin",
-          "mise",
-        ),
-      );
+    if (await detectMise()) {
       this.versionManager = ManagerIdentifier.Mise;
       return;
-    } catch (error: any) {
-      // If the Mise binary doesn't exist, then continue checking
     }
 
     if (os.platform() === "win32") {

--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -30,24 +30,52 @@ export class Mise extends VersionManager {
     const misePath = config.get<string | undefined>(
       "rubyVersionManager.miseExecutablePath",
     );
-    const miseUri = misePath
-      ? vscode.Uri.file(misePath)
-      : vscode.Uri.joinPath(
-          vscode.Uri.file(os.homedir()),
-          ".local",
-          "bin",
-          "mise",
-        );
 
-    try {
-      await vscode.workspace.fs.stat(miseUri);
-      return miseUri;
-    } catch (error: any) {
-      // Couldn't find it
+    if (misePath) {
+      const configuredPath = vscode.Uri.file(misePath);
+
+      try {
+        await vscode.workspace.fs.stat(configuredPath);
+        return configuredPath;
+      } catch (error: any) {
+        throw new Error(
+          `Mise executable configured as ${configuredPath}, but that file doesn't exist`,
+        );
+      }
+    }
+
+    // Possible mise installation paths
+    //
+    // 1. Installation from curl | sh (per mise.jdx.dev Getting Started)
+    // 2. Homebrew M series
+    const possiblePaths = [
+      vscode.Uri.joinPath(
+        vscode.Uri.file(os.homedir()),
+        ".local",
+        "bin",
+        "mise",
+      ),
+      vscode.Uri.joinPath(
+        vscode.Uri.file("/"),
+        "opt",
+        "homebrew",
+        "bin",
+        "mise",
+      ),
+    ];
+
+    for (const possiblePath of possiblePaths) {
+      try {
+        await vscode.workspace.fs.stat(possiblePath);
+        return possiblePath;
+      } catch (error: any) {
+        // Continue looking
+      }
     }
 
     throw new Error(
-      `The Ruby LSP version manager is configured to be Mise, but ${miseUri.fsPath} does not exist`,
+      `The Ruby LSP version manager is configured to be Mise, but could not find Mise installation. Searched in
+        ${possiblePaths.join(", ")}`,
     );
   }
 }


### PR DESCRIPTION
### Motivation

The installation path of Mise differs through the installation method chosen. Using Homebrew results in a path under `/opt/homebrew` where as the installation method from the Mise website is typically under `$HOME/.local`.

### Implementation

When a custom mise path is not defined, 2 potential installation locations are tried instead.

### Automated Tests

Skipping for now per discussion in PR.

### Manual Tests

Extension manually started and observed Mise path of `/opt/homebrew` detected in logs.

```
2024-12-12 16:29:05.413 [info] (manager) Discovered version manager mise
2024-12-12 16:29:05.414 [info] (manager) Running command: `/opt/homebrew/bin/mise x -- ruby -W0 -rjson -e 'STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR" + { env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION, gemPath: Gem.path }.to_json + "RUBY_LSP_ACTIVATION_SEPARATOR")'` in /Users/adam/code/github.com/midstack/manager using shell: /opt/homebrew/bin/fish
```

Closes #2878