### PR TITLE
Exclude certain Bundler settings when composing bundle

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -357,10 +357,17 @@ module RubyLsp
         Bundler::Settings.new
       end
 
+      # List of Bundler settings that don't make sense for the composed bundle and are better controlled manually by the
+      # user
+      ignored_settings = ["bin", "cache_all", "cache_all_platforms"]
+
       # Map all settings to their environment variable names with `key_for` and their values. For example, the if the
       # setting name `e` is `path` with a value of `vendor/bundle`, then it will return `"BUNDLE_PATH" =>
       # "vendor/bundle"`
-      settings.all.to_h do |e|
+      settings
+        .all
+        .reject { |setting| ignored_settings.include?(setting) }
+        .to_h do |e|
         key = settings.key_for(e)
         value = Array(settings[e]).join(":").tr(" ", ":")
 


### PR DESCRIPTION
### Motivation

Closes #2440, closes #3196

Certain Bundler settings are better used only when the user is in control, like deciding when to package gems or if Bundler should automatically install binstubs for all gems.

This PR starts ignoring certain settings from the composed environment.

### Implementation

Added a list of ignored settings that we reject before building the environment that we'll use to run bundle install/update.

### Automated Tests

Added tests for both bundle bin and bundle package related settings.