### PR TITLE
Add an add on generator

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -31,7 +31,7 @@ parser = OptionParser.new do |opts|
 
   opts.on(
     "--new-addon [NAME]",
-    "Create a new Ruby LSP add-on",
+    "Create a new Ruby LSP add-on gem",
   ) do |name|
     options[:new_addon] = name
   end
@@ -154,6 +154,9 @@ if options[:doctor]
   return
 end
 
+if options[:new_addon]
+
+end
 # Ensure all output goes out stderr by default to allow puts/p/pp to work
 # without specifying output device.
 $> = $stderr

--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -29,6 +29,13 @@ parser = OptionParser.new do |opts|
     options[:branch] = branch
   end
 
+  opts.on(
+    "--new-addon [NAME]",
+    "Create a new Ruby LSP add-on",
+  ) do |name|
+    options[:new_addon] = name
+  end
+
   opts.on("--doctor", "Run troubleshooting steps") do
     options[:doctor] = true
   end

--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -155,7 +155,9 @@ if options[:doctor]
 end
 
 if options[:new_addon]
-
+  require "ruby_lsp/generator"
+  RubyLsp::Generator.new(options[:new_addon]).run
+  exit(0)
 end
 # Ensure all output goes out stderr by default to allow puts/p/pp to work
 # without specifying output device.

--- a/jekyll/add-ons.markdown
+++ b/jekyll/add-ons.markdown
@@ -55,6 +55,19 @@ authors to benefit from types declared by the Ruby LSP.
 As an example, check out [Ruby LSP Rails](https://github.com/Shopify/ruby-lsp-rails), which is a Ruby LSP add-on to
 provide Rails related features.
 
+### Creating a New Add-on
+
+The `ruby-lsp` executable now includes a `--new-addon` option to help you quickly create new Ruby LSP add-ons. This feature is designed to work in two scenarios:
+
+1. **Inside an existing project**: If you're already working in a project with a `Gemfile`, the tool will add the necessary files and directory structure for your new add-on.
+2. **Outside a project**: If you're not in a project, the tool will help you create a new gem and then set up the add-on inside it.
+
+To create a new add-on, run the following command:
+
+```bash
+ruby-lsp --new-addon ADDON_NAME
+```
+
 ### Activating the add-on
 
 The Ruby LSP discovers add-ons based on the existence of an `addon.rb` file placed inside a `ruby_lsp` folder.  For

--- a/lib/ruby_lsp/generator.rb
+++ b/lib/ruby_lsp/generator.rb
@@ -1,0 +1,106 @@
+# typed: strict
+# frozen_string_literal: true
+
+module RubyLsp
+  class Generator
+    extend T::Sig
+
+    sig { params(addon_name: T.nilable(String)).void }
+    def initialize(addon_name)
+      @addon_name = T.let(addon_name, T.nilable(String))
+    end
+
+    sig { void }
+    def run
+      if inside_existing_project?
+        create_addon_files
+      else
+        create_new_gem
+      end
+    end
+
+    private
+
+    sig { returns(T::Boolean) }
+    def inside_existing_project?
+      File.exist?("Gemfile")
+    end
+
+    sig { void }
+    def create_addon_files
+      addon_name = T.must(@addon_name)
+      addon_dir = T.let("lib/ruby_lsp/#{addon_name}", String)
+      FileUtils.mkdir_p(addon_dir)
+
+      # Create addon.rb
+      File.write(
+        "#{addon_dir}/addon.rb",
+        <<~RUBY,
+          # typed: strict
+          # frozen_string_literal: true
+
+          require 'sorbet-runtime'
+
+          module RubyLsp
+            module #{camelize(addon_name)}
+              class Addon
+                extend T::Sig
+
+                # Your add-on logic here
+              end
+            end
+          end
+        RUBY
+      )
+
+      # Create a test file
+      test_dir = T.let("test/ruby_lsp/#{addon_name}", String)
+      FileUtils.mkdir_p(test_dir)
+      File.write(
+        "#{test_dir}/addon_test.rb",
+        <<~RUBY,
+          # typed: strict
+          # frozen_string_literal: true
+
+          require "test_helper"
+
+          module RubyLsp
+            module #{camelize(addon_name)}
+              class AddonTest < Minitest::Test
+                extend T::Sig
+
+                sig { void }
+                def test_example
+                  assert true
+                end
+              end
+            end
+          end
+        RUBY
+      )
+
+      puts "Add-on '#{addon_name}' created successfully!"
+    end
+
+    sig { void }
+    def create_new_gem
+      puts "No existing project found. Would you like to create a new gem? (y/n)"
+      response = T.let(gets.chomp.downcase, String)
+
+      if response == "y"
+        addon_name = T.must(@addon_name)
+        system("bundle gem #{addon_name}")
+        Dir.chdir(addon_name) do
+          create_addon_files
+        end
+      else
+        puts "Exiting without creating a new gem."
+      end
+    end
+
+    sig { params(string: String).returns(String) }
+    def camelize(string)
+      string.split("_").map(&:capitalize).join
+    end
+  end
+end

--- a/lib/ruby_lsp/generator.rb
+++ b/lib/ruby_lsp/generator.rb
@@ -36,15 +36,11 @@ module RubyLsp
       File.write(
         "#{addon_dir}/addon.rb",
         <<~RUBY,
-          # typed: strict
           # frozen_string_literal: true
-
-          require 'sorbet-runtime'
 
           module RubyLsp
             module #{camelize(addon_name)}
               class Addon
-                extend T::Sig
 
                 # Your add-on logic here
               end
@@ -59,7 +55,6 @@ module RubyLsp
       File.write(
         "#{test_dir}/addon_test.rb",
         <<~RUBY,
-          # typed: strict
           # frozen_string_literal: true
 
           require "test_helper"
@@ -67,9 +62,7 @@ module RubyLsp
           module RubyLsp
             module #{camelize(addon_name)}
               class AddonTest < Minitest::Test
-                extend T::Sig
 
-                sig { void }
                 def test_example
                   assert true
                 end
@@ -84,17 +77,10 @@ module RubyLsp
 
     sig { void }
     def create_new_gem
-      puts "No existing project found. Would you like to create a new gem? (y/n)"
-      response = T.let(gets.chomp.downcase, String)
-
-      if response == "y"
-        addon_name = T.must(@addon_name)
-        system("bundle gem #{addon_name}")
-        Dir.chdir(addon_name) do
-          create_addon_files
-        end
-      else
-        puts "Exiting without creating a new gem."
+      addon_name = T.must(@addon_name)
+      system("bundle gem #{addon_name}")
+      Dir.chdir(addon_name) do
+        create_addon_files
       end
     end
 

--- a/lib/ruby_lsp/generator.rb
+++ b/lib/ruby_lsp/generator.rb
@@ -30,7 +30,13 @@ module RubyLsp
 
     sig { params(string: String).returns(String) }
     def camelize(string)
-      string.split("_").map(&:capitalize).join
+      return string if string == "ruby-lsp"
+
+      string
+        .gsub("ruby-lsp-", "")
+        .split(/[-_]/)
+        .map(&:capitalize)
+        .join
     end
 
     sig { void }
@@ -78,8 +84,7 @@ module RubyLsp
 
       create_test_file
 
-      puts "Add-on '#{addon_name}' created successfully! Please follow guidelines on https://shopify.github.io/ruby-lsp/add-ons.html
-      for best practice"
+      puts "Add-on '#{addon_name}' created successfully! Please follow guidelines on https://shopify.github.io/ruby-lsp/add-ons.html"
     end
 
     sig { void }

--- a/lib/ruby_lsp/generator.rb
+++ b/lib/ruby_lsp/generator.rb
@@ -13,8 +13,10 @@ module RubyLsp
     sig { void }
     def run
       if inside_existing_project?
+        puts "Inside existing project. Creating add-on files..."
         create_addon_files
       else
+        puts "Not inside existing project. Prompting to create new gem..."
         create_new_gem
       end
     end

--- a/lib/ruby_lsp/generator.rb
+++ b/lib/ruby_lsp/generator.rb
@@ -26,6 +26,11 @@ module RubyLsp
       File.exist?("Gemfile")
     end
 
+    sig { params(string: String).returns(String) }
+    def camelize(string)
+      string.split("_").map(&:capitalize).join
+    end
+
     sig { void }
     def create_addon_files
       addon_name = T.must(@addon_name)
@@ -40,9 +45,27 @@ module RubyLsp
 
           module RubyLsp
             module #{camelize(addon_name)}
-              class Addon
+              class Addon < ::RubyLsp::Addon
+                # Performs any activation that needs to happen once when the language server is booted
+                def activate(global_state, message_queue)
+                  # Add your logic here
+                end
 
-                # Your add-on logic here
+                # Performs any cleanup when shutting down the server, like terminating a subprocess
+                def deactivate
+                  # Add your logic here
+                end
+
+                # Returns the name of the add-on
+                def name
+                  "Ruby LSP My Gem"
+                end
+
+                # Defining a version for the add-on is mandatory. This version doesn't necessarily need to match the version of
+                # the gem it belongs to
+                def version
+                  "0.1.0"
+                end
               end
             end
           end
@@ -82,11 +105,6 @@ module RubyLsp
       Dir.chdir(addon_name) do
         create_addon_files
       end
-    end
-
-    sig { params(string: String).returns(String) }
-    def camelize(string)
-      string.split("_").map(&:capitalize).join
     end
   end
 end


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

Closes #2901 

Add-ons have a bit of boilerplate code that is tedious to setup. This pull request will add generator command into executable that can both add the add-on structure to an existing gem or create a brand new add-on gem.

### Implementation

Add-on Creation Logic:

- Add executable ruby-lsp --new-addon [ADD-ON]

=> If inside an existing project (detected by Gemfile), creates add-on files in lib/ruby_lsp/<addon_name>.

=> If outside a project, prompts to create a new gem using bundle gem and then adds the add-on files.

- Added a private camelize method to transform some_name into SomeName for module naming.

- Creates addon.rb and addon_test.rb with boilerplate code following best practices.

- Updates notes on the add-on docs to include the newest feature


### Manual Tests


https://github.com/user-attachments/assets/bc5bc1d1-8d20-4cd0-91e0-d455f5b06541


https://github.com/user-attachments/assets/0f91a45e-9b41-45a9-bf32-d91e08fb64b1


