### PR TITLE
Pass machine ID to server for telemetry

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -32,6 +32,9 @@ module RubyLsp
     sig { returns(URI::Generic) }
     attr_reader :workspace_uri
 
+    sig { returns(T.nilable(String)) }
+    attr_reader :telemetry_machine_id
+
     sig { void }
     def initialize
       @workspace_uri = T.let(URI::Generic.from_path(path: Dir.pwd), URI::Generic)
@@ -57,6 +60,7 @@ module RubyLsp
       @client_capabilities = T.let(ClientCapabilities.new, ClientCapabilities)
       @enabled_feature_flags = T.let({}, T::Hash[Symbol, T::Boolean])
       @mutex = T.let(Mutex.new, Mutex)
+      @telemetry_machine_id = T.let(nil, T.nilable(String))
     end
 
     sig { type_parameters(:T).params(block: T.proc.returns(T.type_parameter(:T))).returns(T.type_parameter(:T)) }
@@ -175,6 +179,7 @@ module RubyLsp
       enabled_flags = options.dig(:initializationOptions, :enabledFeatureFlags)
       @enabled_feature_flags = enabled_flags if enabled_flags
 
+      @telemetry_machine_id = options.dig(:initializationOptions, :telemetryMachineId)
       notifications
     end
 

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -302,6 +302,14 @@ module RubyLsp
       assert_equal("rubocop_internal", state.formatter)
     end
 
+    def test_saves_telemetry_machine_id
+      state = GlobalState.new
+      assert_nil(state.telemetry_machine_id)
+
+      state.apply_options({ initializationOptions: { telemetryMachineId: "test_machine_id" } })
+      assert_equal("test_machine_id", state.telemetry_machine_id)
+    end
+
     private
 
     def stub_direct_dependencies(dependencies)

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -244,6 +244,7 @@ function collectClientOptions(
       indexing: configuration.get("indexing"),
       addonSettings: configuration.get("addonSettings"),
       enabledFeatureFlags: enabledFeatureFlags(),
+      telemetryMachineId: vscode.env.machineId,
     },
   };
 }


### PR DESCRIPTION
### Motivation

Pass the unique machine identifier to the server as an initialization option, so that it can be used to estimate number of unique users on server telemetry events.

Reminder that we [do not collect any telemetry by default](https://github.com/Shopify/ruby-lsp/tree/main/vscode#telemetry), unless a VS Code extension implements the `getTelemetrySenderObject` command.

### Implementation

Started passing the value from the extension and saving it in the global state.

### Automated Tests

Added a test.