### PR TITLE
Adjust Sorbet/TrueSigil cop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,7 +52,6 @@ Sorbet/TrueSigil:
     - "lib/ruby_lsp/scripts/compose_bundle.rb"
   Exclude:
     - "**/*.rake"
-    - "lib/**/*.rb"
 
 Sorbet/StrictSigil:
   Enabled: true


### PR DESCRIPTION
The current config allows any file in `lib/` to be set as `typed: true` instead of `typed: strict`. It's easy to miss the `typed:` level when reviewing newly added files, so let's change the config so that exclusions need to be explicitly listed under `Sorbet/StrictSigil`.