### PR TITLE
Move RuboCop file watching to the server

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -29,6 +29,9 @@ module RubyLsp
     sig { returns(ClientCapabilities) }
     attr_reader :client_capabilities
 
+    sig { returns(URI::Generic) }
+    attr_reader :workspace_uri
+
     sig { void }
     def initialize
       @workspace_uri = T.let(URI::Generic.from_path(path: Dir.pwd), URI::Generic)

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -14,12 +14,7 @@ import {
 } from "./common";
 import { WorkspaceChannel } from "./workspaceChannel";
 
-const WATCHED_FILES = [
-  "Gemfile.lock",
-  "gems.locked",
-  ".rubocop.yml",
-  ".rubocop",
-];
+const WATCHED_FILES = ["Gemfile.lock", "gems.locked"];
 
 export class Workspace implements WorkspaceInterface {
   public lspClient?: Client;


### PR DESCRIPTION
### Motivation

Closes #1457

This was originally attempted in #1921 and #2510. This PR moves watching `.rubocop.yml` to the server, so that we can avoid a full server restart and instead just create a new instance of the RuboCop runner.

This PR still suffers from the same issue reported in both previous attempts: trying to clear existing diagnostics after changing `.rubocop.yml` simply does not work. I believe this must be some sort of bug in the client or some assumption we're not satisfying. Clearing diagnostics works normally when closing files on `textDocument/didClose` notifications, so I see no reason why it wouldn't work while processing a did change watched files notification.

Despite the bug, since we're trying to improve stability of the LSP, I think it's still worth moving forward. Launching the server is still the most critical part in our entire life cycle and reducing the amount of times we restart helps prevent unnecessary pain for developers. Additionally, simply editing the file with the stale diagnostics already makes them go away immediately, so the bug is not that terrible.

I created an issue to discuss the bug with the maintainers of the protocol https://github.com/microsoft/vscode-languageserver-node/issues/1594.

### Implementation

Stopped restarting the server on `.rubocop.yml` and `.rubocop` modifications. Instead, we watch the files in the server and simply re-create the instance of the runner.

Note that this has the added benefit of working on any editor.