### PR TITLE
Extract dynamic reference marker

### DIFF
--- a/lib/ruby-lsp.rb
+++ b/lib/ruby-lsp.rb
@@ -3,4 +3,5 @@
 
 module RubyLsp
   VERSION = File.read(File.expand_path("../VERSION", __dir__)).strip
+  DYNAMIC_REFERENCE_MARKER = "<dynamic_reference>"
 end

--- a/lib/ruby_lsp/listeners/code_lens.rb
+++ b/lib/ruby_lsp/listeners/code_lens.rb
@@ -18,8 +18,7 @@ module RubyLsp
         String,
       )
       ACCESS_MODIFIERS = T.let([:public, :private, :protected], T::Array[Symbol])
-      SUPPORTED_TEST_LIBRARIES = T.let(["minitest", "test-unit"], T::Array[String])
-      DYNAMIC_REFERENCE_MARKER = T.let("<dynamic_reference>", String)
+      SUPPORTED_TEST_LIBRARIES = ["minitest", "test-unit"]
 
       #: (ResponseBuilders::CollectionResponseBuilder[Interface::CodeLens] response_builder, GlobalState global_state, URI::Generic uri, Prism::Dispatcher dispatcher) -> void
       def initialize(response_builder, global_state, uri, dispatcher)

--- a/lib/ruby_lsp/listeners/spec_style.rb
+++ b/lib/ruby_lsp/listeners/spec_style.rb
@@ -7,8 +7,6 @@ module RubyLsp
       extend T::Sig
       include Requests::Support::Common
 
-      DYNAMIC_REFERENCE_MARKER = "<dynamic_reference>"
-
       #: (response_builder: ResponseBuilders::TestCollection, global_state: GlobalState, dispatcher: Prism::Dispatcher, uri: URI::Generic) -> void
       def initialize(response_builder, global_state, dispatcher, uri)
         @response_builder = response_builder

--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -119,7 +119,6 @@ module RubyLsp
       include Requests::Support::Common
 
       ACCESS_MODIFIERS = [:public, :private, :protected].freeze
-      DYNAMIC_REFERENCE_MARKER = "<dynamic_reference>"
       BASE_COMMAND = T.let(
         begin
           Bundler.with_original_env { Bundler.default_lockfile }


### PR DESCRIPTION
I want to reference this from the new `DiscoverTests` request in ruby-lsp-rails.