### PR TITLE
Fix off by one error when fetching lazy comments

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -87,7 +87,7 @@ module RubyIndexer
         # Find the group that is either immediately or two lines above the current entry
         correct_group = grouped.find do |group|
           comment_end_line = group.last.location.start_line
-          (comment_end_line - 1..comment_end_line).cover?(@location.start_line - 1)
+          (comment_end_line..comment_end_line + 1).cover?(@location.start_line - 1)
         end
 
         # If we found something, we join the comments together. Otherwise, the entry has no documentation and we don't


### PR DESCRIPTION
### Motivation

Closes #3165

Our logic was inverted when checking if the comments are associated to a declaration on lazy fetching. We want to consider if the comment line PLUS one covers the declaration and not minus 1 as that would be moving us in the opposite direction.

### Implementation

Switched the range to use +1.

### Automated Tests

Added tests for a few different scenarios.