### PR TITLE
Fix backward compatibility for Bundler versions < 2.2.17

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -360,7 +360,7 @@ module RubyLsp
       # setting name `e` is `path` with a value of `vendor/bundle`, then it will return `"BUNDLE_PATH" =>
       # "vendor/bundle"`
       settings.all.to_h do |e|
-        key = Bundler::Settings.key_for(e)
+        key = settings.key_for(e)
         value = Array(settings[e]).join(":").tr(" ", ":")
 
         [key, value]

--- a/sorbet/rbi/shims/bundler.rbi
+++ b/sorbet/rbi/shims/bundler.rbi
@@ -3,7 +3,7 @@
 module Bundler
   class Settings
     sig { params(name: String).returns(String) }
-    def self.key_for(name); end
+    def key_for(name); end
   end
 
   module CLI

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -939,7 +939,7 @@ class SetupBundlerTest < Minitest::Test
     end
 
     env = settings.all.to_h do |e|
-      key = Bundler::Settings.key_for(e)
+      key = settings.key_for(e)
       value = Array(settings[e]).join(":").tr(" ", ":")
 
       [key, value]


### PR DESCRIPTION
### Motivation
Hi!

One of the projects that I'm working with still uses Bundler version `2.1.4` (sad, I know!) and Ruby LSP errors out upon initialization with this version. In fact, it won't be able to initialize with any Bundler prior to version `2.2.17` (more details in Implementation section)!

I believe that Ruby LSP is now an essential part of any VS Code's Ruby project and I want to make it backward compatible with previous versions of Bundler so that people don't have to switch to other editors/IDEs when they can't simply upgrade to newer version of Bundler due to certain project limitations.

Luckily, the fix is not that complicated!

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation
Let's take a look at the PR that introduced the usage of `Bundler::Settings.key_for(e)` in Ruby LSP:   https://github.com/Shopify/ruby-lsp/pull/2535.

It might look okay at first until you realize that `def self.key_for(key)` for `Bundler::Settings` was only [introduced](https://github.com/rubygems/rubygems/pull/4565/files#diff-4a1b03faae1e535ebbffc47b0e06e57e4c6b38f404c8f5f8d66e65e0a7526ce6R462) in [bundler-v2.2.17](https://github.com/rubygems/rubygems/releases/tag/bundler-v2.2.17), meaning that `Bundler::Settings.key_for(e)` **won't work for any Bundler version < 2.2.17**.

Considering that instance method `def key_for(key)` is [still in place in latest Bundler version](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/settings.rb#L331) and don't seem to be going away - I suggest we use it instead! Plus we already have an instance of `Bundler::Settings` available in our local variable [settings](https://github.com/Shopify/ruby-lsp/blob/main/lib/ruby_lsp/setup_bundler.rb#L353).

I was also thinking about an explicit Bundler version check approach but didn't find any benefits. There's even a drawback - we'd be missing out the [caching mechanism](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/settings.rb#L332) (introduced by [this PR](https://github.com/rubygems/rubygems/pull/6963)) that instance method provides in newer versions of Bundler if we keep using the class method instead.

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests
I updated corresponding `test/setup_bundler_test.rb`.

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests
**Actual result:**
```
GIVEN ruby project with Bundler version < 2.2.17
WHEN Ruby LSP is being initialized
THEN "undefined method `key_for' for Bundler::Settings:Class (NoMethodError)" error occurs
AND Ruby LSP fails to initialize

GIVEN ruby project with Bundler version >= 2.2.17
WHEN Ruby LSP is being initialized
THEN no errors occur
AND Ruby LSP initializes successfully
```
Attaching an error example that is currently happening: [undefined_method_key_for_for_Bundler_Settings_Class_NoMethodError.txt](https://github.com/user-attachments/files/18717970/undefined_method_key_for_for_Bundler_Settings_Class_NoMethodError.txt).

**Expected Result:**
```
GIVEN ruby project with Bundler version < 2.2.17
WHEN Ruby LSP is being initialized
THEN no errors occur
AND Ruby LSP initializes successfully

GIVEN ruby project with Bundler version >= 2.2.17
WHEN Ruby LSP is being initialized
THEN no errors occur
AND Ruby LSP initializes successfully
```

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
