### PR TITLE
Search for expected add-on in test

### DIFF
--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -54,7 +54,9 @@ module RubyLsp
 
     def test_addons_are_automatically_tracked
       Addon.load_addons(@global_state, @outgoing_queue)
-      assert_equal(123, T.unsafe(Addon.addons.first).field)
+
+      addon = Addon.addons.find { |addon| addon.is_a?(@addon) }
+      assert_equal(123, T.unsafe(addon).field)
     end
 
     def test_loading_addons_initializes_them


### PR DESCRIPTION
### Motivation

This test is flaky because sometimes `Addon.addons.first` returns the RuboCop add-on instead of the one defined in the test.

Let's avoid having this test be order dependent.