### PR TITLE
Never include workspace name as part of relative test URI

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -495,7 +495,7 @@ export class TestController {
 
       // Find the position of the `test/spec/feature` directory. There may be many in applications that are divided by
       // components, so we want to show each individual test directory as a separate item
-      const relativePath = vscode.workspace.asRelativePath(uri);
+      const relativePath = vscode.workspace.asRelativePath(uri, false);
       const pathParts = relativePath.split(path.sep);
       const dirPosition = this.testDirectoryPosition(pathParts);
       const firstLevelName = pathParts.slice(0, dirPosition + 1).join(path.sep);


### PR DESCRIPTION
### Motivation

I noticed that the new test discovery was not working for the Ruby LSP's own workspace config. The reason was because `vscode.workspace.asRelativePath` defaults to returning the workspace name as part of the path, which was generating an invalid test file path.

### Implementation

We just need to pass `false` as the second argument to never include the workspace name when getting a relative path and then everything works.

### Automated Tests

We need to stub `asRelativePath` in the tests to force it to return our fake workspace folders, which is why the test didn't catch this in the first place.

I'm not sure how we could restructure the test to still have the fake folder and avoid stubbing the `asRelativePath` function. For now, let's just ensure the bug is fixed.