### PR TITLE
Check if lockfile is valid before composing bundle

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1292,6 +1292,13 @@ module RubyLsp
       command = "#{Gem.ruby} #{File.expand_path("../../exe/ruby-lsp-launcher", __dir__)} #{@global_state.workspace_uri}"
       id = message[:id]
 
+      begin
+        Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+      rescue Bundler::LockfileError => e
+        send_message(Error.new(id: id, code: BUNDLE_COMPOSE_FAILED_CODE, message: e.message))
+        return
+      end
+
       # We compose the bundle in a thread so that the LSP continues to work while we're checking for its validity. Once
       # we return the response back to the editor, then the restart is triggered
       Thread.new do


### PR DESCRIPTION
### Motivation

After #3066 moves forward, we can start getting smarter about our checks of when it's valid to restart. For example, we don't need to go all the way to composing the bundle, if we already know the lockfile's syntax is invalid.

### Implementation

Started parsing the lockfile before composing the bundle, so that we can more quickly reject a restart request if there's an issue.

### Automated Tests

Added a test.