### PR TITLE
Fix singleton indexing under compact namespaces

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -143,7 +143,7 @@ module RubyIndexer
 
       if current_owner
         expression = node.expression
-        name = (expression.is_a?(Prism::SelfNode) ? "<Class:#{@stack.last}>" : "<Class:#{expression.slice}>")
+        name = (expression.is_a?(Prism::SelfNode) ? "<Class:#{last_name_in_stack}>" : "<Class:#{expression.slice}>")
         real_nesting = actual_nesting(name)
 
         existing_entries = T.cast(@index[real_nesting.join("::")], T.nilable(T::Array[Entry::SingletonClass]))
@@ -376,7 +376,6 @@ module RubyIndexer
         ))
 
         @owner_stack << singleton
-        @stack << "<Class:#{@stack.last}>"
       end
     end
 
@@ -386,7 +385,6 @@ module RubyIndexer
 
       if node.receiver.is_a?(Prism::SelfNode)
         @owner_stack.pop
-        @stack.pop
       end
     end
 
@@ -1126,6 +1124,16 @@ module RubyIndexer
       @owner_stack << entry
       @index.add(entry)
       @stack << short_name
+    end
+
+    # Returns the last name in the stack not as we found it, but in terms of declared constants. For example, if the
+    # last entry in the stack is a compact namespace like `Foo::Bar`, then the last name is `Bar`
+    sig { returns(T.nilable(String)) }
+    def last_name_in_stack
+      name = @stack.last
+      return unless name
+
+      name.split("::").last
     end
   end
 end

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -647,5 +647,24 @@ module RubyIndexer
       entry = @index["Foo"].first
       assert_empty(entry.comments)
     end
+
+    def test_singleton_inside_compact_namespace
+      index(<<~RUBY)
+        module Foo::Bar
+          class << self
+            def baz; end
+          end
+        end
+      RUBY
+
+      # Verify we didn't index the incorrect name
+      assert_nil(@index["Foo::Bar::<Class:Foo::Bar>"])
+
+      # Verify we indexed the correct name
+      assert_entry("Foo::Bar::<Class:Bar>", Entry::SingletonClass, "/fake/path/foo.rb:1-2:3-5")
+
+      method = @index["baz"]&.first
+      assert_equal("Foo::Bar::<Class:Bar>", method.owner.name)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Fixes one of the bugs reported in #3050

We were assigning incorrect names to singleton classes defined inside compact namespaces. The issue is that we were simply taking the last entry in the stack, but when using compact namespaces that entry may include multiple names.

### Implementation

Started ensuring we use only the last part of the name to define the singleton.

I also noticed that we were pushing and popping from the name stack when entering a singleton method defined with `def self.foo`. That's actually unnecessary. The name stack is only used for constants and inside a method definition we'll only find instance variables (which use the owner stack rather than the name stack).

I removed the pushing and popping in that case.

### Automated Tests

Added a test.