### PR TITLE
Fail build on ESLint warnings

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -726,7 +726,7 @@
     "watch": "tsc -watch -p ./",
     "pretest": "yarn run compile",
     "format": "eslint '**/*.ts' --fix && prettier '**/*.{json,md,yaml,yml}' --write",
-    "lint": "eslint '**/*.ts' && prettier '**/*.{json,md,yaml,yml}' --check",
+    "lint": "eslint '**/*.ts' --max-warnings=0 && prettier '**/*.{json,md,yaml,yml}' --check",
     "test": "node ./out/test/runTest.js"
   },
   "resolutions": {


### PR DESCRIPTION
We want to enforce that warnings addressed.

Currenty there is one warning, so this will fail. @st0012 will look it, and once that's addressed we can merge this.