### PR TITLE
Ignore untrusted workspace error for telemetry

### DIFF
--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -9,6 +9,8 @@ import { VersionManager, ActivationResult } from "./versionManager";
 // which Ruby version should be used for each project, in addition to other customizations such as GEM_HOME.
 //
 // Learn more: https://github.com/Shopify/shadowenv
+export class UntrustedWorkspaceError extends Error {}
+
 export class Shadowenv extends VersionManager {
   async activate(): Promise<ActivationResult> {
     try {
@@ -57,7 +59,7 @@ export class Shadowenv extends VersionManager {
           return this.activate();
         }
 
-        throw new Error(
+        throw new UntrustedWorkspaceError(
           "Cannot activate Ruby environment in an untrusted workspace",
         );
       }


### PR DESCRIPTION
### Motivation

In efforts to make our telemetry as useful as possible, I think we should ignore errors that we cannot recover from. When the version manager is Shadowenv and the current workspace is untrusted, there's nothing we can do.

Auto-trusting a workspace is a security issue because it would execute arbitrary Shadow Lisp files, so that's not an option.

Since only the user can decide to trust a workspace, there really is nothing we can do if they dismissed our offer to trust it.

### Implementation

Started ignoring untrusted workspace errors for telemetry. Also, added the workspace name as an attribute, which is useful when trying to discover specific types of errors.

### Automated Tests

Added a test.