### PR TITLE
Make RBS signature opacity optional

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -517,6 +517,11 @@
             }
           },
           "default": {}
+        },
+        "rubyLsp.sigOpacityLevel": {
+          "description": "Controls the level of opacity for inline RBS comment signatures",
+          "type": "string",
+          "default": "1"
         }
       }
     },

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -29,7 +29,15 @@ export async function activate(context: vscode.ExtensionContext) {
   await migrateExperimentalFeaturesSetting();
 
   const rbs = new RBS();
-  context.subscriptions.push(rbs);
+
+  context.subscriptions.push(
+    rbs,
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      if (event.affectsConfiguration("rubyLsp.sigOpacityLevel")) {
+        rbs.reload();
+      }
+    }),
+  );
 
   const logger = await createLogger(context);
   context.subscriptions.push(logger);

--- a/vscode/src/rbs.ts
+++ b/vscode/src/rbs.ts
@@ -16,9 +16,10 @@ export class RBS {
   private disposables: vscode.Disposable[] = [];
 
   constructor() {
-    // Create decoration type with 40% opacity
     this.decorationType = vscode.window.createTextEditorDecorationType({
-      opacity: "0.4",
+      opacity: vscode.workspace
+        .getConfiguration("rubyLsp")
+        .get<string>("sigOpacityLevel")!,
     });
 
     // Register event handlers
@@ -28,6 +29,18 @@ export class RBS {
     );
 
     // Initial update
+    this.updateDecorations();
+  }
+
+  reload() {
+    const opacity = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get<string>("sigOpacityLevel")!;
+
+    this.decorationType.dispose();
+    this.decorationType = vscode.window.createTextEditorDecorationType({
+      opacity,
+    });
     this.updateDecorations();
   }
 


### PR DESCRIPTION
### Motivation

Make the opacity on signatures optional, with the default being turned off.

### Implementation

Started reading the opacity from a setting and ensured we reload the decorations if the setting is updated.