### PR TITLE
Add JSON test reporter for minitest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,7 @@ Sorbet/TrueSigil:
     - "lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb"
     - "lib/ruby_lsp/load_sorbet.rb"
     - "lib/ruby_lsp/scripts/compose_bundle.rb"
+    - "lib/ruby_lsp/test_unit_test_runner.rb"
   Exclude:
     - "**/*.rake"
     - "lib/**/*.rb"
@@ -67,7 +68,9 @@ Sorbet/StrictSigil:
     - "lib/ruby_lsp/load_sorbet.rb"
     - "lib/ruby_lsp/scripts/compose_bundle.rb"
     - "lib/ruby_lsp/test_helper.rb"
-    - "lib/ruby_lsp/test_unit_test_runner.rb" # runs as part of host app where sorbet-runtime may not be available
+    # runs as part of host app where sorbet-runtime may not be available. Using RBS signatures we can get to
+    # `typed: true` but not yet `typed: strict`
+    - "lib/ruby_lsp/test_unit_test_runner.rb"
 
 Layout/ClassStructure:
   Enabled: true

--- a/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
+++ b/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
@@ -1,0 +1,107 @@
+# typed: strict
+# frozen_string_literal: true
+
+require_relative "test_reporter"
+
+require "minitest"
+
+module Minitest
+  module Reporters
+    class RubyLspReporter < ::Minitest::AbstractReporter
+      class << self
+        #: (Hash[untyped, untyped]) -> void
+        def minitest_plugin_init(_options)
+          Minitest.reporter.reporters = [RubyLspReporter.new]
+        end
+      end
+
+      #: (singleton(Minitest::Test) test_class, String method_name) -> void
+      def prerecord(test_class, method_name)
+        uri = uri_from_test_class(test_class, method_name)
+        return unless uri
+
+        RubyLsp::TestReporter.start_test(
+          id: "#{test_class.name}##{method_name}",
+          uri: uri,
+        )
+      end
+
+      #: (Minitest::Result result) -> void
+      def record(result)
+        super
+
+        if result.error?
+          record_error(result)
+        elsif result.passed?
+          record_pass(result)
+        elsif result.skipped?
+          record_skip(result)
+        elsif result.failure
+          record_fail(result)
+        end
+      end
+
+      #: (Minitest::Result result) -> void
+      def record_pass(result)
+        RubyLsp::TestReporter.record_pass(
+          id: id_from_result(result),
+          uri: uri_from_result(result),
+        )
+      end
+
+      #: (Minitest::Result result) -> void
+      def record_skip(result)
+        RubyLsp::TestReporter.record_skip(
+          id: id_from_result(result),
+          message: result.failure.message,
+          uri: uri_from_result(result),
+        )
+      end
+
+      #: (Minitest::Result result) -> void
+      def record_fail(result)
+        RubyLsp::TestReporter.record_fail(
+          id: id_from_result(result),
+          message: result.failure.message,
+          uri: uri_from_result(result),
+        )
+      end
+
+      #: (Minitest::Result result) -> void
+      def record_error(result)
+        RubyLsp::TestReporter.record_error(
+          id: id_from_result(result),
+          uri: uri_from_result(result),
+          message: result.failures.first.message,
+        )
+      end
+
+      private
+
+      #: (Minitest::Result result) -> String
+      def id_from_result(result)
+        "#{result.klass}##{result.name}"
+      end
+
+      #: (Minitest::Result result) -> URI::Generic
+      def uri_from_result(result)
+        file = result.source_location[0]
+        absolute_path = File.expand_path(file, Dir.pwd)
+        URI::Generic.from_path(path: absolute_path)
+      end
+
+      #: (singleton(Minitest::Test) test_class, String method_name) -> URI::Generic?
+      def uri_from_test_class(test_class, method_name)
+        file, _line = test_class.instance_method(method_name).source_location
+        return unless file
+
+        return if file.start_with?("(eval at ") # test is dynamically defined
+
+        absolute_path = File.expand_path(file, Dir.pwd)
+        URI::Generic.from_path(path: absolute_path)
+      end
+    end
+  end
+end
+
+Minitest.extensions << Minitest::Reporters::RubyLspReporter

--- a/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
+++ b/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
@@ -28,8 +28,6 @@ module Minitest
 
       #: (Minitest::Result result) -> void
       def record(result)
-        super
-
         if result.error?
           record_error(result)
         elsif result.passed?

--- a/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
+++ b/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
@@ -39,6 +39,8 @@ module Minitest
         end
       end
 
+      private
+
       #: (Minitest::Result result) -> void
       def record_pass(result)
         RubyLsp::TestReporter.record_pass(
@@ -73,8 +75,6 @@ module Minitest
           message: result.failures.first.message,
         )
       end
-
-      private
 
       #: (Minitest::Result result) -> String
       def id_from_result(result)

--- a/lib/ruby_lsp/test_reporter.rb
+++ b/lib/ruby_lsp/test_reporter.rb
@@ -49,7 +49,7 @@ module RubyLsp
         send_message("skip", params)
       end
 
-      #: (id: String, message: String?, uri: String) -> void
+      #: (id: String, message: String?, uri: URI::Generic) -> void
       def record_error(id:, message:, uri:)
         params = {
           id: id,

--- a/test/fixtures/minitest_example.rb
+++ b/test/fixtures/minitest_example.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "test_helper"
+require "minitest/autorun"
+require_relative "../../lib/ruby_indexer/lib/ruby_indexer/uri"
 
 # We are only testing the output of the runner, there's no need for to be random.
 Minitest::Test.i_suck_and_my_tests_are_order_dependent!

--- a/test/fixtures/minitest_example.rb
+++ b/test/fixtures/minitest_example.rb
@@ -5,7 +5,7 @@ require "test_helper"
 # We are only testing the output of the runner, there's no need for to be random.
 Minitest::Test.i_suck_and_my_tests_are_order_dependent!
 
-class Sample < Minitest::Test
+class SampleTest < Minitest::Test
   def test_that_passes
     assert_equal(1, 1)
     assert_equal(2, 2)

--- a/test/fixtures/minitest_example.rb
+++ b/test/fixtures/minitest_example.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# We are only testing the output of the runner, there's no need for to be random.
+Minitest::Test.i_suck_and_my_tests_are_order_dependent!
+
+class Sample < Minitest::Test
+  def test_that_passes
+    assert_equal(1, 1)
+    assert_equal(2, 2)
+  end
+
+  def test_that_fails
+    assert_equal(1, 2)
+  end
+
+  def test_that_is_pending
+    skip("pending test")
+  end
+
+  def test_that_raises
+    raise "oops"
+  end
+end

--- a/test/fixtures/test_unit_example.rb
+++ b/test/fixtures/test_unit_example.rb
@@ -4,7 +4,7 @@
 require "test-unit"
 require "ruby_lsp/test_unit_test_runner"
 
-class Sample < Test::Unit::TestCase
+class SampleTest < Test::Unit::TestCase
   def test_that_passes
     assert_equal(1, 1)
     assert_equal(2, 2)

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -19,7 +19,7 @@ module RubyLsp
       stdout.binmode
       stdout.sync = true
 
-      actual = parse_output(stdout)
+      actual = parse_json_api_stream(stdout)
 
       uri = URI::Generic.from_path(path: "#{Dir.pwd}/test/fixtures/minitest_example.rb").to_s
       expected = [
@@ -88,15 +88,6 @@ module RubyLsp
     end
 
     private
-
-    def parse_output(output)
-      output.each_line("\r\n\r\n").map do |headers|
-        content_length = headers[/Content-Length: (\d+)/i, 1]
-        flunk("Error reading response") unless content_length
-        data = output.read(Integer(content_length))
-        JSON.parse(data)
-      end
-    end
 
     def error_location
       ruby_version = Gem::Version.new(RUBY_VERSION)

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -90,15 +90,12 @@ module RubyLsp
     private
 
     def parse_output(output)
-      result = []
-      while (headers = output.gets("\r\n\r\n"))
+      output.each_line("\r\n\r\n").map do |headers|
         content_length = headers[/Content-Length: (\d+)/i, 1]
         flunk("Error reading response") unless content_length
         data = output.read(Integer(content_length))
-        json = JSON.parse(T.must(data))
-        result << json
+        JSON.parse(data)
       end
-      result
     end
   end
 end

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -78,7 +78,7 @@ module RubyLsp
           "method" => "error",
           "params" => {
             "id" => "Sample#test_that_raises",
-            "message" => "RuntimeError: oops\n    test/fixtures/minitest_example.rb:23:in 'Sample#test_that_raises'",
+            "message" => "RuntimeError: oops\n    test/fixtures/minitest_example.rb:23:in #{error_location}",
             "uri" => uri,
           },
         },
@@ -95,6 +95,18 @@ module RubyLsp
         flunk("Error reading response") unless content_length
         data = output.read(Integer(content_length))
         JSON.parse(data)
+      end
+    end
+
+    def error_location
+      ruby_version = Gem::Version.new(RUBY_VERSION)
+
+      # TODO: confirm when this behavior changed
+      # Also note the difference in the initial character.
+      if ruby_version >= Gem::Version.new("3.4")
+        "'Sample#test_that_raises'"
+      else
+        "`test_that_raises'"
       end
     end
   end

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -1,0 +1,104 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RubyLsp
+  class MinitestTestRunnerTest < Minitest::Test
+    def test_minitest_output
+      plugin_path = "lib/ruby_lsp/ruby_lsp_reporter_plugin.rb"
+      env = { "RUBYOPT" => "-r./#{plugin_path}" }
+      _stdin, stdout, _stderr, _wait_thr = T.unsafe(Open3).popen3(
+        env,
+        "bundle",
+        "exec",
+        "ruby",
+        "-Itest",
+        "test/fixtures/minitest_example.rb",
+      )
+      stdout.binmode
+      stdout.sync = true
+
+      actual = parse_output(stdout)
+
+      uri = URI::Generic.from_path(path: "#{Dir.pwd}/test/fixtures/minitest_example.rb").to_s
+      expected = [
+        {
+          "method" => "start",
+          "params" => {
+            "id" => "Sample#test_that_fails",
+            "uri" => uri,
+          },
+        },
+        {
+          "method" => "fail",
+          "params" => {
+            "id" => "Sample#test_that_fails",
+            "message" => "--- expected\n+++ actual\n@@ -1 +1 @@\n-1\n+2\n",
+            "uri" => uri,
+          },
+        },
+        {
+          "method" => "start",
+          "params" => {
+            "id" => "Sample#test_that_is_pending",
+            "uri" => uri,
+          },
+        },
+        {
+          "method" => "skip",
+          "params" => {
+            "id" => "Sample#test_that_is_pending",
+            "message" => "pending test",
+            "uri" => uri,
+          },
+        },
+        {
+          "method" => "start",
+          "params" => {
+            "id" => "Sample#test_that_passes",
+            "uri" => uri,
+          },
+        },
+        {
+          "method" => "pass",
+          "params" => {
+            "id" => "Sample#test_that_passes",
+            "uri" => uri,
+          },
+        },
+        {
+          "method" => "start",
+          "params" => {
+            "id" => "Sample#test_that_raises",
+            "uri" => uri,
+          },
+        },
+        {
+          "method" => "error",
+          "params" => {
+            "id" => "Sample#test_that_raises",
+            "message" => "RuntimeError: oops\n    test/fixtures/minitest_example.rb:23:in 'Sample#test_that_raises'",
+            "uri" => uri,
+          },
+        },
+      ]
+      assert_equal(8, actual.size)
+      assert_equal(expected, actual)
+    end
+
+    private
+
+    def parse_output(output)
+      result = []
+      while (headers = output.gets("\r\n\r\n"))
+        content_length = headers[/Content-Length: (\d+)/i, 1]
+        flunk("Error reading response") unless content_length
+        data = output.read(Integer(content_length))
+        json = JSON.parse(T.must(data))
+        result << json
+      end
+      result
+    end
+  end
+end

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -26,14 +26,14 @@ module RubyLsp
         {
           "method" => "start",
           "params" => {
-            "id" => "Sample#test_that_fails",
+            "id" => "SampleTest#test_that_fails",
             "uri" => uri,
           },
         },
         {
           "method" => "fail",
           "params" => {
-            "id" => "Sample#test_that_fails",
+            "id" => "SampleTest#test_that_fails",
             "message" => "--- expected\n+++ actual\n@@ -1 +1 @@\n-1\n+2\n",
             "uri" => uri,
           },
@@ -41,14 +41,14 @@ module RubyLsp
         {
           "method" => "start",
           "params" => {
-            "id" => "Sample#test_that_is_pending",
+            "id" => "SampleTest#test_that_is_pending",
             "uri" => uri,
           },
         },
         {
           "method" => "skip",
           "params" => {
-            "id" => "Sample#test_that_is_pending",
+            "id" => "SampleTest#test_that_is_pending",
             "message" => "pending test",
             "uri" => uri,
           },
@@ -56,28 +56,28 @@ module RubyLsp
         {
           "method" => "start",
           "params" => {
-            "id" => "Sample#test_that_passes",
+            "id" => "SampleTest#test_that_passes",
             "uri" => uri,
           },
         },
         {
           "method" => "pass",
           "params" => {
-            "id" => "Sample#test_that_passes",
+            "id" => "SampleTest#test_that_passes",
             "uri" => uri,
           },
         },
         {
           "method" => "start",
           "params" => {
-            "id" => "Sample#test_that_raises",
+            "id" => "SampleTest#test_that_raises",
             "uri" => uri,
           },
         },
         {
           "method" => "error",
           "params" => {
-            "id" => "Sample#test_that_raises",
+            "id" => "SampleTest#test_that_raises",
             "message" => "RuntimeError: oops\n    test/fixtures/minitest_example.rb:23:in #{error_location}",
             "uri" => uri,
           },
@@ -104,7 +104,7 @@ module RubyLsp
       # TODO: confirm when this behavior changed
       # Also note the difference in the initial character.
       if ruby_version >= Gem::Version.new("3.4")
-        "'Sample#test_that_raises'"
+        "'SampleTest#test_that_raises'"
       else
         "`test_that_raises'"
       end

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -92,8 +92,6 @@ module RubyLsp
     def error_location
       ruby_version = Gem::Version.new(RUBY_VERSION)
 
-      # TODO: confirm when this behavior changed
-      # Also note the difference in the initial character.
       if ruby_version >= Gem::Version.new("3.4")
         "'SampleTest#test_that_raises'"
       else

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -34,7 +34,7 @@ module RubyLsp
           "method" => "fail",
           "params" => {
             "id" => "SampleTest#test_that_fails",
-            "message" => "--- expected\n+++ actual\n@@ -1 +1 @@\n-1\n+2\n",
+            "message" => "Expected: 1\n  Actual: 2",
             "uri" => uri,
           },
         },
@@ -78,7 +78,7 @@ module RubyLsp
           "method" => "error",
           "params" => {
             "id" => "SampleTest#test_that_raises",
-            "message" => "RuntimeError: oops\n    test/fixtures/minitest_example.rb:23:in #{error_location}",
+            "message" => "RuntimeError: oops\n    test/fixtures/minitest_example.rb:24:in #{error_location}",
             "uri" => uri,
           },
         },

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,12 +35,13 @@ require "debug/prelude"
 require "debug/config"
 DEBUGGER__::CONFIG[:skip_path] = Array(DEBUGGER__::CONFIG[:skip_path]) + SORBET_PATHS
 
-minitest_reporter = if ENV["SPEC_REPORTER"]
-  Minitest::Reporters::SpecReporter.new(color: true)
-else
-  Minitest::Reporters::DefaultReporter.new(color: true)
-end
-Minitest::Reporters.use!(minitest_reporter)
+# TODO: figure out how to re-enable (enabling it breaks minitest_test_runner_test)
+# minitest_reporter = if ENV["SPEC_REPORTER"]
+#   Minitest::Reporters::SpecReporter.new(color: true)
+# else
+#   Minitest::Reporters::DefaultReporter.new(color: true)
+# end
+# Minitest::Reporters.use!(minitest_reporter)
 
 module Minitest
   class Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,13 +35,12 @@ require "debug/prelude"
 require "debug/config"
 DEBUGGER__::CONFIG[:skip_path] = Array(DEBUGGER__::CONFIG[:skip_path]) + SORBET_PATHS
 
-# TODO: figure out how to re-enable (enabling it breaks minitest_test_runner_test)
-# minitest_reporter = if ENV["SPEC_REPORTER"]
-#   Minitest::Reporters::SpecReporter.new(color: true)
-# else
-#   Minitest::Reporters::DefaultReporter.new(color: true)
-# end
-# Minitest::Reporters.use!(minitest_reporter)
+minitest_reporter = if ENV["SPEC_REPORTER"]
+  Minitest::Reporters::SpecReporter.new(color: true)
+else
+  Minitest::Reporters::DefaultReporter.new(color: true)
+end
+Minitest::Reporters.use!(minitest_reporter)
 
 module Minitest
   class Test

--- a/test/test_unit_test_runner_test.rb
+++ b/test/test_unit_test_runner_test.rb
@@ -25,14 +25,14 @@ module RubyLsp
         {
           "method" => "start",
           "params" => {
-            "id" => "Sample#test_that_fails",
+            "id" => "SampleTest#test_that_fails",
             "uri" => uri,
           },
         },
         {
           "method" => "fail",
           "params" => {
-            "id" => "Sample#test_that_fails",
+            "id" => "SampleTest#test_that_fails",
             "message" => "<1> expected but was\n<2>.",
             "uri" => uri,
           },
@@ -40,14 +40,14 @@ module RubyLsp
         {
           "method" => "start",
           "params" => {
-            "id" => "Sample#test_that_is_pending",
+            "id" => "SampleTest#test_that_is_pending",
             "uri" => uri,
           },
         },
         {
           "method" => "skip",
           "params" => {
-            "id" => "Sample#test_that_is_pending",
+            "id" => "SampleTest#test_that_is_pending",
             "message" => "pending test",
             "uri" => uri,
           },
@@ -55,28 +55,28 @@ module RubyLsp
         {
           "method" => "start",
           "params" => {
-            "id" => "Sample#test_that_passes",
+            "id" => "SampleTest#test_that_passes",
             "uri" => uri,
           },
         },
         {
           "method" => "pass",
           "params" => {
-            "id" => "Sample#test_that_passes",
+            "id" => "SampleTest#test_that_passes",
             "uri" => uri,
           },
         },
         {
           "method" => "start",
           "params" => {
-            "id" => "Sample#test_that_raises",
+            "id" => "SampleTest#test_that_raises",
             "uri" => uri,
           },
         },
         {
           "method" => "error",
           "params" => {
-            "id" => "Sample#test_that_raises",
+            "id" => "SampleTest#test_that_raises",
             "message" => "RuntimeError: oops",
             "uri" => uri,
           },


### PR DESCRIPTION
Addresses https://github.com/Shopify/ruby-lsp/issues/3176

This adds a custom reporter for use with the upcoming changes planned for the Test Explorer UI. It emits the test progress as a series of events, for easy consumption by the VS Code extension.

To test the runner output locally:
```
RUBYOPT="-r./lib/ruby_lsp/ruby_lsp_reporter_plugin.rb" bundle exec ruby -Itest test/fixtures/minitest_example.rb
```