### PR TITLE
Revert returning error responses for non existing locations

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -15,7 +15,6 @@ module RubyLsp
     extend T::Helpers
     extend T::Generic
 
-    class LocationNotFoundError < StandardError; end
     ParseResultType = type_member
 
     # This maximum number of characters for providing expensive features, like semantic highlighting and diagnostics.
@@ -200,15 +199,7 @@ module RubyLsp
       def find_char_position(position)
         # Find the character index for the beginning of the requested line
         until @current_line == position[:line]
-          until LINE_BREAK == @source[@pos]
-            @pos += 1
-
-            if @pos >= @source.length
-              # Pack the code points back into the original string to provide context in the error message
-              raise LocationNotFoundError, "Requested position: #{position}\nSource:\n\n#{@source.pack("U*")}"
-            end
-          end
-
+          @pos += 1 until LINE_BREAK == @source[@pos]
           @pos += 1
           @current_line += 1
         end

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -126,17 +126,6 @@ module RubyLsp
             code: Constant::ErrorCodes::INVALID_PARAMS,
             message: e.full_message,
           ))
-        when Document::LocationNotFoundError
-          send_message(Error.new(
-            id: message[:id],
-            code: Constant::ErrorCodes::REQUEST_FAILED,
-            message: <<~MESSAGE,
-              Request #{message[:method]} failed to find the target position.
-              The file might have been modified while the server was in the middle of searching for the target.
-              If you experience this regularly, please report any findings and extra information on
-              https://github.com/Shopify/ruby-lsp/issues/2446
-            MESSAGE
-          ))
         else
           send_message(Error.new(
             id: message[:id],

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -782,29 +782,6 @@ class RubyDocumentTest < Minitest::Test
     assert_nil(document.cache_get("textDocument/codeLens"))
   end
 
-  def test_locating_a_non_existing_location_raises
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY.chomp, version: 1, uri: @uri, global_state: @global_state)
-      class Foo
-      end
-    RUBY
-
-    # Exactly at the last character doesn't raise
-    document.locate_node({ line: 1, character: 2 })
-
-    # Anything beyond does
-    error = assert_raises(RubyLsp::Document::LocationNotFoundError) do
-      document.locate_node({ line: 3, character: 2 })
-    end
-
-    assert_match(/Requested position: {(:)?line[\s:=>]+3, (:)?character[\s:=>]+2}/, error.message)
-    assert_match(<<~MESSAGE.chomp, error.message)
-      Source:
-
-      class Foo
-      end
-    MESSAGE
-  end
-
   def test_document_tracks_latest_edit_context
     document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       class Foo

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -721,36 +721,6 @@ class ServerTest < Minitest::Test
     end
   end
 
-  def test_requests_to_a_non_existing_position_return_error
-    uri = URI("file:///foo.rb")
-
-    @server.process_message({
-      method: "textDocument/didOpen",
-      params: {
-        textDocument: {
-          uri: uri,
-          text: "class Foo\nend",
-          version: 1,
-          languageId: "ruby",
-        },
-      },
-    })
-
-    @server.process_message({
-      id: 1,
-      method: "textDocument/completion",
-      params: {
-        textDocument: {
-          uri: uri,
-        },
-        position: { line: 10, character: 0 },
-      },
-    })
-
-    error = find_message(RubyLsp::Error)
-    assert_match("Request textDocument/completion failed to find the target position.", error.message)
-  end
-
   def test_cancelling_requests_returns_nil
     uri = URI("file:///foo.rb")
 


### PR DESCRIPTION
### Motivation

Revert #2938

It seems that reverting the cancellation didn't fully fix #3019, so I think this is the culprit. It's the only other PR in v0.23 that we started returning error responses for.

### Implementation

Just reverted back to the original implementation.