### PR TITLE
Request diagnostic refresh when RuboCop configs change

### DIFF
--- a/lib/ruby_lsp/client_capabilities.rb
+++ b/lib/ruby_lsp/client_capabilities.rb
@@ -11,7 +11,8 @@ module RubyLsp
     attr_reader :supports_watching_files,
       :supports_request_delegation,
       :window_show_message_supports_extra_properties,
-      :supports_progress
+      :supports_progress,
+      :supports_diagnostic_refresh
 
     sig { void }
     def initialize
@@ -32,6 +33,9 @@ module RubyLsp
 
       # The editor supports displaying progress requests
       @supports_progress = T.let(false, T::Boolean)
+
+      # The editor supports server initiated refresh for diagnostics
+      @supports_diagnostic_refresh = T.let(false, T::Boolean)
     end
 
     sig { params(capabilities: T::Hash[Symbol, T.untyped]).void }
@@ -57,6 +61,8 @@ module RubyLsp
 
       progress = capabilities.dig(:window, :workDoneProgress)
       @supports_progress = progress if progress
+
+      @supports_diagnostic_refresh = workspace_capabilities.dig(:diagnostics, :refreshSupport) || false
     end
 
     sig { returns(T::Boolean) }

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -162,7 +162,9 @@ module RubyLsp
 
     sig { override.returns(T::Hash[Symbol, T.untyped]) }
     def to_hash
-      { method: @method, params: T.unsafe(@params).to_hash }
+      hash = { method: @method }
+      hash[:params] = T.unsafe(@params).to_hash if @params
+      hash
     end
   end
 
@@ -206,7 +208,9 @@ module RubyLsp
 
     sig { override.returns(T::Hash[Symbol, T.untyped]) }
     def to_hash
-      { id: @id, method: @method, params: T.unsafe(@params).to_hash }
+      hash = { id: @id, method: @method }
+      hash[:params] = T.unsafe(@params).to_hash if @params
+      hash
     end
   end
 


### PR DESCRIPTION
### Motivation

The explanation in https://github.com/microsoft/vscode-languageserver-node/issues/1594#issuecomment-2582033204 solved our issue clearing diagnostics. Push and pull diagnostics are two different collections, so you cannot clear diagnostics acquired via pull using a push with an empty array.

The correct solution is to request a diagnostic refresh to the editor, which will then trigger pull diagnostics for all open documents.

### Implementation

Changed the implementation to clear our cache and then request a diagnostic refresh, which now correctly recomputes the diagnostics using the new RuboCop configs.

### Automated Tests

Added a test to verify that we're request the refresh.

### Manual Tests


https://github.com/user-attachments/assets/2a29ce82-4b23-47cf-8af0-8267980feec4