### PR TITLE
Set buffer encoding when running activation script

### DIFF
--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -106,6 +106,7 @@ export abstract class VersionManager {
       cwd: this.bundleUri.fsPath,
       shell,
       env: process.env,
+      encoding: "utf-8",
     });
   }
 

--- a/vscode/src/test/suite/ruby/asdf.test.ts
+++ b/vscode/src/test/suite/ruby/asdf.test.ts
@@ -53,6 +53,7 @@ suite("Asdf", () => {
           shell: "/bin/bash",
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );
@@ -104,6 +105,7 @@ suite("Asdf", () => {
           shell: "/opt/homebrew/bin/fish",
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );

--- a/vscode/src/test/suite/ruby/custom.test.ts
+++ b/vscode/src/test/suite/ruby/custom.test.ts
@@ -52,6 +52,7 @@ suite("Custom", () => {
           shell,
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -60,6 +60,7 @@ suite("Mise", () => {
           shell: vscode.env.shell,
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );
@@ -119,6 +120,7 @@ suite("Mise", () => {
           shell: vscode.env.shell,
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );

--- a/vscode/src/test/suite/ruby/none.test.ts
+++ b/vscode/src/test/suite/ruby/none.test.ts
@@ -49,6 +49,7 @@ suite("None", () => {
           shell,
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );

--- a/vscode/src/test/suite/ruby/rbenv.test.ts
+++ b/vscode/src/test/suite/ruby/rbenv.test.ts
@@ -50,6 +50,7 @@ suite("Rbenv", () => {
           shell: vscode.env.shell,
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );
@@ -107,6 +108,7 @@ suite("Rbenv", () => {
           shell: vscode.env.shell,
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );
@@ -151,6 +153,7 @@ suite("Rbenv", () => {
           shell: vscode.env.shell,
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );

--- a/vscode/src/test/suite/ruby/rvm.test.ts
+++ b/vscode/src/test/suite/ruby/rvm.test.ts
@@ -61,6 +61,7 @@ suite("RVM", () => {
           cwd: workspacePath,
           shell: vscode.env.shell,
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );


### PR DESCRIPTION
### Motivation

We've been getting some errors in telemetry when transforming the activation hash into a JSON complaining that there's no conversion between ASCII-8BIT and UTF-8. Indeed, there's no way to convert the encodings properly, but I don't understand why the encoding is ASCII-8BIT to begin with.

I tried setting `LANG=C`, `LC_ALL=C` and changed a bunch of VS Code settings, but I'm still unable to reproduce the issue. I want to try forcing the Buffer encoding to be UTF-8 when running the activation script, in hopes that this will fix the issue.

### Implementation

Started setting the encoding for the exec call.

### Automated Tests

Adjusted our existing tests.