### PR TITLE
Prefer exact matches when guessing types

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -120,8 +120,16 @@ module RubyIndexer
       )]))
     end
     def first_unqualified_const(name)
+      # Look for an exact match first
       _name, entries = @entries.find do |const_name, _entries|
-        const_name.end_with?(name)
+        const_name == name || const_name.end_with?("::#{name}")
+      end
+
+      # If an exact match is not found, then try to find a constant that ends with the name
+      unless entries
+        _name, entries = @entries.find do |const_name, _entries|
+          const_name.end_with?(name)
+        end
       end
 
       T.cast(

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1561,6 +1561,23 @@ module RubyIndexer
       assert_equal("Foo::Bar", entry.name)
     end
 
+    def test_first_unqualified_const_prefers_exact_matches
+      index(<<~RUBY)
+        module Foo
+          class ParseResultType
+          end
+        end
+
+        module Namespace
+          class Type
+          end
+        end
+      RUBY
+
+      entry = T.must(@index.first_unqualified_const("Type")&.first)
+      assert_equal("Namespace::Type", entry.name)
+    end
+
     def test_completion_does_not_duplicate_overridden_methods
       index(<<~RUBY)
         class Foo


### PR DESCRIPTION
### Motivation

I noticed we weren't guessing the correct types even in situations where I expected us to. The issue turns out to be not preferring exact matches.

For example, where `type` is used in the LSP itself, we ended up guessing `ParseResultType` from Prism because that was the first constant ending with `Type` that we found.

I think we can improve our accuracy by preferring exact matches over partial ones.

### Implementation

Started looking for exact matches first, falling back to our original partial matches.

### Automated Tests

Added a test that reproduces the scenario.