### PR TITLE
Set up Git submodules on `dev up`

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,6 +3,7 @@ name: ruby-lsp
 type: ruby
 
 up:
+  - submodules
   - ruby
   - bundler
   - node:


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

This ensures Git submodule set up is performed automatically for Shopify employees contributing to the repo.

For everyone else, the test that uses them already fails with a helpful error message:

```
Prism fixtures not found. Run `git submodule update --init` to fetch them.
```

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

The appropriate entry is added to the `up` config in `dev.yml`
