### PR TITLE
Github issue: https://github.com/Shopify/ruby-lsp/issues/2837

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -2260,16 +2260,13 @@
           "end": "(?=,|\\|\\s*)",
           "patterns": [
             {
-              "match": "\\G([&*]?)([a-zA-Z][\\w_]*)|(_[\\w_]*)",
+              "match": "\\G([&*]?)([a-zA-Z_][\\w_]*)",
               "captures": {
                 "1": {
                   "name": "storage.type.variable.ruby"
                 },
                 "2": {
                   "name": "variable.other.block.ruby"
-                },
-                "3": {
-                  "name": "variable.other.block.unused.ruby variable.other.constant.ruby"
                 }
               }
             }


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->
https://github.com/Shopify/ruby-lsp/issues/2837

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

What:
Removes the distinction between block variables prefixed with underscore and those not prefixed with underscore.

Why:
As per the github issue: the leading underscore is just a convention. From Ruby's perspective, it's still a parameter and even referring to it still works.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The regex was making 3 capture groups, one of which was specifically for variables prefixed with an underescore. I removed that group and modified the other variable group to include the underscore prefix. 

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

I saw there was `grammars.test.ts` but I'm running into a lot of errors trying to run the tests. It's a work in progress

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

With changes
<img width="349" alt="with changes" src="https://github.com/user-attachments/assets/49501559-7e45-44cd-980b-fa26b73990c1" />
ges:

Without changes:
<img width="366" alt="without changes" src="https://github.com/user-attachments/assets/183821c0-42ca-413b-a3db-23f3fb738bd3" />
