### PR TITLE
Improve RuboCop internal error message

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -36,8 +36,8 @@ module RubyLsp
 
         MESSAGE = <<~EOS
           An internal error occurred %s.
-          Updating to a newer version of RuboCop may solve this.
-          For more details, run RuboCop on the command line.
+          Updating to a newer version of RuboCop (and its extensions) may solve this.
+          For more details, run `bundle exec rubocop` on the command line.
         EOS
 
         sig { params(rubocop_error: T.any(RuboCop::ErrorWithAnalyzedFileLocation, StandardError)).void }


### PR DESCRIPTION
In https://github.com/Shopify/ruby-lsp/issues/2992, the error is likely from `rubocop-rails` rather than RuboCop itself.