### PR TITLE
Run indexer tests last

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,4 +21,4 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
-task default: ["test:indexer", :test]
+task default: [:test, "test:indexer"]

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -1,8 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "sorbet-runtime"
 require "bundler"
+require "sorbet-runtime"
 require "bundler/cli"
 require "bundler/cli/install"
 require "bundler/cli/update"

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "bundler"
+require "bundler/setup"
 require "sorbet-runtime"
 require "bundler/cli"
 require "bundler/cli/install"


### PR DESCRIPTION
Currently the indexer tests run first in CI, taking around 2 minutes. But most of our PRs are not related to indexing. If it we run the main tests first then we'll get faster feedback for failures.