### PR TITLE
Avoid failing if file is quickly created and deleted

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1036,6 +1036,10 @@ module RubyLsp
       when Constant::FileChangeType::DELETED
         index.delete(uri)
       end
+    rescue Errno::ENOENT
+      # If a file is created and then delete immediately afterwards, we will process the created notification before we
+      # receive the deleted one, but the file no longer exists. This may happen when running a test suite that creates
+      # and deletes files automatically.
     end
 
     sig { params(uri: URI::Generic).void }


### PR DESCRIPTION
### Motivation

I noticed that we were crashing if a file was quickly created and deleted. Before we got to processing the created notification, the file would already no longer be there and trying to read from disk would raise.

This can happen when running tests that automatically created/delete files or if switching branches quickly.

### Implementation

Just started rescuing `Errno::ENOENT`. If the file is no longer there, it probably means we just haven't processed its deleted notification.

### Automated Tests

Added a test that fails before the fix.