### PR TITLE
Add redirect for Slack workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://github.com/Shopify/ruby-lsp/workflows/CI/badge.svg)](https://github.com/Shopify/ruby-lsp/actions/workflows/ci.yml)
 [![Ruby LSP extension](https://img.shields.io/badge/VS%20Code-Ruby%20LSP-success?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp)
-[![Ruby DX Slack](https://img.shields.io/badge/Slack-Ruby%20DX-success?logo=slack)](https://join.slack.com/t/ruby-dx/shared_invite/zt-2yd77ayis-yAiVc1TX_kH0mHMBbi89dA)
+[![Ruby DX Slack](https://img.shields.io/badge/Slack-Ruby%20DX-success?logo=slack)](https://shopify.github.io/ruby-lsp/invite)
 
 # Ruby LSP
 
@@ -13,7 +13,7 @@ for Ruby, used to improve rich features in editors. It is a part of a wider goal
 experience to Ruby developers using modern standards for cross-editor features, documentation and debugging.
 
 Want to discuss Ruby developer experience? Consider joining the public
-[Ruby DX Slack workspace](https://join.slack.com/t/ruby-dx/shared_invite/zt-2yd77ayis-yAiVc1TX_kH0mHMBbi89dA).
+[Ruby DX Slack workspace](https://shopify.github.io/ruby-lsp/invite).
 
 ## Getting Started
 

--- a/jekyll/Gemfile
+++ b/jekyll/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 # We only need to use Jekyll with CRuby
 gem "jekyll", "~> 4.4.1"
 gem "jekyll-feed", "~> 0.12"
+gem "jekyll-redirect-from"
 
 # Theme
 gem "just-the-docs", "~> 0.10.1"

--- a/jekyll/Gemfile.lock
+++ b/jekyll/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
@@ -173,6 +175,7 @@ DEPENDENCIES
   csv
   jekyll (~> 4.4.1)
   jekyll-feed (~> 0.12)
+  jekyll-redirect-from
   just-the-docs (~> 0.10.1)
 
 BUNDLED WITH

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -27,6 +27,7 @@ theme: just-the-docs
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-redirect-from
 destination: ../docs
 
 # Copied from just-the-docs's _config.yml

--- a/jekyll/add-ons.markdown
+++ b/jekyll/add-ons.markdown
@@ -11,7 +11,7 @@ parent: Ruby LSP
 > The Ruby LSP add-on system is currently experimental and subject to changes in the API
 
 Need help writing add-ons? Consider joining the `#ruby-lsp-addons` channel in the [Ruby DX Slack
-workspace](https://join.slack.com/t/ruby-dx/shared_invite/zt-2yd77ayis-yAiVc1TX_kH0mHMBbi89dA).
+workspace](https://shopify.github.io/ruby-lsp/invite).
 
 ## Motivation and goals
 

--- a/jekyll/index.markdown
+++ b/jekyll/index.markdown
@@ -15,7 +15,7 @@ for Ruby, used to improve rich features in editors. It is a part of a wider goal
 experience to Ruby developers using modern standards for cross-editor features, documentation and debugging.
 
 Want to discuss Ruby developer experience? Consider joining the public
-[Ruby DX Slack workspace](https://join.slack.com/t/ruby-dx/shared_invite/zt-2yd77ayis-yAiVc1TX_kH0mHMBbi89dA).
+[Ruby DX Slack workspace](https://shopify.github.io/ruby-lsp/invite).
 
 ## Table of Contents
 
@@ -531,7 +531,7 @@ requirements
 ## Experimental Features
 
 Ruby LSP also provides experimental features that are not enabled by default. If you have feedback about these features,
-you can let us know in the [DX Slack](https://join.slack.com/t/ruby-dx/shared_invite/zt-2yd77ayis-yAiVc1TX_kH0mHMBbi89dA) or by [creating an issue](https://github.com/Shopify/ruby-lsp/issues/new/choose).
+you can let us know in the [DX Slack](https://shopify.github.io/ruby-lsp/invite) or by [creating an issue](https://github.com/Shopify/ruby-lsp/issues/new/choose).
 
 ### Ancestors Hierarchy Request
 

--- a/jekyll/invite.markdown
+++ b/jekyll/invite.markdown
@@ -1,0 +1,3 @@
+---
+redirect_to: https://join.slack.com/t/ruby-dx/shared_invite/zt-2yd77ayis-yAiVc1TX_kH0mHMBbi89dA
+---

--- a/jekyll/vscode-extension.markdown
+++ b/jekyll/vscode-extension.markdown
@@ -58,7 +58,7 @@ As with most LLM chat functionality, suggestions may not be fully accurate, espe
 continue chatting with the `@ruby` agent to fine tune the suggestions given, before deciding to move forward with
 generation.
 
-If you have feedback about this feature, you can let us know in the [DX Slack](https://join.slack.com/t/ruby-dx/shared_invite/zt-2yd77ayis-yAiVc1TX_kH0mHMBbi89dA) or by [creating an issue](https://github.com/Shopify/ruby-lsp/issues/new).
+If you have feedback about this feature, you can let us know in the [DX Slack](https://shopify.github.io/ruby-lsp/invite) or by [creating an issue](https://github.com/Shopify/ruby-lsp/issues/new).
 
 ## Usage
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -51,7 +51,7 @@ As with most LLM chat functionality, suggestions may not be fully accurate, espe
 continue chatting with the `@ruby` agent to fine tune the suggestions given, before deciding to move forward with
 generation.
 
-If you have feedback about this feature, you can let us know in the [DX Slack](https://join.slack.com/t/ruby-dx/shared_invite/zt-2yd77ayis-yAiVc1TX_kH0mHMBbi89dA) or by [creating an issue](https://github.com/Shopify/ruby-lsp/issues/new).
+If you have feedback about this feature, you can let us know in the [DX Slack](https://shopify.github.io/ruby-lsp/invite) or by [creating an issue](https://github.com/Shopify/ruby-lsp/issues/new).
 
 ## Usage
 


### PR DESCRIPTION
I noticed that https://railsatscale.com/2024-10-03-the-ruby-lsp-addon-system/ still points to the expired Slack invite.

Rather than having to refresh this link in multiple places, let's set up a redirect at `https://shopify.github.io/ruby-lsp/invite`.