### PR TITLE
Reject binary encoded environment variables in activation script

### DIFF
--- a/vscode/activation.rb
+++ b/vscode/activation.rb
@@ -1,3 +1,3 @@
-env = ENV.map { |k, v| "#{k}RUBY_LSP_VS#{v}" }
+env = ENV.filter_map { |k, v| "#{k}RUBY_LSP_VS#{v}" if v.dup.force_encoding(Encoding::UTF_8).valid_encoding? }
 env.unshift(RUBY_VERSION, Gem.path.join(","), !!defined?(RubyVM::YJIT))
 STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR#{env.join("RUBY_LSP_FS")}RUBY_LSP_ACTIVATION_SEPARATOR")

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ruby-lsp",
   "displayName": "Ruby LSP",
   "description": "VS Code plugin for connecting with the Ruby LSP",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "publisher": "Shopify",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Motivation

Unfortunately, using `-EUTF-8:UTF-8` was not enough to fix the issues we're seeing on telemetry for people who have prompts that involve glyphs with their shells configured to binary.

We're still seeing this

```
'IO#write': "\xE2" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError) 
```

### Implementation

I managed to create an integration test in Ruby that reproduces this exact problem. As a fix, I propose we just filter out any environment variable that has binary encoding. I don't believe we would be losing anything important and I don't know what else we can do to prevent these failures.

### Automated Tests

Added a test.

### Manual Tests

I'll ship this as a prerelease once approved so that we can test.