### PR TITLE
Fix range and workspace processing for test discovery updates

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -49,8 +49,8 @@ export interface ServerTestItem {
   label: string;
   uri: string;
   range: {
-    start: { line: number; column: number };
-    end: { line: number; column: number };
+    start: { line: number; character: number };
+    end: { line: number; character: number };
   };
   children: ServerTestItem[];
   tags: string[];

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -609,18 +609,21 @@ export class TestController {
     }
 
     let initialCollection = this.testController.items;
+    let workspaceFolder = workspaceFolders[0];
 
     // If there's more than one workspace folder, then the first level is the workspace
     if (workspaceFolders.length > 1) {
+      workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)!;
+
       initialCollection = initialCollection.get(
-        vscode.workspace.getWorkspaceFolder(uri)!.uri.toString(),
+        workspaceFolder.uri.toString(),
       )!.children;
     }
 
     // There's always a first level, but not always a second level
     const { firstLevelUri, secondLevelUri } = await this.directoryLevelUris(
       uri,
-      workspaceFolders[0],
+      workspaceFolder,
     );
 
     let item = initialCollection.get(firstLevelUri.toString());
@@ -678,8 +681,8 @@ export class TestController {
       const end = item.range.end;
 
       testItem.range = new vscode.Range(
-        new vscode.Position(start.line, start.column),
-        new vscode.Position(end.line, end.column),
+        new vscode.Position(start.line, start.character),
+        new vscode.Position(end.line, end.character),
       );
 
       const serverTags = item.tags.map((tag) => new vscode.TestTag(tag));


### PR DESCRIPTION
### Motivation

I noticed a small batch of improvements we need to make to the test controller.

### Implementation

1. We should invalidate test results when the test file is updated
2. We were always passing the first workspace folder, when in fact we should use the one associated with the document being saved
3. We were incorrectly trying to read `column` from the server response, but the field is actually `character`