### PR TITLE
add highlight for do...end blocks

### DIFF
--- a/lib/ruby_lsp/listeners/document_highlight.rb
+++ b/lib/ruby_lsp/listeners/document_highlight.rb
@@ -119,7 +119,8 @@ module RubyLsp
             Prism::RequiredParameterNode, Prism::RestParameterNode
             [target, node_value(target)]
           when Prism::ModuleNode, Prism::ClassNode, Prism::SingletonClassNode, Prism::DefNode, Prism::CaseNode,
-            Prism::WhileNode, Prism::UntilNode, Prism::ForNode, Prism::IfNode, Prism::UnlessNode
+            Prism::WhileNode, Prism::UntilNode, Prism::ForNode, Prism::IfNode, Prism::UnlessNode, Prism::BlockNode,
+            Prism::LambdaNode
             target
           end
 
@@ -184,6 +185,8 @@ module RubyLsp
             :on_for_node_enter,
             :on_if_node_enter,
             :on_unless_node_enter,
+            :on_block_node_enter,
+            :on_lambda_node_enter,
           )
         end
       end
@@ -576,6 +579,20 @@ module RubyLsp
         return unless @target.is_a?(Prism::UnlessNode)
 
         add_matching_end_highlights(node.keyword_loc, node.end_keyword_loc)
+      end
+
+      sig { params(node: Prism::BlockNode).void }
+      def on_block_node_enter(node)
+        return unless @target.is_a?(Prism::BlockNode)
+
+        add_matching_end_highlights(node.opening_loc, node.closing_loc)
+      end
+
+      sig { params(node: Prism::LambdaNode).void }
+      def on_lambda_node_enter(node)
+        return unless @target.is_a?(Prism::LambdaNode)
+
+        add_matching_end_highlights(node.opening_loc, node.closing_loc)
       end
 
       private

--- a/test/expectations/document_highlight/do_blocks.exp.json
+++ b/test/expectations/document_highlight/do_blocks.exp.json
@@ -1,0 +1,36 @@
+{
+    "params": [
+        {
+            "line": 0,
+            "character": 10
+        }
+    ],
+    "result": [
+      {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 10
+            },
+            "end": {
+              "line": 0,
+              "character": 12
+            }
+          },
+          "kind": 1
+        },
+        {
+            "range": {
+                "start": {
+                    "line": 2,
+                    "character": 0
+                },
+                "end": {
+                    "line": 2,
+                    "character": 3
+                }
+            },
+            "kind": 1
+        }
+    ]
+}

--- a/test/expectations/document_highlight/lambda_literal_do_end.exp.json
+++ b/test/expectations/document_highlight/lambda_literal_do_end.exp.json
@@ -1,0 +1,36 @@
+{
+    "params": [
+        {
+            "line": 0,
+            "character": 19
+        }
+    ],
+    "result": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 18
+          },
+          "end": {
+            "line": 0,
+            "character": 20
+          }
+        },
+        "kind": 1
+      },
+      {
+        "range": {
+          "start": {
+            "line": 2,
+            "character": 0
+          },
+          "end": {
+            "line": 2,
+            "character": 3
+          }
+        },
+        "kind": 1
+      }
+    ]
+}


### PR DESCRIPTION
### Motivation

Closes #2929

As I was investigating the problem with the issue above I discovered that the highlight functionality for highlight do blocks was not implemented.

### Implementation

This PR enhances the existing Highlight feature to add support for highlighting blocks.

### Automated Tests

Added new expectations using the existing "do block" fixture files.

### Manual Tests

Go to the start of a `do` block, it should highlight its matching `end`
