### PR TITLE
Check if bundle is valid before restarting

### DIFF
--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -8,14 +8,24 @@
 
 setup_error = nil
 install_error = nil
+reboot = false
 
-# Read the initialize request before even starting the server. We need to do this to figure out the workspace URI.
-# Editors are not required to spawn the language server process on the same directory as the workspace URI, so we need
-# to ensure that we're setting up the bundle in the right place
-$stdin.binmode
-headers = $stdin.gets("\r\n\r\n")
-content_length = headers[/Content-Length: (\d+)/i, 1].to_i
-raw_initialize = $stdin.read(content_length)
+workspace_uri = ARGV.first
+
+raw_initialize = if workspace_uri && !workspace_uri.start_with?("--")
+  # If there's an argument without `--`, then it's the server asking to compose the bundle and passing to this
+  # executable the workspace URI. We can't require gems at this point, so we built a fake initialize request manually
+  reboot = true
+  "{\"params\":{\"workspaceFolders\":[{\"uri\":\"#{workspace_uri}\"}]}}"
+else
+  # Read the initialize request before even starting the server. We need to do this to figure out the workspace URI.
+  # Editors are not required to spawn the language server process on the same directory as the workspace URI, so we need
+  # to ensure that we're setting up the bundle in the right place
+  $stdin.binmode
+  headers = $stdin.gets("\r\n\r\n")
+  content_length = headers[/Content-Length: (\d+)/i, 1].to_i
+  $stdin.read(content_length)
+end
 
 # Compose the Ruby LSP bundle in a forked process so that we can require gems without polluting the main process
 # `$LOAD_PATH` and `Gem.loaded_specs`. Windows doesn't support forking, so we need a separate path to support it
@@ -89,6 +99,13 @@ rescue StandardError => e
   # If Bundler.setup fails, we need to restore the original $LOAD_PATH so that we can still require the Ruby LSP server
   # in degraded mode
   $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+end
+
+# When performing a lockfile re-boot, this executable is invoked to set up the composed bundle ahead of time. In this
+# flow, we are not booting the LSP yet, just checking if the bundle is valid before rebooting
+if reboot
+  # Use the exit status to signal to the server if composing the bundle succeeded
+  exit(install_error || setup_error ? 1 : 0)
 end
 
 # Now that the bundle is set up, we can begin actually launching the server. Note that `Bundler.setup` will have already

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -57,6 +57,7 @@ module RubyLsp
       @lockfile_hash_path = T.let(@custom_dir + "main_lockfile_hash", Pathname)
       @last_updated_path = T.let(@custom_dir + "last_updated", Pathname)
       @error_path = T.let(@custom_dir + "install_error", Pathname)
+      @already_composed_path = T.let(@custom_dir + "bundle_is_composed", Pathname)
 
       dependencies, bundler_version = load_dependencies
       @dependencies = T.let(dependencies, T::Hash[String, T.untyped])
@@ -70,6 +71,23 @@ module RubyLsp
     sig { returns(T::Hash[String, String]) }
     def setup!
       raise BundleNotLocked if !@launcher && @gemfile&.exist? && !@lockfile&.exist?
+
+      # If the bundle was composed ahead of time using our custom `rubyLsp/composeBundle` request, then we can skip the
+      # entire process and just return the composed environment
+      if @already_composed_path.exist?
+        $stderr.puts("Ruby LSP> Composed bundle was set up ahead of time. Skipping...")
+        @already_composed_path.delete
+
+        env = bundler_settings_as_env
+        env["BUNDLE_GEMFILE"] = @custom_gemfile.exist? ? @custom_gemfile.to_s : @gemfile.to_s
+
+        if env["BUNDLE_PATH"]
+          env["BUNDLE_PATH"] = File.expand_path(env["BUNDLE_PATH"], @project_path)
+        end
+
+        env["BUNDLER_VERSION"] = @bundler_version.to_s if @bundler_version
+        return env
+      end
 
       # Automatically create and ignore the .ruby-lsp folder for users
       @custom_dir.mkpath unless @custom_dir.exist?

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -37,6 +37,8 @@ module RubyLsp
     CODE = -32900
   end
 
+  BUNDLE_COMPOSE_FAILED_CODE = -33000
+
   # A notification to be sent to the client
   class Message
     extend T::Sig

--- a/project-words
+++ b/project-words
@@ -26,6 +26,7 @@ dont
 eglot
 Eglot
 eruby
+exitstatus
 EXTGLOB
 fakehome
 FIXEDENCODING

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -858,6 +858,24 @@ class SetupBundlerTest < Minitest::Test
     end
   end
 
+  def test_only_returns_environment_if_bundle_was_composed_ahead_of_time
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        FileUtils.mkdir(".ruby-lsp")
+        FileUtils.touch(File.join(".ruby-lsp", "bundle_is_composed"))
+
+        require "bundler/cli/update"
+        require "bundler/cli/install"
+        Bundler::CLI::Update.expects(:new).never
+        Bundler::CLI::Install.expects(:new).never
+
+        assert_output("", "Ruby LSP> Composed bundle was set up ahead of time. Skipping...\n") do
+          refute_empty(RubyLsp::SetupBundler.new(dir, launcher: true).setup!)
+        end
+      end
+    end
+  end
+
   private
 
   def with_default_external_encoding(encoding, &block)


### PR DESCRIPTION
### Motivation

The more we restart the server, the higher the risk that something related to Bundler may fail and prevent users from having a smooth experience.

I think we can be a bit smarter about when we restart the server by checking if composing the bundle is successful before we try. If we know that composing fails, it's better to continue running the current version of the server than crashing.

### Implementation

The proposal is to add a custom request that allows the client to ask the server if composing the bundle succeeds. That way, if there's a lockfile update, we can first check if the update produces a valid bundle.

If we couldn't compose the bundle, then we avoid restarting. Otherwise, we trigger the restart, but skip composing the bundle since we just did that ahead of time - saving time for the user and allow them to skip directly to indexing.

### Note

This solution doesn't fully solve #1458, but it does move the needle a little bit at least for VS Code. The big challenge in moving lockfile watching to the server is how to transfer the state of the server currently running to the new instance we launch.

For example, when we receive a notification that the lockfile was changed, we would need to:

1. Compose the new bundle
2. Replace the current process with a new one, using the new bundle (via `exec`)
3. Transfer the state of the previous process to the new one. We need all configurations that were applied during initialize (think the global state), the state of all current documents (the store object) and other pieces of state that exist in the version of the server running before the relaunch

I have not yet figured out how to achieve 3.

### Automated Tests

Added tests.