### PR TITLE
Synchronize store operations in server instead

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -97,33 +97,31 @@ module RubyLsp
 
     sig { params(edits: T::Array[T::Hash[Symbol, T.untyped]], version: Integer).void }
     def push_edits(edits, version:)
-      @global_state.synchronize do
-        edits.each do |edit|
-          range = edit[:range]
-          scanner = create_scanner
+      edits.each do |edit|
+        range = edit[:range]
+        scanner = create_scanner
 
-          start_position = scanner.find_char_position(range[:start])
-          end_position = scanner.find_char_position(range[:end])
+        start_position = scanner.find_char_position(range[:start])
+        end_position = scanner.find_char_position(range[:end])
 
-          @source[start_position...end_position] = edit[:text]
-        end
+        @source[start_position...end_position] = edit[:text]
+      end
 
-        @version = version
-        @needs_parsing = true
-        @cache.clear
+      @version = version
+      @needs_parsing = true
+      @cache.clear
 
-        last_edit = edits.last
-        return unless last_edit
+      last_edit = edits.last
+      return unless last_edit
 
-        last_edit_range = last_edit[:range]
+      last_edit_range = last_edit[:range]
 
-        @last_edit = if last_edit_range[:start] == last_edit_range[:end]
-          Insert.new(last_edit_range)
-        elsif last_edit[:text].empty?
-          Delete.new(last_edit_range)
-        else
-          Replace.new(last_edit_range)
-        end
+      @last_edit = if last_edit_range[:start] == last_edit_range[:end]
+        Insert.new(last_edit_range)
+      elsif last_edit[:text].empty?
+        Delete.new(last_edit_range)
+      else
+        Replace.new(last_edit_range)
       end
     end
 

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -65,15 +65,13 @@ module RubyLsp
       ).returns(Document[T.untyped])
     end
     def set(uri:, source:, version:, language_id:)
-      @global_state.synchronize do
-        @state[uri.to_s] = case language_id
-        when Document::LanguageId::ERB
-          ERBDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
-        when Document::LanguageId::RBS
-          RBSDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
-        else
-          RubyDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
-        end
+      @state[uri.to_s] = case language_id
+      when Document::LanguageId::ERB
+        ERBDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
+      when Document::LanguageId::RBS
+        RBSDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
+      else
+        RubyDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
       end
     end
 
@@ -94,9 +92,7 @@ module RubyLsp
 
     sig { params(uri: URI::Generic).void }
     def delete(uri)
-      @global_state.synchronize do
-        @state.delete(uri.to_s)
-      end
+      @state.delete(uri.to_s)
     end
 
     sig { params(uri: URI::Generic).returns(T::Boolean) }

--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -1034,4 +1034,24 @@ suite("Client", () => {
       ),
     );
   }).timeout(20000);
+
+  test("requests for documents that were not opened by the client", async () => {
+    const uri = vscode.Uri.joinPath(
+      workspaceUri,
+      "lib",
+      "ruby_lsp",
+      "server.rb",
+    );
+
+    const response: vscode.DocumentSymbol[] = await client.sendRequest(
+      "textDocument/documentSymbol",
+      {
+        textDocument: {
+          uri: uri.toString(),
+        },
+      },
+    );
+
+    assert.ok(response.length > 0);
+  }).timeout(20000);
 });


### PR DESCRIPTION
### Motivation

Closes #3027

The deadlock bug was introduced in #2976. Essentially, if the editor opens a URI for a non-existing file, we try to acquire the same lock twice.

Once [here](https://github.com/Shopify/ruby-lsp/blob/17d5fc733b758bbbedaf36fb17ac3914548086bf/lib/ruby_lsp/base_server.rb#L53) to verify if the request requires a document to be parsed and the second time [here](https://github.com/Shopify/ruby-lsp/blob/17d5fc733b758bbbedaf36fb17ac3914548086bf/lib/ruby_lsp/store.rb#L68) when we read the file from disk and save it in the store.

Trying to acquire the same mutex lock twice raises the deadlock error.

### Implementation

I stopped synchronizing anything inside basic store operations. It just increases the chance of mistakes like these. I moved the responsibility of synchronizing back to the server.

### Automated Tests

To catch this regression, we need a client/server integration test because the first synchronization happens only by reading a request from the STDIN pipe. I added one to ensure we don't hit the same issue again.