### PR TITLE
feat: Handle instance variable target nodes in document symbol

### DIFF
--- a/lib/ruby_lsp/listeners/document_symbol.rb
+++ b/lib/ruby_lsp/listeners/document_symbol.rb
@@ -41,6 +41,7 @@ module RubyLsp
           :on_module_node_enter,
           :on_module_node_leave,
           :on_instance_variable_write_node_enter,
+          :on_instance_variable_target_node_enter,
           :on_instance_variable_operator_write_node_enter,
           :on_instance_variable_or_write_node_enter,
           :on_instance_variable_and_write_node_enter,
@@ -264,6 +265,16 @@ module RubyLsp
 
       sig { params(node: Prism::InstanceVariableWriteNode).void }
       def on_instance_variable_write_node_enter(node)
+        create_document_symbol(
+          name: node.name.to_s,
+          kind: Constant::SymbolKind::FIELD,
+          range_location: node.name_loc,
+          selection_range_location: node.name_loc,
+        )
+      end
+
+      sig { params(node: Prism::InstanceVariableTargetNode).void }
+      def on_instance_variable_target_node_enter(node)
         create_document_symbol(
           name: node.name.to_s,
           kind: Constant::SymbolKind::FIELD,

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -33,6 +33,29 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
     assert_equal("@quux", T.must(response[4]).name)
   end
 
+  def test_instance_variable_with_destructuring_assignment
+    source = <<~RUBY
+      @a, @b = [1, 2]
+      @c, @d, @e = [3, 4, 5]
+    RUBY
+    uri = URI("file:///fake.rb")
+
+    document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri)
+
+    dispatcher = Prism::Dispatcher.new
+    listener = RubyLsp::Requests::DocumentSymbol.new(uri, dispatcher)
+    dispatcher.dispatch(document.parse_result.value)
+    response = listener.perform
+
+    assert_equal(5, response.size)
+
+    assert_equal("@a", T.must(response[0]).name)
+    assert_equal("@b", T.must(response[1]).name)
+    assert_equal("@c", T.must(response[2]).name)
+    assert_equal("@d", T.must(response[3]).name)
+    assert_equal("@e", T.must(response[4]).name)
+  end
+
   def test_labels_blank_names
     source = <<~RUBY
       def


### PR DESCRIPTION
### Motivation

Resolve #2896 
 Currently, when using destructuring assignment for instance variables only a single document symbol is created. This change ensures each instance variable gets its own document symbol. 

### Implementation

I've created new listener method to fetch instance_variable_target_node

### Automated Tests

Added new test case `test_instance_variable_parallel_assignment` that verifies:
* Basic destructuring assignment of instance variables
* Correct symbol creation and naming for each instance variable
* Proper ordering of symbols
