### PR TITLE
Fix Encoding::UndefinedConversionError in activation.rb

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -29,7 +29,7 @@ class IntegrationTest < Minitest::Test
   def test_activation_script_succeeds_even_on_binary_encoding
     ENV["LC_ALL"] = "C"
     ENV["LANG"] = "C"
-    ENV["PS1"] = "\xE2".b
+    ENV["PS1"] = "\xE2\x96\xB7".b
 
     _stdout, stderr, status = Open3.capture3(
       "ruby",
@@ -39,7 +39,7 @@ class IntegrationTest < Minitest::Test
 
     assert_equal(0, status.exitstatus, stderr)
 
-    activation_string = T.must(/RUBY_LSP_ACTIVATION_SEPARATOR(.*)RUBY_LSP_ACTIVATION_SEPARATOR/.match(stderr))[1]
+    activation_string = T.must(/RUBY_LSP_ACTIVATION_SEPARATOR(.*)RUBY_LSP_ACTIVATION_SEPARATOR/m.match(stderr))[1]
     version, gem_path, yjit, *fields = T.must(activation_string).split("RUBY_LSP_FS")
 
     assert_equal(RUBY_VERSION, version)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -46,6 +46,8 @@ class IntegrationTest < Minitest::Test
     refute_nil(gem_path)
     assert(yjit)
 
+    assert_includes(fields, "PS1RUBY_LSP_VS#{ENV["PS1"]}")
+
     fields.each do |field|
       key, value = field.split("RUBY_LSP_VS")
       refute_equal(key.encoding, Encoding::BINARY) if key
@@ -75,7 +77,6 @@ class IntegrationTest < Minitest::Test
 
     fields.each do |field|
       key, value = field.split("RUBY_LSP_VS")
-      refute_equal(key, "INVALID_UTF8")
       refute_equal(key.encoding, Encoding::BINARY) if key
       refute_equal(value.encoding, Encoding::BINARY) if value
     end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -53,6 +53,34 @@ class IntegrationTest < Minitest::Test
     end
   end
 
+  def test_activation_script_succeeds_on_invalid_unicode
+    ENV["LC_ALL"] = "C"
+    ENV["LANG"] = "C"
+    ENV["INVALID_UTF8"] = "\xE2\x80".b
+
+    _stdout, stderr, status = Open3.capture3(
+      "ruby",
+      "-EUTF-8:UTF-8",
+      File.join(__dir__, "..", "vscode", "activation.rb"),
+    )
+
+    assert_equal(0, status.exitstatus, stderr)
+
+    activation_string = T.must(/RUBY_LSP_ACTIVATION_SEPARATOR(.*)RUBY_LSP_ACTIVATION_SEPARATOR/m.match(stderr))[1]
+    version, gem_path, yjit, *fields = T.must(activation_string).split("RUBY_LSP_FS")
+
+    assert_equal(RUBY_VERSION, version)
+    refute_nil(gem_path)
+    assert(yjit)
+
+    fields.each do |field|
+      key, value = field.split("RUBY_LSP_VS")
+      refute_equal(key, "INVALID_UTF8")
+      refute_equal(key.encoding, Encoding::BINARY) if key
+      refute_equal(value.encoding, Encoding::BINARY) if value
+    end
+  end
+
   def test_uses_same_bundler_version_as_main_app
     in_temp_dir do |dir|
       File.write(File.join(dir, "Gemfile"), <<~RUBY)

--- a/vscode/activation.rb
+++ b/vscode/activation.rb
@@ -1,3 +1,7 @@
-env = ENV.filter_map { |k, v| v = v.dup.force_encoding(Encoding::UTF_8); "#{k}RUBY_LSP_VS#{v}" if v.valid_encoding? }
+env = ENV.filter_map do |k, v|
+  "#{k}RUBY_LSP_VS#{v.encode(Encoding::UTF_8)}"
+rescue Encoding::UndefinedConversionError
+  nil
+end
 env.unshift(RUBY_VERSION, Gem.path.join(","), !!defined?(RubyVM::YJIT))
 STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR#{env.join("RUBY_LSP_FS")}RUBY_LSP_ACTIVATION_SEPARATOR")

--- a/vscode/activation.rb
+++ b/vscode/activation.rb
@@ -1,3 +1,3 @@
-env = ENV.filter_map { |k, v| "#{k}RUBY_LSP_VS#{v}" if v.dup.force_encoding(Encoding::UTF_8).valid_encoding? }
+env = ENV.filter_map { |k, v| v = v.dup.force_encoding(Encoding::UTF_8); "#{k}RUBY_LSP_VS#{v}" if v.valid_encoding? }
 env.unshift(RUBY_VERSION, Gem.path.join(","), !!defined?(RubyVM::YJIT))
 STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR#{env.join("RUBY_LSP_FS")}RUBY_LSP_ACTIVATION_SEPARATOR")

--- a/vscode/activation.rb
+++ b/vscode/activation.rb
@@ -1,7 +1,6 @@
 env = ENV.filter_map do |k, v|
-  "#{k}RUBY_LSP_VS#{v.encode(Encoding::UTF_8)}"
-rescue Encoding::UndefinedConversionError
-  nil
+  utf_8_value = v.dup.force_encoding(Encoding::UTF_8)
+  "#{k}RUBY_LSP_VS#{utf_8_value}" if utf_8_value.valid_encoding?
 end
 env.unshift(RUBY_VERSION, Gem.path.join(","), !!defined?(RubyVM::YJIT))
 STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR#{env.join("RUBY_LSP_FS")}RUBY_LSP_ACTIVATION_SEPARATOR")


### PR DESCRIPTION
### Motivation

Another fix for #3200. The [last one](https://github.com/Shopify/ruby-lsp/issues/3161) only checked for malformed UTF-8, not correct UTF-8 with ASCII encoding, which is the issue.

### Implementation

I changed it so it converts everything to UTF-8 to avoid the Encoding::UndefinedConversionError error.

### Automated Tests

I updated the test so it fails on the previous fix.

### Manual Tests

On macOS, add a unicode character to your system shell prompt and launch vscode using the .app, not from the command line.
