### PR TITLE
Try to relaunch if gems are modified between install and setup

### DIFF
--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -83,18 +83,19 @@ begin
     Bundler.setup
     $stderr.puts("Composed Bundle set up successfully")
   end
-rescue StandardError => e
-  # If installing gems failed for any reason, we don't want to exit the process prematurely. We can still provide most
-  # features in a degraded mode. We simply save the error so that we can report to the user that certain gems might be
-  # missing, but we respect the LSP life cycle.
-  #
-  # If an install error occurred and one of the gems is not installed, Bundler.setup is guaranteed to fail with
-  # `Bundler::GemNotFound`. We don't set `setup_error` here because that would essentially report the same problem twice
-  # to telemetry, which is not useful
-  unless install_error && e.is_a?(Bundler::GemNotFound)
-    setup_error = e
-    $stderr.puts("Failed to set up composed Bundle\n#{e.full_message}")
+rescue Bundler::GemNotFound, Bundler::GitError
+  # Sometimes, we successfully set up the bundle, but users either change their Gemfile or uninstall gems from an
+  # external process. If there's no install error, but the gem is still not found, then we need to attempt to start from
+  # scratch
+  unless install_error || ARGV.include?("--retry")
+    $stderr.puts("Initial bundle compose succeeded, but Bundler.setup failed. Trying to restart from scratch...")
+    exec(Gem.ruby, File.expand_path("ruby-lsp-launcher", __dir__), *ARGV, "--retry")
   end
+
+  $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+rescue StandardError => e
+  setup_error = e
+  $stderr.puts("Failed to set up composed Bundle\n#{e.full_message}")
 
   # If Bundler.setup fails, we need to restore the original $LOAD_PATH so that we can still require the Ruby LSP server
   # in degraded mode


### PR DESCRIPTION
### Motivation

If a user manages to change their Gemfile or uninstall a gem from an external command  while we're in the middle of running bundle install, Bundler may have already instantiated its internal state of the previous version of the Gemfile/dependency states.

This means composing the bundle will succeed, but then when we reach `Bundler.setup`, it will fail because now the Gemfile is in a different state or expected gems are no longer installed.

### Implementation

I propose we perform a single retry to begin the process from scratch if we notice that this happened. That way, the bundle is recomposed and the user will hopefully not change the Gemfile in the middle of launch twice.

### Automated Tests

Added a test.