### PR TITLE
Fix command capitalization consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template_vscode.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template_vscode.yml
@@ -21,7 +21,7 @@ body:
 
         ### When submitting
 
-        Please run the `Collect Ruby LSP Information for Issue Reporting` command through VS Code's command
+        Please run the `Collect Ruby LSP information for issue reporting` command through VS Code's command
         palette and paste the result below.
 
   - type: textarea
@@ -31,7 +31,7 @@ body:
       value: |
         ### Ruby LSP Information
 
-        <!-- Please run `Collect Ruby LSP Information for Issue Reporting` from VS Code's command palette and paste the result here -->
+        <!-- Please run `Collect Ruby LSP information for issue reporting` from VS Code's command palette and paste the result here -->
 
         ### Reproduction steps
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -151,7 +151,7 @@
       },
       {
         "command": "rubyLsp.collectRubyLspInfo",
-        "title": "Collect Ruby LSP Information for Issue Reporting",
+        "title": "Collect Ruby LSP information for issue reporting",
         "category": "Ruby LSP"
       }
     ],


### PR DESCRIPTION
Noticed when reviewing https://github.com/Shopify/ruby-lsp/pull/2986

The rest are fine:

<img width="299" alt="Screenshot 2024-12-17 at 10 27 38 AM" src="https://github.com/user-attachments/assets/6bca8223-8acc-4b8d-8cbc-3ddc6aa57809" />
