### PR TITLE
Return early if magic source link URI has no path

### DIFF
--- a/lib/ruby_lsp/listeners/document_link.rb
+++ b/lib/ruby_lsp/listeners/document_link.rb
@@ -128,7 +128,10 @@ module RubyLsp
         gem_version = resolve_version(uri)
         return if gem_version.nil?
 
-        file_path = self.class.gem_paths.dig(uri.gem_name, gem_version, CGI.unescape(uri.path))
+        path = uri.path
+        return unless path
+
+        file_path = self.class.gem_paths.dig(uri.gem_name, gem_version, CGI.unescape(path))
         return if file_path.nil?
 
         @response_builder << Interface::DocumentLink.new(

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -31,6 +31,25 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
     listener.perform
   end
 
+  def test_magic_source_links_on_unsaved_files
+    source = <<~RUBY
+      # source://erb/#1
+      def bar
+      end
+    RUBY
+
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/documentLink",
+        params: { textDocument: { uri: uri } },
+      )
+
+      server.pop_response
+      assert_empty(server.pop_response.response)
+    end
+  end
+
   private
 
   def substitute(original)


### PR DESCRIPTION
### Motivation

This error was caught by our telemetry. If someone is manually typing a magic source link or if there's some error in Tapioca's generation, then the URI's path might be `nil`, which then fails when we pass it to `CGI.unescape` with a `no implicit conversion of nil to String`.

### Implementation

Started checking if there's a path before trying to unescape it.

### Automated Tests

Added a test that fails in main.