### PR TITLE
Fix composed bundle reference to gemfile in higher-level directory

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -158,7 +158,8 @@ module RubyLsp
       # If there's a top level Gemfile, we want to evaluate from the composed bundle. We get the source from the top
       # level Gemfile, so if there isn't one we need to add a default source
       if @gemfile&.exist? && @lockfile&.exist?
-        parts << "eval_gemfile(File.expand_path(\"../#{@gemfile_name}\", __dir__))"
+        gemfile_path = @gemfile.relative_path_from(@custom_dir.realpath)
+        parts << "eval_gemfile(File.expand_path(\"#{gemfile_path}\", __dir__))"
       else
         parts.unshift('source "https://rubygems.org"')
       end


### PR DESCRIPTION
### Motivation

When Bundler is run in a directory without a gemfile, it searches up the directory hierarchy for a parent directory with a gemfile and uses the first one it finds. If that gemfile contains `ruby-lsp` (and `debug`), then Ruby LSP works correctly. If it does not, Ruby LSP creates a malformed composed bundle gemfile and fails with errors from Bundler. This is due to the composed bundle code assuming the gemfile is in the working directory.

I discovered this because I tried adding a fallback gemfile to my gems directory so when I open a gem that does not have its own development gemfile I can still use some dev tools via bundler.

### Implementation

This PR fixes the issue by putting the proper path in the composed bundle gemfile.

This was the most minimal fix. It might be better to use bundler's concept of what the project directory is. That is, if I'm in `proj/test` and run bundler it will find `proj/Gemfile` and consider `proj` to be the project directory, not `proj/test`. Ruby LSP could mimic that behavior and use/create the `.ruby-lsp` composed bundle in `proj`. That would prevent accidentally creating extra unnecessary extra `.ruby-lsp` directories, but it would be a bigger change. The vscode plugin currently looks for the composed bundle in the working directory.

### Automated Tests

I added a test case.

I had written [another test last time I worked on this](https://github.com/Shopify/ruby-lsp/pull/2403/files#diff-7f08ccf0130264f75f0238da24571ca6dc6ad5d2b27a62d27490f27e5d7fac48R145) because I ran into a case that wasn't caught by existing tests, but I can't remember what that was so I don't know if it's still useful.

### Manual Tests

In a directory `project`, do `bundle init && bundle` and then create `project/subdir`. Either cd into `subdir` and run `ruby-lsp` or open `subdir` in vscode. Observe without this fix that if fails with a "No such file" error from bundler due to `.ruby-lsp/Gemfile` trying to eval `../Gemfile`.
