### PR TITLE
Handle missing specs when listing transitive dependencies

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -273,7 +273,13 @@ module RubyIndexer
       end
 
       others.concat(this_gem.to_spec.dependencies) if this_gem
-      others.concat(others.filter_map { |d| d.to_spec&.dependencies }.flatten)
+      others.concat(
+        others.filter_map do |d|
+          d.to_spec&.dependencies
+        rescue Gem::MissingSpecError
+          nil
+        end.flatten,
+      )
       others.uniq!
       others.map!(&:name)
 


### PR DESCRIPTION
### Motivation

This PR fixes a mistake made in #2937. We cannot invoke `to_spec` without rescuing `Gem::MissingSpecError` because that gets raised whenever there's a gem that doesn't match platform constraints.

### Implementation

Added the missing rescue.

### Automated Tests

Added a test that fails before the fix so that we catch this next time.