### PR TITLE
Make RBS inline signature tokens more specific

### DIFF
--- a/vscode/grammars/rbs.injection.json
+++ b/vscode/grammars/rbs.injection.json
@@ -8,10 +8,14 @@
   ],
   "repository": {
     "rbs-signature": {
-      "begin": "(?m)(^[^#\"']*)(#:)",
+      "begin": "(^[^#\"']*)(#:)",
       "beginCaptures": {
-        "1": { "name": "source.ruby" },
-        "2": { "name": "comment.line.number-sign.rbs" }
+        "1": {
+          "name": "source.ruby"
+        },
+        "2": {
+          "name": "comment.line.signature.rbs"
+        }
       },
       "end": "$",
       "name": "meta.type.signature.rbs",
@@ -21,28 +25,28 @@
           "name": "support.type.builtin.rbs"
         },
         {
-          "match": "\\b[A-Z][A-Za-z0-9_]*(\\?|\\b)",
+          "match": "\\b[A-Z][A-Za-z0-9_]*\\b",
           "name": "variable.other.constant.rbs"
         },
         {
           "match": "[\\[\\]]",
-          "name": "variable.other.constant.rbs"
+          "name": "punctuation.section.type_parameters.rbs"
         },
         {
-          "match": "(\\?|\\b)[a-z][A-Za-z0-9_]*:",
+          "match": "\\b[a-z][A-Za-z0-9_]*(?=:)",
           "name": "constant.other.symbol.hashkey.parameter.function.rbs"
         },
         {
-          "match": "(\\?|\\b)[a-z][A-Za-z0-9_]*\\b",
+          "match": "\\b[a-z][A-Za-z0-9_]*\\b",
           "name": "variable.parameter.function.rbs"
         },
         {
           "match": "->",
-          "name": "comment.line.number-sign.rbs"
+          "name": "punctuation.section.signature.return.rbs"
         },
         {
           "match": "[\\(\\)\\{\\},\\|\\*&:?]",
-          "name": "comment.line.number-sign.rbs"
+          "name": "punctuation.section.signature.rbs"
         }
       ]
     }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -517,6 +517,11 @@
             }
           },
           "default": {}
+        },
+        "rubyLsp.sigOpacityLevel": {
+          "description": "Controls the level of opacity for inline RBS comment signatures",
+          "type": "string",
+          "default": "1"
         }
       }
     },

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -29,7 +29,15 @@ export async function activate(context: vscode.ExtensionContext) {
   await migrateExperimentalFeaturesSetting();
 
   const rbs = new RBS();
-  context.subscriptions.push(rbs);
+
+  context.subscriptions.push(
+    rbs,
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      if (event.affectsConfiguration("rubyLsp.sigOpacityLevel")) {
+        rbs.reload();
+      }
+    }),
+  );
 
   const logger = await createLogger(context);
   context.subscriptions.push(logger);

--- a/vscode/src/rbs.ts
+++ b/vscode/src/rbs.ts
@@ -16,9 +16,10 @@ export class RBS {
   private disposables: vscode.Disposable[] = [];
 
   constructor() {
-    // Create decoration type with 40% opacity
     this.decorationType = vscode.window.createTextEditorDecorationType({
-      opacity: "0.4",
+      opacity: vscode.workspace
+        .getConfiguration("rubyLsp")
+        .get<string>("sigOpacityLevel")!,
     });
 
     // Register event handlers
@@ -28,6 +29,18 @@ export class RBS {
     );
 
     // Initial update
+    this.updateDecorations();
+  }
+
+  reload() {
+    const opacity = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get<string>("sigOpacityLevel")!;
+
+    this.decorationType.dispose();
+    this.decorationType = vscode.window.createTextEditorDecorationType({
+      opacity,
+    });
     this.updateDecorations();
   }
 

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -344,27 +344,48 @@ suite("Grammars", () => {
       test("inline method signature", () => {
         const ruby = "#: (String) -> (String | nil)";
         const expectedTokens = [
-          ["#:", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
           [" ", ["meta.type.signature.rbs"]],
-          ["(", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "(",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [
             "String",
             ["meta.type.signature.rbs", "variable.other.constant.rbs"],
           ],
-          [")", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            ")",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["->", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "->",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.signature.return.rbs",
+            ],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["(", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "(",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [
             "String",
             ["meta.type.signature.rbs", "variable.other.constant.rbs"],
           ],
           [" ", ["meta.type.signature.rbs"]],
-          ["|", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "|",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
           ["nil", ["meta.type.signature.rbs", "support.type.builtin.rbs"]],
-          [")", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            ")",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
         ];
         const actualTokens = tokenizeRBS(ruby);
         assert.deepStrictEqual(actualTokens, expectedTokens);
@@ -373,31 +394,61 @@ suite("Grammars", () => {
       test("inline method signature with block", () => {
         const ruby = "#: (String) { (String) -> boolish } -> void";
         const expectedTokens = [
-          ["#:", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
           [" ", ["meta.type.signature.rbs"]],
-          ["(", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "(",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [
             "String",
             ["meta.type.signature.rbs", "variable.other.constant.rbs"],
           ],
-          [")", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            ")",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["{", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "{",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["(", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "(",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [
             "String",
             ["meta.type.signature.rbs", "variable.other.constant.rbs"],
           ],
-          [")", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            ")",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["->", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "->",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.signature.return.rbs",
+            ],
+          ],
           [" ", ["meta.type.signature.rbs"]],
           ["boolish", ["meta.type.signature.rbs", "support.type.builtin.rbs"]],
           [" ", ["meta.type.signature.rbs"]],
-          ["}", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "}",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["->", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "->",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.signature.return.rbs",
+            ],
+          ],
           [" ", ["meta.type.signature.rbs"]],
           ["void", ["meta.type.signature.rbs", "support.type.builtin.rbs"]],
         ];
@@ -408,29 +459,68 @@ suite("Grammars", () => {
       test("inline method signature with &", () => {
         const ruby = "#: [X] (X & Object) -> Class[X]";
         const expectedTokens = [
-          ["#:", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
           [" ", ["meta.type.signature.rbs"]],
-          ["[", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
+          [
+            "[",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.type_parameters.rbs",
+            ],
+          ],
           ["X", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
-          ["]", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
+          [
+            "]",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.type_parameters.rbs",
+            ],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["(", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "(",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           ["X", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
           [" ", ["meta.type.signature.rbs"]],
-          ["&", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "&",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
           [
             "Object",
             ["meta.type.signature.rbs", "variable.other.constant.rbs"],
           ],
-          [")", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            ")",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["->", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "->",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.signature.return.rbs",
+            ],
+          ],
           [" ", ["meta.type.signature.rbs"]],
           ["Class", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
-          ["[", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
+          [
+            "[",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.type_parameters.rbs",
+            ],
+          ],
           ["X", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
-          ["]", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
+          [
+            "]",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.type_parameters.rbs",
+            ],
+          ],
         ];
         const actualTokens = tokenizeRBS(ruby);
         assert.deepStrictEqual(actualTokens, expectedTokens);
@@ -439,19 +529,43 @@ suite("Grammars", () => {
       test("inline method signature * and **", () => {
         const ruby = "#: (*Foo, **Bar) -> void";
         const expectedTokens = [
-          ["#:", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
           [" ", ["meta.type.signature.rbs"]],
-          ["(", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
-          ["*", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "(",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
+          [
+            "*",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           ["Foo", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
-          [",", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            ",",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["*", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
-          ["*", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "*",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
+          [
+            "*",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           ["Bar", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
-          [")", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            ")",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
           [" ", ["meta.type.signature.rbs"]],
-          ["->", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          [
+            "->",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.signature.return.rbs",
+            ],
+          ],
           [" ", ["meta.type.signature.rbs"]],
           ["void", ["meta.type.signature.rbs", "support.type.builtin.rbs"]],
         ];
@@ -463,14 +577,18 @@ suite("Grammars", () => {
       test("inline method signature with keyword", () => {
         const ruby = "#: return: String";
         const expectedTokens = [
-          ["#:", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
           [" ", ["meta.type.signature.rbs"]],
           [
-            "return:",
+            "return",
             [
               "meta.type.signature.rbs",
               "constant.other.symbol.hashkey.parameter.function.rbs",
             ],
+          ],
+          [
+            ":",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
           ],
           [" ", ["meta.type.signature.rbs"]],
           [
@@ -500,7 +618,7 @@ suite("Grammars", () => {
         const ruby = "attr_reader :name #: String";
         const expectedTokens = [
           ["attr_reader :name ", ["meta.type.signature.rbs", "source.ruby"]],
-          ["#:", ["meta.type.signature.rbs", "comment.line.number-sign.rbs"]],
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
           [" ", ["meta.type.signature.rbs"]],
           [
             "String",


### PR DESCRIPTION
### Motivation

Some of the tokens we were using were too generic or didn't give themes enough possibility for customization. We should ensure that any punctuation used in signatures is tokenized as both a signature and a punctation, so that themes can decide if they want to use the same colour for everything or if they want to make it distinct.

### Implementation

Updated some of the tokens.

### Automated Tests

Updated the tests.