### PR TITLE
Add test item filtering for resolve command

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -44,17 +44,23 @@ import { WorkspaceChannel } from "./workspaceChannel";
 
 type EnabledFeatures = Record<string, boolean>;
 
-export interface ServerTestItem {
+export interface BasicTestItem {
   id: string;
   label: string;
   uri: string;
+  children: (ServerTestItem | BasicTestItem)[];
+  tags: string[];
+}
+
+export type ServerTestItem = BasicTestItem & {
+  children: ServerTestItem[];
   range: {
     start: { line: number; character: number };
     end: { line: number; character: number };
   };
-  children: ServerTestItem[];
-  tags: string[];
-}
+};
+
+export type LspTestItem = BasicTestItem | ServerTestItem;
 
 interface ServerErrorTelemetryEvent {
   type: "error";
@@ -496,10 +502,10 @@ export default class Client extends LanguageClient implements ClientInterface {
     });
   }
 
-  async resolveTestCommand(
-    items: vscode.TestItem[],
+  async resolveTestCommands(
+    items: LspTestItem[],
   ): Promise<{ command: string }> {
-    return this.sendRequest("rubyLsp/resolveTestCommand", {
+    return this.sendRequest("rubyLsp/resolveTestCommands", {
       items,
     });
   }


### PR DESCRIPTION
### Motivation

Step towards #3177

To be able to execute tests, we need to first handle the explorer's inclusions and exclusions properly and build the right request for the server.

It's a recursive process because inclusions will typically have parent test items, while exclusions may remove specific examples. We have to ensure that if all examples of a group/file have been excluded, then that entire group/file must be removed as well.

### Implementation

Created a method to build the test items in the format expected by the server. It first filters all items recursively and then builds the result into the format we need.

### Automated Tests

Added a test.