### PR TITLE
Prevent double activation when multiple documents are opened

### DIFF
--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -142,12 +142,17 @@ export class RubyLsp {
       const workspaceFolder = vscode.workspace.getWorkspaceFolder(
         activeDocument.uri,
       );
-      if (workspaceFolder) {
+
+      if (
+        workspaceFolder &&
+        !this.workspacesBeingLaunched.has(workspaceFolder.index)
+      ) {
         const existingWorkspace = this.workspaces.get(
           workspaceFolder.uri.toString(),
         );
 
         if (workspaceFolder && !existingWorkspace) {
+          this.workspacesBeingLaunched.add(workspaceFolder.index);
           await this.activateWorkspace(workspaceFolder, false);
         }
       }


### PR DESCRIPTION
### Motivation

When we started preventing double activation on lazy activations #2693, I forgot to do the same for when the user starts the editor with multiple documents opened.

### Implementation

We need to remember that we're already activating the workspace, so that we don't accidentally launch multiple duplicates for the same folder.