### PR TITLE
Fix #3265 (Environment variables can't be overridden in debug launch)

### DIFF
--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -112,10 +112,10 @@ export class Debugger
 
     if (debugConfiguration.env) {
       // If the user has their own debug launch configurations, we still need to inject the Ruby environment
-      debugConfiguration.env = Object.assign(
-        debugConfiguration.env,
-        workspace.ruby.env,
-      );
+      debugConfiguration.env = {
+        ...workspace.ruby.env,
+        ...debugConfiguration.env,
+      };
     } else {
       debugConfiguration.env = workspace.ruby.env;
     }


### PR DESCRIPTION
Fixes #3265

<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

I license this fix under public domain.

### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

https://stackoverflow.com/q/79419598/11107541 and associated #3265

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Make launch config env variables take precedence over variables from Ruby activation.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

I haven't written any, because I don't have the motivation to.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

See repro details in https://stackoverflow.com/q/79419598/11107541.
