### PR TITLE
Replace interpolated string pattern with regexp

### DIFF
--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -626,7 +626,7 @@ export class RubyLsp {
                 delete newConfig.useBundler;
 
                 const command = (newConfig.command || "").replace(
-                  /\$\{workspaceRoot\}\//,
+                  `\${workspaceRoot}/`,
                   "",
                 );
                 const script = newConfig.script || "";


### PR DESCRIPTION
### Motivation

To suppress this warning: `Unexpected template string expression`

### Implementation

Use regexp instead.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
