### PR TITLE
Ensure requests are not assuming the presence of file paths for entries

### DIFF
--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -330,7 +330,8 @@ module RubyLsp
 
         methods.each do |target_method|
           uri = target_method.uri
-          next if sorbet_level_true_or_higher?(@sorbet_level) && not_in_dependencies?(T.must(uri.full_path))
+          full_path = uri.full_path
+          next if sorbet_level_true_or_higher?(@sorbet_level) && (!full_path || not_in_dependencies?(full_path))
 
           @response_builder << Interface::LocationLink.new(
             target_uri: uri.to_s,
@@ -403,7 +404,11 @@ module RubyLsp
           # additional behavior on top of jumping to RBIs. The only sigil where Sorbet cannot handle constants is typed
           # ignore
           uri = entry.uri
-          next if @sorbet_level != RubyDocument::SorbetLevel::Ignore && not_in_dependencies?(T.must(uri.full_path))
+          full_path = uri.full_path
+
+          if @sorbet_level != RubyDocument::SorbetLevel::Ignore && (!full_path || not_in_dependencies?(full_path))
+            next
+          end
 
           @response_builder << Interface::LocationLink.new(
             target_uri: uri.to_s,

--- a/lib/ruby_lsp/requests/rename.rb
+++ b/lib/ruby_lsp/requests/rename.rb
@@ -116,8 +116,8 @@ module RubyLsp
         T.must(@global_state.index[fully_qualified_name]).each do |entry|
           # Do not rename files that are not part of the workspace
           uri = entry.uri
-          file_path = T.must(uri.full_path)
-          next unless file_path.start_with?(@global_state.workspace_path)
+          file_path = uri.full_path
+          next unless file_path&.start_with?(@global_state.workspace_path)
 
           case entry
           when RubyIndexer::Entry::Class, RubyIndexer::Entry::Module, RubyIndexer::Entry::Constant,

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -22,10 +22,10 @@ module RubyLsp
       def perform
         @index.fuzzy_search(@query).filter_map do |entry|
           uri = entry.uri
-          file_path = T.must(uri.full_path)
+          file_path = uri.full_path
 
           # We only show symbols declared in the workspace
-          in_dependencies = !not_in_dependencies?(file_path)
+          in_dependencies = file_path && !not_in_dependencies?(file_path)
           next if in_dependencies
 
           # We should never show private symbols when searching the entire workspace

--- a/test/requests/workspace_symbol_test.rb
+++ b/test/requests/workspace_symbol_test.rb
@@ -107,4 +107,14 @@ class WorkspaceSymbolTest < Minitest::Test
     assert_equal("baz", T.must(result).name)
     assert_equal(RubyLsp::Constant::SymbolKind::PROPERTY, T.must(result).kind)
   end
+
+  def test_returns_symbols_from_unsaved_files
+    @index.index_single(URI("untitled:Untitled-1"), <<~RUBY)
+      class Foo; end
+    RUBY
+
+    result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "Foo").perform.first
+    assert_equal("Foo", T.must(result).name)
+    assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
+  end
 end


### PR DESCRIPTION
### Motivation

One more bug fix to include in the next release 😅. In #2941, we started indexing unsaved files. However, we didn't fix the requests that were assuming the presence of a file path in entries with `T.must`.

We need to handle the possibility of there not being a file path, so that we can account for entries in unsaved files.

### Implementation

Fixed all of the occurrences I could find where we assumed the file path to be there.

### Automated Tests

Added tests that reproduce each one of the bugs.