### PR TITLE
Assorted RBS grammar fixes

### DIFF
--- a/vscode/grammars/rbs.injection.json
+++ b/vscode/grammars/rbs.injection.json
@@ -8,12 +8,9 @@
   ],
   "repository": {
     "rbs-signature": {
-      "begin": "(^[^#\"']*)(#:)",
+      "begin": "(?<![\"'][^\"']*)(#:)",
       "beginCaptures": {
         "1": {
-          "name": "source.ruby"
-        },
-        "2": {
           "name": "comment.line.signature.rbs"
         }
       },
@@ -47,6 +44,10 @@
         {
           "match": "[\\(\\)\\{\\},\\|\\*&:?]",
           "name": "punctuation.section.signature.rbs"
+        },
+        {
+          "match": "#.*$",
+          "name": "comment.line.number-sign.rbs"
         }
       ]
     }

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -601,8 +601,29 @@ suite("Grammars", () => {
       });
 
       test("grammar is not applied to `#:` in comments", () => {
-        const ruby = "# some comments says #: foo";
-        const expectedTokens = [["# some comments says #: foo", []]];
+        const ruby = "# some comments says #: Foo";
+        const expectedTokens = [
+          ["# some comments says ", []],
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
+          [" ", ["meta.type.signature.rbs"]],
+          ["Foo", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
+        ];
+        const actualTokens = tokenizeRBS(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+
+      test("grammar is applied to comments inside RBS comments", () => {
+        const ruby = "#: Foo # some comments";
+        const expectedTokens = [
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
+          [" ", ["meta.type.signature.rbs"]],
+          ["Foo", ["meta.type.signature.rbs", "variable.other.constant.rbs"]],
+          [" ", ["meta.type.signature.rbs"]],
+          [
+            "# some comments",
+            ["meta.type.signature.rbs", "comment.line.number-sign.rbs"],
+          ],
+        ];
         const actualTokens = tokenizeRBS(ruby);
         assert.deepStrictEqual(actualTokens, expectedTokens);
       });
@@ -617,7 +638,7 @@ suite("Grammars", () => {
       test("grammar is applied to `#:` in trailing comments", () => {
         const ruby = "attr_reader :name #: String";
         const expectedTokens = [
-          ["attr_reader :name ", ["meta.type.signature.rbs", "source.ruby"]],
+          ["attr_reader :name ", []],
           ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
           [" ", ["meta.type.signature.rbs"]],
           [


### PR DESCRIPTION
### Motivation

Fixes grammar for RBS comments:

1. Properly matches comments inside RBS comments so with `#: Integer # some comment` the `# some comment` is properly highlighted as a `comment.line.number-sign.rbs`
2. Do not match preceding Ruby so with `x = 42 #: Integer` the `x = 42` is properly highlighted using the Ruby grammar

### Automated Tests

See tests.
