### PR TITLE
Ensure `URI.from_path` is available to minitest runner

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
+++ b/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require_relative "test_reporter"
+require "ruby_indexer/lib/ruby_indexer/uri"
 
 require "minitest"
 

--- a/project-words
+++ b/project-words
@@ -74,6 +74,7 @@ quickfixes
 quux
 quxx
 rdbg
+rbundler
 readlines
 realpath
 reparsing

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -8,7 +8,7 @@ module RubyLsp
     def test_minitest_output
       plugin_path = "lib/ruby_lsp/ruby_lsp_reporter_plugin.rb"
       env = { "RUBYOPT" => "-r./#{plugin_path}" }
-      _stdin, stdout, _stderr, _wait_thr = T.unsafe(Open3).popen3(
+      _stdin, stdout, stderr, wait_thr = T.unsafe(Open3).popen3(
         env,
         "bundle",
         "exec",
@@ -16,6 +16,8 @@ module RubyLsp
         "-Itest",
         "test/fixtures/minitest_example.rb",
       )
+      flunk("command failed: #{stderr.read}") unless wait_thr.value.success?
+
       stdout.binmode
       stdout.sync = true
 

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -7,7 +7,8 @@ module RubyLsp
   class MinitestTestRunnerTest < Minitest::Test
     def test_minitest_output
       plugin_path = "lib/ruby_lsp/ruby_lsp_reporter_plugin.rb"
-      env = { "RUBYOPT" => "-r./#{plugin_path}" }
+      # In Ruby 3.1, the require fails unless Bundler is set up.
+      env = { "RUBYOPT" => "-rbundler/setup -r./#{plugin_path}" }
       _stdin, stdout, stderr, wait_thr = T.unsafe(Open3).popen3(
         env,
         "bundle",


### PR DESCRIPTION
When starting to verify this with Rails, I discovered the we need to ensure `URI.from_path` is available (it's already there for test-unit), since we use it in `uri_from_test_class`.