### PR TITLE
Update links for reporting issues

### DIFF
--- a/jekyll/composed-bundle.markdown
+++ b/jekyll/composed-bundle.markdown
@@ -40,4 +40,4 @@ the `ruby-lsp` language server gem to ensure fast distribution of bug fixes and 
 {: .note }
 Setting up the composed bundle requires several integrations with Bundler and there are many edge cases to consider,
 like how to handle configurations or installing private dependencies. If you encounter a problem with the composed
-bundle setup, please let us know by [reporting an issue](https://github.com/Shopify/ruby-lsp/issues/new).
+bundle setup, please let us know by [reporting an issue](https://github.com/Shopify/ruby-lsp/issues/new/choose).

--- a/jekyll/index.markdown
+++ b/jekyll/index.markdown
@@ -507,7 +507,7 @@ Finding a general solution to this problem is not trivial due to the number of d
 systems, shells, plugins and version managers. On top of those, people configure their shell environments differently.
 For example, some users may source their version managers in `~/.zshrc` while others will do it in `~/.zshenv`  or `~/.zprofile`.<br><br>
 If experiencing issues, keep in mind that shell configurations could be interfering, check
-[troubleshooting](troubleshooting) and, if none of the listed solutions work, please [report an issue](https://github.com/Shopify/ruby-lsp/issues/new).
+[troubleshooting](troubleshooting) and, if none of the listed solutions work, please [report an issue](https://github.com/Shopify/ruby-lsp/issues/new/choose).
 
 ### Test explorer
 
@@ -525,7 +525,7 @@ requirements
 ## Experimental Features
 
 Ruby LSP also provides experimental features that are not enabled by default. If you have feedback about these features,
-you can let us know in the [DX Slack](https://join.slack.com/t/ruby-dx/shared_invite/zt-2c8zjlir6-uUDJl8oIwcen_FS_aA~b6Q) or by [creating an issue](https://github.com/Shopify/ruby-lsp/issues/new).
+you can let us know in the [DX Slack](https://join.slack.com/t/ruby-dx/shared_invite/zt-2c8zjlir6-uUDJl8oIwcen_FS_aA~b6Q) or by [creating an issue](https://github.com/Shopify/ruby-lsp/issues/new/choose).
 
 ### Ancestors Hierarchy Request
 

--- a/jekyll/troubleshooting.markdown
+++ b/jekyll/troubleshooting.markdown
@@ -116,7 +116,7 @@ requests, which means the dialogue will never go away.
 
 This is always the result of a bug in the server. It should always fail gracefully without getting into a corrupt state
 that prevents it from responding to new requests coming from the editor. If you encounter this, please submit a bug
-report [here](https://github.com/Shopify/ruby-lsp/issues/new?labels=bug&template=bug_template.yml) including the
+report [here](https://github.com/Shopify/ruby-lsp/issues/new/choose) including the
 steps that led to the server getting stuck.
 
 ### Missing Features
@@ -185,7 +185,7 @@ Does the server status say it's running? If it is running, but you are missing c
 [features documentation](https://shopify.github.io/ruby-lsp/#general-features) to ensure we already added support for it.
 
 If the feature is listed as fully supported, but not working for you, report [an
-issue](https://github.com/Shopify/ruby-lsp/issues/new?labels=bug&projects=&template=bug_template.yml) so that we can
+issue](https://github.com/Shopify/ruby-lsp/issues/new/choose) so that we can
 assist.
 
 ### Check the VS Code output tab
@@ -245,5 +245,5 @@ In the meantime, you can [configure Ruby LSP to ignore a particular gem or file 
 ## After troubleshooting
 
 If after troubleshooting the Ruby LSP is still not initializing properly, please report an issue
-[here](https://github.com/Shopify/ruby-lsp/issues/new?labels=bug&template=bug_template.yml) so that we can assist
+[here](https://github.com/Shopify/ruby-lsp/issues/new/choose) so that we can assist
 in fixing the problem. Remember to include the steps taken when trying to diagnose the issue.


### PR DESCRIPTION
The link https://github.com/Shopify/ruby-lsp/issues/new?labels=bug&template=bug_template.yml wasn't working because we split the template as VS Code / non-VS Code.

I think it's sufficient to link to the [choose](https://github.com/Shopify/ruby-lsp/issues/new/choose) page where users can select the appropriate issue type.