### PR TITLE
Add test helper methods from Rails add-on

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,7 @@ Sorbet/StrictSigil:
     - "lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb"
     - "lib/ruby_lsp/load_sorbet.rb"
     - "lib/ruby_lsp/scripts/compose_bundle.rb"
+    - "lib/ruby_lsp/test_helper.rb"
 
 Layout/ClassStructure:
   Enabled: true

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 # NOTE: This module is intended to be used by addons for writing their own tests, so keep that in mind if changing.
@@ -65,8 +65,6 @@ module RubyLsp
       end
     end
 
-    # TODO: write correct sig
-    sig { params(message_queue: T.untyped, type: T.untyped).returns(T.untyped) }
     def pop_log_notification(message_queue, type)
       log = message_queue.pop
       return log if log.params.type == type
@@ -75,8 +73,6 @@ module RubyLsp
       log
     end
 
-    # TODO: write correct sig
-    sig { params(outgoing_queue: T.untyped, block: T.untyped).returns(T.untyped) }
     def pop_message(outgoing_queue, &block)
       message = outgoing_queue.pop
       return message if block.call(message)

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -8,6 +8,9 @@ module RubyLsp
     class TestError < StandardError; end
 
     extend T::Sig
+    extend T::Helpers
+
+    requires_ancestor { Kernel }
 
     sig do
       type_parameters(:T)

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -5,6 +5,8 @@
 
 module RubyLsp
   module TestHelper
+    class TestError < StandardError; end
+
     extend T::Sig
 
     sig do
@@ -59,7 +61,7 @@ module RubyLsp
       result = server.pop_response until result.is_a?(RubyLsp::Result) || result.is_a?(RubyLsp::Error)
 
       if result.is_a?(RubyLsp::Error)
-        raise "Failed to execute request #{result.message}"
+        raise TestError, "Failed to execute request #{result.message}"
       else
         result
       end

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -52,5 +52,37 @@ module RubyLsp
         server.run_shutdown
       end
     end
+
+    sig { params(server: RubyLsp::Server).returns(RubyLsp::Result) }
+    def pop_result(server)
+      result = server.pop_response
+      result = server.pop_response until result.is_a?(RubyLsp::Result) || result.is_a?(RubyLsp::Error)
+
+      if result.is_a?(RubyLsp::Error)
+        raise "Failed to execute request #{result.message}"
+      else
+        result
+      end
+    end
+
+    # TODO: write correct sig
+    sig { params(message_queue: T.untyped, type: T.untyped).returns(T.untyped) }
+    def pop_log_notification(message_queue, type)
+      log = message_queue.pop
+      return log if log.params.type == type
+
+      log = message_queue.pop until log.params.type == type
+      log
+    end
+
+    # TODO: write correct sig
+    sig { params(outgoing_queue: T.untyped, block: T.untyped).returns(T.untyped) }
+    def pop_message(outgoing_queue, &block)
+      message = outgoing_queue.pop
+      return message if block.call(message)
+
+      message = outgoing_queue.pop until block.call(message)
+      message
+    end
   end
 end

--- a/sorbet/rbi/shims/test_helper.rbi
+++ b/sorbet/rbi/shims/test_helper.rbi
@@ -1,0 +1,5 @@
+# typed: true
+
+module RubyLsp::TestHelper
+  include Kernel # for `raise`
+end

--- a/sorbet/rbi/shims/test_helper.rbi
+++ b/sorbet/rbi/shims/test_helper.rbi
@@ -1,5 +1,0 @@
-# typed: true
-
-module RubyLsp::TestHelper
-  include Kernel # for `raise`
-end


### PR DESCRIPTION
These methods are currently in ruby-lsp-rails but we also need them for testing the Tapioca LSP. Once this is released, we can remove them from the other places.

I've verified it [here](https://github.com/Shopify/ruby-lsp-rails/actions/runs/12395982615/job/34602952817). You can see there are some failures but those are releated to changes in the indexing API which we will need to deal with separately.