### PR TITLE
Prevent relative require completion from failing on permissions

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -471,6 +471,9 @@ module RubyLsp
             path_node_to_complete,
           )
         end
+      rescue Errno::EPERM
+        # If the user writes a relative require pointing to a path that the editor has no permissions to read, then glob
+        # might fail with EPERM
       end
 
       sig { params(node: Prism::CallNode, name: String).void }


### PR DESCRIPTION
### Motivation

We have some cases in our telemetry where the user typed in a relative require pointing to a directory that the editor doesn't have permission to read.

This will cause an `Errno::EPERM` and currently makes completion crash.

### Implementation

Started rescuing the error. If we can't read the directory, we can't list files.

### Automated Tests

I tried writing a test for this, but for some reason removing all permissions with `FileUtils.chmod` doesn't reproduce. Glob just returns an empty array instead.

Not sure if the behaviour is platform specific, but rather than spending a disproportionate amount of effort writing this one test, I think it's safe to just rescue.