### PR TITLE
Add new run handler for test controller

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -814,6 +814,7 @@
     "vscode-textmate": "^9.2.0"
   },
   "dependencies": {
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "^9.0.1",
+    "vscode-jsonrpc": "^8.2.1"
   }
 }

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -504,7 +504,7 @@ export default class Client extends LanguageClient implements ClientInterface {
 
   async resolveTestCommands(
     items: LspTestItem[],
-  ): Promise<{ command: string }> {
+  ): Promise<{ commands: string[]; reporterPaths: string[] | undefined }> {
     return this.sendRequest("rubyLsp/resolveTestCommands", {
       items,
     });

--- a/vscode/src/test/suite/fakeTestServer.js
+++ b/vscode/src/test/suite/fakeTestServer.js
@@ -1,0 +1,29 @@
+const path = require("path");
+const os = require("os");
+
+function sendMessage(message) {
+  const jsonMessage = JSON.stringify(message);
+  // eslint-disable-next-line no-console
+  process.stdout.write(`Content-Length: ${jsonMessage.length}\r\n\r\n${jsonMessage}`);
+}
+
+const serverFilePath = path.join(__dirname, "..", "..", "..", "..", "test", "server_test.rb");
+const uri = os.platform() === "win32" ? `file:///${serverFilePath.replace(/\\/g, '/')}` : `file://${serverFilePath}`;
+
+setTimeout(() => {
+  sendMessage({
+    method: "start",
+    params: { id: "ServerTest::NestedTest#test_something", uri: uri },
+  });
+}, 1000);
+
+setTimeout(() => {
+  setTimeout(() => {
+    sendMessage({
+      method: "pass",
+      params: { id: "ServerTest::NestedTest#test_something", uri: uri },
+    });
+
+    setTimeout(() => {}, 1000);
+  }, 1000);
+}, 1000);

--- a/vscode/yarn.lock
+++ b/vscode/yarn.lock
@@ -5384,6 +5384,11 @@ vscode-jsonrpc@8.2.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz#f43dfa35fb51e763d17cd94dcca0c9458f35abf9"
   integrity sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==
 
+vscode-jsonrpc@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz#a322cc0f1d97f794ffd9c4cd2a898a0bde097f34"
+  integrity sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==
+
 vscode-languageclient@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz#cdfe20267726c8d4db839dc1e9d1816e1296e854"


### PR DESCRIPTION
### Motivation

Closes #3177

This PR adds a new run handler for the test controller, which asks the server for the resolve commands and then executes them with streaming updates.

**Important**: after this PR, there are still some details to iron out and this doesn't fully work out of the box. For example, we need the Test Unit reporter to automatically select the custom one.

We also may need a way for add-ons to register their reporter paths so that they are required automatically.

However, this implements the bulk of the integration, so it will be easier to deal with the other details once this is shipped.

### Implementation

1. Added the JSON RPC package as an explicit dependency. It is already a transitive dependency of the LSP package, so this is not actually adding anything, but our linters enforce the good practice of declaring explicit dependencies
2. Added the run handler when the feature flag is enabled. It will ask the server for commands and execute them using JSON RPC to receive notifications back about the state of tests, which it then uses to update the UI

### Automated Tests

The easiest way I found of testing this is to create a small fake test server script, so that we can mock the resolve commands return and still have something that will print JSON RPC notifications.

I also extract a common part of the test.