### PR TITLE
Provide additional debugging help when the debugger exits with an error

### DIFF
--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -314,8 +314,9 @@ export class Debugger
       this.debugProcess.on("close", (code) => {
         if (code) {
           const message =
-            `Debugger exited with status ${code}. ` +
-            "Check the Ruby LSP output channel for more information.";
+            `Debugger exited with status ${code}.\n` +
+            `Please make sure \`bundle ${args.join(" ")}\` runs without errors in the terminal.\n` +
+            "Check the Ruby LSP output channel for more information.\n";
           this.logDebuggerMessage(message);
           reject(new Error(message));
         }


### PR DESCRIPTION
### Motivation

In most cases, the issue that causes the debugger to exit can be surfaced by running the same command in the terminal. We can provide that helpful message to the user when the debugger exits with an error.


<img width="331" alt="Screenshot 2024-12-05 at 14 41 39" src="https://github.com/user-attachments/assets/6e0bba90-6a93-4f47-b750-0a5dc34cd071">


### Implementation


### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
