### PR TITLE
Retain editor focus after Run In Terminal

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -184,8 +184,18 @@ export class TestController {
       this.terminal = this.getTerminal();
     }
 
+    const activeEditor = vscode.window.activeTextEditor;
     this.terminal.show();
     this.terminal.sendText(command);
+    if (activeEditor) {
+      setTimeout(() => {
+        vscode.window.showTextDocument(
+          activeEditor.document,
+          activeEditor.viewColumn,
+          false,
+        );
+      }, 100);
+    }
 
     this.telemetry.logUsage("ruby_lsp.code_lens", {
       type: "counter",


### PR DESCRIPTION
I discovered that you can trigger a Code Lens with a keybinding, which is useful for Run In Terminal.

But currently the focus stays with the terminal so you need to focus back to the editor after doing so. This PR changes it to switch back automatically.

This does impact the current flow. For example, if someone is used to triggering a breakpoint with `binding.b`, they will now need to focus on the Terminal panel before doing anything. I expect the majority of uses for Run In Terminal are likely not doing that though, so overall it should be an improvement. 

(Note: There is another change needed after this for the keyboard functionality to fully work).