### PR TITLE
Allow snippets for Cursor editor

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -170,7 +170,7 @@ module RubyLsp
 
       sig { params(line: Integer, character: Integer).void }
       def move_cursor_to(line, character)
-        return unless @client_name.start_with?("Visual Studio Code")
+        return unless /Visual Studio Code|Cursor/.match?(@client_name)
 
         position = Interface::Position.new(
           line: line,

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -883,6 +883,46 @@ class OnTypeFormattingTest < Minitest::Test
     assert_equal(expected_edits.to_json, T.must(edits).to_json)
   end
 
+  def test_includes_snippets_on_cursor
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
+
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "class Foo",
+      }],
+      version: 2,
+    )
+    document.parse!
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(
+      document,
+      { line: 1, character: 2 },
+      "\n",
+      "Cursor",
+    ).perform
+    expected_edits = [
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "\n",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "end",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "$0",
+      },
+    ]
+    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+  end
+
   def test_does_not_confuse_class_parameter_with_keyword
     document = RubyLsp::RubyDocument.new(
       source: +"",


### PR DESCRIPTION
### Motivation

Fixes the behaviour described in https://github.com/Shopify/ruby-lsp/discussions/3094#discussioncomment-11997299.

While the LSP spec doesn't standardize snippet support, we use a custom middleware to allow moving the user's cursor around when applying on type formatting. We were checking to apply this only in VS Code, but not Cursor.

### Implementation

Added Cursor to the mix.

### Automated Tests

Added a test.