### PR TITLE
Resolve commands for test unit items

### DIFF
--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -25,6 +25,7 @@ require "fileutils"
 require "open3"
 require "securerandom"
 require "shellwords"
+require "set"
 
 require "ruby-lsp"
 require "ruby_lsp/base_server"

--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -4,7 +4,7 @@
 require "test_helper"
 
 module RubyLsp
-  class ResolveTestCommandsTest < Minitest::Test
+  class ResolveTestCommandsMinitestTest < Minitest::Test
     def test_resolve_test_command_specific_examples
       with_server do |server|
         server.process_message({
@@ -566,6 +566,502 @@ module RubyLsp
         assert_equal(
           [
             "bundle exec ruby -Itest /test/server_test.rb --name \"/^ServerTest#test_server$/\"",
+            "bundle exec ruby -Itest /test/unit/**/*",
+          ],
+          result[:commands],
+        )
+      end
+    end
+  end
+
+  class ResolveTestCommandsTestUnitTest < Minitest::Test
+    def test_resolve_test_command_specific_examples
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerTest",
+                uri: "file:///test/server_test.rb",
+                label: "ServerTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [
+                  {
+                    id: "ServerTest#test_server",
+                    uri: "file:///test/server_test.rb",
+                    label: "test_server",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["test_unit"],
+                    children: [],
+                  },
+                ],
+              },
+              {
+                id: "StoreTest",
+                uri: "file:///test/store_test.rb",
+                label: "StoreTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [
+                  {
+                    id: "StoreTest#test_store",
+                    uri: "file:///test/store_test.rb",
+                    label: "test_store",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["test_unit"],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest$/\" --name \"/test_server$/\"",
+            "bundle exec ruby -Itest /test/store_test.rb --testcase \"/^StoreTest$/\" --name \"/test_store$/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
+
+    def test_resolve_test_command_group_mixed_with_examples
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerTest",
+                uri: "file:///test/server_test.rb",
+                label: "ServerTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [],
+              },
+              {
+                id: "StoreTest",
+                uri: "file:///test/store_test.rb",
+                label: "StoreTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [
+                  {
+                    id: "StoreTest#test_store",
+                    uri: "file:///test/store_test.rb",
+                    label: "test_store",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["test_unit"],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest$/\"",
+            "bundle exec ruby -Itest /test/store_test.rb --testcase \"/^StoreTest$/\" --name \"/test_store$/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
+
+    def test_resolve_test_command_multiple_examples_from_same_group
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerTest",
+                uri: "file:///test/server_test.rb",
+                label: "ServerTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_uni", "test_group"],
+                children: [
+                  {
+                    id: "ServerTest#test_server",
+                    uri: "file:///test/server_test.rb",
+                    label: "test_server",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["test_unit"],
+                    children: [],
+                  },
+                  {
+                    id: "ServerTest#test_server_again",
+                    uri: "file:///test/server_test.rb",
+                    label: "test_server_again",
+                    range: {
+                      start: { line: 12, character: 2 },
+                      end: { line: 30, character: 3 },
+                    },
+                    tags: ["test_unit"],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest$/\" " \
+              "--name \"/(test_server|test_server_again)$/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
+
+    def test_resolve_test_command_multiple_test_groups
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerTest",
+                uri: "file:///test/server_test.rb",
+                label: "ServerTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [],
+              },
+              {
+                id: "OtherServerTest",
+                uri: "file:///test/server_test.rb",
+                label: "OtherServerTest",
+                range: {
+                  start: { line: 32, character: 0 },
+                  end: { line: 60, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest$/\"",
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^OtherServerTest$/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
+
+    def test_resolve_test_command_complex_case
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerTest",
+                uri: "file:///test/server_test.rb",
+                label: "ServerTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [
+                  {
+                    id: "ServerTest#test_server",
+                    uri: "file:///test/server_test.rb",
+                    label: "test_server",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["test_unit"],
+                    children: [],
+                  },
+                  {
+                    id: "ServerTest#test_server_again",
+                    uri: "file:///test/server_test.rb",
+                    label: "test_server_again",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["test_unit"],
+                    children: [],
+                  },
+                ],
+              },
+              {
+                id: "OtherServerTest",
+                uri: "file:///test/server_test.rb",
+                label: "OtherServerTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [],
+              },
+              {
+                id: "StoreTest",
+                uri: "file:///test/store_test.rb",
+                label: "StoreTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [
+                  {
+                    id: "StoreTest#test_store",
+                    uri: "file:///test/store_test.rb",
+                    label: "test_store",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["test_unit"],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest$/\" " \
+              "--name \"/(test_server|test_server_again)$/\"",
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^OtherServerTest$/\"",
+            "bundle exec ruby -Itest /test/store_test.rb --testcase \"/^StoreTest$/\" --name \"/test_store$/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
+
+    def test_resolve_test_command_examples_with_dynamic_references
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "<dynamic_reference>::ServerTest",
+                uri: "file:///test/server_test.rb",
+                label: "<dynamic_reference>::ServerTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [
+                  {
+                    id: "<dynamic_reference>::ServerTest#test_server",
+                    uri: "file:///test/server_test.rb",
+                    label: "test_server",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["test_unit"],
+                    children: [],
+                  },
+                ],
+              },
+              {
+                id: "<dynamic_reference>::StoreTest",
+                uri: "file:///test/store_test.rb",
+                label: "<dynamic_reference>::StoreTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^.*::ServerTest$/\" --name \"/test_server$/\"",
+            "bundle exec ruby -Itest /test/store_test.rb --testcase \"/^.*::StoreTest$/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
+
+    def test_resolve_test_command_examples_with_no_parent_items
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "CompletionTest#test_with_typed_false",
+                label: "test_with_typed_false",
+                uri: "file:///test/requests/completion_test.rb",
+                tags: ["debug", "test_unit"],
+                children: [],
+                range: { start: { line: 704, character: 2 }, end: { line: 728, character: 5 } },
+              },
+              {
+                id: "CompletionTest#test_with_typed_true",
+                label: "test_with_typed_true",
+                uri: "file:///test/requests/completion_test.rb",
+                tags: ["debug", "test_unit"],
+                children: [],
+                range: { start: { line: 730, character: 2 }, end: { line: 754, character: 5 } },
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Itest /test/requests/completion_test.rb --testcase \"/^CompletionTest$/\" " \
+              "--name \"/(test_with_typed_false|test_with_typed_true)$/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
+
+    def test_resolve_test_command_nested_test_groups
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerTest::MainTest",
+                uri: "file:///test/server_test.rb",
+                label: "ServerTest::MainTest",
+                range: {
+                  start: { line: 10, character: 2 },
+                  end: { line: 20, character: 3 },
+                },
+                tags: ["test_unit", "test_group"],
+                children: [
+                  {
+                    id: "ServerTest::MainTest::NestedTest",
+                    uri: "file:///test/server_test.rb",
+                    label: "ServerTest::MainTest::NestedTest",
+                    range: {
+                      start: { line: 12, character: 4 },
+                      end: { line: 14, character: 5 },
+                    },
+                    tags: ["test_unit", "test_group"],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest::MainTest::NestedTest$/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
+
+    def test_resolve_test_command_mix_of_directories_and_examples
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "file:///test/unit",
+                uri: "file:///test/unit",
+                label: "/test/unit",
+                tags: ["test_dir"],
+                children: [],
+              },
+              {
+                id: "ServerTest#test_server",
+                uri: "file:///test/server_test.rb",
+                label: "test_server",
+                range: {
+                  start: { line: 1, character: 2 },
+                  end: { line: 10, character: 3 },
+                },
+                tags: ["test_unit"],
+                children: [],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest$/\" --name \"/test_server$/\"",
             "bundle exec ruby -Itest /test/unit/**/*",
           ],
           result[:commands],


### PR DESCRIPTION
### Motivation

Closes #3175

This PR implements test command solution for a hierarchy including Test Unit groups and examples.

### Implementation

The processing for entire directories or files is the same for both Minitest and Test Unit. Additionally, you can have test groups for both frameworks in the same file (just define multiple classes inheriting from different parents), but you cannot have examples belonging to different frameworks within the same group.

The idea is to partition the groups into Minitest and Test Unit and then we can handle them separately, with their own specific requirements.

Note that Test Unit has one small disadvantage for merging the command. It is not possible to execute examples from different groups in a single command. The reason is because class names are matched by the `--testcase` argument and `--name` only matches the method names. You can't create a single regex that will match multiple class/method combinations and you also cannot pass more than one testcase.

Because of these, I just created separate commands when we have examples filtered from different groups.

### Automated Tests

I added all of the same scenarios we have for Minitest, but changing it for Test Unit.