### PR TITLE
Tag Test Unit and Minitest spec test items

### DIFF
--- a/lib/ruby_lsp/listeners/spec_style.rb
+++ b/lib/ruby_lsp/listeners/spec_style.rb
@@ -109,6 +109,7 @@ module RubyLsp
             description,
             @uri,
             range_from_node(node),
+            tags: [:minitest],
           )
           @response_builder.add(test_item)
         else
@@ -140,6 +141,7 @@ module RubyLsp
           description,
           @uri,
           range_from_node(node),
+          tags: [:minitest],
         )
         parent_test_group.add(test_item)
       end

--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -103,6 +103,7 @@ module RubyLsp
         @index = T.let(global_state.index, RubyIndexer::Index)
         @visibility_stack = T.let([:public], T::Array[Symbol])
         @nesting = T.let([], T::Array[String])
+        @framework_tag = T.let(:minitest, Symbol)
 
         dispatcher.register(
           self,
@@ -132,15 +133,15 @@ module RubyLsp
           [node.superclass&.slice].compact
         end
 
-        if attached_ancestors.include?("Test::Unit::TestCase") ||
-            non_declarative_minitest?(attached_ancestors, fully_qualified_name)
+        @framework_tag = :test_unit if attached_ancestors.include?("Test::Unit::TestCase")
 
+        if @framework_tag == :test_unit || non_declarative_minitest?(attached_ancestors, fully_qualified_name)
           @response_builder.add(Requests::Support::TestItem.new(
             fully_qualified_name,
             fully_qualified_name,
             @uri,
             range_from_node(node),
-            tags: [:minitest],
+            tags: [@framework_tag],
           ))
         end
 
@@ -189,7 +190,7 @@ module RubyLsp
           name,
           @uri,
           range_from_node(node),
-          tags: [:minitest],
+          tags: [@framework_tag],
         ))
       end
 

--- a/test/requests/discover_tests_test.rb
+++ b/test/requests/discover_tests_test.rb
@@ -21,6 +21,7 @@ module RubyLsp
           items[0][:children].map { |i| i[:label] },
         )
         assert_equal(["test_public", "test_public_2"], items[1][:children].map { |i| i[:label] })
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
@@ -46,6 +47,7 @@ module RubyLsp
         assert_equal(["test_baz"], items[3][:children].map { |i| i[:label] })
         assert_equal(["test_foo_bar", "test_foo_bar_2"], items[4][:children].map { |i| i[:label] })
         assert_equal(["test_foo_bar_baz"], items[5][:children].map { |i| i[:label] })
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
@@ -65,6 +67,7 @@ module RubyLsp
         assert_equal(["test_something", "test_something_else"], items[0][:children].map { |i| i[:label] })
         assert_equal(["test_nested"], items[1][:children].map { |i| i[:label] })
         assert_equal(["test_stuff", "test_other_stuff"], items[2][:children].map { |i| i[:label] })
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
@@ -90,6 +93,7 @@ module RubyLsp
 
         assert_equal(["test_something"], items[0][:children].map { |i| i[:label] })
         assert_equal(["test_hello"], items[1][:children].map { |i| i[:label] })
+        assert_all_items_tagged_with(items, :test_unit)
       end
     end
 
@@ -128,6 +132,7 @@ module RubyLsp
         )
         assert_equal(["test_something"], items[0][:children].map { |i| i[:label] })
         assert_equal(["test_something"], items[1][:children].map { |i| i[:label] })
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
@@ -155,6 +160,7 @@ module RubyLsp
         )
         assert_equal(["test_something"], items[0][:children].map { |i| i[:label] })
         assert_equal(["test_something"], items[1][:children].map { |i| i[:label] })
+        assert_all_items_tagged_with(items, :test_unit)
       end
     end
 
@@ -187,6 +193,7 @@ module RubyLsp
           items.map { |i| i[:label] },
         )
         assert_equal(["test_something"], items[0][:children].map { |i| i[:label] })
+        assert_all_items_tagged_with(items, :test_unit)
       end
     ensure
       FileUtils.rm(T.must(path))
@@ -212,6 +219,7 @@ module RubyLsp
 
         test_something = children[0]
         assert_equal(5, test_something[:range].start.line)
+        assert_all_items_tagged_with(items, :test_unit)
       end
     end
 
@@ -220,6 +228,7 @@ module RubyLsp
 
       with_minitest_spec_configured(source) do |items|
         assert_equal(["BogusSpec"], items.map { |i| i[:label] })
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
@@ -238,6 +247,7 @@ module RubyLsp
           ["test one", "test two", "test three"],
           nested_specs.map { |i| i[:label] },
         )
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
@@ -256,6 +266,7 @@ module RubyLsp
           ["it_level_one", "nested", "it_level_one_again"],
           nested_specs.map { |i| i[:label] },
         )
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
@@ -268,6 +279,7 @@ module RubyLsp
           ["dynamic_name"],
           nested_specs.map { |i| i[:label] },
         )
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
@@ -277,6 +289,7 @@ module RubyLsp
       with_minitest_spec_configured(source) do |items|
         nested_specs = items[0][:children][0][:children]
         assert_empty(nested_specs)
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
@@ -299,10 +312,19 @@ module RubyLsp
           ],
           items[0][:children].map { |i| i[:label] },
         )
+        assert_all_items_tagged_with(items, :minitest)
       end
     end
 
     private
+
+    def assert_all_items_tagged_with(items, tag)
+      items.each do |item|
+        assert_includes(item[:tags], tag)
+        children = item[:children]
+        assert_all_items_tagged_with(children, tag) unless children.empty?
+      end
+    end
 
     def with_minitest_test(source, &block)
       with_server(source) do |server, uri|


### PR DESCRIPTION
### Motivation

We need to ensure that all test items are properly tagged with the framework they are related to so that we can resolve commands.

We were talking about refactoring this to be a separate attribute in test items, but let's first ensure that all items tag and then we move ahead with the refactor.

### Implementation

Ensured `Minitest::Spec` and `Test::Unit::TestCase` tests are all tagged.

### Automated Tests

Added tests verifying that all test groups and their children are tagged with a framework.