### PR TITLE
Update Kate editor regarding incremental text updates

### DIFF
--- a/jekyll/editors.markdown
+++ b/jekyll/editors.markdown
@@ -301,8 +301,8 @@ To use it with Ruby LSP, you can override particular configuration items in the 
 }
 ```
 
-In the Kate settings in tab "LSP-Client" the option "Incrementally synchronize documents with the LSP server" must be enabled.
-Otherwise errors like [this](https://github.com/Shopify/ruby-lsp/issues/3148) occur, when editing a ruby file.
+In the Kate settings, under the "LSP-Client" tab, the option "Incrementally synchronize documents with the LSP server" must be enabled. 
+Otherwise, errors like [this](https://github.com/Shopify/ruby-lsp/issues/3148) can occur when editing a Ruby file.
 
 Kate will start an instance of the Ruby LSP server in the background for any Ruby project matching the `rootIndicationFileNames`.
 If starting Ruby LSP succeeds, the entries in the LSP-Client menu are activated.


### PR DESCRIPTION
### Motivation

The LSP-Plugin of the Kate editor doesn't send incremental updates for the edited ruby text file, unless the option "Incrementally synchronize documents with the LSP server" is enabled. But it is disabled by default and ruby-lsp doesn't request full file synchronization, but incremental only. Enabling the option fixes the issue.

The option is described here: https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html


### Manual Tests

I verified the issue with kate-23.08.5 on Linux and kate-24.12 on Windows. Both systems showed the linked error message when editing a ruby file, but the option fixes it. File updates are then immediately available in the LSP suggestions.
