### PR TITLE
Allow for under development feature flags

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -80,6 +80,8 @@ export const SUPPORTED_LANGUAGE_IDS = ["ruby", "erb"];
 // A list of feature flags where the key is the name and the value is the rollout percentage.
 //
 // Note: names added here should also be added to the `rubyLsp.optedOutFeatureFlags` enum in the `package.json` file
+// Note 2: -1 is a special value used to indicate under development features. Those can only be enabled explicitly and
+// are not impacted by the user's choice of opting into all flags
 export const FEATURE_FLAGS = {
   tapiocaAddon: 0.5,
   launcher: 0.1,
@@ -127,12 +129,16 @@ export function featureEnabled(feature: keyof typeof FEATURE_FLAGS): boolean {
     return false;
   }
 
+  const percentage = FEATURE_FLAGS[feature];
+
   // If the user opted-in to all features, return true
-  if (flagConfiguration.all || flagConfiguration[feature]) {
+  if (
+    (flagConfiguration.all && percentage !== -1) ||
+    flagConfiguration[feature]
+  ) {
     return true;
   }
 
-  const percentage = FEATURE_FLAGS[feature];
   const machineId = vscode.env.machineId;
   // Create a digest of the concatenated machine ID and feature name, which will generate a unique hash for this
   // user-feature combination

--- a/vscode/src/test/suite/common.test.ts
+++ b/vscode/src/test/suite/common.test.ts
@@ -110,4 +110,32 @@ suite("Common", () => {
     stub.restore();
     assert.strictEqual(result, true);
   });
+
+  test("only returns true if explicitly opting into under development flags", () => {
+    (FEATURE_FLAGS as any).fakeFeature = -1;
+
+    // With only `all` enabled
+    const firstStub = sandbox
+      .stub(vscode.workspace, "getConfiguration")
+      .returns({
+        get: () => {
+          return { all: true };
+        },
+      } as any);
+
+    firstStub.restore();
+    assert.strictEqual(featureEnabled("fakeFeature" as any), false);
+
+    // With fakeFeature enabled
+    const secondStub = sandbox
+      .stub(vscode.workspace, "getConfiguration")
+      .returns({
+        get: () => {
+          return { all: true, fakeFeature: true };
+        },
+      } as any);
+
+    assert.strictEqual(featureEnabled("fakeFeature" as any), true);
+    secondStub.restore();
+  });
 });


### PR DESCRIPTION
### Motivation

In addition to being able to roll out feature flags gradually, it would be nice if we could have flags that are only on if explicitly enabled. That allows us to hide under development functionality that's not ready even for beta testers.

This PR adds support for under development flags.

### Implementation

Started considering -1 as the indication that a flag is under development. If the value is -1, that flag is not enabled based on the `all` setting and can only be turned on by explicitly opting in.

### Automated Tests

Added a test.