### PR TITLE
Remove unnecessary uses of `extend T::Sig`

### DIFF
--- a/lib/rubocop/cop/ruby_lsp/use_register_with_handler_method.rb
+++ b/lib/rubocop/cop/ruby_lsp/use_register_with_handler_method.rb
@@ -63,8 +63,6 @@ module RuboCop
       #   end
       # end
       class UseRegisterWithHandlerMethod < RuboCop::Cop::Base
-        extend T::Sig
-
         MSG_MISSING_HANDLER = "Registered to `%{listener}` without a handler defined."
         MSG_MISSING_LISTENER = "Created a handler without registering the associated `%{listener}` event."
 

--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -3,8 +3,6 @@
 
 module RubyIndexer
   class Configuration
-    extend T::Sig
-
     CONFIGURATION_SCHEMA = T.let(
       {
         "excluded_gems" => Array,

--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -3,8 +3,6 @@
 
 module RubyIndexer
   class DeclarationListener
-    extend T::Sig
-
     OBJECT_NESTING = T.let(["Object"].freeze, T::Array[String])
     BASIC_OBJECT_NESTING = T.let(["BasicObject"].freeze, T::Array[String])
 

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -11,8 +11,6 @@ module RubyIndexer
       end
     end
 
-    extend T::Sig
-
     #: String
     attr_reader :name
 
@@ -171,8 +169,6 @@ module RubyIndexer
     end
 
     class Class < Namespace
-      extend T::Sig
-
       # The unresolved name of the parent class. This may return `nil`, which indicates the lack of an explicit parent
       # and therefore ::Object is the correct parent class
       #: String?
@@ -192,8 +188,6 @@ module RubyIndexer
     end
 
     class SingletonClass < Class
-      extend T::Sig
-
       #: (Location location, Location name_location, String? comments) -> void
       def update_singleton_information(location, name_location, comments)
         @location = location
@@ -282,7 +276,6 @@ module RubyIndexer
       DEFAULT_NAME = T.let(:"<anonymous block>", Symbol)
 
       class << self
-        extend T::Sig
         #: -> BlockParameter
         def anonymous
           new(name: DEFAULT_NAME)
@@ -298,8 +291,6 @@ module RubyIndexer
 
     # A forwarding method parameter, e.g. `def foo(...)`
     class ForwardingParameter < Parameter
-      extend T::Sig
-
       #: -> void
       def initialize
         # You can't name a forwarding parameter, it's always called `...`
@@ -349,8 +340,6 @@ module RubyIndexer
     end
 
     class Accessor < Member
-      extend T::Sig
-
       # @override
       #: -> Array[Signature]
       def signatures
@@ -366,8 +355,6 @@ module RubyIndexer
     end
 
     class Method < Member
-      extend T::Sig
-
       #: Array[Signature]
       attr_reader :signatures
 
@@ -394,8 +381,6 @@ module RubyIndexer
     # target in [rdoc-ref:Index#resolve]. If the right hand side contains a constant that doesn't exist, then it's not
     # possible to resolve the alias and it will remain an UnresolvedAlias until the right hand side constant exists
     class UnresolvedConstantAlias < Entry
-      extend T::Sig
-
       #: String
       attr_reader :target
 
@@ -413,8 +398,6 @@ module RubyIndexer
 
     # Alias represents a resolved alias, which points to an existing constant target
     class ConstantAlias < Entry
-      extend T::Sig
-
       #: String
       attr_reader :target
 
@@ -463,8 +446,6 @@ module RubyIndexer
     # example, if we have `alias a b`, we create an unresolved alias for `a` because we aren't sure immediate what `b`
     # is referring to
     class UnresolvedMethodAlias < Entry
-      extend T::Sig
-
       #: String
       attr_reader :new_name, :old_name
 
@@ -483,8 +464,6 @@ module RubyIndexer
 
     # A method alias is a resolved alias entry that points to the exact method target it refers to
     class MethodAlias < Entry
-      extend T::Sig
-
       #: (Member | MethodAlias)
       attr_reader :target
 
@@ -528,8 +507,6 @@ module RubyIndexer
     # However RBS can represent the concept of method overloading, with different return types based on the arguments
     # passed, so we need to store all the signatures.
     class Signature
-      extend T::Sig
-
       #: Array[Parameter]
       attr_reader :parameters
 

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -3,8 +3,6 @@
 
 module RubyIndexer
   class Index
-    extend T::Sig
-
     class UnresolvableAliasError < StandardError; end
     class NonExistingNamespaceError < StandardError; end
     class IndexNotEmptyError < StandardError; end
@@ -16,8 +14,6 @@ module RubyIndexer
     attr_reader :configuration
 
     class << self
-      extend T::Sig
-
       # Returns the real nesting of a constant name taking into account top level
       # references that may be included anywhere in the name or nesting where that
       # constant was found

--- a/lib/ruby_indexer/lib/ruby_indexer/location.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/location.rb
@@ -3,11 +3,7 @@
 
 module RubyIndexer
   class Location
-    extend T::Sig
-
     class << self
-      extend T::Sig
-
       #: (Prism::Location prism_location, (^(Integer arg0) -> Integer | Prism::CodeUnitsCache) code_units_cache) -> instance
       def from_prism_location(prism_location, code_units_cache)
         new(

--- a/lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb
@@ -33,7 +33,6 @@ module RubyIndexer
   #
   # See https://en.wikipedia.org/wiki/Trie for more information
   class PrefixTree
-    extend T::Sig
     extend T::Generic
 
     Value = type_member
@@ -108,7 +107,6 @@ module RubyIndexer
     end
 
     class Node
-      extend T::Sig
       extend T::Generic
 
       Value = type_member

--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -3,8 +3,6 @@
 
 module RubyIndexer
   class RBSIndexer
-    extend T::Sig
-
     HAS_UNTYPED_FUNCTION = T.let(!!defined?(RBS::Types::UntypedFunction), T::Boolean)
 
     #: (Index index) -> void

--- a/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
@@ -3,8 +3,6 @@
 
 module RubyIndexer
   class ReferenceFinder
-    extend T::Sig
-
     class Target
       extend T::Helpers
 
@@ -12,8 +10,6 @@ module RubyIndexer
     end
 
     class ConstTarget < Target
-      extend T::Sig
-
       #: String
       attr_reader :fully_qualified_name
 
@@ -25,8 +21,6 @@ module RubyIndexer
     end
 
     class MethodTarget < Target
-      extend T::Sig
-
       #: String
       attr_reader :method_name
 
@@ -38,8 +32,6 @@ module RubyIndexer
     end
 
     class InstanceVariableTarget < Target
-      extend T::Sig
-
       #: String
       attr_reader :name
 
@@ -51,8 +43,6 @@ module RubyIndexer
     end
 
     class Reference
-      extend T::Sig
-
       #: String
       attr_reader :name
 

--- a/lib/ruby_indexer/lib/ruby_indexer/uri.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/uri.rb
@@ -3,16 +3,12 @@
 
 module URI
   class Generic
-    extend T::Sig
-
     # Avoid a deprecation warning with Ruby 3.4 where the default parser was changed to RFC3986.
     # This condition must remain even after support for 3.4 has been dropped for users that have
     # `uri` in their lockfile, decoupling it from the ruby version.
     PARSER = T.let(const_defined?(:RFC2396_PARSER) ? RFC2396_PARSER : DEFAULT_PARSER, RFC2396_Parser)
 
     class << self
-      extend T::Sig
-
       #: (path: String, ?fragment: String?, ?scheme: String, ?load_path_entry: String?) -> URI::Generic
       def from_path(path:, fragment: nil, scheme: "file", load_path_entry: nil)
         # On Windows, if the path begins with the disk name, we need to add a leading slash to make it a valid URI

--- a/lib/ruby_indexer/lib/ruby_indexer/visibility_scope.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/visibility_scope.rb
@@ -5,11 +5,7 @@ module RubyIndexer
   # Represents the visibility scope in a Ruby namespace. This keeps track of whether methods are in a public, private or
   # protected section, and whether they are module functions.
   class VisibilityScope
-    extend T::Sig
-
     class << self
-      extend T::Sig
-
       #: -> instance
       def module_function_scope
         new(module_func: true, visibility: Entry::Visibility::PRIVATE)

--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -35,8 +35,6 @@ module RubyLsp
     class IncompatibleApiError < StandardError; end
 
     class << self
-      extend T::Sig
-
       #: Array[Addon]
       attr_accessor :addons
 

--- a/lib/ruby_lsp/client_capabilities.rb
+++ b/lib/ruby_lsp/client_capabilities.rb
@@ -5,8 +5,6 @@ module RubyLsp
   # This class stores all client capabilities that the Ruby LSP and its add-ons depend on to ensure that we're
   # not enabling functionality unsupported by the editor connecting to the server
   class ClientCapabilities
-    extend T::Sig
-
     #: bool
     attr_reader :supports_watching_files,
       :supports_request_delegation,

--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -3,7 +3,6 @@
 
 module RubyLsp
   class ERBDocument < Document
-    extend T::Sig
     extend T::Generic
 
     ParseResultType = type_member { { fixed: Prism::ParseResult } }
@@ -73,8 +72,6 @@ module RubyLsp
     end
 
     class ERBScanner
-      extend T::Sig
-
       #: String
       attr_reader :ruby, :host_language
 

--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -3,8 +3,6 @@
 
 module RubyLsp
   class GlobalState
-    extend T::Sig
-
     #: String
     attr_reader :test_library
 

--- a/lib/ruby_lsp/listeners/code_lens.rb
+++ b/lib/ruby_lsp/listeners/code_lens.rb
@@ -6,7 +6,6 @@ require "shellwords"
 module RubyLsp
   module Listeners
     class CodeLens
-      extend T::Sig
       include Requests::Support::Common
 
       BASE_COMMAND = T.let(

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module Listeners
     class Completion
-      extend T::Sig
       include Requests::Support::Common
 
       KEYWORDS = [

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module Listeners
     class Definition
-      extend T::Sig
       include Requests::Support::Common
 
       MAX_NUMBER_OF_DEFINITION_CANDIDATES_WITHOUT_RECEIVER = 10

--- a/lib/ruby_lsp/listeners/document_highlight.rb
+++ b/lib/ruby_lsp/listeners/document_highlight.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module Listeners
     class DocumentHighlight
-      extend T::Sig
       include Requests::Support::Common
 
       GLOBAL_VARIABLE_NODES = T.let(

--- a/lib/ruby_lsp/listeners/document_link.rb
+++ b/lib/ruby_lsp/listeners/document_link.rb
@@ -6,7 +6,6 @@ require "ruby_lsp/requests/support/source_uri"
 module RubyLsp
   module Listeners
     class DocumentLink
-      extend T::Sig
       include Requests::Support::Common
 
       GEM_TO_VERSION_MAP = T.let(
@@ -17,8 +16,6 @@ module RubyLsp
       )
 
       class << self
-        extend T::Sig
-
         #: -> Hash[String, Hash[String, Hash[String, String]]]
         def gem_paths
           @gem_paths ||= T.let(

--- a/lib/ruby_lsp/listeners/document_symbol.rb
+++ b/lib/ruby_lsp/listeners/document_symbol.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module Listeners
     class DocumentSymbol
-      extend T::Sig
       include Requests::Support::Common
 
       ATTR_ACCESSORS = T.let([:attr_reader, :attr_writer, :attr_accessor].freeze, T::Array[Symbol])

--- a/lib/ruby_lsp/listeners/folding_ranges.rb
+++ b/lib/ruby_lsp/listeners/folding_ranges.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module Listeners
     class FoldingRanges
-      extend T::Sig
       include Requests::Support::Common
 
       #: (ResponseBuilders::CollectionResponseBuilder[Interface::FoldingRange] response_builder, Array[Prism::Comment] comments, Prism::Dispatcher dispatcher) -> void

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module Listeners
     class Hover
-      extend T::Sig
       include Requests::Support::Common
 
       ALLOWED_TARGETS = T.let(

--- a/lib/ruby_lsp/listeners/inlay_hints.rb
+++ b/lib/ruby_lsp/listeners/inlay_hints.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module Listeners
     class InlayHints
-      extend T::Sig
       include Requests::Support::Common
 
       RESCUE_STRING_LENGTH = T.let("rescue".length, Integer)

--- a/lib/ruby_lsp/listeners/semantic_highlighting.rb
+++ b/lib/ruby_lsp/listeners/semantic_highlighting.rb
@@ -5,7 +5,6 @@ module RubyLsp
   module Listeners
     class SemanticHighlighting
       include Requests::Support::Common
-      extend T::Sig
 
       SPECIAL_RUBY_METHODS = T.let(
         [

--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module Listeners
     class SignatureHelp
-      extend T::Sig
       include Requests::Support::Common
 
       #: (ResponseBuilders::SignatureHelp response_builder, GlobalState global_state, NodeContext node_context, Prism::Dispatcher dispatcher, RubyDocument::SorbetLevel sorbet_level) -> void

--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -5,15 +5,12 @@ module RubyLsp
   module Listeners
     class TestStyle
       class << self
-        extend T::Sig
-
         #: (Array[Hash[Symbol, untyped]]) -> Array[String]
         def resolve_test_commands(items)
           []
         end
       end
 
-      extend T::Sig
       include Requests::Support::Common
 
       ACCESS_MODIFIERS = [:public, :private, :protected].freeze

--- a/lib/ruby_lsp/node_context.rb
+++ b/lib/ruby_lsp/node_context.rb
@@ -5,8 +5,6 @@ module RubyLsp
   # This class allows listeners to access contextual information about a node in the AST, such as its parent,
   # its namespace nesting, and the surrounding CallNode (e.g. a method call).
   class NodeContext
-    extend T::Sig
-
     #: Prism::Node?
     attr_reader :node, :parent
 

--- a/lib/ruby_lsp/rbs_document.rb
+++ b/lib/ruby_lsp/rbs_document.rb
@@ -3,7 +3,6 @@
 
 module RubyLsp
   class RBSDocument < Document
-    extend T::Sig
     extend T::Generic
 
     ParseResultType = type_member { { fixed: T::Array[RBS::AST::Declarations::Base] } }

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -7,7 +7,6 @@ module RubyLsp
     # request is used to to resolve the edit field for a given code action, if it is not already provided in the
     # textDocument/codeAction response. We can use it for scenarios that require more computation such as refactoring.
     class CodeActionResolve < Request
-      extend T::Sig
       include Support::Common
 
       NEW_VARIABLE_NAME = "new_variable"

--- a/lib/ruby_lsp/requests/code_actions.rb
+++ b/lib/ruby_lsp/requests/code_actions.rb
@@ -7,8 +7,6 @@ module RubyLsp
     # request informs the editor of RuboCop quick fixes that can be applied. These are accessible by hovering over a
     # specific diagnostic.
     class CodeActions < Request
-      extend T::Sig
-
       EXTRACT_TO_VARIABLE_TITLE = "Refactor: Extract Variable"
       EXTRACT_TO_METHOD_TITLE = "Refactor: Extract Method"
       TOGGLE_BLOCK_STYLE_TITLE = "Refactor: Toggle block style"
@@ -29,8 +27,6 @@ module RubyLsp
       )
 
       class << self
-        extend T::Sig
-
         #: -> Interface::CodeActionRegistrationOptions
         def provider
           Interface::CodeActionRegistrationOptions.new(

--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -11,11 +11,7 @@ module RubyLsp
     # [code lens](https://microsoft.github.io/language-server-protocol/specification#textDocument_codeLens)
     # request informs the editor of runnable commands such as testing and debugging.
     class CodeLens < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> Interface::CodeLensOptions
         def provider
           Interface::CodeLensOptions.new(resolve_provider: false)

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -8,11 +8,7 @@ module RubyLsp
     # The [completion](https://microsoft.github.io/language-server-protocol/specification#textDocument_completion)
     # suggests possible completions according to what the developer is typing.
     class Completion < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> Interface::CompletionOptions
         def provider
           Interface::CompletionOptions.new(

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -14,7 +14,6 @@ module RubyLsp
     # At most 10 definitions are included, to ensure low latency during request processing and rendering the completion
     # item.
     class CompletionResolve < Request
-      extend T::Sig
       include Requests::Support::Common
 
       # set a limit on the number of documentation entries returned, to avoid rendering performance issues

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -9,7 +9,6 @@ module RubyLsp
     # request](https://microsoft.github.io/language-server-protocol/specification#textDocument_definition) jumps to the
     # definition of the symbol under the cursor.
     class Definition < Request
-      extend T::Sig
       extend T::Generic
 
       #: ((RubyDocument | ERBDocument) document, GlobalState global_state, Hash[Symbol, untyped] position, Prism::Dispatcher dispatcher, RubyDocument::SorbetLevel sorbet_level) -> void

--- a/lib/ruby_lsp/requests/diagnostics.rb
+++ b/lib/ruby_lsp/requests/diagnostics.rb
@@ -7,11 +7,7 @@ module RubyLsp
     # [diagnostics](https://microsoft.github.io/language-server-protocol/specification#textDocument_publishDiagnostics)
     # request informs the editor of RuboCop offenses for a given file.
     class Diagnostics < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> Interface::DiagnosticRegistrationOptions
         def provider
           Interface::DiagnosticRegistrationOptions.new(

--- a/lib/ruby_lsp/requests/discover_tests.rb
+++ b/lib/ruby_lsp/requests/discover_tests.rb
@@ -8,7 +8,6 @@ module RubyLsp
     # This is a custom request to ask the server to parse a test file and discover all available examples in it. Add-ons
     # can augment the behavior through listeners, allowing them to handle discovery for different frameworks
     class DiscoverTests < Request
-      extend T::Sig
       include Support::Common
 
       #: (GlobalState global_state, RubyDocument document, Prism::Dispatcher dispatcher) -> void

--- a/lib/ruby_lsp/requests/document_highlight.rb
+++ b/lib/ruby_lsp/requests/document_highlight.rb
@@ -13,8 +13,6 @@ module RubyLsp
     # For writable elements like constants or variables, their read/write occurrences should be highlighted differently.
     # This is achieved by sending different "kind" attributes to the editor (2 for read and 3 for write).
     class DocumentHighlight < Request
-      extend T::Sig
-
       #: (GlobalState global_state, (RubyDocument | ERBDocument) document, Hash[Symbol, untyped] position, Prism::Dispatcher dispatcher) -> void
       def initialize(global_state, document, position, dispatcher)
         super()

--- a/lib/ruby_lsp/requests/document_link.rb
+++ b/lib/ruby_lsp/requests/document_link.rb
@@ -9,11 +9,7 @@ module RubyLsp
     # makes `# source://PATH_TO_FILE#line` comments in a Ruby/RBI file clickable if the file exists.
     # When the user clicks the link, it'll open that location.
     class DocumentLink < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> Interface::DocumentLinkOptions
         def provider
           Interface::DocumentLinkOptions.new(resolve_provider: false)

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -13,11 +13,7 @@ module RubyLsp
     # In VS Code, symbol search known as 'Go To Symbol in Editor' and can be accessed with Ctrl/Cmd-Shift-O,
     # or by opening the command palette and inserting an `@` symbol.
     class DocumentSymbol < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> Interface::DocumentSymbolOptions
         def provider
           Interface::DocumentSymbolOptions.new

--- a/lib/ruby_lsp/requests/folding_ranges.rb
+++ b/lib/ruby_lsp/requests/folding_ranges.rb
@@ -8,11 +8,7 @@ module RubyLsp
     # The [folding ranges](https://microsoft.github.io/language-server-protocol/specification#textDocument_foldingRange)
     # request informs the editor of the ranges where and how code can be folded.
     class FoldingRanges < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> TrueClass
         def provider
           true

--- a/lib/ruby_lsp/requests/formatting.rb
+++ b/lib/ruby_lsp/requests/formatting.rb
@@ -7,13 +7,9 @@ module RubyLsp
     # request uses RuboCop to fix auto-correctable offenses in the document. This requires enabling format on save and
     # registering the ruby-lsp as the Ruby formatter.
     class Formatting < Request
-      extend T::Sig
-
       class Error < StandardError; end
 
       class << self
-        extend T::Sig
-
         #: -> TrueClass
         def provider
           true

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -8,12 +8,9 @@ module RubyLsp
     # The [hover request](https://microsoft.github.io/language-server-protocol/specification#textDocument_hover)
     # displays the documentation for the symbol currently under the cursor.
     class Hover < Request
-      extend T::Sig
       extend T::Generic
 
       class << self
-        extend T::Sig
-
         #: -> Interface::HoverOptions
         def provider
           Interface::HoverOptions.new

--- a/lib/ruby_lsp/requests/inlay_hints.rb
+++ b/lib/ruby_lsp/requests/inlay_hints.rb
@@ -9,11 +9,7 @@ module RubyLsp
     # are labels added directly in the code that explicitly show the user something that might
     # otherwise just be implied.
     class InlayHints < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> Interface::InlayHintOptions
         def provider
           Interface::InlayHintOptions.new(resolve_provider: false)

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -6,11 +6,7 @@ module RubyLsp
     # The [on type formatting](https://microsoft.github.io/language-server-protocol/specification#textDocument_onTypeFormatting)
     # request formats code as the user is typing. For example, automatically adding `end` to class definitions.
     class OnTypeFormatting < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> Interface::DocumentOnTypeFormattingRegistrationOptions
         def provider
           Interface::DocumentOnTypeFormattingRegistrationOptions.new(

--- a/lib/ruby_lsp/requests/prepare_rename.rb
+++ b/lib/ruby_lsp/requests/prepare_rename.rb
@@ -7,7 +7,6 @@ module RubyLsp
     # [prepare_rename](https://microsoft.github.io/language-server-protocol/specification#textDocument_prepareRename)
     # # request checks the validity of a rename operation at a given location.
     class PrepareRename < Request
-      extend T::Sig
       include Support::Common
 
       #: (RubyDocument document, Hash[Symbol, untyped] position) -> void

--- a/lib/ruby_lsp/requests/prepare_type_hierarchy.rb
+++ b/lib/ruby_lsp/requests/prepare_type_hierarchy.rb
@@ -9,13 +9,9 @@ module RubyLsp
     #
     # Currently only supports supertypes due to a limitation of the index.
     class PrepareTypeHierarchy < Request
-      extend T::Sig
-
       include Support::Common
 
       class << self
-        extend T::Sig
-
         #: -> Interface::TypeHierarchyOptions
         def provider
           Interface::TypeHierarchyOptions.new

--- a/lib/ruby_lsp/requests/range_formatting.rb
+++ b/lib/ruby_lsp/requests/range_formatting.rb
@@ -6,8 +6,6 @@ module RubyLsp
     # The [range formatting](https://microsoft.github.io/language-server-protocol/specification#textDocument_rangeFormatting)
     # is used to format a selection or to format on paste.
     class RangeFormatting < Request
-      extend T::Sig
-
       #: (GlobalState global_state, RubyDocument document, Hash[Symbol, untyped] params) -> void
       def initialize(global_state, document, params)
         super()

--- a/lib/ruby_lsp/requests/references.rb
+++ b/lib/ruby_lsp/requests/references.rb
@@ -7,7 +7,6 @@ module RubyLsp
     # [references](https://microsoft.github.io/language-server-protocol/specification#textDocument_references)
     # request finds all references for the selected symbol.
     class References < Request
-      extend T::Sig
       include Support::Common
 
       #: (GlobalState global_state, Store store, (RubyDocument | ERBDocument) document, Hash[Symbol, untyped] params) -> void

--- a/lib/ruby_lsp/requests/rename.rb
+++ b/lib/ruby_lsp/requests/rename.rb
@@ -7,14 +7,11 @@ module RubyLsp
     # [rename](https://microsoft.github.io/language-server-protocol/specification#textDocument_rename)
     # request renames all instances of a symbol in a document.
     class Rename < Request
-      extend T::Sig
       include Support::Common
 
       class InvalidNameError < StandardError; end
 
       class << self
-        extend T::Sig
-
         #: -> Interface::RenameOptions
         def provider
           Interface::RenameOptions.new(prepare_provider: true)

--- a/lib/ruby_lsp/requests/request.rb
+++ b/lib/ruby_lsp/requests/request.rb
@@ -4,8 +4,8 @@
 module RubyLsp
   module Requests
     class Request
-      extend T::Sig
       extend T::Generic
+      extend T::Sig
 
       class InvalidFormatter < StandardError; end
 

--- a/lib/ruby_lsp/requests/selection_ranges.rb
+++ b/lib/ruby_lsp/requests/selection_ranges.rb
@@ -11,7 +11,6 @@ module RubyLsp
     #
     # Note that if using VSCode Neovim, you will need to be in Insert mode for this to work correctly.
     class SelectionRanges < Request
-      extend T::Sig
       include Support::Common
 
       #: ((RubyDocument | ERBDocument) document) -> void

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -9,11 +9,7 @@ module RubyLsp
     # highlighting](https://microsoft.github.io/language-server-protocol/specification#textDocument_semanticTokens)
     # request informs the editor of the correct token types to provide consistent and accurate highlighting for themes.
     class SemanticHighlighting < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> Interface::SemanticTokensRegistrationOptions
         def provider
           Interface::SemanticTokensRegistrationOptions.new(

--- a/lib/ruby_lsp/requests/show_syntax_tree.rb
+++ b/lib/ruby_lsp/requests/show_syntax_tree.rb
@@ -7,8 +7,6 @@ module RubyLsp
     # request](https://microsoft.github.io/language-server-protocol/specification#requestMessage) that displays the AST
     # for the current document or for the current selection in a new tab.
     class ShowSyntaxTree < Request
-      extend T::Sig
-
       #: (RubyDocument document, Hash[Symbol, untyped]? range) -> void
       def initialize(document, range)
         super()

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -9,11 +9,7 @@ module RubyLsp
     # request](https://microsoft.github.io/language-server-protocol/specification#textDocument_signatureHelp) displays
     # information about the parameters of a method as you type an invocation.
     class SignatureHelp < Request
-      extend T::Sig
-
       class << self
-        extend T::Sig
-
         #: -> Interface::SignatureHelpOptions
         def provider
           # Identifier characters are automatically included, such as A-Z, a-z, 0-9, _, * or :

--- a/lib/ruby_lsp/requests/support/annotation.rb
+++ b/lib/ruby_lsp/requests/support/annotation.rb
@@ -5,7 +5,6 @@ module RubyLsp
   module Requests
     module Support
       class Annotation
-        extend T::Sig
         #: (arity: (Integer | T::Range[Integer]), ?receiver: bool) -> void
         def initialize(arity:, receiver: false)
           @arity = arity

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -8,7 +8,6 @@ module RubyLsp
         # WARNING: Methods in this class may be used by Ruby LSP add-ons such as
         # https://github.com/Shopify/ruby-lsp-rails, or add-ons by created by developers outside of Shopify, so be
         # cautious of changing anything.
-        extend T::Sig
         extend T::Helpers
 
         requires_ancestor { Kernel }

--- a/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_diagnostic.rb
@@ -5,8 +5,6 @@ module RubyLsp
   module Requests
     module Support
       class RuboCopDiagnostic
-        extend T::Sig
-
         RUBOCOP_TO_LSP_SEVERITY = T.let(
           {
             info: Constant::DiagnosticSeverity::HINT,

--- a/lib/ruby_lsp/requests/support/rubocop_formatter.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_formatter.rb
@@ -9,7 +9,6 @@ module RubyLsp
   module Requests
     module Support
       class RuboCopFormatter
-        extend T::Sig
         include Formatter
 
         #: -> void

--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -32,8 +32,6 @@ module RubyLsp
   module Requests
     module Support
       class InternalRuboCopError < StandardError
-        extend T::Sig
-
         MESSAGE = <<~EOS
           An internal error occurred %s.
           Updating to a newer version of RuboCop may solve this.
@@ -54,8 +52,6 @@ module RubyLsp
 
       # :nodoc:
       class RuboCopRunner < ::RuboCop::Runner
-        extend T::Sig
-
         class ConfigurationError < StandardError; end
 
         DEFAULT_ARGS = T.let(
@@ -127,8 +123,6 @@ module RubyLsp
         end
 
         class << self
-          extend T::Sig
-
           #: (String cop_name) -> singleton(::RuboCop::Cop::Base)?
           def find_cop_by_name(cop_name)
             cop_registry[cop_name]&.first

--- a/lib/ruby_lsp/requests/support/selection_range.rb
+++ b/lib/ruby_lsp/requests/support/selection_range.rb
@@ -5,8 +5,6 @@ module RubyLsp
   module Requests
     module Support
       class SelectionRange < Interface::SelectionRange
-        extend T::Sig
-
         #: (Hash[Symbol, untyped] position) -> bool
         def cover?(position)
           start_covered = range.start.line < position[:line] ||

--- a/lib/ruby_lsp/requests/support/sorbet.rb
+++ b/lib/ruby_lsp/requests/support/sorbet.rb
@@ -6,8 +6,6 @@ module RubyLsp
     module Support
       class Sorbet
         class << self
-          extend T::Sig
-
           ANNOTATIONS = T.let(
             {
               abstract!: Annotation.new(arity: 0),

--- a/lib/ruby_lsp/requests/support/source_uri.rb
+++ b/lib/ruby_lsp/requests/support/source_uri.rb
@@ -6,8 +6,6 @@ require "uri/file"
 module URI
   # Must be kept in sync with the one in Tapioca
   class Source < URI::File
-    extend T::Sig
-
     COMPONENT = T.let(
       [
         :scheme,
@@ -33,8 +31,6 @@ module URI
     attr_reader :gem_version
 
     class << self
-      extend T::Sig
-
       #: (gem_name: String, gem_version: String?, path: String, line_number: String?) -> URI::Source
       def build(gem_name:, gem_version:, path:, line_number:)
         super(

--- a/lib/ruby_lsp/requests/support/syntax_tree_formatter.rb
+++ b/lib/ruby_lsp/requests/support/syntax_tree_formatter.rb
@@ -13,7 +13,6 @@ module RubyLsp
     module Support
       # :nodoc:
       class SyntaxTreeFormatter
-        extend T::Sig
         include Support::Formatter
 
         #: -> void

--- a/lib/ruby_lsp/requests/support/test_item.rb
+++ b/lib/ruby_lsp/requests/support/test_item.rb
@@ -10,8 +10,6 @@ module RubyLsp
       # Note: this test item object can only represent test groups or examples discovered inside files. It cannot be
       # used to represent test files, directories or workspaces
       class TestItem
-        extend T::Sig
-
         #: String
         attr_reader :id, :label
 

--- a/lib/ruby_lsp/requests/type_hierarchy_supertypes.rb
+++ b/lib/ruby_lsp/requests/type_hierarchy_supertypes.rb
@@ -7,8 +7,6 @@ module RubyLsp
     # request](https://microsoft.github.io/language-server-protocol/specification#typeHierarchy_supertypes)
     # displays the list of ancestors (supertypes) for the selected type.
     class TypeHierarchySupertypes < Request
-      extend T::Sig
-
       include Support::Common
 
       #: (RubyIndexer::Index index, Hash[Symbol, untyped] item) -> void

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -7,7 +7,6 @@ module RubyLsp
     # request allows fuzzy searching declarations in the entire project. On VS Code, use CTRL/CMD + T to search for
     # symbols.
     class WorkspaceSymbol < Request
-      extend T::Sig
       include Support::Common
 
       #: (GlobalState global_state, String? query) -> void

--- a/lib/ruby_lsp/response_builders/collection_response_builder.rb
+++ b/lib/ruby_lsp/response_builders/collection_response_builder.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module ResponseBuilders
     class CollectionResponseBuilder < ResponseBuilder
-      extend T::Sig
       extend T::Generic
 
       ResponseType = type_member { { upper: Object } }

--- a/lib/ruby_lsp/response_builders/document_symbol.rb
+++ b/lib/ruby_lsp/response_builders/document_symbol.rb
@@ -4,13 +4,9 @@
 module RubyLsp
   module ResponseBuilders
     class DocumentSymbol < ResponseBuilder
-      extend T::Sig
-
       ResponseType = type_member { { fixed: T::Array[Interface::DocumentSymbol] } }
 
       class SymbolHierarchyRoot
-        extend T::Sig
-
         #: Array[Interface::DocumentSymbol]
         attr_reader :children
 

--- a/lib/ruby_lsp/response_builders/hover.rb
+++ b/lib/ruby_lsp/response_builders/hover.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module ResponseBuilders
     class Hover < ResponseBuilder
-      extend T::Sig
       extend T::Generic
 
       ResponseType = type_member { { fixed: String } }

--- a/lib/ruby_lsp/response_builders/response_builder.rb
+++ b/lib/ruby_lsp/response_builders/response_builder.rb
@@ -4,8 +4,8 @@
 module RubyLsp
   module ResponseBuilders
     class ResponseBuilder
-      extend T::Sig
       extend T::Generic
+      extend T::Sig
 
       abstract!
 

--- a/lib/ruby_lsp/response_builders/semantic_highlighting.rb
+++ b/lib/ruby_lsp/response_builders/semantic_highlighting.rb
@@ -6,8 +6,6 @@ module RubyLsp
     class SemanticHighlighting < ResponseBuilder
       class UndefinedTokenType < StandardError; end
 
-      extend T::Sig
-
       TOKEN_TYPES = T.let(
         {
           namespace: 0,
@@ -99,8 +97,6 @@ module RubyLsp
       end
 
       class SemanticToken
-        extend T::Sig
-
         #: Integer
         attr_reader :start_line
 
@@ -145,8 +141,6 @@ module RubyLsp
       end
 
       class SemanticTokenEncoder
-        extend T::Sig
-
         #: -> void
         def initialize
           @current_row = T.let(0, Integer)

--- a/lib/ruby_lsp/response_builders/signature_help.rb
+++ b/lib/ruby_lsp/response_builders/signature_help.rb
@@ -4,8 +4,6 @@
 module RubyLsp
   module ResponseBuilders
     class SignatureHelp < ResponseBuilder
-      extend T::Sig
-
       ResponseType = type_member { { fixed: T.nilable(Interface::SignatureHelp) } }
 
       #: -> void

--- a/lib/ruby_lsp/response_builders/test_collection.rb
+++ b/lib/ruby_lsp/response_builders/test_collection.rb
@@ -4,7 +4,6 @@
 module RubyLsp
   module ResponseBuilders
     class TestCollection < ResponseBuilder
-      extend T::Sig
       extend T::Generic
 
       ResponseType = type_member { { fixed: Requests::Support::TestItem } }

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -3,7 +3,6 @@
 
 module RubyLsp
   class RubyDocument < Document
-    extend T::Sig
     extend T::Generic
 
     ParseResultType = type_member { { fixed: Prism::ParseResult } }
@@ -35,8 +34,6 @@ module RubyLsp
     end
 
     class << self
-      extend T::Sig
-
       #: (Prism::Node node, Integer char_position, code_units_cache: (^(Integer arg0) -> Integer | Prism::CodeUnitsCache), ?node_types: Array[singleton(Prism::Node)]) -> NodeContext
       def locate(node, char_position, code_units_cache:, node_types: [])
         queue = T.let(node.child_nodes.compact, T::Array[T.nilable(Prism::Node)])

--- a/lib/ruby_lsp/scope.rb
+++ b/lib/ruby_lsp/scope.rb
@@ -3,8 +3,6 @@
 
 module RubyLsp
   class Scope
-    extend T::Sig
-
     #: Scope?
     attr_reader :parent
 
@@ -33,8 +31,6 @@ module RubyLsp
     end
 
     class Local
-      extend T::Sig
-
       #: Symbol
       attr_reader :type
 

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -3,8 +3,6 @@
 
 module RubyLsp
   class Server < BaseServer
-    extend T::Sig
-
     # Only for testing
     #: GlobalState
     attr_reader :global_state

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -3,8 +3,6 @@
 
 module RubyLsp
   class Store
-    extend T::Sig
-
     class NonExistingDocumentError < StandardError; end
 
     #: Hash[Symbol, RequestConfig]

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -7,7 +7,6 @@ module RubyLsp
   module TestHelper
     class TestError < StandardError; end
 
-    extend T::Sig
     extend T::Helpers
 
     requires_ancestor { Kernel }

--- a/lib/ruby_lsp/type_inferrer.rb
+++ b/lib/ruby_lsp/type_inferrer.rb
@@ -5,8 +5,6 @@ module RubyLsp
   # A minimalistic type checker to try to resolve types that can be inferred without requiring a type system or
   # annotations
   class TypeInferrer
-    extend T::Sig
-
     #: (RubyIndexer::Index index) -> void
     def initialize(index)
       @index = index
@@ -168,8 +166,6 @@ module RubyLsp
 
     # A known type
     class Type
-      extend T::Sig
-
       #: String
       attr_reader :name
 

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -64,8 +64,6 @@ module RubyLsp
 
   class Notification < Message
     class << self
-      extend T::Sig
-
       #: (String message, ?type: Integer) -> Notification
       def window_show_message(message, type: Constant::MessageType::INFO)
         new(
@@ -141,8 +139,6 @@ module RubyLsp
       end
     end
 
-    extend T::Sig
-
     # @override
     #: -> Hash[Symbol, untyped]
     def to_hash
@@ -153,11 +149,7 @@ module RubyLsp
   end
 
   class Request < Message
-    extend T::Sig
-
     class << self
-      extend T::Sig
-
       #: (Integer id, (Interface::RelativePattern | String) pattern, ?kind: Integer, ?registration_id: String?) -> Request
       def register_watched_files(
         id,
@@ -201,8 +193,6 @@ module RubyLsp
   end
 
   class Error
-    extend T::Sig
-
     #: String
     attr_reader :message
 
@@ -232,8 +222,6 @@ module RubyLsp
 
   # The final result of running a request before its IO is finalized
   class Result
-    extend T::Sig
-
     #: untyped
     attr_reader :response
 
@@ -254,8 +242,6 @@ module RubyLsp
 
   # A request configuration, to turn on/off features
   class RequestConfig
-    extend T::Sig
-
     #: Hash[Symbol, bool]
     attr_accessor :configuration
 

--- a/test/requests/support/sorbet_test.rb
+++ b/test/requests/support/sorbet_test.rb
@@ -4,8 +4,6 @@
 require "test_helper"
 
 class SorbetTest < Minitest::Test
-  extend T::Sig
-
   def test_abstract!
     assert(annotation?("abstract!"))
     assert(annotation?("abstract!()"))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,7 +44,6 @@ Minitest::Reporters.use!(minitest_reporter)
 
 module Minitest
   class Test
-    extend T::Sig
     include RubyLsp::TestHelper
 
     Minitest::Test.make_my_diffs_pretty!


### PR DESCRIPTION
(we still need it some places for `abstract!`)