### PR TITLE
Handle module_function with no arguments

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/visibility_scope.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/visibility_scope.rb
@@ -1,0 +1,36 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyIndexer
+  # Represents the visibility scope in a Ruby namespace. This keeps track of whether methods are in a public, private or
+  # protected section, and whether they are module functions.
+  class VisibilityScope
+    extend T::Sig
+
+    class << self
+      extend T::Sig
+
+      sig { returns(T.attached_class) }
+      def module_function_scope
+        new(module_func: true, visibility: Entry::Visibility::PRIVATE)
+      end
+
+      sig { returns(T.attached_class) }
+      def public_scope
+        new
+      end
+    end
+
+    sig { returns(Entry::Visibility) }
+    attr_reader :visibility
+
+    sig { returns(T::Boolean) }
+    attr_reader :module_func
+
+    sig { params(visibility: Entry::Visibility, module_func: T::Boolean).void }
+    def initialize(visibility: Entry::Visibility::PUBLIC, module_func: false)
+      @visibility = visibility
+      @module_func = module_func
+    end
+  end
+end

--- a/lib/ruby_indexer/ruby_indexer.rb
+++ b/lib/ruby_indexer/ruby_indexer.rb
@@ -5,6 +5,7 @@ require "yaml"
 require "did_you_mean"
 
 require "ruby_indexer/lib/ruby_indexer/uri"
+require "ruby_indexer/lib/ruby_indexer/visibility_scope"
 require "ruby_indexer/lib/ruby_indexer/declaration_listener"
 require "ruby_indexer/lib/ruby_indexer/reference_finder"
 require "ruby_indexer/lib/ruby_indexer/enhancement"


### PR DESCRIPTION
### Motivation

Closes #2653

This PR handles the other missing part of `module_function`, which is when it gets invoked with no argument. After looking into the Ruby source code, it seems that `module_func` is a flag considered as part of the visibility scope.

Invoking `module_function` will both:

1. Start marking new methods as singleton methods
2. Push `private` into the stack

### Implementation

I created a new `VisibilityScope` object to help us encapsulate all aspects of visibility, so that we don't forget to handle `module_func` where necessary.

Then I started handling the case of `module_function` with no arguments, which essentially pushes a new scope into the stack with `module_func: true` and visibility private.

### Automated Tests

Added a few tests.