### PR TITLE
Add command to show LSP's internal state for diagnosing issues

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -139,6 +139,11 @@
         "category": "Ruby LSP"
       },
       {
+        "command": "rubyLsp.diagnoseState",
+        "title": "Diagnose language server state",
+        "category": "Ruby LSP"
+      },
+      {
         "command": "rubyLsp.railsGenerate",
         "title": "Rails generate",
         "category": "Ruby LSP"

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -20,6 +20,7 @@ export enum Command {
   RunTestInTerminal = "rubyLsp.runTestInTerminal",
   DebugTest = "rubyLsp.debugTest",
   ShowSyntaxTree = "rubyLsp.showSyntaxTree",
+  DiagnoseState = "rubyLsp.diagnoseState",
   DisplayAddons = "rubyLsp.displayAddons",
   RunTask = "rubyLsp.runTask",
   BundleInstall = "rubyLsp.bundleInstall",

--- a/vscode/src/documentProvider.ts
+++ b/vscode/src/documentProvider.ts
@@ -12,6 +12,9 @@ export default class DocumentProvider
       case "show-syntax-tree":
         response = uri.query;
         break;
+      case "show-diagnose-state":
+        response = uri.query;
+        break;
     }
 
     return response;


### PR DESCRIPTION
### Motivation

Add a command to trigger the new custom diagnose request, so that it's easy to see the information at a glance.

### Implementation

It's the same implementation as show syntax tree, we use a custom resource to show a read-only document containing the relevant information.

### Manual Tests

1. Launch the extension on this branch
2. On the second VS Code window, open the Ruby LSP code itself (you need the server changes to verify all pieces together)
3. Invoke the new command
4. Verify you see the internal state of the server