### PR TITLE
Enforce that CI matrix contains `required_ruby_version` & `.ruby-version`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}

--- a/test/ci_configuration_test.rb
+++ b/test/ci_configuration_test.rb
@@ -1,0 +1,59 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+require "yaml"
+
+class CiConfigurationTest < Minitest::Test
+  def test_matrix_includes_development_ruby_version
+    development_ruby_version = development_ruby_version_from_dot_ruby_version_file
+
+    each_ci_matrix_ruby_entry do |matrix_ruby_versions, path|
+      assert_includes(
+        matrix_ruby_versions,
+        development_ruby_version,
+        "CI matrix #{path.join(".")} does not include development ruby version #{development_ruby_version}",
+      )
+    end
+  end
+
+  private
+
+  def development_ruby_version_from_dot_ruby_version_file
+    contents = File.read(".ruby-version").chomp
+    flunk("Failed to read .ruby-version file") if contents.empty?
+
+    major_and_minor_only = contents[/\d+\.\d+/]
+    flunk("Failed to extract major and minor version from .ruby-version file") if major_and_minor_only.nil?
+
+    major_and_minor_only
+  end
+
+  def each_ci_matrix_ruby_entry(&block)
+    each_ci_matrix_entry do |matrix, path|
+      matrix_ruby_versions = matrix["ruby"]
+      next if matrix_ruby_versions.nil?
+
+      yield(matrix_ruby_versions, path)
+    end
+  end
+
+  def each_ci_matrix_entry(hash = read_ci_workflow, path: [], &block)
+    case hash
+    when Hash
+      hash.each do |key, value|
+        if key == "matrix"
+          yield(value, path)
+        else
+          each_ci_matrix_entry(value, path: path + [key], &block)
+        end
+      end
+    when Array
+      hash.each_with_index { |value, index| each_ci_matrix_entry(value, path: path + [index], &block) }
+    end
+  end
+
+  def read_ci_workflow
+    YAML.load_file(".github/workflows/ci.yml")
+  end
+end


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Our CI matrix should always include, at least:
- the Ruby version being used in development, as specified in `.ruby-version`, and
- the minimum Ruby version we support according to `required_ruby_version` in `ruby-lsp.gemspec`

#2017 dropped Ruby 3.0 from the CI matrix without changing the requirement in the gemspec.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This adds a pair of tests to enforce all CI matrix `ruby: [...]` entries contain the Ruby versions listed
- as the development Ruby version in `.ruby-version`, and
- as the `required_ruby_version` in `ruby-lsp.gemspec`.

Ruby 3.0 is also added back to the CI matrix, which gets the test passing again.

There should be no consumer facing changes. If we do want to remove Ruby 3.0 again, then that belongs in a separate PR which also changes the `ruby-lsp.gemspec` (and is probably a major version bump).

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

Yes, see above.
