### PR TITLE
Remove `help-wanted` label from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template_non_vscode.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template_non_vscode.yml
@@ -4,7 +4,6 @@ description: File a bug report about the Ruby LSP with non-VS Code editors
 labels:
   - bug
   - non-vscode
-  - help-wanted
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
It doesn't make sense to auto-add this to every new issue.