### PR TITLE
Coerce non UTF-8 separators to UTF-8

### DIFF
--- a/vscode/activation.rb
+++ b/vscode/activation.rb
@@ -1,3 +1,3 @@
 env = ENV.filter_map { |k, v| "#{k}RUBY_LSP_VS#{v}" if v.dup.force_encoding(Encoding::UTF_8).valid_encoding? }
 env.unshift(RUBY_VERSION, Gem.path.join(","), !!defined?(RubyVM::YJIT))
-STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR#{env.join("RUBY_LSP_FS")}RUBY_LSP_ACTIVATION_SEPARATOR")
+STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR#{env.join("RUBY_LSP_FS")}RUBY_LSP_ACTIVATION_SEPARATOR".encode('UTF-8', invalid: :replace, undef: :replace))


### PR DESCRIPTION
### Motivation

Fixes https://github.com/Shopify/ruby-lsp/issues/3200

This issue is marked as closed, but I and others are still seeing it occur in 0.9.5. 
