### PR TITLE
Enhancement - Move node range caluclation out of loop in completion listener

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -110,13 +110,14 @@ module RubyLsp
         name = constant_name(node)
         return if name.nil?
 
+        range = range_from_location(node.location)
         candidates = @index.constant_completion_candidates(name, @node_context.nesting)
         candidates.each do |entries|
           complete_name = T.must(entries.first).name
           @response_builder << build_entry_completion(
             complete_name,
             name,
-            range_from_location(node.location),
+            range,
             entries,
             top_level?(complete_name),
           )
@@ -335,6 +336,7 @@ module RubyLsp
         type = @type_inferrer.infer_receiver_type(@node_context)
         return unless type
 
+        range = range_from_location(location)
         @index.instance_variable_completion_candidates(name, type.name).each do |entry|
           variable_name = entry.name
 
@@ -346,7 +348,7 @@ module RubyLsp
             label: variable_name,
             label_details: label_details,
             text_edit: Interface::TextEdit.new(
-              range: range_from_location(location),
+              range: range,
               new_text: variable_name,
             ),
             kind: Constant::CompletionItemKind::FIELD,


### PR DESCRIPTION
### Motivation

In the Completion listener, we calculate the node range within the each loop for both constant completion candidates and instance variable completion candidates.

### Implementation

Moved the range calculation outside the loop, as the node is already accessible outside the loop.

### Automated Tests

Not applicable

### Manual Tests

Not applicable