### PR TITLE
Prevent race condition when saving file during initial indexing

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -13,6 +13,9 @@ module RubyIndexer
     #: Configuration
     attr_reader :configuration
 
+    #: bool
+    attr_reader :initial_indexing_completed
+
     class << self
       # Returns the real nesting of a constant name taking into account top level
       # references that may be included anywhere in the name or nesting where that
@@ -366,8 +369,6 @@ module RubyIndexer
           "The index is not empty. To prevent invalid entries, `index_all` can only be called once."
       end
 
-      @initial_indexing_completed = true
-
       RBSIndexer.new(self).index_ruby_core
       # Calculate how many paths are worth 1% of progress
       progress_step = (uris.length / 100.0).ceil
@@ -380,6 +381,8 @@ module RubyIndexer
 
         index_file(uri, collect_comments: false)
       end
+
+      @initial_indexing_completed = true
     end
 
     #: (URI::Generic uri, String source, ?collect_comments: bool) -> void


### PR DESCRIPTION
### Motivation

We had two cases for possible race conditions, which may be related to some of the issues the community has been reported about the LSP getting stuck.

1. We were not handling Ruby file changes under a mutex lock
2. If the user saved a file before initial indexing is complete, that would index the same file without handling changes twice, resulting in duplicate entries

### Implementation

Added the mutex lock for processing the did change watched file notifications. For 2), I started delaying the processing of these notifications until indexing is complete so that changes are only processed when the index state is stabled.

### Automated Tests

Added a test that reproduces the duplicate entries.