### PR TITLE
Extract shared behaviour of test discovery listeners

### DIFF
--- a/lib/ruby_lsp/listeners/spec_style.rb
+++ b/lib/ruby_lsp/listeners/spec_style.rb
@@ -3,7 +3,7 @@
 
 module RubyLsp
   module Listeners
-    class SpecStyle < DiscoverTests
+    class SpecStyle < TestDiscovery
       extend T::Sig
 
       #: (response_builder: ResponseBuilders::TestCollection, global_state: GlobalState, dispatcher: Prism::Dispatcher, uri: URI::Generic) -> void

--- a/lib/ruby_lsp/listeners/test_discovery.rb
+++ b/lib/ruby_lsp/listeners/test_discovery.rb
@@ -3,7 +3,7 @@
 
 module RubyLsp
   module Listeners
-    class DiscoverTests
+    class TestDiscovery
       extend T::Helpers
       abstract!
 

--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -3,7 +3,7 @@
 
 module RubyLsp
   module Listeners
-    class TestStyle < DiscoverTests
+    class TestStyle < TestDiscovery
       class << self
         # Resolves the minimal set of commands required to execute the requested tests
         #: (Array[Hash[Symbol, untyped]]) -> Array[String]
@@ -78,7 +78,7 @@ module RubyLsp
           regexes = groups_and_examples.flat_map do |group, info|
             examples = info[:examples]
             group_regex = Shellwords.escape(group).gsub(
-              Shellwords.escape(DiscoverTests::DYNAMIC_REFERENCE_MARKER),
+              Shellwords.escape(TestDiscovery::DYNAMIC_REFERENCE_MARKER),
               ".*",
             )
             if examples.empty?
@@ -104,7 +104,7 @@ module RubyLsp
           groups_and_examples.map do |group, info|
             examples = info[:examples]
             group_regex = Shellwords.escape(group).gsub(
-              Shellwords.escape(DiscoverTests::DYNAMIC_REFERENCE_MARKER),
+              Shellwords.escape(TestDiscovery::DYNAMIC_REFERENCE_MARKER),
               ".*",
             )
             command = +"#{BASE_COMMAND} -Itest #{file_path} --testcase \"/^#{group_regex}$/\""

--- a/lib/ruby_lsp/requests/discover_tests.rb
+++ b/lib/ruby_lsp/requests/discover_tests.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "ruby_lsp/listeners/discover_tests"
+require "ruby_lsp/listeners/test_discovery"
 require "ruby_lsp/listeners/test_style"
 require "ruby_lsp/listeners/spec_style"
 


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

Closes #3241 

There's a certain amount of shared behaviour between the `TestStyle` and `SpecStyle` listeners. Both need to track class/module nesting, handle dynamic references, manage visibility stacks, and process node enter/leave events. By extracting this common functionality into a shared parent class, we can reduce code duplication and improve maintainability.

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

This PR introduces a new abstract `DiscoverTests` class that both `TestStyle` and `SpecStyle` inherit from. The parent class handles:

- Tracking class/module nesting
- Visibility stack management
- Node enter/leave handlers for classes and modules
- Dynamic reference handling
- Ancestry resolution
- Fully qualified name calculation

The specialized test discovery logic remains in the child classes, while common state tracking and node handling is centralized in the parent. 

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
Do we need to add more automated tests or do the existing tests suffice?

<!-- ### Manual Tests

Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
