### PR TITLE
feat: implement remove newlines in brackets before toggle block to on…

### DIFF
--- a/test/requests/code_action_resolve_expectations_test.rb
+++ b/test/requests/code_action_resolve_expectations_test.rb
@@ -23,6 +23,90 @@ class CodeActionResolveExpectationsTest < ExpectationsTestRunner
     assert_equal(build_code_action(json_expectations(expected)), JSON.parse(actual.to_json))
   end
 
+  def assert_match_to_expected(source, expected)
+    actual = run_expectations(source)
+    assert_equal(build_code_action(expected), JSON.parse(actual.to_json))
+  end
+
+  def test_toggle_block_do_end_to_brackets
+    @__params = {
+      kind: "refactor.rewrite",
+      title: "Refactor: Toggle block style",
+      data: {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 2, character: 3 },
+        },
+        uri: "file:///fake",
+      },
+    }
+    source = <<~RUBY
+      [1, 2, 3].each do |number|
+        puts number * 2
+      end
+    RUBY
+    expected = {
+      "title" => "Refactor: Toggle block style",
+      "edit" => {
+        "documentChanges" => [{
+          "textDocument": {
+            "uri": "file:///fake",
+            "version": nil,
+          },
+          "edits" => [{
+            "range" => {
+              "start" => { "line" => 0, "character" => 15 },
+              "end" => { "line" => 2, "character" => 3 },
+            },
+            "newText" => "{ |number| puts number * 2 }",
+          }],
+        }],
+      },
+    }
+    assert_match_to_expected(source, expected)
+  end
+
+  def test_toggle_block_do_end_with_hash_to_brackets
+    @__params = {
+      kind: "refactor.rewrite",
+      title: "Refactor: Toggle block style",
+      data: {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 5, character: 3 },
+        },
+        uri: "file:///fake",
+      },
+    }
+    source = <<~RUBY
+      arr.map do |a|
+        {
+          id: a.id,
+          name: a.name
+        }
+      end
+    RUBY
+    expected = {
+      "title" => "Refactor: Toggle block style",
+      "edit" => {
+        "documentChanges" => [{
+          "textDocument": {
+            "uri": "file:///fake",
+            "version": nil,
+          },
+          "edits" => [{
+            "range" => {
+              "start" => { "line" => 0, "character" => 8 },
+              "end" => { "line" => 5, "character" => 3 },
+            },
+            "newText" => "{ |a| { id: a.id, name: a.name } }",
+          }],
+        }],
+      },
+    }
+    assert_match_to_expected(source, expected)
+  end
+
   private
 
   def default_args


### PR DESCRIPTION

### Motivation

Close #2968 
The current block conversion from `do..end` to brackets fails when handling complex data structures like Hashes or Arrays. Simply converting line breaks to semicolons doesn't maintain code validity in these cases.

### Implementation

- Added `remove_newlines_in_brackets` method to properly handle newlines within Hash/Array literals

### Automated Tests

1. `test_toggle_block_do_end_to_brackets`: Verifies basic block conversion functionality
2. `test_toggle_block_do_end_with_hash_to_brackets`: Ensures proper handling of Hash literals within blocks

