### PR TITLE
Refactor: centralize add-on cleanup in test helper

### DIFF
--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -43,6 +43,7 @@ module RubyLsp
       ensure
         if load_addons
           RubyLsp::Addon.addons.each(&:deactivate)
+          RubyLsp::Addon.addon_classes.clear
           RubyLsp::Addon.addons.clear
         end
         server.run_shutdown

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -213,32 +213,28 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
       class Test < Minitest::Test; end
     RUBY
 
-    begin
-      create_code_lens_addon
+    create_code_lens_addon
 
-      with_server(source) do |server, uri|
-        server.process_message({
-          id: 1,
-          method: "textDocument/codeLens",
-          params: { textDocument: { uri: uri }, position: { line: 1, character: 2 } },
-        })
+    with_server(source) do |server, uri|
+      server.process_message({
+        id: 1,
+        method: "textDocument/codeLens",
+        params: { textDocument: { uri: uri }, position: { line: 1, character: 2 } },
+      })
 
-        # Pop the re-indexing notification
-        server.pop_response
+      # Pop the re-indexing notification
+      server.pop_response
 
-        result = server.pop_response
-        assert_instance_of(RubyLsp::Result, result)
+      result = server.pop_response
+      assert_instance_of(RubyLsp::Result, result)
 
-        response = result.response
+      response = result.response
 
-        assert_equal(response.size, 4)
-        assert_match("▶ Run", response[0].command.title)
-        assert_match("▶ Run In Terminal", response[1].command.title)
-        assert_match("Debug", response[2].command.title)
-        assert_match("Run Test", response[3].command.title)
-      ensure
-        RubyLsp::Addon.addon_classes.clear
-      end
+      assert_equal(response.size, 4)
+      assert_match("▶ Run", response[0].command.title)
+      assert_match("▶ Run In Terminal", response[1].command.title)
+      assert_match("Debug", response[2].command.title)
+      assert_match("Run Test", response[3].command.title)
     end
   end
 

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1002,22 +1002,18 @@ class CompletionTest < Minitest::Test
       R
     RUBY
 
-    begin
-      create_completion_addon
+    create_completion_addon
 
-      with_server(source) do |server, uri|
-        server.process_message(
-          id: 1,
-          method: "textDocument/completion",
-          params: { textDocument: { uri: uri }, position: { character: 1, line: 0 } },
-        )
-        response = server.pop_response.response
+    with_server(source) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/completion",
+        params: { textDocument: { uri: uri }, position: { character: 1, line: 0 } },
+      )
+      response = server.pop_response.response
 
-        assert_equal(1, response.size)
-        assert_match("MyCompletion", response[0].label)
-      end
-    ensure
-      RubyLsp::Addon.addon_classes.clear
+      assert_equal(1, response.size)
+      assert_match("MyCompletion", response[0].label)
     end
   end
 

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -226,32 +226,28 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       RubyLsp
     RUBY
 
-    begin
-      create_definition_addon
+    create_definition_addon
 
-      with_server(source, stub_no_typechecker: true) do |server, uri|
-        server.global_state.index.index_file(
-          URI::Generic.from_path(
-            load_path_entry: "#{Dir.pwd}/lib",
-            path: File.expand_path(
-              "../../test/fixtures/class_reference_target.rb",
-              __dir__,
-            ),
+    with_server(source, stub_no_typechecker: true) do |server, uri|
+      server.global_state.index.index_file(
+        URI::Generic.from_path(
+          load_path_entry: "#{Dir.pwd}/lib",
+          path: File.expand_path(
+            "../../test/fixtures/class_reference_target.rb",
+            __dir__,
           ),
-        )
-        server.process_message(
-          id: 1,
-          method: "textDocument/definition",
-          params: { textDocument: { uri: uri }, position: { character: 0, line: 0 } },
-        )
-        response = server.pop_response.response
+        ),
+      )
+      server.process_message(
+        id: 1,
+        method: "textDocument/definition",
+        params: { textDocument: { uri: uri }, position: { character: 0, line: 0 } },
+      )
+      response = server.pop_response.response
 
-        assert_equal(2, response.size)
-        assert_match("class_reference_target.rb", response[0].target_uri)
-        assert_match("generated_by_addon.rb", response[1].uri)
-      end
-    ensure
-      RubyLsp::Addon.addon_classes.clear
+      assert_equal(2, response.size)
+      assert_match("class_reference_target.rb", response[0].target_uri)
+      assert_match("generated_by_addon.rb", response[1].uri)
     end
   end
 

--- a/test/requests/discover_tests_test.rb
+++ b/test/requests/discover_tests_test.rb
@@ -327,29 +327,25 @@ module RubyLsp
         end
       RUBY
 
-      begin
-        create_test_discovery_addon
+      create_test_discovery_addon
 
-        with_server(source) do |server, uri|
-          server.process_message({
-            id: 1,
-            method: "rubyLsp/discoverTests",
-            params: { textDocument: { uri: uri } },
-          })
+      with_server(source) do |server, uri|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/discoverTests",
+          params: { textDocument: { uri: uri } },
+        })
 
-          response = pop_result(server)
+        response = pop_result(server)
 
-          assert_instance_of(RubyLsp::Result, response)
-          items = response.response
+        assert_instance_of(RubyLsp::Result, response)
+        items = response.response
 
-          test_classes = items.map { |i| i[:label] }
-          assert_equal(["MyTest"], test_classes)
+        test_classes = items.map { |i| i[:label] }
+        assert_equal(["MyTest"], test_classes)
 
-          test_methods = items[0][:children].map { |i| i[:label] }
-          assert_equal(["should do something", "should do something else"], test_methods)
-        end
-      ensure
-        RubyLsp::Addon.addon_classes.clear
+        test_methods = items[0][:children].map { |i| i[:label] }
+        assert_equal(["should do something", "should do something else"], test_methods)
       end
     end
 

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -81,31 +81,28 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
       end
     RUBY
 
-    begin
-      create_document_symbol_addon
-      with_server(source) do |server, uri|
-        server.process_message({
-          id: 1,
-          method: "textDocument/documentSymbol",
-          params: { textDocument: { uri: uri } },
-        })
+    create_document_symbol_addon
 
-        # Pop the re-indexing notification
-        server.pop_response
+    with_server(source) do |server, uri|
+      server.process_message({
+        id: 1,
+        method: "textDocument/documentSymbol",
+        params: { textDocument: { uri: uri } },
+      })
 
-        result = server.pop_response
-        assert_instance_of(RubyLsp::Result, result)
+      # Pop the re-indexing notification
+      server.pop_response
 
-        response = result.response
+      result = server.pop_response
+      assert_instance_of(RubyLsp::Result, result)
 
-        assert_equal(1, response.count)
-        assert_equal("Foo", response.first.name)
+      response = result.response
 
-        test_symbol = response.first.children.first
-        assert_equal(LanguageServer::Protocol::Constant::SymbolKind::METHOD, test_symbol.kind)
-      end
-    ensure
-      RubyLsp::Addon.addon_classes.clear
+      assert_equal(1, response.count)
+      assert_equal("Foo", response.first.name)
+
+      test_symbol = response.first.children.first
+      assert_equal(LanguageServer::Protocol::Constant::SymbolKind::METHOD, test_symbol.kind)
     end
   end
 

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -338,30 +338,26 @@ class HoverExpectationsTest < ExpectationsTestRunner
       Post
     RUBY
 
-    begin
-      create_hover_addon
+    create_hover_addon
 
-      with_server(source, stub_no_typechecker: true) do |server, uri|
-        server.process_message(
-          id: 1,
-          method: "textDocument/hover",
-          params: { textDocument: { uri: uri }, position: { character: 0, line: 4 } },
-        )
+    with_server(source, stub_no_typechecker: true) do |server, uri|
+      server.process_message(
+        id: 1,
+        method: "textDocument/hover",
+        params: { textDocument: { uri: uri }, position: { character: 0, line: 4 } },
+      )
 
-        assert_match(<<~RESPONSE.strip, server.pop_response.response.contents.value)
-          Title
+      assert_match(<<~RESPONSE.strip, server.pop_response.response.contents.value)
+        Title
 
-          **Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4)
-          Links
-
+        **Definitions**: [fake.rb](file:///fake.rb#L2,1-3,4)
+        Links
 
 
-          Hello
-          Documentation from middleware: Post
-        RESPONSE
-      end
-    ensure
-      RubyLsp::Addon.addon_classes.clear
+
+        Hello
+        Documentation from middleware: Post
+      RESPONSE
     end
   end
 

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -49,36 +49,32 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
       end
     RUBY
 
-    begin
-      create_semantic_highlighting_addon
+    create_semantic_highlighting_addon
 
-      with_server(source) do |server, uri|
-        server.process_message({
-          id: 1,
-          method: "textDocument/semanticTokens/full",
-          params: { textDocument: { uri: uri } },
-        })
+    with_server(source) do |server, uri|
+      server.process_message({
+        id: 1,
+        method: "textDocument/semanticTokens/full",
+        params: { textDocument: { uri: uri } },
+      })
 
-        result = server.pop_response
-        assert_instance_of(RubyLsp::Result, result)
+      result = server.pop_response
+      assert_instance_of(RubyLsp::Result, result)
 
-        decoded_response = decode_tokens(result.response.data)
-        assert_equal(
-          { delta_line: 0, delta_start_char: 6, length: 4, token_type: 2, token_modifiers: 1 },
-          decoded_response[0],
-        )
-        assert_equal(
-          { delta_line: 1, delta_start_char: 2, length: 13, token_type: 13, token_modifiers: 0 },
-          decoded_response[1],
-        )
-        # This is the token modified by the add-on
-        assert_equal(
-          { delta_line: 1, delta_start_char: 2, length: 13, token_type: 15, token_modifiers: 1 },
-          decoded_response[2],
-        )
-      end
-    ensure
-      RubyLsp::Addon.addon_classes.clear
+      decoded_response = decode_tokens(result.response.data)
+      assert_equal(
+        { delta_line: 0, delta_start_char: 6, length: 4, token_type: 2, token_modifiers: 1 },
+        decoded_response[0],
+      )
+      assert_equal(
+        { delta_line: 1, delta_start_char: 2, length: 13, token_type: 13, token_modifiers: 0 },
+        decoded_response[1],
+      )
+      # This is the token modified by the add-on
+      assert_equal(
+        { delta_line: 1, delta_start_char: 2, length: 13, token_type: 15, token_modifiers: 1 },
+        decoded_response[2],
+      )
     end
   end
 


### PR DESCRIPTION


<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->

Following up on https://github.com/Shopify/ruby-lsp/pull/3271#discussion_r1981880002. The test helper should be handling all add-on cleanup.

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Moved lingering add-on cleanup logic from individual tests into the `with_server` method's ensure block, to centralize cleanup responsibility and reduce duplication across the test suite.

<!-- ### Automated Tests

We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

<!-- ### Manual Tests

Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
