### PR TITLE
Fix debug platform inclusion for Windows

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -145,6 +145,22 @@ class IntegrationTest < Minitest::Test
     end
   end
 
+  def test_composed_bundle_includes_debug
+    in_temp_dir do |dir|
+      Bundler.with_unbundled_env do
+        launch(dir)
+
+        _stdout, stderr = capture_subprocess_io do
+          system(
+            { "BUNDLE_GEMFILE" => File.join(dir, ".ruby-lsp", "Gemfile") },
+            "bundle exec ruby -e 'require \"debug\"'",
+          )
+        end
+        assert_empty(stderr)
+      end
+    end
+  end
+
   private
 
   def launch(workspace_path)


### PR DESCRIPTION
### Motivation

As reported in https://github.com/Shopify/ruby-lsp/issues/1767#issuecomment-2525369170, the `mri` platform indeed [excludes Windows](https://github.com/rubygems/rubygems/blob/3d0a916dcf73c35993a3fc5d47cf4b35e45c3ea1/bundler/lib/bundler/current_ruby.rb#L52). Without the right platform constraints, using `debug` on Windows is not possible.

### Implementation

I reached out to the RubyGems team and apparently there's no platform constraint for MRI on any operating system.

They suggested using `install_if` as a workaround. This isn't exactly the same as a platform constraint, but it seems to achieve the same from practical standpoint.

### Automated Tests

Added a test that should guarantee that `debug` is available on the platforms we support.