### PR TITLE
Pass Ruby interpreter path when replacing process by launcher

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -64,7 +64,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
   # which gives us the opportunity to control which specs are activated and enter degraded mode if any gems failed to
   # install rather than failing to boot the server completely
   if options[:launcher]
-    command = +File.expand_path("ruby-lsp-launcher", __dir__)
+    command = +"#{Gem.ruby} #{File.expand_path("ruby-lsp-launcher", __dir__)}"
     command << " --debug" if options[:debug]
     exit exec(command)
   end


### PR DESCRIPTION
### Motivation

Fixes the error reported in https://github.com/Shopify/ruby-lsp/issues/2936#issuecomment-2513031746.

On Windows, it's not possible to invoke `exec` with an executable script because the OS doesn't understand the shebang line that defines the Ruby interpreter. We need to manually invoke the Ruby interpreter to run the file.

### Implementation

Started adding `Gem.ruby` to invoke the Ruby interpreter directly. This works on Linux and MacOS too.