### PR TITLE
Use unique IDs for registering watchers

### DIFF
--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -23,6 +23,7 @@ require "language_server-protocol"
 require "rbs"
 require "fileutils"
 require "open3"
+require "securerandom"
 
 require "ruby-lsp"
 require "ruby_lsp/base_server"

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -176,11 +176,19 @@ module RubyLsp
     class << self
       extend T::Sig
 
-      sig { params(id: Integer, pattern: T.any(Interface::RelativePattern, String), kind: Integer).returns(Request) }
+      sig do
+        params(
+          id: Integer,
+          pattern: T.any(Interface::RelativePattern, String),
+          kind: Integer,
+          registration_id: T.nilable(String),
+        ).returns(Request)
+      end
       def register_watched_files(
         id,
         pattern,
-        kind: Constant::WatchKind::CREATE | Constant::WatchKind::CHANGE | Constant::WatchKind::DELETE
+        kind: Constant::WatchKind::CREATE | Constant::WatchKind::CHANGE | Constant::WatchKind::DELETE,
+        registration_id: nil
       )
         new(
           id: id,
@@ -188,7 +196,7 @@ module RubyLsp
           params: Interface::RegistrationParams.new(
             registrations: [
               Interface::Registration.new(
-                id: "workspace/didChangeWatchedFiles",
+                id: registration_id || SecureRandom.uuid,
                 method: "workspace/didChangeWatchedFiles",
                 register_options: Interface::DidChangeWatchedFilesRegistrationOptions.new(
                   watchers: [

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -521,6 +521,25 @@ class ServerTest < Minitest::Test
     end
   end
 
+  def test_did_change_watched_files_processes_unique_change_entries
+    @server.expects(:handle_rubocop_config_change).once
+    @server.process_message({
+      method: "workspace/didChangeWatchedFiles",
+      params: {
+        changes: [
+          {
+            uri: URI::Generic.from_path(path: File.join(Dir.pwd, ".rubocop.yml")).to_s,
+            type: RubyLsp::Constant::FileChangeType::CHANGED,
+          },
+          {
+            uri: URI::Generic.from_path(path: File.join(Dir.pwd, ".rubocop.yml")).to_s,
+            type: RubyLsp::Constant::FileChangeType::CHANGED,
+          },
+        ],
+      },
+    })
+  end
+
   def test_workspace_addons
     create_test_addons
     @server.load_addons


### PR DESCRIPTION
### Motivation

Closes #3137

We were using the same registration ID for two different file watchers. That made VS Code override the entry, but one of them became a dangling object that didn't get appropriately cleaned up when the LSP shuts down.

Because that old file watcher was still active, the LSP client itself was not cleared either as a reference was still being held and then notifications for `didChangeWatchedFiles` were sent to a client that was already stopped, resulting in the `Notify file events failed` message.

We should always use unique IDs when registering file watchers.

### Implementation

I did 3 small things:

1. Ensured unique IDs for registering the watchers
2. Started watching `.rubocop`, which we watched before but I missed in my refactor PR
3. Started ensuring that we're only processing changes once

The last point is necessary because add-ons may register for watching the same patterns as one another or as the Ruby LSP and that results in duplicate changes being sent to the server.

The most optimal solution is #3145, but that is going to require more effort, so let's just fix the issue for now.

### Automated Tests

Added a test and verified manually that the issue is gone.