### PR TITLE
Use local executables when working on the Ruby LSP

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -186,6 +186,20 @@ export class Ruby implements RubyInterface {
     if (!this.error) {
       this.fetchRubyVersionInfo();
       await this.setupBundlePath();
+
+      // When working on the Ruby LSP itself, we want to use the local version of our executables rather than the ones
+      // globally installed. That allows us to catch mistakes made in the launch process before they are released
+      if (
+        path.basename(this.workspaceFolder.uri.fsPath) === "ruby-lsp" &&
+        os.platform() !== "win32"
+      ) {
+        const localExecutablesUri = vscode.Uri.joinPath(
+          this.workspaceFolder.uri,
+          "exe",
+        );
+
+        this._env.PATH = `${localExecutablesUri.fsPath}${path.delimiter}${this._env.PATH}`;
+      }
     }
   }
 

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-process-env */
 import * as assert from "assert";
 import * as path from "path";
+import os from "os";
 
 import * as vscode from "vscode";
 import sinon from "sinon";
@@ -167,4 +168,45 @@ suite("Ruby environment activation", () => {
 
     assert.deepStrictEqual(ruby.env, { BUNDLE_GEMFILE: ".ruby-lsp/Gemfile" });
   });
+
+  test("Adds local exe directory to PATH when working on the Ruby LSP itself", async () => {
+    if (os.platform() === "win32") {
+      // We don't mutate the path on Windows
+      return;
+    }
+
+    const manager = process.env.CI
+      ? ManagerIdentifier.None
+      : ManagerIdentifier.Chruby;
+
+    const configStub = sinon
+      .stub(vscode.workspace, "getConfiguration")
+      .returns({
+        get: (name: string) => {
+          if (name === "rubyVersionManager") {
+            return { identifier: manager };
+          } else if (name === "bundleGemfile") {
+            return "";
+          }
+
+          return undefined;
+        },
+      } as unknown as vscode.WorkspaceConfiguration);
+
+    const workspacePath = path.dirname(
+      path.dirname(path.dirname(path.dirname(__dirname))),
+    );
+    const lspFolder: vscode.WorkspaceFolder = {
+      uri: vscode.Uri.file(workspacePath),
+      name: path.basename(workspacePath),
+      index: 0,
+    };
+    const ruby = new Ruby(context, lspFolder, outputChannel, FAKE_TELEMETRY);
+    await ruby.activateRuby();
+
+    const firstEntry = ruby.env.PATH!.split(path.delimiter)[0];
+    assert.match(firstEntry, /ruby-lsp\/exe$/);
+
+    configStub.restore();
+  }).timeout(10000);
 });


### PR DESCRIPTION
### Motivation

I was trying to make some more improvements to our launcher and I realized we were missing something we should have probably done about 2 years ago.

When working on the LSP itself, we don't use the local version of the launcher. We use the local version of the server, but only after the bundle has been composed. Composing the bundle uses whatever latest version is globally installed.

This is detrimental to us catching bugs in the launch process before releasing it to users. We need to change that.

### Implementation

To ensure that the local version of the executable is always chosen when working on the LSP, I started mutating the `PATH` to include the `exe` directory.

That way, whenever `ruby-lsp` is invoked, the first thing that will be found is the local executable.

### Automated Tests

Added a test to make sure the `PATH` is being mutated.