### PR TITLE
Require bundler before loading the `intall_error` report

### DIFF
--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -48,6 +48,9 @@ end
 error_path = File.join(".ruby-lsp", "install_error")
 
 install_error = if File.exist?(error_path)
+  # The error report may contain error objects reported by bundler.
+  # Therefore, we need to require bunder before loading the error report.
+  require "bundler"
   Marshal.load(File.read(error_path))
 end
 


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->
fix #3038

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
The `install_error` may include error objects reported by bundler. To avoid the `Marshal.load` error, we need to reuiqre bundler before loading the `install_error` report.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Add `require "bundler"` before loading the `install_error` report.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

* Install local build version of `ruby-lsp`
* Start the `ruby-lsp` plugin
* Check "Composed Bundle set up successfully" message

```
2025-01-11 00:46:59.167 [info] (rggen) Running command: `rbenv exec ruby -W0 -rjson -e 'STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR" + { env: ENV.to_h, yjit: !!defined?(RubyVM::YJIT), version: RUBY_VERSION, gemPath: Gem.path }.to_json + "RUBY_LSP_ACTIVATION_SEPARATOR")'` in /home/taichi/workspace/rggen using shell: /usr/bin/bash
2025-01-11 00:47:02.390 [info] (rggen) Ruby LSP> Skipping composed bundle setup since LSP dependencies are already in /home/taichi/workspace/rggen/Gemfile
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git

2025-01-11 00:47:05.322 [info] (rggen) Fetching gem metadata from https://rubygems.org/........
Fetching date 3.4.1

Retrying download gem from https://rubygems.org/ due to error (2/4): Bundler::PermissionError There was an error while trying to write to `/opt/rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/cache/date-3.4.1.gem`. It is likely that you need to grant write permissions for that path.

Retrying download gem from https://rubygems.org/ due to error (3/4): Bundler::PermissionError There was an error while trying to write to `/opt/rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/cache/date-3.4.1.gem`. It is likely that you need to grant write permissions for that path.

Retrying download gem from https://rubygems.org/ due to error (4/4): Bundler::PermissionError There was an error while trying to write to `/opt/rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/cache/date-3.4.1.gem`. It is likely that you need to grant write permissions for that path.

fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
Composed Bundle set up successfully
```