### PR TITLE
Allow add-ons to extend test discovery

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -233,5 +233,10 @@ module RubyLsp
     # @overridable
     #: (ResponseBuilders::CollectionResponseBuilder[Interface::CompletionItem] response_builder, NodeContext node_context, Prism::Dispatcher dispatcher, URI::Generic uri) -> void
     def create_completion_listener(response_builder, node_context, dispatcher, uri); end
+
+    # Creates a new Discover Tests listener. This method is invoked on every DiscoverTests request
+    # @overridable
+    #: (ResponseBuilders::TestCollection response_builder, Prism::Dispatcher dispatcher, URI::Generic uri) -> void
+    def create_discover_tests_listener(response_builder, dispatcher, uri); end
   end
 end

--- a/lib/ruby_lsp/requests/discover_tests.rb
+++ b/lib/ruby_lsp/requests/discover_tests.rb
@@ -38,6 +38,11 @@ module RubyLsp
         if @index.entries_for(uri.to_s)
           Listeners::TestStyle.new(@response_builder, @global_state, @dispatcher, @document.uri)
           Listeners::SpecStyle.new(@response_builder, @global_state, @dispatcher, @document.uri)
+
+          Addon.addons.each do |addon|
+            addon.create_discover_tests_listener(@response_builder, @dispatcher, @document.uri)
+          end
+
           @dispatcher.visit(@document.parse_result.value)
         else
           @global_state.synchronize do
@@ -51,6 +56,10 @@ module RubyLsp
 
             Listeners::TestStyle.new(@response_builder, @global_state, @dispatcher, @document.uri)
             Listeners::SpecStyle.new(@response_builder, @global_state, @dispatcher, @document.uri)
+
+            Addon.addons.each do |addon|
+              addon.create_discover_tests_listener(@response_builder, @dispatcher, @document.uri)
+            end
 
             # Dispatch the events both for indexing the test file and discovering the tests. The order here is
             # important because we need the index to be aware of the existing classes/modules/methods before the test


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

Closes #3172 

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The Ruby LSP currently provides test discovery for standard frameworks like `Minitest` and `Test::Unit`. Users working with custom testing frameworks or DSLs need the ability to discover and run those tests as well.

This PR adds support for add-ons to extend test discovery.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Added support for test discovery add-ons by:

- Adding an overridable listener `create_discover_tests_listener` to the `Addon` class
- Calling this method on each registered add-on during test discovery

This enables add-ons to extend Ruby LSP's test discovery with custom test frameworks or DSLs.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

- Added a test to verify the add-on mechanism works correctly

<!--  ### Manual Tests

Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
