### PR TITLE
Add support for ERB syntax highlighting in Heredoc sections

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -1692,6 +1692,44 @@
       ]
     },
     {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)ERB)\\b\\1))",
+      "comment": "Heredoc with embedded ERB",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.erb",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)ERB)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "text.html.erb",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "text.html.erb"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)XML)\\b\\1))",
       "comment": "Heredoc with embedded XML",
       "end": "(?!\\G)",

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -37,6 +37,10 @@ const EMBEDDED_HEREDOC_LANGUAGES: InferrableLanguageConfigOrLabel[] = [
     label: "C++",
   },
   {
+    label: "ERB",
+    contentName: "text.html.erb",
+  },
+  {
     label: "GraphQL",
     delimiters: ["GRAPHQL", "GQL"],
   },


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

Closes #2863

### Implementation

This is a follow up of this PR #2903

Added `.erb` grammar to the vscode grammar extension.

### Automated Tests

Added test for erb grammar in the grammars.test.ts

### Manual Tests

I run the extension locally. The grammar is taking the ERB block in the heredoc. But for some reason, reusing the `text.html.erb` grammar of the RubyLSP extension gives different syntax highlighting than in a example.erb file.

`example.rb`
![image](https://github.com/user-attachments/assets/cb7725e1-e45d-49be-a5a4-a1e9e993fb87)
`example.erb`
![image](https://github.com/user-attachments/assets/be9bddf7-aa18-4357-b3a2-28283a0d5bec)

