### PR TITLE
Remove server side document selectors

### DIFF
--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -19,7 +19,7 @@ module RubyLsp
         sig { returns(Interface::CodeActionRegistrationOptions) }
         def provider
           Interface::CodeActionRegistrationOptions.new(
-            document_selector: [Interface::DocumentFilter.new(language: "ruby")],
+            document_selector: nil,
             resolve_provider: true,
           )
         end

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -15,7 +15,7 @@ module RubyLsp
         sig { returns(Interface::DiagnosticRegistrationOptions) }
         def provider
           Interface::DiagnosticRegistrationOptions.new(
-            document_selector: [Interface::DocumentFilter.new(language: "ruby")],
+            document_selector: nil,
             inter_file_dependencies: false,
             workspace_diagnostics: false,
           )

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -13,13 +13,9 @@ module RubyLsp
       class << self
         extend T::Sig
 
-        sig { returns(Interface::FoldingRangeRegistrationOptions) }
+        sig { returns(TrueClass) }
         def provider
-          Interface::FoldingRangeRegistrationOptions.new(
-            document_selector: [
-              Interface::DocumentFilter.new(language: "ruby"),
-            ],
-          )
+          true
         end
       end
 

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -14,13 +14,9 @@ module RubyLsp
       class << self
         extend T::Sig
 
-        sig { returns(Interface::DocumentFormattingRegistrationOptions) }
+        sig { returns(TrueClass) }
         def provider
-          Interface::DocumentFormattingRegistrationOptions.new(
-            document_selector: [
-              Interface::DocumentFilter.new(language: "ruby"),
-            ],
-          )
+          true
         end
       end
 

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -14,7 +14,7 @@ module RubyLsp
         sig { returns(Interface::DocumentOnTypeFormattingRegistrationOptions) }
         def provider
           Interface::DocumentOnTypeFormattingRegistrationOptions.new(
-            document_selector: [Interface::DocumentFilter.new(language: "ruby")],
+            document_selector: nil,
             first_trigger_character: "{",
             more_trigger_character: ["\n", "|", "d"],
           )

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -17,7 +17,7 @@ module RubyLsp
         sig { returns(Interface::SemanticTokensRegistrationOptions) }
         def provider
           Interface::SemanticTokensRegistrationOptions.new(
-            document_selector: [{ language: "ruby" }, { language: "erb" }],
+            document_selector: nil,
             legend: Interface::SemanticTokensLegend.new(
               token_types: ResponseBuilders::SemanticHighlighting::TOKEN_TYPES.keys,
               token_modifiers: ResponseBuilders::SemanticHighlighting::TOKEN_MODIFIERS.keys,


### PR DESCRIPTION
### Motivation

I finally understood the mysterious requests we were receiving from URIs we didn't care about or the duplicate requests thanks to https://github.com/microsoft/vscode-languageserver-node/issues/1487#issuecomment-2597590940.

We were overriding the document selectors we define in the client in the server, with a much more simplistic approach. In the client, we take steps to ensure that we're handling only certain schemes with specific patterns and not duplicating client handling for the `untitled` scheme.

All of that configuration was lost for many requests because the server was simply broadcasting the document selector as `{ language: "ruby" }`, which is not scoped to any scheme or pattern.

This results in every language server running in the current VS Code window advertise that they handle any Ruby file, which is why we kept receiving duplicate requests and why we kept receiving requests for schemes we are not interested in handling - like the `vscode-chat-code-block://` scheme.

### Implementation

Since our document selector logic is so complex and requires knowledge of default gem paths, bundled gem paths, workspace paths and so on, we should not override it from the server. Trying to implement the same document selector logic on both ends would probably lead to unnecessary headache.

All of our requests already specify in `server.rb` if they need to return early for a certain document type, so there's no risk of receiving undesired requests that we don't know how to handle.

Considering that, I just set all document selectors in requests to `nil`, which [makes the editor prefer the one configured by the client](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentRegistrationOptions).