### PR TITLE
Accept module/class node's constant path for constant name

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -43,11 +43,18 @@ module RubyIndexer
             Prism::ConstantPathNode,
             Prism::ConstantReadNode,
             Prism::ConstantPathTargetNode,
+            Prism::CallNode,
+            Prism::MissingNode,
           ),
         ).returns(T.nilable(String))
       end
       def constant_name(node)
-        node.full_name
+        case node
+        when Prism::CallNode, Prism::MissingNode
+          nil
+        else
+          node.full_name
+        end
       rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError,
              Prism::ConstantPathNode::MissingNodesInConstantPathError
         nil

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -2168,5 +2168,19 @@ module RubyIndexer
       assert_equal(["TopLevel", "Another", "Foo"], Index.actual_nesting(["::TopLevel", "Another"], "Foo"))
       assert_equal(["TopLevel"], Index.actual_nesting(["First", "::TopLevel"], nil))
     end
+
+    def test_constant_name
+      node = Prism.parse("class var::Foo; end").value.statements.body.first.constant_path
+      assert_nil(Index.constant_name(node))
+
+      node = Prism.parse("class ; end").value.statements.body.first.constant_path
+      assert_nil(Index.constant_name(node))
+
+      node = Prism.parse("class method_call; end").value.statements.body.first.constant_path
+      assert_nil(Index.constant_name(node))
+
+      node = Prism.parse("class Foo; end").value.statements.body.first.constant_path
+      assert_equal("Foo", Index.constant_name(node))
+    end
   end
 end


### PR DESCRIPTION
### Motivation

It's useful to pass a module/class `constant_path` directly into `constant_name`, but that means our typing isn't satisfied because `constant_path` can be a missing node or a call node too.

### Implementation

Started accounting for those possible cases so that we can pass a constant path directly.

### Automated Tests

Added tests.