### PR TITLE
Infer types for method calls on immediately instantiated objects

### DIFF
--- a/jekyll/index.markdown
+++ b/jekyll/index.markdown
@@ -169,6 +169,14 @@ It also allows developers to discover constants or methods that are available to
 Sorry, your browser doesn't support embedded videos. This video illustrates the completion feature, providing completion candidates as the user types.
 </video>
 
+{: .note }
+Completion for method calls can only be provided when the type of the receiver is known. For example, when typing `foo.`
+it's only possible to show method completion candidates if know the type of `foo`. Since the Ruby LSP does not require
+users to adopt a type system, completion for methods ends up being available only when types can be determined even
+without annotations (e.g.: methods invoked on literals, constants, direct instantiations of objects using `new`).<br><br>
+If you would like to have more accurate completion, consider adopting a
+[type system](design-and-roadmap#accuracy-correctness-and-type-checking).
+
 ### Signature Help
 
 Signature help often appears right after users finish typing a method, providing hints about the method's parameters. This feature is invaluable for understanding the expected arguments and improving code accuracy.

--- a/test/type_inferrer_test.rb
+++ b/test/type_inferrer_test.rb
@@ -471,6 +471,31 @@ module RubyLsp
       assert_equal("Object", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
+    def test_infer_object_instantiation_receiver
+      node_context = index_and_locate(<<~RUBY, { line: 1, character: 8 })
+        class Foo; end
+        Foo.new.bar
+      RUBY
+
+      assert_equal("Foo", @type_inferrer.infer_receiver_type(node_context).name)
+    end
+
+    def test_infer_object_instantiation_receiver_is_ignored_if_new_is_overridden
+      node_context = index_and_locate(<<~RUBY, { line: 8, character: 8 })
+        module Bar
+          def new; end
+        end
+
+        class Foo
+          extend Bar
+        end
+
+        Foo.new.bar
+      RUBY
+
+      assert_nil(@type_inferrer.infer_receiver_type(node_context))
+    end
+
     private
 
     def index_and_locate(source, position)


### PR DESCRIPTION
### Motivation

Closes #2994

This PR adds inference for methods invoked directly on an object instantiation. It's fairly easy to add, so I think it's worth getting it done.

### Implementation

When the receiver of a method call is another method call using `new`, we infer the type of the constant receiver and then return the attached version of it. For example:

```ruby
# In this case, `Foo::<Class:Foo>` is the receiver of `new`, but new will return an
# object. Thus the right type is the attached class, which is `Foo`
Foo.new.something
```

The only exception is if the method `new` was overridden, which is valid in Ruby. We cannot guarantee that the override actually returns a new object of the class, so it's better to not infer anything in those cases.

### Automated Tests

Added tests.