### PR TITLE
Use bundled environment activation script file

### DIFF
--- a/project-words
+++ b/project-words
@@ -26,6 +26,7 @@ dont
 eglot
 Eglot
 eruby
+EUTF
 exitstatus
 EXTGLOB
 fakehome

--- a/vscode/activation.rb
+++ b/vscode/activation.rb
@@ -1,0 +1,3 @@
+env = ENV.map { |k, v| "#{k}RUBY_LSP_VS#{v}" }
+env.unshift(RUBY_VERSION, Gem.path.join(","), !!defined?(RubyVM::YJIT))
+STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR#{env.join("RUBY_LSP_FS")}RUBY_LSP_ACTIVATION_SEPARATOR")

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ruby-lsp",
   "displayName": "Ruby LSP",
   "description": "VS Code plugin for connecting with the Ruby LSP",
-  "version": "0.8.20",
+  "version": "0.9.1",
   "publisher": "Shopify",
   "repository": {
     "type": "git",

--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -258,9 +258,6 @@ export class Debugger
 
       this.logDebuggerMessage(`Spawning debugger in directory ${cwd}`);
       this.logDebuggerMessage(`   Command bundle ${args.join(" ")}`);
-      this.logDebuggerMessage(
-        `   Environment ${JSON.stringify(configuration.env)}`,
-      );
 
       this.debugProcess = spawn("bundle", args, {
         shell: true,

--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -135,6 +135,7 @@ export class Ruby implements RubyInterface {
         new None(
           this.workspaceFolder,
           this.outputChannel,
+          this.context,
           this.manuallySelectRuby.bind(this),
           workspaceRubyPath,
         ),
@@ -170,6 +171,7 @@ export class Ruby implements RubyInterface {
             new None(
               this.workspaceFolder,
               this.outputChannel,
+              this.context,
               this.manuallySelectRuby.bind(this),
               globalRubyPath,
             ),
@@ -323,6 +325,7 @@ export class Ruby implements RubyInterface {
           new Asdf(
             this.workspaceFolder,
             this.outputChannel,
+            this.context,
             this.manuallySelectRuby.bind(this),
           ),
         );
@@ -332,6 +335,7 @@ export class Ruby implements RubyInterface {
           new Chruby(
             this.workspaceFolder,
             this.outputChannel,
+            this.context,
             this.manuallySelectRuby.bind(this),
           ),
         );
@@ -341,6 +345,7 @@ export class Ruby implements RubyInterface {
           new Rbenv(
             this.workspaceFolder,
             this.outputChannel,
+            this.context,
             this.manuallySelectRuby.bind(this),
           ),
         );
@@ -350,6 +355,7 @@ export class Ruby implements RubyInterface {
           new Rvm(
             this.workspaceFolder,
             this.outputChannel,
+            this.context,
             this.manuallySelectRuby.bind(this),
           ),
         );
@@ -359,6 +365,7 @@ export class Ruby implements RubyInterface {
           new Mise(
             this.workspaceFolder,
             this.outputChannel,
+            this.context,
             this.manuallySelectRuby.bind(this),
           ),
         );
@@ -368,6 +375,7 @@ export class Ruby implements RubyInterface {
           new RubyInstaller(
             this.workspaceFolder,
             this.outputChannel,
+            this.context,
             this.manuallySelectRuby.bind(this),
           ),
         );
@@ -377,6 +385,7 @@ export class Ruby implements RubyInterface {
           new Custom(
             this.workspaceFolder,
             this.outputChannel,
+            this.context,
             this.manuallySelectRuby.bind(this),
           ),
         );
@@ -386,6 +395,7 @@ export class Ruby implements RubyInterface {
           new None(
             this.workspaceFolder,
             this.outputChannel,
+            this.context,
             this.manuallySelectRuby.bind(this),
           ),
         );
@@ -395,6 +405,7 @@ export class Ruby implements RubyInterface {
           new Shadowenv(
             this.workspaceFolder,
             this.outputChannel,
+            this.context,
             this.manuallySelectRuby.bind(this),
           ),
         );

--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -31,9 +31,10 @@ export class Chruby extends VersionManager {
   constructor(
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel: WorkspaceChannel,
+    context: vscode.ExtensionContext,
     manuallySelectRuby: () => Promise<void>,
   ) {
-    super(workspaceFolder, outputChannel, manuallySelectRuby);
+    super(workspaceFolder, outputChannel, context, manuallySelectRuby);
 
     const configuredRubies = vscode.workspace
       .getConfiguration("rubyLsp")
@@ -199,7 +200,7 @@ export class Chruby extends VersionManager {
     ].join(";");
 
     const result = await this.runScript(
-      `${rubyExecutableUri.fsPath} -W0 -e '${script}'`,
+      `${rubyExecutableUri.fsPath} -EUTF-8:UTF-8 -e '${script}'`,
     );
 
     const [defaultGems, gemHome, yjit, version] =

--- a/vscode/src/ruby/none.ts
+++ b/vscode/src/ruby/none.ts
@@ -19,10 +19,11 @@ export class None extends VersionManager {
   constructor(
     workspaceFolder: vscode.WorkspaceFolder,
     outputChannel: WorkspaceChannel,
+    context: vscode.ExtensionContext,
     manuallySelectRuby: () => Promise<void>,
     rubyPath?: string,
   ) {
-    super(workspaceFolder, outputChannel, manuallySelectRuby);
+    super(workspaceFolder, outputChannel, context, manuallySelectRuby);
     this.rubyPath = rubyPath ?? "ruby";
   }
 

--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -50,6 +50,7 @@ async function launchClient(workspaceUri: vscode.Uri) {
       get: (_name: string) => undefined,
       update: (_name: string, _value: any) => Promise.resolve(),
     },
+    extensionUri: vscode.Uri.file(path.join(workspaceUri.fsPath, "vscode")),
   } as unknown as vscode.ExtensionContext;
   const fakeLogger = new FakeLogger();
   const outputChannel = new WorkspaceChannel("fake", fakeLogger as any);

--- a/vscode/src/test/suite/debugger.test.ts
+++ b/vscode/src/test/suite/debugger.test.ts
@@ -198,12 +198,14 @@ suite("Debugger", () => {
       'source "https://rubygems.org"\ngem "debug"',
     );
 
+    const extensionPath = path.dirname(path.dirname(path.dirname(__dirname)));
     const context = {
       subscriptions: [],
       workspaceState: {
         get: () => undefined,
         update: () => undefined,
       },
+      extensionUri: vscode.Uri.file(extensionPath),
     } as unknown as vscode.ExtensionContext;
     const outputChannel = new WorkspaceChannel("fake", LOG_CHANNEL);
     const workspaceFolder: vscode.WorkspaceFolder = {

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -10,8 +10,12 @@ import { Ruby, ManagerIdentifier } from "../../ruby";
 import { WorkspaceChannel } from "../../workspaceChannel";
 import { LOG_CHANNEL } from "../../common";
 import * as common from "../../common";
-import { ACTIVATION_SEPARATOR } from "../../ruby/versionManager";
 import { Shadowenv, UntrustedWorkspaceError } from "../../ruby/shadowenv";
+import {
+  ACTIVATION_SEPARATOR,
+  FIELD_SEPARATOR,
+  VALUE_SEPARATOR,
+} from "../../ruby/versionManager";
 
 import { FAKE_TELEMETRY } from "./fakeTelemetry";
 
@@ -30,6 +34,7 @@ suite("Ruby environment activation", () => {
       get: () => undefined,
       update: () => undefined,
     },
+    extensionUri: vscode.Uri.file(path.join(workspacePath, "vscode")),
   } as unknown as vscode.ExtensionContext;
   const outputChannel = new WorkspaceChannel("fake", LOG_CHANNEL);
 
@@ -125,16 +130,16 @@ suite("Ruby environment activation", () => {
         },
       } as unknown as vscode.WorkspaceConfiguration);
 
-    const envStub = {
-      env: { ANY: "true" },
-      yjit: true,
-      version: "3.3.5",
-      gemPath: ["~/.gem/ruby/3.3.5", "/opt/rubies/3.3.5/lib/ruby/gems/3.3.0"],
-    };
+    const envStub = [
+      "3.3.5",
+      "~/.gem/ruby/3.3.5,/opt/rubies/3.3.5/lib/ruby/gems/3.3.0",
+      "true",
+      `ANY${VALUE_SEPARATOR}true`,
+    ].join(FIELD_SEPARATOR);
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
-      stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
+      stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
     const ruby = new Ruby(

--- a/vscode/src/test/suite/ruby/asdf.test.ts
+++ b/vscode/src/test/suite/ruby/asdf.test.ts
@@ -8,7 +8,11 @@ import sinon from "sinon";
 import { Asdf } from "../../../ruby/asdf";
 import { WorkspaceChannel } from "../../../workspaceChannel";
 import * as common from "../../../common";
-import { ACTIVATION_SEPARATOR } from "../../../ruby/versionManager";
+import {
+  ACTIVATION_SEPARATOR,
+  FIELD_SEPARATOR,
+  VALUE_SEPARATOR,
+} from "../../../ruby/versionManager";
 
 suite("Asdf", () => {
   if (os.platform() === "win32") {
@@ -16,6 +20,15 @@ suite("Asdf", () => {
     console.log("Skipping Asdf tests on Windows");
     return;
   }
+  const context = {
+    extensionMode: vscode.ExtensionMode.Test,
+    subscriptions: [],
+    workspaceState: {
+      get: (_name: string) => undefined,
+      update: (_name: string, _value: any) => Promise.resolve(),
+    },
+    extensionUri: vscode.Uri.parse("file:///fake"),
+  } as unknown as vscode.ExtensionContext;
 
   test("Finds Ruby based on .tool-versions", async () => {
     // eslint-disable-next-line no-process-env
@@ -26,16 +39,22 @@ suite("Asdf", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const asdf = new Asdf(workspaceFolder, outputChannel, async () => {});
-    const envStub = {
-      env: { ANY: "true" },
-      yjit: true,
-      version: "3.0.0",
-    };
+    const asdf = new Asdf(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
+    const envStub = [
+      "3.0.0",
+      "/path/to/gems",
+      "true",
+      `ANY${VALUE_SEPARATOR}true`,
+    ].join(FIELD_SEPARATOR);
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
-      stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
+      stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
     const findInstallationStub = sinon
@@ -47,12 +66,13 @@ suite("Asdf", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `. ${os.homedir()}/.asdf/asdf.sh && asdf exec ruby -W0 -rjson -e '${asdf.activationScript}'`,
+        `. ${os.homedir()}/.asdf/asdf.sh && asdf exec ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
         {
           cwd: workspacePath,
           shell: "/bin/bash",
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );
@@ -75,16 +95,22 @@ suite("Asdf", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const asdf = new Asdf(workspaceFolder, outputChannel, async () => {});
-    const envStub = {
-      env: { ANY: "true" },
-      yjit: true,
-      version: "3.0.0",
-    };
+    const asdf = new Asdf(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
 
+    const envStub = [
+      "3.0.0",
+      "/path/to/gems",
+      "true",
+      `ANY${VALUE_SEPARATOR}true`,
+    ].join(FIELD_SEPARATOR);
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
-      stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
+      stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
     const findInstallationStub = sinon
@@ -98,12 +124,13 @@ suite("Asdf", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `. ${os.homedir()}/.asdf/asdf.fish && asdf exec ruby -W0 -rjson -e '${asdf.activationScript}'`,
+        `. ${os.homedir()}/.asdf/asdf.fish && asdf exec ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
         {
           cwd: workspacePath,
           shell: "/opt/homebrew/bin/fish",
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );

--- a/vscode/src/test/suite/ruby/chruby.test.ts
+++ b/vscode/src/test/suite/ruby/chruby.test.ts
@@ -50,6 +50,16 @@ suite("Chruby", () => {
     return;
   }
 
+  const context = {
+    extensionMode: vscode.ExtensionMode.Test,
+    subscriptions: [],
+    workspaceState: {
+      get: (_name: string) => undefined,
+      update: (_name: string, _value: any) => Promise.resolve(),
+    },
+    extensionUri: vscode.Uri.parse("file:///fake"),
+  } as unknown as vscode.ExtensionContext;
+
   let rootPath: string;
   let workspacePath: string;
   let workspaceFolder: vscode.WorkspaceFolder;
@@ -84,7 +94,12 @@ suite("Chruby", () => {
   test("Finds Ruby when .ruby-version is inside workspace", async () => {
     fs.writeFileSync(path.join(workspacePath, ".ruby-version"), RUBY_VERSION);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -96,7 +111,12 @@ suite("Chruby", () => {
   test("Finds Ruby when .ruby-version is inside on parent directories", async () => {
     fs.writeFileSync(path.join(rootPath, ".ruby-version"), RUBY_VERSION);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -128,7 +148,12 @@ suite("Chruby", () => {
 
     fs.writeFileSync(path.join(rootPath, ".ruby-version"), RUBY_VERSION);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -173,7 +198,12 @@ suite("Chruby", () => {
       `${RUBY_VERSION}-rc1`,
     );
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -203,7 +233,12 @@ suite("Chruby", () => {
 
     fs.writeFileSync(path.join(rootPath, ".ruby-version"), RUBY_VERSION);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [vscode.Uri.file(rubyHome)];
 
     const { env, version, yjit } = await chruby.activate();
@@ -225,7 +260,12 @@ suite("Chruby", () => {
             : "",
       } as any);
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     configStub.restore();
 
     const result = await chruby.activate();
@@ -245,7 +285,12 @@ suite("Chruby", () => {
       `${MAJOR}.${MINOR}`,
     );
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -272,7 +317,12 @@ suite("Chruby", () => {
       `${MAJOR}.${MINOR}`,
     );
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, ".rubies")),
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
@@ -283,7 +333,12 @@ suite("Chruby", () => {
   });
 
   test("Uses latest Ruby as a fallback if no .ruby-version is found", async () => {
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -295,7 +350,12 @@ suite("Chruby", () => {
   test("Doesn't try to fallback to latest version if there's a Gemfile with ruby constraints", async () => {
     fs.writeFileSync(path.join(workspacePath, "Gemfile"), "ruby '3.3.0'");
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -308,7 +368,12 @@ suite("Chruby", () => {
   test("Uses closest Ruby if the version specified in .ruby-version is not installed (patch difference)", async () => {
     fs.writeFileSync(path.join(workspacePath, ".ruby-version"), "ruby '3.3.3'");
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -320,7 +385,12 @@ suite("Chruby", () => {
   test("Uses closest Ruby if the version specified in .ruby-version is not installed (minor difference)", async () => {
     fs.writeFileSync(path.join(workspacePath, ".ruby-version"), "ruby '3.2.0'");
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];
@@ -335,7 +405,12 @@ suite("Chruby", () => {
       "ruby '3.4.0-preview1'",
     );
 
-    const chruby = new Chruby(workspaceFolder, outputChannel, async () => {});
+    const chruby = new Chruby(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
     chruby.rubyInstallationUris = [
       vscode.Uri.file(path.join(rootPath, "opt", "rubies")),
     ];

--- a/vscode/src/test/suite/ruby/custom.test.ts
+++ b/vscode/src/test/suite/ruby/custom.test.ts
@@ -9,9 +9,23 @@ import sinon from "sinon";
 import { Custom } from "../../../ruby/custom";
 import { WorkspaceChannel } from "../../../workspaceChannel";
 import * as common from "../../../common";
-import { ACTIVATION_SEPARATOR } from "../../../ruby/versionManager";
+import {
+  ACTIVATION_SEPARATOR,
+  FIELD_SEPARATOR,
+  VALUE_SEPARATOR,
+} from "../../../ruby/versionManager";
 
 suite("Custom", () => {
+  const context = {
+    extensionMode: vscode.ExtensionMode.Test,
+    subscriptions: [],
+    workspaceState: {
+      get: (_name: string) => undefined,
+      update: (_name: string, _value: any) => Promise.resolve(),
+    },
+    extensionUri: vscode.Uri.parse("file:///fake"),
+  } as unknown as vscode.ExtensionContext;
+
   test("Invokes custom script and then Ruby", async () => {
     const workspacePath = fs.mkdtempSync(
       path.join(os.tmpdir(), "ruby-lsp-test-"),
@@ -23,35 +37,46 @@ suite("Custom", () => {
       index: 0,
     };
     const outputChannel = new WorkspaceChannel("fake", common.LOG_CHANNEL);
-    const custom = new Custom(workspaceFolder, outputChannel, async () => {});
+    const custom = new Custom(
+      workspaceFolder,
+      outputChannel,
+      context,
+      async () => {},
+    );
 
-    const envStub = {
-      env: { ANY: "true" },
-      yjit: true,
-      version: "3.0.0",
-    };
+    const envStub = [
+      "3.0.0",
+      "/path/to/gems",
+      "true",
+      `ANY${VALUE_SEPARATOR}true`,
+    ].join(FIELD_SEPARATOR);
 
     const execStub = sinon.stub(common, "asyncExec").resolves({
       stdout: "",
-      stderr: `${ACTIVATION_SEPARATOR}${JSON.stringify(envStub)}${ACTIVATION_SEPARATOR}`,
+      stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
     const commandStub = sinon
       .stub(custom, "customCommand")
       .returns("my_version_manager activate_env");
     const { env, version, yjit } = await custom.activate();
+    const activationUri = vscode.Uri.joinPath(
+      context.extensionUri,
+      "activation.rb",
+    );
 
     // We must not set the shell on Windows
     const shell = os.platform() === "win32" ? undefined : vscode.env.shell;
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `my_version_manager activate_env && ruby -W0 -rjson -e '${custom.activationScript}'`,
+        `my_version_manager activate_env && ruby -EUTF-8:UTF-8 '${activationUri.fsPath}'`,
         {
           cwd: uri.fsPath,
           shell,
           // eslint-disable-next-line no-process-env
           env: process.env,
+          encoding: "utf-8",
         },
       ),
     );

--- a/vscode/src/test/suite/ruby/rubyInstaller.test.ts
+++ b/vscode/src/test/suite/ruby/rubyInstaller.test.ts
@@ -22,6 +22,16 @@ suite("RubyInstaller", () => {
     return;
   }
 
+  const context = {
+    extensionMode: vscode.ExtensionMode.Test,
+    subscriptions: [],
+    workspaceState: {
+      get: (_name: string) => undefined,
+      update: (_name: string, _value: any) => Promise.resolve(),
+    },
+    extensionUri: vscode.Uri.parse("file:///fake"),
+  } as unknown as vscode.ExtensionContext;
+
   let rootPath: string;
   let workspacePath: string;
   let workspaceFolder: vscode.WorkspaceFolder;
@@ -58,6 +68,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
+      context,
       async () => {},
     );
     const { env, version, yjit } = await windows.activate();
@@ -77,6 +88,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
+      context,
       async () => {},
     );
     const { env, version, yjit } = await windows.activate();
@@ -96,6 +108,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
+      context,
       async () => {},
     );
     const result = ["/fake/dir", "/other/fake/dir", true, RUBY_VERSION].join(
@@ -120,6 +133,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
+      context,
       async () => {},
     );
     const result = [

--- a/vscode/src/test/suite/ruby/shadowenv.test.ts
+++ b/vscode/src/test/suite/ruby/shadowenv.test.ts
@@ -30,6 +30,19 @@ suite("Shadowenv", () => {
     return;
   }
 
+  const extensionPath = path.dirname(
+    path.dirname(path.dirname(path.dirname(path.dirname(__dirname)))),
+  );
+  const context = {
+    extensionMode: vscode.ExtensionMode.Test,
+    subscriptions: [],
+    workspaceState: {
+      get: (_name: string) => undefined,
+      update: (_name: string, _value: any) => Promise.resolve(),
+    },
+    extensionUri: vscode.Uri.file(path.join(extensionPath, "vscode")),
+  } as unknown as vscode.ExtensionContext;
+
   let rootPath: string;
   let workspacePath: string;
   let workspaceFolder: vscode.WorkspaceFolder;
@@ -133,6 +146,7 @@ suite("Shadowenv", () => {
     const shadowenv = new Shadowenv(
       workspaceFolder,
       outputChannel,
+      context,
       async () => {},
     );
     const { env, version, yjit } = await shadowenv.activate();
@@ -153,6 +167,7 @@ suite("Shadowenv", () => {
     const shadowenv = new Shadowenv(
       workspaceFolder,
       outputChannel,
+      context,
       async () => {},
     );
     const { env, version, yjit } = await shadowenv.activate();
@@ -179,6 +194,7 @@ suite("Shadowenv", () => {
     const shadowenv = new Shadowenv(
       workspaceFolder,
       outputChannel,
+      context,
       async () => {},
     );
     const { env, version, yjit } = await shadowenv.activate();
@@ -209,6 +225,7 @@ suite("Shadowenv", () => {
     const shadowenv = new Shadowenv(
       workspaceFolder,
       outputChannel,
+      context,
       async () => {},
     );
 
@@ -232,6 +249,7 @@ suite("Shadowenv", () => {
     const shadowenv = new Shadowenv(
       workspaceFolder,
       outputChannel,
+      context,
       async () => {},
     );
 


### PR DESCRIPTION
### Motivation

We've been seeing 3 types of common issues in our telemetry when running the activation script - in particular for Shadowenv, but this affects all other managers except chruby and RubyInstaller:

1. Pipe encoding issues. It appears that some users have their shell's encoding configured to ASCII-8BIT, which is incompatible with the JSON we try to return and results in an unknown conversion error
2. Incompatible library for the JSON gem. Since it's a native extension, if `json` was compiled for a different Ruby version, we will fail to require it and thus fail to activate
3. Syntax errors. Depending on the user's shell and its configurations, we sometimes hit weird syntax errors, which happen both when requiring json and when running the script

This PR proposes a few changes to try to address these issues.

### Implementation

We figured out that the first issue happens when the user sets `LANG=C` in their shell and has a prompt that includes certain unicode/glyph characters, which makes Ruby consider the encoding of the PS1 environment variable as `ASCII-8BIT`. To fix that, I started setting `LANG` and using the `-E` switch to force Ruby's encoding.

To address the other issues, my suggestion is to bundle the activation script in the extension, so that we can avoid running it with `ruby -e`. That helps us avoid escaping and syntax issues for different shells (e.g.: we no longer need to worry about quoting).

Additionally, I'm no longer using JSON to communicate. We essentially only need to pass key value pairs between the script and the extension, so I think we can avoid the issues coming from JSON by using a predefined separator to split them.

In this case, I'm just using a predefined string to separate values and we return/expect them in order. Note that we need a very unique separator, otherwise we risk incorrectly splitting the result. 

For example, if we were to use line breaks, that would fail because you can have them in values for environment variables, which would make us incorrectly split the output.

### Automated Tests

Adjusted current tests.

### Manual Tests

Since I'm making changes to one of the most sensitive parts of activation, I want to cut a prerelease version for this branch to give us an opportunity to catch mistakes before stabilizing the approach.