### PR TITLE
Fix regexp patterns for block parameters

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -2246,7 +2246,7 @@
       ]
     },
     {
-      "begin": "(?<={|{\\s|[^A-Za-z0-9_:@$]do|^do|[^A-Za-z0-9_:@$]do\\s|^do\\s)(\\|)",
+      "begin": "(?<={|{\\s+|[^A-Za-z0-9_:@$]do|^do|[^A-Za-z0-9_:@$]do\\s+|^do\\s+)(\\|)",
       "name": "meta.block.parameters.ruby",
       "captures": {
         "1": {
@@ -2260,7 +2260,7 @@
           "end": "(?=,|\\|\\s*)",
           "patterns": [
             {
-              "match": "\\G([&*]?)([a-zA-Z_][\\w_]*)",
+              "match": "\\G((?:&|\\*\\*?)?)([a-zA-Z_][\\w_]*)",
               "captures": {
                 "1": {
                   "name": "storage.type.variable.ruby"


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->

close #3184
close #3211

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

VS Code plugin does not highlight the cases below.

* Rest keyword block parameter
* Block parameter separator `|` with two or more spaces before it

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

For first issue, I changed the pattern to check variable type.

Before:

https://github.com/Shopify/ruby-lsp/blob/841e92ca74a9003ceb7128fcd8ce4d3cd1a0687a/vscode/grammars/ruby.cson.json#L2263

After:

https://github.com/taichi-ishitani/ruby-lsp/blob/d325628031b55e434525804356ccd7324131d0cf/vscode/grammars/ruby.cson.json#L2263

For second issue, I added the `+` quantification to the whitespace pattern within the beginning pattern of the block parameters.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

I ran the extension and confirmed that such blocks are highlighted correctly.
![image](https://github.com/user-attachments/assets/921be288-d475-480b-a4b6-0e08caa0cab3)

