### PR TITLE
Append test output when a test fails

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -279,6 +279,12 @@ export class TestController {
           run.appendOutput(output.replace(/\r?\n/g, "\r\n"), undefined, test);
           run.passed(test, Date.now() - start);
         } catch (err: any) {
+          run.appendOutput(
+            err.message.replace(/\r?\n/g, "\r\n"),
+            undefined,
+            test,
+          );
+
           const duration = Date.now() - start;
 
           if (err.killed) {


### PR DESCRIPTION

<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

When a test fails `assertTestPasses` throws an error with the stdout of the command. This wasn't added to the test's output in the `catch` handler which made VSCode report the test run as not recording any output.

Closes #3090

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->


### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
The current tests for test controller are minimal and I don't know where to get started to implement a test for this specific behavior.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

I ran the extension and with a project where my (failed) tests weren't showing any output. This PR fixed it.