### PR TITLE
Fix local variable assignment highlighting with no spaces

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -160,7 +160,7 @@
           "name": "variable.ruby"
         }
       },
-      "match": "^\\s*([a-z]([A-Za-z0-9_])*)\\s*=[^=>]",
+      "match": "^\\s*([a-z]([A-Za-z0-9_])*)\\s*(?==[^=>])",
       "comment": "A local variable assignment"
     },
     {

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -339,6 +339,7 @@ suite("Grammars", () => {
         const actualTokens = tokenizeRuby(ruby);
         assert.deepStrictEqual(actualTokens, expectedTokens);
       });
+
       test("or assignment", () => {
         const ruby = "local ||= 1";
         const expectedTokens = [
@@ -354,6 +355,7 @@ suite("Grammars", () => {
         const actualTokens = tokenizeRuby(ruby);
         assert.deepStrictEqual(actualTokens, expectedTokens);
       });
+
       test("and assignment in a condition", () => {
         const ruby = "if local &&= 1";
         const expectedTokens = [
@@ -371,6 +373,7 @@ suite("Grammars", () => {
         const actualTokens = tokenizeRuby(ruby);
         assert.deepStrictEqual(actualTokens, expectedTokens);
       });
+
       test("assignment in a condition", () => {
         const ruby = "if (local = 1)";
         const expectedTokens = [
@@ -384,6 +387,7 @@ suite("Grammars", () => {
         const actualTokens = tokenizeRuby(ruby);
         assert.deepStrictEqual(actualTokens, expectedTokens);
       });
+
       test("operation assignment in a condition", () => {
         const ruby = "if (local += 1)";
         const expectedTokens = [
@@ -395,6 +399,33 @@ suite("Grammars", () => {
           [" ", ["source.ruby"]],
           ["1", ["source.ruby", "constant.numeric.ruby"]],
           [")", ["source.ruby", "punctuation.section.function.ruby"]],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+
+      test("assignment to a string with no spaces", () => {
+        const ruby = "local='string'";
+        const expectedTokens = [
+          ["local", ["source.ruby", "variable.ruby"]],
+          ["=", ["source.ruby", "keyword.operator.assignment.ruby"]],
+          [
+            "'",
+            [
+              "source.ruby",
+              "string.quoted.single.ruby",
+              "punctuation.definition.string.begin.ruby",
+            ],
+          ],
+          ["string", ["source.ruby", "string.quoted.single.ruby"]],
+          [
+            "'",
+            [
+              "source.ruby",
+              "string.quoted.single.ruby",
+              "punctuation.definition.string.end.ruby",
+            ],
+          ],
         ];
         const actualTokens = tokenizeRuby(ruby);
         assert.deepStrictEqual(actualTokens, expectedTokens);


### PR DESCRIPTION
### Motivation

Closes #2892

The way we were matching local variables was causing assignments with no spaces after the equal sign to be incorrectly matched (see #2892 for examples).

### Implementation

Used a positive lookahead to check if the equal sign is there without matching it as part of the capture, which makes the rest of the line be processed properly.

### Automated Tests

Added a new test covering this scenario.