### PR TITLE
Add support for ASDF v0.16

### DIFF
--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -12,9 +12,26 @@ import { VersionManager, ActivationResult } from "./versionManager";
 // Learn more: https://github.com/asdf-vm/asdf
 export class Asdf extends VersionManager {
   async activate(): Promise<ActivationResult> {
-    const asdfUri = await this.findAsdfInstallation();
+    // These directories are where we can find the ASDF executable for v0.16 and above
+    const possibleExecutablePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "bin"),
+    ];
+
+    // Prefer the path configured by the user, then the ASDF scripts for versions below v0.16 and finally the
+    // executables for v0.16 and above
+    const asdfPath =
+      (await this.getConfiguredAsdfPath()) ??
+      (await this.findAsdfInstallation()) ??
+      (await this.findExec(possibleExecutablePaths, "asdf"));
+
+    // If there's no extension name, then we are using the ASDF executable directly. If there is an extension, then it's
+    // a shell script and we have to source it first
+    const baseCommand =
+      path.extname(asdfPath) === "" ? asdfPath : `. ${asdfPath} && asdf`;
+
     const parsedResult = await this.runEnvActivationScript(
-      `. ${asdfUri.fsPath} && asdf exec ruby`,
+      `${baseCommand} exec ruby`,
     );
 
     return {
@@ -26,27 +43,9 @@ export class Asdf extends VersionManager {
   }
 
   // Only public for testing. Finds the ASDF installation URI based on what's advertised in the ASDF documentation
-  async findAsdfInstallation(): Promise<vscode.Uri> {
+  async findAsdfInstallation(): Promise<string | undefined> {
     const scriptName =
       path.basename(vscode.env.shell) === "fish" ? "asdf.fish" : "asdf.sh";
-
-    const config = vscode.workspace.getConfiguration("rubyLsp");
-    const asdfPath = config.get<string | undefined>(
-      "rubyVersionManager.asdfExecutablePath",
-    );
-
-    if (asdfPath) {
-      const configuredPath = vscode.Uri.file(asdfPath);
-
-      try {
-        await vscode.workspace.fs.stat(configuredPath);
-        return configuredPath;
-      } catch (error: any) {
-        throw new Error(
-          `ASDF executable configured as ${configuredPath}, but that file doesn't exist`,
-        );
-      }
-    }
 
     // Possible ASDF installation paths as described in https://asdf-vm.com/guide/getting-started.html#_3-install-asdf.
     // In order, the methods of installation are:
@@ -80,14 +79,40 @@ export class Asdf extends VersionManager {
     for (const possiblePath of possiblePaths) {
       try {
         await vscode.workspace.fs.stat(possiblePath);
-        return possiblePath;
+        return possiblePath.fsPath;
       } catch (error: any) {
         // Continue looking
       }
     }
 
-    throw new Error(
-      `Could not find ASDF installation. Searched in ${possiblePaths.join(", ")}`,
+    this.outputChannel.info(
+      `Could not find installation for ASDF < v0.16. Searched in ${possiblePaths.join(", ")}`,
     );
+    return undefined;
+  }
+
+  private async getConfiguredAsdfPath(): Promise<string | undefined> {
+    const config = vscode.workspace.getConfiguration("rubyLsp");
+    const asdfPath = config.get<string | undefined>(
+      "rubyVersionManager.asdfExecutablePath",
+    );
+
+    if (!asdfPath) {
+      return;
+    }
+
+    const configuredPath = vscode.Uri.file(asdfPath);
+
+    try {
+      await vscode.workspace.fs.stat(configuredPath);
+      this.outputChannel.info(
+        `Using configured ASDF executable path: ${asdfPath}`,
+      );
+      return configuredPath.fsPath;
+    } catch (error: any) {
+      throw new Error(
+        `ASDF executable configured as ${configuredPath}, but that file doesn't exist`,
+      );
+    }
   }
 }


### PR DESCRIPTION
### Motivation

Closes #3143

Add support for ASDF v0.16 which changes the version manager to be a compiled executable rather than shell scripts.

### Implementation

The idea is to:

- Search for the configured ASDF path first
- Then the script version of ASDF
- Then the executable version

If we're using a shell script (in which case extname will not be empty), then we need to source the script first. Otherwise, we can just invoke the executable directly.

### Automated Tests

Added tests.