### PR TITLE
Fix folding ranges when a line is surrounded by comments and contains code

### DIFF
--- a/lib/ruby_lsp/listeners/folding_ranges.rb
+++ b/lib/ruby_lsp/listeners/folding_ranges.rb
@@ -195,7 +195,7 @@ module RubyLsp
       def push_comment_ranges
         # Group comments that are on consecutive lines and then push ranges for each group that has at least 2 comments
         @comments.chunk_while do |this, other|
-          this.location.end_line + 1 == other.location.start_line
+          this.location.end_line + 1 == other.location.start_line && !this.trailing? && !other.trailing?
         end.each do |chunk|
           next if chunk.length == 1
 

--- a/test/expectations/folding_ranges/block_comments_surround.exp.json
+++ b/test/expectations/folding_ranges/block_comments_surround.exp.json
@@ -1,0 +1,27 @@
+{
+  "result": [
+    {
+      "startLine": 2,
+      "endLine": 4,
+      "kind": "region"
+    },
+    {
+      "startLine": 2,
+      "endLine": 4,
+      "kind": "region"
+    },
+    {
+      "startLine": 0,
+      "endLine": 1,
+      "kind": "comment"
+    },
+    {
+      "startLine": 3,
+      "endLine": 4,
+      "kind": "comment"
+    }
+  ],
+  "params": [
+
+  ]
+}

--- a/test/fixtures/block_comments_surround.rb
+++ b/test/fixtures/block_comments_surround.rb
@@ -1,0 +1,6 @@
+# Lorem 
+# Ipsum
+foo do # Dolor
+  # Sit
+  # Amet
+end


### PR DESCRIPTION
### Motivation
This would previously create one comment folding range from the first comment all the way to the bottom comment (5 lines in total)

Now the two comment blocks are considered by themselves.

Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/d2e64391-ba91-49a4-8908-3d1838b46160) ![image](https://github.com/user-attachments/assets/3033715c-5d83-43dd-83b4-e2004ed2a851)  |  ![image](https://github.com/user-attachments/assets/93b70cbb-0649-4ba5-a030-b8bd68b1f51b) ![image](https://github.com/user-attachments/assets/7afad117-710b-47ae-bed3-7bd01cba3b6c)

### Implementation

A Prism comment has a method saying wether it is preceeded by code or not. Never consider these trailing comments to be foldable.

### Automated Tests

Yes. Expectation diff:

```diff
diff --git a/test/expectations/folding_ranges/block_comments_surround.exp.json b/test/expectations/folding_ranges/block_comments_surround.exp.json
index b0264ed1..cafcbeca 100644
--- a/test/expectations/folding_ranges/block_comments_surround.exp.json
+++ b/test/expectations/folding_ranges/block_comments_surround.exp.json
@@ -12,11 +12,6 @@
     },
     {
       "startLine": 0,
-      "endLine": 1,
-      "kind": "comment"
-    },
-    {
-      "startLine": 3,
       "endLine": 4,
       "kind": "comment"
     }
```

### Manual Tests

Test code:

```rb
# Lorem
# Ipsum
foo do # Dolor
  # Sit
  # Amet
end
```
