### PR TITLE
Fix Bundler default bindir on Windows

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -79,7 +79,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
   end
 
   bundler_path = File.join(Gem.default_bindir, "bundle")
-  base_command = (File.exist?(bundler_path) ? "#{Gem.ruby} #{bundler_path}" : "bundle").dup
+  base_command = (!Gem.win_platform? && File.exist?(bundler_path) ? "#{Gem.ruby} #{bundler_path}" : "bundle").dup
 
   if env["BUNDLER_VERSION"]
     base_command << " _#{env["BUNDLER_VERSION"]}_"

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -281,7 +281,7 @@ module RubyLsp
       # When not updating, we run `(bundle check || bundle install)`
       # When updating, we run `((bundle check && bundle update ruby-lsp debug) || bundle install)`
       bundler_path = File.join(Gem.default_bindir, "bundle")
-      base_command = (File.exist?(bundler_path) ? "#{Gem.ruby} #{bundler_path}" : "bundle").dup
+      base_command = (!Gem.win_platform? && File.exist?(bundler_path) ? "#{Gem.ruby} #{bundler_path}" : "bundle").dup
 
       if env["BUNDLER_VERSION"]
         base_command << " _#{env["BUNDLER_VERSION"]}_"


### PR DESCRIPTION
### Motivation

It seems that #2987 broke things on Windows under certain conditions. For some reason, running the Bundler executable using `Gem.ruby` and the default bin dir doesn't work. I'm not sure why our integration tests still pass, but let's fix this first and investigate later.

This PR fixes the main build once we cut a release.

### Implementation

Started using simply `bundle` directly on Windows.