### PR TITLE
Check if RuboCop is available before searching for add-on

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -94,7 +94,8 @@ module RubyLsp
       @workspace_uri = URI(workspace_uri) if workspace_uri
 
       specified_formatter = options.dig(:initializationOptions, :formatter)
-      rubocop_has_addon = Gem::Requirement.new(">= 1.70.0").satisfied_by?(Gem::Version.new(::RuboCop::Version::STRING))
+      rubocop_has_addon = defined?(::RuboCop::Version::STRING) &&
+        Gem::Requirement.new(">= 1.70.0").satisfied_by?(Gem::Version.new(::RuboCop::Version::STRING))
 
       if specified_formatter
         @formatter = specified_formatter


### PR DESCRIPTION
### Motivation

This is a fix for the bug I just introduced in #3067 🤦‍♂️. We cannot assume that the `RuboCop` constant will be defined because projects may use a different formatter. We need to check first.

### Implementation

Started checking if the constant we need is defined as part of the check.

### Automated Tests

Part of why this wasn't caught is because our integration tests were ignoring the response return for the initialize request.

That makes the tests extremely weak because the LSP will actually rescue anything that happens during initialize and then simply return an error back to the client, which means that tests passed despite initialization failing.

I started properly checking for what response was returned, so that we can fail tests if initialization was not successful. Without the fix, tests now properly fail.