### PR TITLE
Locate targets under mutex lock

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -21,7 +21,8 @@ module RubyLsp
       @mutex = T.let(Mutex.new, Mutex)
       @worker = T.let(new_worker, Thread)
       @current_request_id = T.let(1, Integer)
-      @store = T.let(Store.new, Store)
+      @global_state = T.let(GlobalState.new, GlobalState)
+      @store = T.let(Store.new(@global_state), Store)
       @outgoing_dispatcher = T.let(
         Thread.new do
           unless @test_mode
@@ -33,7 +34,6 @@ module RubyLsp
         Thread,
       )
 
-      @global_state = T.let(GlobalState.new, GlobalState)
       Thread.main.priority = 1
 
       # We read the initialize request in `exe/ruby-lsp` to be able to determine the workspace URI where Bundler should

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -43,13 +43,14 @@ module RubyLsp
     sig { returns(T.any(Interface::SemanticTokens, Object)) }
     attr_accessor :semantic_tokens
 
-    sig { params(source: String, version: Integer, uri: URI::Generic, encoding: Encoding).void }
-    def initialize(source:, version:, uri:, encoding: Encoding::UTF_8)
+    sig { params(source: String, version: Integer, uri: URI::Generic, global_state: GlobalState).void }
+    def initialize(source:, version:, uri:, global_state:)
+      @source = source
+      @version = version
+      @global_state = global_state
       @cache = T.let(Hash.new(EMPTY_CACHE), T::Hash[String, T.untyped])
       @semantic_tokens = T.let(EMPTY_CACHE, T.any(Interface::SemanticTokens, Object))
-      @encoding = T.let(encoding, Encoding)
-      @source = T.let(source, String)
-      @version = T.let(version, Integer)
+      @encoding = T.let(global_state.encoding, Encoding)
       @uri = T.let(uri, URI::Generic)
       @needs_parsing = T.let(true, T::Boolean)
       @parse_result = T.let(T.unsafe(nil), ParseResultType)

--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -63,9 +63,11 @@ module RubyLsp
       ).returns(NodeContext)
     end
     def locate_node(position, node_types: [])
+      char_position, _ = find_index_by_position(position)
+
       RubyDocument.locate(
         @parse_result.value,
-        create_scanner.find_char_position(position),
+        char_position,
         code_units_cache: @code_units_cache,
         node_types: node_types,
       )

--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -19,8 +19,8 @@ module RubyLsp
     end
     attr_reader :code_units_cache
 
-    sig { params(source: String, version: Integer, uri: URI::Generic, encoding: Encoding).void }
-    def initialize(source:, version:, uri:, encoding: Encoding::UTF_8)
+    sig { params(source: String, version: Integer, uri: URI::Generic, global_state: GlobalState).void }
+    def initialize(source:, version:, uri:, global_state:)
       # This has to be initialized before calling super because we call `parse` in the parent constructor, which
       # overrides this with the proper virtual host language source
       @host_language_source = T.let("", String)

--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -53,6 +53,12 @@ module RubyLsp
       )
       @client_capabilities = T.let(ClientCapabilities.new, ClientCapabilities)
       @enabled_feature_flags = T.let({}, T::Hash[Symbol, T::Boolean])
+      @mutex = T.let(Mutex.new, Mutex)
+    end
+
+    sig { type_parameters(:T).params(block: T.proc.returns(T.type_parameter(:T))).returns(T.type_parameter(:T)) }
+    def synchronize(&block)
+      @mutex.synchronize(&block)
     end
 
     sig { params(addon_name: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }

--- a/lib/ruby_lsp/rbs_document.rb
+++ b/lib/ruby_lsp/rbs_document.rb
@@ -8,8 +8,8 @@ module RubyLsp
 
     ParseResultType = type_member { { fixed: T::Array[RBS::AST::Declarations::Base] } }
 
-    sig { params(source: String, version: Integer, uri: URI::Generic, encoding: Encoding).void }
-    def initialize(source:, version:, uri:, encoding: Encoding::UTF_8)
+    sig { params(source: String, version: Integer, uri: URI::Generic, global_state: GlobalState).void }
+    def initialize(source:, version:, uri:, global_state:)
       @syntax_error = T.let(false, T::Boolean)
       super
     end

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -92,9 +92,7 @@ module RubyLsp
         source_range = @code_action.dig(:data, :range)
         return Error::EmptySelection if source_range[:start] == source_range[:end]
 
-        scanner = @document.create_scanner
-        start_index = scanner.find_char_position(source_range[:start])
-        end_index = scanner.find_char_position(source_range[:end])
+        start_index, end_index = @document.find_index_by_position(source_range[:start], source_range[:end])
         extracted_source = T.must(@document.source[start_index...end_index])
 
         # Find the closest statements node, so that we place the refactor in a valid position
@@ -192,9 +190,7 @@ module RubyLsp
         source_range = @code_action.dig(:data, :range)
         return Error::EmptySelection if source_range[:start] == source_range[:end]
 
-        scanner = @document.create_scanner
-        start_index = scanner.find_char_position(source_range[:start])
-        end_index = scanner.find_char_position(source_range[:end])
+        start_index, end_index = @document.find_index_by_position(source_range[:start], source_range[:end])
         extracted_source = T.must(@document.source[start_index...end_index])
 
         # Find the closest method declaration node, so that we place the refactor in a valid position

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -40,7 +40,8 @@ module RubyLsp
         @dispatcher = dispatcher
         # Completion always receives the position immediately after the character that was just typed. Here we adjust it
         # back by 1, so that we find the right node
-        char_position = document.create_scanner.find_char_position(params[:position]) - 1
+        char_position, _ = document.find_index_by_position(params[:position])
+        char_position -= 1
         delegate_request_if_needed!(global_state, document, char_position)
 
         node_context = RubyDocument.locate(

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -29,7 +29,7 @@ module RubyLsp
         )
         @dispatcher = dispatcher
 
-        char_position = document.create_scanner.find_char_position(position)
+        char_position, _ = document.find_index_by_position(position)
         delegate_request_if_needed!(global_state, document, char_position)
 
         node_context = RubyDocument.locate(

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -25,7 +25,7 @@ module RubyLsp
       end
       def initialize(global_state, document, position, dispatcher)
         super()
-        char_position = document.create_scanner.find_char_position(position)
+        char_position, _ = document.find_index_by_position(position)
         delegate_request_if_needed!(global_state, document, char_position)
 
         node_context = RubyDocument.locate(

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -34,7 +34,7 @@ module RubyLsp
       def initialize(document, global_state, position, dispatcher, sorbet_level)
         super()
 
-        char_position = document.create_scanner.find_char_position(position)
+        char_position, _ = document.find_index_by_position(position)
         delegate_request_if_needed!(global_state, document, char_position)
 
         node_context = RubyDocument.locate(

--- a/lib/ruby_lsp/requests/prepare_rename.rb
+++ b/lib/ruby_lsp/requests/prepare_rename.rb
@@ -24,7 +24,7 @@ module RubyLsp
 
       sig { override.returns(T.nilable(Interface::Range)) }
       def perform
-        char_position = @document.create_scanner.find_char_position(@position)
+        char_position, _ = @document.find_index_by_position(@position)
 
         node_context = RubyDocument.locate(
           @document.parse_result.value,

--- a/lib/ruby_lsp/requests/references.rb
+++ b/lib/ruby_lsp/requests/references.rb
@@ -30,7 +30,7 @@ module RubyLsp
       sig { override.returns(T::Array[Interface::Location]) }
       def perform
         position = @params[:position]
-        char_position = @document.create_scanner.find_char_position(position)
+        char_position, _ = @document.find_index_by_position(position)
 
         node_context = RubyDocument.locate(
           @document.parse_result.value,

--- a/lib/ruby_lsp/requests/rename.rb
+++ b/lib/ruby_lsp/requests/rename.rb
@@ -40,7 +40,7 @@ module RubyLsp
 
       sig { override.returns(T.nilable(Interface::WorkspaceEdit)) }
       def perform
-        char_position = @document.create_scanner.find_char_position(@position)
+        char_position, _ = @document.find_index_by_position(@position)
 
         node_context = RubyDocument.locate(
           @document.parse_result.value,

--- a/lib/ruby_lsp/requests/show_syntax_tree.rb
+++ b/lib/ruby_lsp/requests/show_syntax_tree.rb
@@ -31,10 +31,7 @@ module RubyLsp
       sig { returns(String) }
       def ast_for_range
         range = T.must(@range)
-
-        scanner = @document.create_scanner
-        start_char = scanner.find_char_position(range[:start])
-        end_char = scanner.find_char_position(range[:end])
+        start_char, end_char = @document.find_index_by_position(range[:start], range[:end])
 
         queue = @tree.statements.body.dup
         found_nodes = []

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -36,7 +36,7 @@ module RubyLsp
       def initialize(document, global_state, position, context, dispatcher, sorbet_level) # rubocop:disable Metrics/ParameterLists
         super()
 
-        char_position = document.create_scanner.find_char_position(position)
+        char_position, _ = document.find_index_by_position(position)
         delegate_request_if_needed!(global_state, document, char_position)
 
         node_context = RubyDocument.locate(

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -142,8 +142,8 @@ module RubyLsp
     end
     attr_reader :code_units_cache
 
-    sig { params(source: String, version: Integer, uri: URI::Generic, encoding: Encoding).void }
-    def initialize(source:, version:, uri:, encoding: Encoding::UTF_8)
+    sig { params(source: String, version: Integer, uri: URI::Generic, global_state: GlobalState).void }
+    def initialize(source:, version:, uri:, global_state:)
       super
       @code_units_cache = T.let(@parse_result.code_units_cache(@encoding), T.any(
         T.proc.params(arg0: Integer).returns(Integer),

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -198,9 +198,8 @@ module RubyLsp
       ).returns(T.nilable(Prism::Node))
     end
     def locate_first_within_range(range, node_types: [])
-      scanner = create_scanner
-      start_position = scanner.find_char_position(range[:start])
-      end_position = scanner.find_char_position(range[:end])
+      start_position, end_position = find_index_by_position(range[:start], range[:end])
+
       desired_range = (start_position...end_position)
       queue = T.let(@parse_result.value.child_nodes.compact, T::Array[T.nilable(Prism::Node)])
 
@@ -232,9 +231,11 @@ module RubyLsp
       ).returns(NodeContext)
     end
     def locate_node(position, node_types: [])
+      char_position, _ = find_index_by_position(position)
+
       RubyDocument.locate(
         @parse_result.value,
-        create_scanner.find_char_position(position),
+        char_position,
         code_units_cache: @code_units_cache,
         node_types: node_types,
       )

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -392,7 +392,6 @@ module RubyLsp
           uri: text_document[:uri],
           source: text_document[:text],
           version: text_document[:version],
-          encoding: @global_state.encoding,
           language_id: language_id,
         )
 

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -13,8 +13,9 @@ module RubyLsp
     sig { returns(String) }
     attr_accessor :client_name
 
-    sig { void }
-    def initialize
+    sig { params(global_state: GlobalState).void }
+    def initialize(global_state)
+      @global_state = global_state
       @state = T.let({}, T::Hash[String, Document[T.untyped]])
       @features_configuration = T.let(
         {
@@ -61,17 +62,16 @@ module RubyLsp
         source: String,
         version: Integer,
         language_id: Document::LanguageId,
-        encoding: Encoding,
       ).returns(Document[T.untyped])
     end
-    def set(uri:, source:, version:, language_id:, encoding: Encoding::UTF_8)
+    def set(uri:, source:, version:, language_id:)
       @state[uri.to_s] = case language_id
       when Document::LanguageId::ERB
-        ERBDocument.new(source: source, version: version, uri: uri, encoding: encoding)
+        ERBDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
       when Document::LanguageId::RBS
-        RBSDocument.new(source: source, version: version, uri: uri, encoding: encoding)
+        RBSDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
       else
-        RubyDocument.new(source: source, version: version, uri: uri, encoding: encoding)
+        RubyDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
       end
     end
 

--- a/test/erb_document_test.rb
+++ b/test/erb_document_test.rb
@@ -4,8 +4,12 @@
 require "test_helper"
 
 class ERBDocumentTest < Minitest::Test
+  def setup
+    @global_state = RubyLsp::GlobalState.new
+  end
+
   def test_erb_file_is_properly_parsed
-    document = RubyLsp::ERBDocument.new(source: +<<~ERB, version: 1, uri: URI("file:///foo.erb"))
+    source = +<<~ERB
       <ul>
         <li><%= foo %><li>
         <li><%= bar %><li>
@@ -13,6 +17,12 @@ class ERBDocumentTest < Minitest::Test
         <li><%- quz %><li>
       </ul>
     ERB
+    document = RubyLsp::ERBDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.erb"),
+      global_state: @global_state,
+    )
 
     document.parse!
 
@@ -24,7 +34,7 @@ class ERBDocumentTest < Minitest::Test
   end
 
   def test_erb_file_parses_in_eval_context
-    document = RubyLsp::ERBDocument.new(source: +<<~ERB, version: 1, uri: URI("file:///foo.erb"))
+    source = +<<~ERB
       <html>
         <head>
           <%= yield :head %>
@@ -34,6 +44,12 @@ class ERBDocumentTest < Minitest::Test
         </body>
       </html>
     ERB
+    document = RubyLsp::ERBDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.erb"),
+      global_state: @global_state,
+    )
 
     document.parse!
 
@@ -45,7 +61,12 @@ class ERBDocumentTest < Minitest::Test
   end
 
   def test_erb_document_handles_windows_newlines
-    document = RubyLsp::ERBDocument.new(source: "<%=\r\nbar %>", version: 1, uri: URI("file:///foo.erb"))
+    document = RubyLsp::ERBDocument.new(
+      source: "<%=\r\nbar %>",
+      version: 1,
+      uri: URI("file:///foo.erb"),
+      global_state: @global_state,
+    )
     document.parse!
 
     refute_predicate(document, :syntax_error?)
@@ -61,28 +82,45 @@ class ERBDocumentTest < Minitest::Test
       "<%= foo %>\n<%= bar",
       "<%= foo %\n<%= bar %>",
     ].each do |source|
-      document = RubyLsp::ERBDocument.new(source: source, version: 1, uri: URI("file:///foo.erb"))
+      document = RubyLsp::ERBDocument.new(
+        source: source,
+        version: 1,
+        uri: URI("file:///foo.erb"),
+        global_state: @global_state,
+      )
       document.parse!
     end
   end
 
   def test_failing_to_parse_indicates_syntax_error
-    document = RubyLsp::ERBDocument.new(source: +<<~ERB, version: 1, uri: URI("file:///foo.erb"))
+    source = +<<~ERB
       <ul>
         <li><%= foo %><li>
         <li><%= end %><li>
       </ul>
     ERB
+    document = RubyLsp::ERBDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.erb"),
+      global_state: @global_state,
+    )
 
     assert_predicate(document, :syntax_error?)
   end
 
   def test_locate
-    document = RubyLsp::ERBDocument.new(source: <<~ERB, version: 1, uri: URI("file:///foo/bar.erb"))
+    source = <<~ERB
       <% Post.all.each do |post| %>
         <h1><%= post.title %></h1>
       <% end %>
     ERB
+    document = RubyLsp::ERBDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo/bar.erb"),
+      global_state: @global_state,
+    )
 
     # Locate the `Post` class
     node_context = document.locate_node({ line: 0, character: 3 })
@@ -100,7 +138,12 @@ class ERBDocumentTest < Minitest::Test
   end
 
   def test_cache_set_and_get
-    document = RubyLsp::ERBDocument.new(source: +"", version: 1, uri: URI("file:///foo/bar.erb"))
+    document = RubyLsp::ERBDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///foo/bar.erb"),
+      global_state: @global_state,
+    )
     value = [1, 2, 3]
 
     assert_equal(value, document.cache_set("textDocument/semanticHighlighting", value))
@@ -108,12 +151,18 @@ class ERBDocumentTest < Minitest::Test
   end
 
   def test_keeps_track_of_virtual_host_language_source
-    document = RubyLsp::ERBDocument.new(source: +<<~ERB, version: 1, uri: URI("file:///foo.erb"))
+    source = +<<~ERB
       <ul>
         <li><%= foo %><li>
         <li><%= end %><li>
       </ul>
     ERB
+    document = RubyLsp::ERBDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.erb"),
+      global_state: @global_state,
+    )
 
     assert_equal(<<~HTML, document.host_language_source)
       <ul>
@@ -124,11 +173,17 @@ class ERBDocumentTest < Minitest::Test
   end
 
   def test_erb_is_parsed_as_a_partial_script
-    document = RubyLsp::ERBDocument.new(source: +<<~ERB, version: 1, uri: URI("file:///foo.erb"))
+    source = +<<~ERB
       <ul>
         <li><%= redo %><li>
       </ul>
     ERB
+    document = RubyLsp::ERBDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.erb"),
+      global_state: @global_state,
+    )
 
     document.parse!
 

--- a/test/rbs_document_test.rb
+++ b/test/rbs_document_test.rb
@@ -4,12 +4,23 @@
 require "test_helper"
 
 class RBSDocumentTest < Minitest::Test
+  def setup
+    @global_state = RubyLsp::GlobalState.new
+  end
+
   def test_parse_result_is_array_of_declarations
-    document = RubyLsp::RBSDocument.new(source: <<~RBS, version: 1, uri: URI("file:///foo.rbs"))
+    source = <<~RBS
       class Foo
         def bar: () -> void
       end
     RBS
+
+    document = RubyLsp::RBSDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.rbs"),
+      global_state: @global_state,
+    )
 
     refute_predicate(document, :syntax_error?)
     assert_equal(:Foo, T.cast(document.parse_result[0], RBS::AST::Declarations::Class).name.name)
@@ -17,11 +28,17 @@ class RBSDocumentTest < Minitest::Test
 
   def test_parsing_remembers_syntax_errors
     # The syntax error is that `-` should be `->`
-    document = RubyLsp::RBSDocument.new(source: +<<~RBS, version: 1, uri: URI("file:///foo.rbs"))
+    source = +<<~RBS
       class Foo
         def bar: () - void
       end
     RBS
+    document = RubyLsp::RBSDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.rbs"),
+      global_state: @global_state,
+    )
 
     assert_predicate(document, :syntax_error?)
 

--- a/test/requests/code_action_resolve_expectations_test.rb
+++ b/test/requests/code_action_resolve_expectations_test.rb
@@ -7,13 +7,14 @@ require_relative "support/expectations_test_runner"
 class CodeActionResolveExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeActionResolve, "code_action_resolve"
 
-  def setup
-    @global_state = RubyLsp::GlobalState.new
-  end
-
   def run_expectations(source)
     params = @__params&.any? ? @__params : default_args
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     RubyLsp::Requests::CodeActionResolve.new(document, @global_state, params).perform
   end

--- a/test/requests/code_actions_expectations_test.rb
+++ b/test/requests/code_actions_expectations_test.rb
@@ -9,7 +9,12 @@ class CodeActionsExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     params = @__params&.any? ? @__params : default_args
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake"))
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///fake"),
+      global_state: @global_state,
+    )
     result = T.let(nil, T.nilable(T::Array[LanguageServer::Protocol::Interface::CodeAction]))
 
     stdout, _ = capture_io do

--- a/test/requests/code_actions_formatting_test.rb
+++ b/test/requests/code_actions_formatting_test.rb
@@ -68,13 +68,6 @@ class CodeActionsFormattingTest < Minitest::Test
     ).returns(T.untyped)
   end
   def assert_corrects_to_expected(diagnostic_code, code_action_title, source, expected)
-    document = RubyLsp::RubyDocument.new(
-      source: source.dup,
-      version: 1,
-      uri: URI::Generic.from_path(path: __FILE__),
-      encoding: Encoding::UTF_16LE,
-    )
-
     global_state = RubyLsp::GlobalState.new
     global_state.apply_options({
       initializationOptions: { linters: ["rubocop"] },
@@ -82,6 +75,13 @@ class CodeActionsFormattingTest < Minitest::Test
     global_state.register_formatter(
       "rubocop",
       RubyLsp::Requests::Support::RuboCopFormatter.new,
+    )
+
+    document = RubyLsp::RubyDocument.new(
+      source: source.dup,
+      version: 1,
+      uri: URI::Generic.from_path(path: __FILE__),
+      global_state: global_state,
     )
 
     diagnostics = RubyLsp::Requests::Diagnostics.new(global_state, document).perform

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -7,13 +7,9 @@ require_relative "support/expectations_test_runner"
 class CodeLensExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeLens, "code_lens"
 
-  def setup
-    @global_state = RubyLsp::GlobalState.new
-  end
-
   def run_expectations(source)
     uri = URI("file://#{@_path}")
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     stub_test_library("minitest")
@@ -31,7 +27,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI("file:///test/fake.rb")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::CodeLens.new(@global_state, uri, dispatcher)
@@ -63,7 +59,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI("file:///spec/fake.rb")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::CodeLens.new(@global_state, uri, dispatcher)
@@ -98,7 +94,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI("file:///test/fake.rb")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::CodeLens.new(@global_state, uri, dispatcher)
@@ -124,7 +120,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI("file:///fake.rb")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     stub_test_library("unknown")
@@ -143,7 +139,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI("file:///fake.rb")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     stub_test_library("rspec")
@@ -162,7 +158,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI::Generic.build(scheme: "untitled", opaque: "Untitled-1")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     stub_test_library("minitest")
@@ -181,7 +177,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI::Generic.build(scheme: "untitled", opaque: "Untitled-1")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     stub_test_library("minitest")
@@ -234,7 +230,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI("file:///fake.rb")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::CodeLens.new(@global_state, uri, dispatcher)

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -8,20 +8,25 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Diagnostics, "diagnostics"
 
   def run_expectations(source)
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
     result = T.let(nil, T.nilable(T::Array[RubyLsp::Interface::Diagnostic]))
-    global_state = RubyLsp::GlobalState.new
-    global_state.apply_options({
+    @global_state.apply_options({
       initializationOptions: { linters: ["rubocop"] },
     })
-    global_state.register_formatter(
+    @global_state.register_formatter(
       "rubocop",
       RubyLsp::Requests::Support::RuboCopFormatter.new,
     )
 
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI::Generic.from_path(path: __FILE__),
+      global_state: @global_state,
+    )
+
     stdout, _ = capture_io do
       result = T.cast(
-        RubyLsp::Requests::Diagnostics.new(global_state, document).perform,
+        RubyLsp::Requests::Diagnostics.new(@global_state, document).perform,
         T::Array[RubyLsp::Interface::Diagnostic],
       )
     end

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class DiagnosticsTest < Minitest::Test
   def setup
+    @uri = URI("file:///fake/file.rb")
     @global_state = RubyLsp::GlobalState.new
     @global_state.apply_options({
       initializationOptions: { linters: ["rubocop"] },
@@ -21,6 +22,7 @@ class DiagnosticsTest < Minitest::Test
       source: File.read(fixture_path),
       version: 1,
       uri: URI::Generic.from_path(path: fixture_path),
+      global_state: @global_state,
     )
 
     result = RubyLsp::Requests::Diagnostics.new(@global_state, document).perform
@@ -28,7 +30,7 @@ class DiagnosticsTest < Minitest::Test
   end
 
   def test_returns_syntax_error_diagnostics
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///fake/file.rb"))
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       def foo
     RUBY
 
@@ -39,7 +41,7 @@ class DiagnosticsTest < Minitest::Test
   end
 
   def test_empty_diagnostics_without_rubocop
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///fake/file.rb"))
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       def foo
         "Hello, world!"
       end
@@ -61,7 +63,7 @@ class DiagnosticsTest < Minitest::Test
   end
 
   def test_empty_diagnostics_with_rubocop
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///fake/file.rb"))
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       def foo
         "Hello, world!"
       end
@@ -73,7 +75,7 @@ class DiagnosticsTest < Minitest::Test
   end
 
   def test_registering_formatter_with_diagnostic_support
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: URI("file:///fake/file.rb"))
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       def foo
         "Hello, world!"
       end
@@ -107,7 +109,7 @@ class DiagnosticsTest < Minitest::Test
   end
 
   def test_ambiguous_syntax_warnings
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY.chomp, version: 1, uri: URI("file:///fake/file.rb"))
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY.chomp, version: 1, uri: @uri, global_state: @global_state)
       b +a
       b -a
       b *a
@@ -122,7 +124,7 @@ class DiagnosticsTest < Minitest::Test
   end
 
   def test_END_inside_method_definition_warning
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY.chomp, version: 1, uri: URI("file:///fake/file.rb"))
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY.chomp, version: 1, uri: @uri, global_state: @global_state)
       def m; END{}; end
     RUBY
 
@@ -131,7 +133,7 @@ class DiagnosticsTest < Minitest::Test
   end
 
   def test_syntax_error_diagnostic
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY.chomp, version: 1, uri: URI("file:///fake/file.rb"))
+    document = RubyLsp::RubyDocument.new(source: <<~RUBY.chomp, version: 1, uri: @uri, global_state: @global_state)
       def foo
     RUBY
 

--- a/test/requests/document_highlight_expectations_test.rb
+++ b/test/requests/document_highlight_expectations_test.rb
@@ -10,11 +10,10 @@ class DocumentHighlightExpectationsTest < ExpectationsTestRunner
   def run_expectations(source)
     uri = URI("file://#{@_path}")
     params = @__params&.any? ? @__params : default_args
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
-    global_state = RubyLsp::GlobalState.new
     dispatcher = Prism::Dispatcher.new
-    listener = RubyLsp::Requests::DocumentHighlight.new(global_state, document, params.first, dispatcher)
+    listener = RubyLsp::Requests::DocumentHighlight.new(@global_state, document, params.first, dispatcher)
     dispatcher.dispatch(document.parse_result.value)
     listener.perform
   end

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -22,7 +22,7 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     uri = URI("file://#{@_path}")
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     parse_result = document.parse_result

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -17,7 +17,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI("file:///fake.rb")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::DocumentSymbol.new(uri, dispatcher)
@@ -40,7 +40,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI("file:///fake.rb")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::DocumentSymbol.new(uri, dispatcher)
@@ -62,7 +62,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
     RUBY
     uri = URI("file:///fake.rb")
 
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::DocumentSymbol.new(uri, dispatcher)
@@ -107,7 +107,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     uri = URI("file://#{@_path}")
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     listener = RubyLsp::Requests::DocumentSymbol.new(uri, dispatcher)

--- a/test/requests/folding_ranges_expectations_test.rb
+++ b/test/requests/folding_ranges_expectations_test.rb
@@ -9,7 +9,7 @@ class FoldingRangesExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     uri = URI("file://#{@_path}")
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     parse_result = document.parse_result

--- a/test/requests/formatting_expectations_test.rb
+++ b/test/requests/formatting_expectations_test.rb
@@ -8,14 +8,18 @@ class FormattingExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::Formatting, "formatting"
 
   def run_expectations(source)
-    global_state = RubyLsp::GlobalState.new
-    global_state.formatter = "rubocop"
-    global_state.register_formatter(
+    @global_state.formatter = "rubocop"
+    @global_state.register_formatter(
       "rubocop",
       RubyLsp::Requests::Support::RuboCopFormatter.new,
     )
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: __FILE__))
-    RubyLsp::Requests::Formatting.new(global_state, document).perform&.first&.new_text
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI::Generic.from_path(path: __FILE__),
+      global_state: @global_state,
+    )
+    RubyLsp::Requests::Formatting.new(@global_state, document).perform&.first&.new_text
   end
 
   def assert_expectations(source, expected)

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -15,12 +15,14 @@ class FormattingTest < Minitest::Test
       "syntax_tree",
       RubyLsp::Requests::Support::SyntaxTreeFormatter.new,
     )
-    @document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI::Generic.from_path(path: __FILE__))
+    source = +<<~RUBY
       class Foo
       def foo
       end
       end
     RUBY
+    @uri = URI::Generic.from_path(path: __FILE__)
+    @document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: @uri, global_state: @global_state)
   end
 
   def test_formats_with_rubocop
@@ -47,7 +49,7 @@ class FormattingTest < Minitest::Test
   def test_does_not_format_with_formatter_is_none
     original_formatter = @global_state.formatter
     @global_state.formatter = "none"
-    document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: URI::Generic.from_path(path: __FILE__))
+    document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: @uri, global_state: @global_state)
     assert_nil(RubyLsp::Requests::Formatting.new(@global_state, document).perform)
   ensure
     @global_state.formatter = original_formatter
@@ -60,7 +62,7 @@ class FormattingTest < Minitest::Test
     TXT
 
     with_syntax_tree_config_file(config_contents) do
-      @document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI::Generic.from_path(path: __FILE__))
+      @document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
         class Foo
         def foo
         {one: "#{"a" * 50}", two: "#{"b" * 50}"}
@@ -86,7 +88,7 @@ class FormattingTest < Minitest::Test
   def test_syntax_tree_formatting_ignores_syntax_invalid_documents
     require "ruby_lsp/requests/formatting"
     @global_state.formatter = "syntax_tree"
-    document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: URI::Generic.from_path(path: __FILE__))
+    document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: @uri, global_state: @global_state)
     assert_nil(RubyLsp::Requests::Formatting.new(@global_state, document).perform)
   end
 
@@ -96,7 +98,7 @@ class FormattingTest < Minitest::Test
     TXT
 
     with_syntax_tree_config_file(config_contents) do
-      @document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI::Generic.from_path(path: __FILE__))
+      @document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
         class Foo
         def foo
         end
@@ -107,12 +109,12 @@ class FormattingTest < Minitest::Test
   end
 
   def test_rubocop_formatting_ignores_syntax_invalid_documents
-    document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: URI::Generic.from_path(path: __FILE__))
+    document = RubyLsp::RubyDocument.new(source: "def foo", version: 1, uri: @uri, global_state: @global_state)
     assert_nil(RubyLsp::Requests::Formatting.new(@global_state, document).perform)
   end
 
   def test_returns_nil_if_document_is_already_formatted
-    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI::Generic.from_path(path: __FILE__))
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       # typed: strict
       # frozen_string_literal: true
 

--- a/test/requests/inlay_hints_expectations_test.rb
+++ b/test/requests/inlay_hints_expectations_test.rb
@@ -10,7 +10,7 @@ class InlayHintsExpectationsTest < ExpectationsTestRunner
   def run_expectations(source)
     params = @__params&.any? ? @__params : default_args
     uri = URI("file://#{@_path}")
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new
     hints_configuration = RubyLsp::RequestConfig.new({ implicitRescue: true, implicitHashValue: true })
@@ -30,7 +30,7 @@ class InlayHintsExpectationsTest < ExpectationsTestRunner
 
   def test_skip_implicit_hash_value
     uri = URI("file://foo.rb")
-    document = RubyLsp::RubyDocument.new(uri: uri, source: <<~RUBY, version: 1)
+    document = RubyLsp::RubyDocument.new(uri: uri, source: <<~RUBY, version: 1, global_state: @global_state)
       {bar:, baz:}
     RUBY
 
@@ -43,7 +43,7 @@ class InlayHintsExpectationsTest < ExpectationsTestRunner
 
   def test_skip_implicit_rescue
     uri = URI("file://foo.rb")
-    document = RubyLsp::RubyDocument.new(uri: uri, source: <<~RUBY, version: 1)
+    document = RubyLsp::RubyDocument.new(uri: uri, source: <<~RUBY, version: 1, global_state: @global_state)
       begin
       rescue
       end

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -4,8 +4,17 @@
 require "test_helper"
 
 class OnTypeFormattingTest < Minitest::Test
+  def setup
+    @global_state = RubyLsp::GlobalState.new
+  end
+
   def test_adding_missing_ends
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -40,7 +49,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_adding_missing_curly_brace_in_string_interpolation
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -71,7 +85,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_adding_missing_pipe
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -102,7 +121,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_pipe_is_not_added_in_regular_or_pipe
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -123,7 +147,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_pipe_is_removed_if_user_adds_manually_after_completion
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -189,7 +218,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_pipe_is_removed_if_user_adds_manually_after_block_argument
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -227,7 +261,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_comment_continuation
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -254,7 +293,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_keyword_handling
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -275,7 +319,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_comment_continuation_with_other_line_break_matches
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     # If the current comment line has another word we match for, such as `while`, we still only want to complete the new
     # comment, but avoid adding an incorrect end to the comment's `while` word
@@ -304,7 +353,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_comment_continuation_when_inserting_new_line_in_the_middle
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     # When inserting a new line between while and blah, the document will have a syntax error momentarily before we auto
     # insert the comment continuation. We must avoid accidentally trying to add an `end` token to `while` while the
@@ -334,7 +388,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_breaking_line_between_keyword_and_more_content
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -370,7 +429,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_breaking_line_between_keyword_when_there_is_content_on_the_next_line
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -391,7 +455,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_breaking_line_immediately_after_keyword
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -423,7 +492,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_auto_indent_after_end_keyword
-    document = RubyLsp::RubyDocument.new(source: +"if foo\nbar\nend", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"if foo\nbar\nend",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
       { line: 2, character: 2 },
@@ -450,6 +524,7 @@ class OnTypeFormattingTest < Minitest::Test
       source: +"if foo\nif bar\n  baz\nend\nend",
       version: 1,
       uri: URI("file:///fake.rb"),
+      global_state: @global_state,
     )
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -481,7 +556,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_auto_indent_after_end_keyword_does_not_add_extra_indentation
-    document = RubyLsp::RubyDocument.new(source: +"if foo\n  bar\nend", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"if foo\n  bar\nend",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
       { line: 2, character: 2 },
@@ -500,7 +580,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_breaking_line_if_a_keyword_is_part_of_method_call
-    document = RubyLsp::RubyDocument.new(source: +"  force({", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"  force({",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
       { line: 1, character: 2 },
@@ -511,7 +596,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_breaking_line_if_a_keyword_in_a_subexpression
-    document = RubyLsp::RubyDocument.new(source: +"  var = (if", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"  var = (if",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
       { line: 1, character: 2 },
@@ -536,7 +626,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_adding_heredoc_delimiter
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -571,7 +666,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_plain_heredoc_completion
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -606,7 +706,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_quoted_heredoc_completion
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -641,7 +746,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_completing_end_token_inside_parameters
-    document = RubyLsp::RubyDocument.new(source: +"foo(proc do\n)", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"foo(proc do\n)",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -667,7 +777,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_completing_end_token_inside_brackets
-    document = RubyLsp::RubyDocument.new(source: +"foo[proc do\n]", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"foo[proc do\n]",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     edits = RubyLsp::Requests::OnTypeFormatting.new(
       document,
@@ -693,7 +808,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_no_snippet_if_not_vs_code
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -724,7 +844,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_includes_snippets_on_vscode_insiders
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -759,7 +884,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_does_not_confuse_class_parameter_with_keyword
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{
@@ -781,7 +911,12 @@ class OnTypeFormattingTest < Minitest::Test
   end
 
   def test_allows_end_completion_when_parenthesis_are_present
-    document = RubyLsp::RubyDocument.new(source: +"", version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
 
     document.push_edits(
       [{

--- a/test/requests/prepare_rename_expectations_test.rb
+++ b/test/requests/prepare_rename_expectations_test.rb
@@ -10,7 +10,7 @@ class PrepareRenameExpectationsTest < ExpectationsTestRunner
   def run_expectations(source)
     position = @__params&.any? ? @__params[:position] : default_position
     uri = URI("file://#{@_path}")
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
     RubyLsp::Requests::PrepareRename.new(document, position).perform
   end
 

--- a/test/requests/range_formatting_test.rb
+++ b/test/requests/range_formatting_test.rb
@@ -10,7 +10,7 @@ class RangeFormattingTest < Minitest::Test
     regular_formatter = RubyLsp::Requests::Support::SyntaxTreeFormatter.new
     @global_state.register_formatter("syntax_tree", regular_formatter)
     @global_state.stubs(:active_formatter).returns(regular_formatter)
-    @document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: URI::Generic.from_path(path: __FILE__))
+    source = +<<~RUBY
       class Foo
 
         def foo
@@ -23,6 +23,12 @@ class RangeFormattingTest < Minitest::Test
         end
       end
     RUBY
+    @document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI::Generic.from_path(path: __FILE__),
+      global_state: @global_state,
+    )
   end
 
   def test_syntax_tree_supports_range_formatting

--- a/test/requests/references_test.rb
+++ b/test/requests/references_test.rb
@@ -20,8 +20,13 @@ class ReferencesTest < Minitest::Test
     global_state = RubyLsp::GlobalState.new
     global_state.index.index_single(URI::Generic.from_path(path: path), source)
 
-    store = RubyLsp::Store.new
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: path))
+    store = RubyLsp::Store.new(global_state)
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI::Generic.from_path(path: path),
+      global_state: global_state,
+    )
 
     RubyLsp::Requests::References.new(
       global_state,

--- a/test/requests/rename_test.rb
+++ b/test/requests/rename_test.rb
@@ -41,8 +41,13 @@ class RenameTest < Minitest::Test
       end
     RUBY
 
-    store = RubyLsp::Store.new
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: path))
+    store = RubyLsp::Store.new(global_state)
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI::Generic.from_path(path: path),
+      global_state: global_state,
+    )
 
     assert_raises(RubyLsp::Requests::Rename::InvalidNameError) do
       RubyLsp::Requests::Rename.new(
@@ -71,8 +76,13 @@ class RenameTest < Minitest::Test
     path = File.expand_path(fixture_path)
     global_state.index.index_single(URI::Generic.from_path(path: path), source)
 
-    store = RubyLsp::Store.new
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI::Generic.from_path(path: path))
+    store = RubyLsp::Store.new(global_state)
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI::Generic.from_path(path: path),
+      global_state: global_state,
+    )
     workspace_edit = T.must(
       RubyLsp::Requests::Rename.new(
         global_state,

--- a/test/requests/selection_ranges_expectations_test.rb
+++ b/test/requests/selection_ranges_expectations_test.rb
@@ -8,7 +8,12 @@ class SelectionRangesExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::SelectionRanges, "selection_ranges"
 
   def run_expectations(source)
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
     actual = RubyLsp::Requests::SelectionRanges.new(document).perform
     params = @__params&.any? ? @__params : default_args
 

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -8,7 +8,13 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::SemanticHighlighting, "semantic_highlighting"
 
   def run_expectations(source)
-    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: URI("file:///fake.rb"))
+    @global_state.apply_options({ capabilities: { general: { positionEncodings: ["utf-8"] } } })
+    document = RubyLsp::RubyDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
     range = @__params&.any? ? @__params.first : nil
 
     if range
@@ -18,10 +24,8 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
     end
 
     dispatcher = Prism::Dispatcher.new
-    global_state = RubyLsp::GlobalState.new
-    global_state.apply_options({})
     listener = RubyLsp::Requests::SemanticHighlighting.new(
-      global_state,
+      @global_state,
       dispatcher,
       document,
       nil,

--- a/test/requests/support/expectations_test_runner.rb
+++ b/test/requests/support/expectations_test_runner.rb
@@ -7,6 +7,10 @@ class ExpectationsTestRunner < Minitest::Test
   TEST_RUBY_LSP_FIXTURES = File.join(TEST_FIXTURES_DIR, "*.{rb,rake}")
   TEST_PRISM_FIXTURES = File.join(TEST_FIXTURES_DIR, "prism/test/prism/fixtures/**", "*.txt")
 
+  def setup
+    @global_state = RubyLsp::GlobalState.new
+  end
+
   class << self
     def expectations_tests(handler_class, expectation_suffix)
       class_eval(<<~RB, __FILE__, __LINE__ + 1)

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -5,7 +5,8 @@ require "test_helper"
 
 class StoreTest < Minitest::Test
   def setup
-    @store = RubyLsp::Store.new
+    @global_state = RubyLsp::GlobalState.new
+    @store = RubyLsp::Store.new(@global_state)
     @store.set(
       uri: URI::Generic.from_path(path: "/foo/bar.rb"),
       source: "def foo; end",
@@ -17,7 +18,7 @@ class StoreTest < Minitest::Test
   def test_get
     uri = URI::Generic.from_path(path: "/foo/bar.rb")
     assert_equal(
-      RubyLsp::RubyDocument.new(source: "def foo; end", version: 1, uri: uri),
+      RubyLsp::RubyDocument.new(source: "def foo; end", version: 1, uri: uri, global_state: @global_state),
       @store.get(uri),
     )
   end
@@ -29,7 +30,7 @@ class StoreTest < Minitest::Test
     uri = URI("file://#{file.path}")
 
     assert_equal(
-      RubyLsp::ERBDocument.new(source: "<%= foo %>", version: 1, uri: uri),
+      RubyLsp::ERBDocument.new(source: "<%= foo %>", version: 1, uri: uri, global_state: @global_state),
       @store.get(uri),
     )
   ensure
@@ -45,7 +46,7 @@ class StoreTest < Minitest::Test
     document = @store.get(uri)
 
     assert_equal(
-      RubyLsp::ERBDocument.new(source: "<%= foo %>", version: 1, uri: uri),
+      RubyLsp::ERBDocument.new(source: "<%= foo %>", version: 1, uri: uri, global_state: @global_state),
       document,
     )
   ensure
@@ -58,7 +59,7 @@ class StoreTest < Minitest::Test
     @store.set(uri: uri, source: "def foo; end", version: 1, language_id: RubyLsp::Document::LanguageId::Ruby)
 
     assert_equal(
-      RubyLsp::RubyDocument.new(source: "def foo; end", version: 1, uri: uri),
+      RubyLsp::RubyDocument.new(source: "def foo; end", version: 1, uri: uri, global_state: @global_state),
       @store.get(uri),
     )
   end
@@ -68,7 +69,7 @@ class StoreTest < Minitest::Test
     @store.set(uri: uri, source: "def foo; end", version: 1, language_id: RubyLsp::Document::LanguageId::Ruby)
 
     assert_equal(
-      RubyLsp::RubyDocument.new(source: "def foo; end", version: 1, uri: uri),
+      RubyLsp::RubyDocument.new(source: "def foo; end", version: 1, uri: uri, global_state: @global_state),
       @store.get(uri),
     )
 
@@ -101,7 +102,7 @@ class StoreTest < Minitest::Test
     uri = URI("file://#{file.path}")
 
     assert_equal(
-      RubyLsp::RubyDocument.new(source: "def great_code; end", version: 1, uri: uri),
+      RubyLsp::RubyDocument.new(source: "def great_code; end", version: 1, uri: uri, global_state: @global_state),
       @store.get(uri),
     )
   ensure
@@ -116,7 +117,7 @@ class StoreTest < Minitest::Test
     uri = URI("file://#{file.path}")
 
     assert_equal(
-      RubyLsp::RubyDocument.new(source: "def great_code; end", version: 1, uri: uri),
+      RubyLsp::RubyDocument.new(source: "def great_code; end", version: 1, uri: uri, global_state: @global_state),
       @store.get(uri),
     )
   ensure
@@ -228,6 +229,7 @@ class StoreTest < Minitest::Test
         source: "def bar; puts 'a'; end",
         version: 1,
         uri: uri,
+        global_state: @global_state,
       ),
       @store.get(uri),
     )

--- a/test/type_inferrer_test.rb
+++ b/test/type_inferrer_test.rb
@@ -479,6 +479,7 @@ module RubyLsp
         source: source,
         version: 1,
         uri: URI::Generic.build(scheme: "file", path: "/fake/path/foo.rb"),
+        global_state: RubyLsp::GlobalState.new,
       )
       document.locate_node(position)
     end


### PR DESCRIPTION
### Motivation

I'm hoping this is the solution for #2446

My hypothesis is that we're seeing a concurrency issue where threads switch in the middle of locating targets and then the document gets mutated. That would render the location we're currently searching for invalid, which can then lead to infinite loops.

### Implementation

My idea is to move our mutex into the global state so that we can use it in more places. Then we lock the mutex while locating targets to avoid having any document edits be applied in the middle.

**Note**: I experimented with passing the mutex down to the document instances, but it was a bit messier.