### PR TITLE
Add glyph for 'Run' code lenses

### DIFF
--- a/lib/ruby_lsp/listeners/code_lens.rb
+++ b/lib/ruby_lsp/listeners/code_lens.rb
@@ -198,7 +198,7 @@ module RubyLsp
 
         @response_builder << create_code_lens(
           node,
-          title: "Run",
+          title: "▶ Run",
           command_name: "rubyLsp.runTest",
           arguments: arguments,
           data: { type: "test", **grouping_data },
@@ -206,7 +206,7 @@ module RubyLsp
 
         @response_builder << create_code_lens(
           node,
-          title: "Run In Terminal",
+          title: "▶ Run In Terminal",
           command_name: "rubyLsp.runTestInTerminal",
           arguments: arguments,
           data: { type: "test_in_terminal", **grouping_data },

--- a/test/expectations/code_lens/minitest_nested_classes_and_modules.exp.json
+++ b/test/expectations/code_lens/minitest_nested_classes_and_modules.exp.json
@@ -12,7 +12,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -46,7 +46,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -114,7 +114,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -147,7 +147,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -213,7 +213,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -246,7 +246,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -312,7 +312,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -346,7 +346,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -414,7 +414,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -447,7 +447,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -513,7 +513,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -547,7 +547,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -615,7 +615,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -648,7 +648,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -714,7 +714,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -747,7 +747,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -813,7 +813,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -847,7 +847,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -915,7 +915,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -948,7 +948,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1014,7 +1014,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1048,7 +1048,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1116,7 +1116,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1149,7 +1149,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1215,7 +1215,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1248,7 +1248,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1314,7 +1314,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1348,7 +1348,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1416,7 +1416,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1449,7 +1449,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_nested_classes_and_modules.rb",
@@ -1504,7 +1504,5 @@
       }
     }
   ],
-  "params": [
-
-  ]
+  "params": []
 }

--- a/test/expectations/code_lens/minitest_spec_tests.exp.json
+++ b/test/expectations/code_lens/minitest_spec_tests.exp.json
@@ -12,7 +12,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -46,7 +46,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -114,7 +114,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -147,7 +147,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -213,7 +213,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -247,7 +247,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -315,7 +315,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -348,7 +348,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -414,7 +414,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -448,7 +448,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -516,7 +516,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -549,7 +549,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -615,7 +615,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -648,7 +648,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -714,7 +714,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -747,7 +747,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -813,7 +813,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -847,7 +847,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -915,7 +915,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -948,7 +948,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1014,7 +1014,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1048,7 +1048,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1116,7 +1116,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1150,7 +1150,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1218,7 +1218,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1251,7 +1251,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1317,7 +1317,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1351,7 +1351,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1419,7 +1419,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1452,7 +1452,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_spec_tests.rb",
@@ -1507,7 +1507,5 @@
       }
     }
   ],
-  "params": [
-
-  ]
+  "params": []
 }

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -12,7 +12,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -46,7 +46,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -114,7 +114,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -147,7 +147,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -213,7 +213,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -246,7 +246,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -312,7 +312,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -345,7 +345,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -411,7 +411,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -444,7 +444,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -510,7 +510,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -543,7 +543,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -609,7 +609,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -643,7 +643,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -711,7 +711,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -744,7 +744,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -810,7 +810,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -843,7 +843,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_tests.rb",
@@ -898,7 +898,5 @@
       }
     }
   ],
-  "params": [
-
-  ]
+  "params": []
 }

--- a/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
+++ b/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
@@ -12,7 +12,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -46,7 +46,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -114,7 +114,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -147,7 +147,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -213,7 +213,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -246,7 +246,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -312,7 +312,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -346,7 +346,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -414,7 +414,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -447,7 +447,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -513,7 +513,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -547,7 +547,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -615,7 +615,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -648,7 +648,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -714,7 +714,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -747,7 +747,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/minitest_with_dynamic_constant_path.rb",
@@ -802,7 +802,5 @@
       }
     }
   ],
-  "params": [
-
-  ]
+  "params": []
 }

--- a/test/expectations/code_lens/nested_minitest_tests.exp.json
+++ b/test/expectations/code_lens/nested_minitest_tests.exp.json
@@ -12,7 +12,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -46,7 +46,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -114,7 +114,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -147,7 +147,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -213,7 +213,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -247,7 +247,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -315,7 +315,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -348,7 +348,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -414,7 +414,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -448,7 +448,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -516,7 +516,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -549,7 +549,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -615,7 +615,7 @@
         }
       },
       "command": {
-        "title": "Run",
+        "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -648,7 +648,7 @@
         }
       },
       "command": {
-        "title": "Run In Terminal",
+        "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
           "/fixtures/nested_minitest_tests.rb",
@@ -703,7 +703,5 @@
       }
     }
   ],
-  "params": [
-
-  ]
+  "params": []
 }

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -40,12 +40,12 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     assert_equal(6, response.size)
 
-    assert_equal("Run In Terminal", T.must(response[1]).command.title)
+    assert_equal("▶ Run In Terminal", T.must(response[1]).command.title)
     assert_equal(
       "bundle exec ruby -Itest /test/fake.rb --name \"/^FooTest(#|::)/\"",
       T.must(response[1]).command.arguments[2],
     )
-    assert_equal("Run In Terminal", T.must(response[4]).command.title)
+    assert_equal("▶ Run In Terminal", T.must(response[4]).command.title)
     assert_equal(
       "bundle exec ruby -Itest /test/fake.rb --name FooTest#test_bar",
       T.must(response[4]).command.arguments[2],
@@ -72,17 +72,17 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     assert_equal(9, response.size)
 
-    assert_equal("Run In Terminal", T.must(response[1]).command.title)
+    assert_equal("▶ Run In Terminal", T.must(response[1]).command.title)
     assert_equal(
       "bundle exec ruby -Ispec /spec/fake.rb --name \"/^FooTest(#|::)/\"",
       T.must(response[1]).command.arguments[2],
     )
-    assert_equal("Run In Terminal", T.must(response[4]).command.title)
+    assert_equal("▶ Run In Terminal", T.must(response[4]).command.title)
     assert_equal(
       "bundle exec ruby -Ispec /spec/fake.rb --name \"/^FooTest::a(#|::)/\"",
       T.must(response[4]).command.arguments[2],
     )
-    assert_equal("Run In Terminal", T.must(response[7]).command.title)
+    assert_equal("▶ Run In Terminal", T.must(response[7]).command.title)
     assert_equal(
       "bundle exec ruby -Ispec /spec/fake.rb --name \"/^FooTest::a#test_0001_b$/\"",
       T.must(response[7]).command.arguments[2],
@@ -107,9 +107,9 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     assert_equal(6, response.size)
 
-    assert_equal("Run In Terminal", T.must(response[1]).command.title)
+    assert_equal("▶ Run In Terminal", T.must(response[1]).command.title)
     assert_equal("bundle exec ruby -Itest /test/fake.rb --testcase /FooTest/", T.must(response[1]).command.arguments[2])
-    assert_equal("Run In Terminal", T.must(response[4]).command.title)
+    assert_equal("▶ Run In Terminal", T.must(response[4]).command.title)
     assert_equal(
       "bundle exec ruby -Itest /test/fake.rb --testcase /FooTest/ --name test_bar",
       T.must(response[4]).command.arguments[2],
@@ -213,8 +213,8 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
         response = result.response
 
         assert_equal(response.size, 4)
-        assert_match("Run", response[0].command.title)
-        assert_match("Run In Terminal", response[1].command.title)
+        assert_match("▶ Run", response[0].command.title)
+        assert_match("▶ Run In Terminal", response[1].command.title)
         assert_match("Debug", response[2].command.title)
         assert_match("Run Test", response[3].command.title)
       ensure


### PR DESCRIPTION
Inspired by https://github.com/rust-lang/rust-analyzer

<img width="213" alt="Screenshot 2024-12-12 at 10 44 08 AM" src="https://github.com/user-attachments/assets/efacfce7-8588-4cfd-9911-cfb14d318d9d" />