### PR TITLE
Account for missing bundle or lockfile in compose bundle request

### DIFF
--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -51,7 +51,7 @@ end
 
 begin
   # Wait until the composed Bundle is finished
-  Process.wait(pid)
+  _, status = Process.wait2(pid)
 rescue Errno::ECHILD
   # In theory, the child process can finish before we even get to the wait call, but that is not an error
 end
@@ -105,7 +105,7 @@ end
 # flow, we are not booting the LSP yet, just checking if the bundle is valid before rebooting
 if reboot
   # Use the exit status to signal to the server if composing the bundle succeeded
-  exit(install_error || setup_error ? 1 : 0)
+  exit(install_error || setup_error ? 1 : status&.exitstatus || 0)
 end
 
 # Now that the bundle is set up, we can begin actually launching the server. Note that `Bundler.setup` will have already

--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -22,6 +22,7 @@ require "prism/visitor"
 require "language_server-protocol"
 require "rbs"
 require "fileutils"
+require "open3"
 
 require "ruby-lsp"
 require "ruby_lsp/base_server"

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -241,8 +241,7 @@ module RubyLsp
 
       # If either the Gemfile or the lockfile have been modified during the process of setting up the bundle, retry
       # composing the bundle from scratch
-
-      if @gemfile && @lockfile
+      if @gemfile&.exist? && @lockfile&.exist?
         current_gemfile_hash = Digest::SHA256.hexdigest(@gemfile.read)
         current_lockfile_hash = Digest::SHA256.hexdigest(@lockfile.read)
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "open3"
 
 class IntegrationTest < Minitest::Test
   def setup


### PR DESCRIPTION
### Motivation

When implementing the new `rubyLsp/composeBundle` request, I had the use case of automated restarts on lockfile changes in mind.

However, you can still trigger a restart manually through the commands and restarts are also triggered when a lockfile is deleted. In those two cases, the request was crashing.

### Implementation

Since we're already running the LSP, `Bundler.default_lockfile` may return the path to a lockfile that no longer exists (it is based on the `BUNDLE_GEMFILE` environment variable, which is already set at that point). We need to check if the file exists before trying to parse it.

Additionally, if the restart command is invoked manually and there's no bundle, we still shouldn't fail because we can compose the bundle regardless.

### Automated Tests

Added tests.