### PR TITLE
Remove typed sigil from fixtures

### DIFF
--- a/test/fixtures/multiline_offense.rb
+++ b/test/fixtures/multiline_offense.rb
@@ -1,4 +1,3 @@
-# typed: true
 # frozen_string_literal: true
 
 # rubocop:enable Metrics/MethodLength

--- a/test/fixtures/rubocop_extension_cop.rb
+++ b/test/fixtures/rubocop_extension_cop.rb
@@ -1,4 +1,3 @@
-# typed: true
 # frozen_string_literal: true
 
 class ExampleTest < Minitest::Test

--- a/test/fixtures/special_ruby_methods.rb
+++ b/test/fixtures/special_ruby_methods.rb
@@ -1,4 +1,3 @@
-# typed: true
 # frozen_string_literal: true
 
 require "foo"


### PR DESCRIPTION
We don't typecheck against fixtures. 