### PR TITLE
Hook server and extension test execution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 gem "bundler", "~> 2.5"
 gem "minitest", "~> 5.25"
+gem "test-unit", require: false
 
 group :development do
   gem "debug", "~> 1.9", require: false
@@ -21,7 +22,6 @@ group :development do
   gem "rubocop", "~> 1.70"
   gem "simplecov", require: false
   gem "syntax_tree", ">= 6.1.1", "< 7"
-  gem "test-unit", require: false
 
   platforms :ruby do # C Ruby (MRI), Rubinius or TruffleRuby, but NOT Windows
     # sorbet-static is not available on Windows. We also skip Tapioca since it depends on sorbet-static-and-runtime

--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -118,6 +118,8 @@ module RubyLsp
 
       include Requests::Support::Common
 
+      MINITEST_REPORTER_PATH = T.let(File.expand_path("ruby_lsp_reporter_plugin.rb", __dir__), String)
+      TEST_UNIT_REPORTER_PATH = T.let(File.expand_path("test_unit_test_runner.rb", __dir__), String)
       ACCESS_MODIFIERS = [:public, :private, :protected].freeze
       DYNAMIC_REFERENCE_MARKER = "<dynamic_reference>"
       BASE_COMMAND = T.let(

--- a/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
+++ b/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
@@ -1,10 +1,14 @@
 # typed: strict
 # frozen_string_literal: true
 
+begin
+  require "minitest"
+rescue LoadError
+  return
+end
+
 require_relative "test_reporter"
 require "ruby_indexer/lib/ruby_indexer/uri"
-
-require "minitest"
 
 module Minitest
   module Reporters
@@ -54,7 +58,6 @@ module Minitest
       def record_skip(result)
         RubyLsp::TestReporter.record_skip(
           id: id_from_result(result),
-          message: result.failure.message,
           uri: uri_from_result(result),
         )
       end

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1462,7 +1462,10 @@ module RubyLsp
 
       send_message(Result.new(
         id: message[:id],
-        response: { commands: Listeners::TestStyle.resolve_test_commands(items) },
+        response: {
+          commands: Listeners::TestStyle.resolve_test_commands(items),
+          reporterPaths: [Listeners::TestStyle::MINITEST_REPORTER_PATH, Listeners::TestStyle::TEST_UNIT_REPORTER_PATH],
+        },
       ))
     end
   end

--- a/lib/ruby_lsp/test_reporter.rb
+++ b/lib/ruby_lsp/test_reporter.rb
@@ -39,11 +39,10 @@ module RubyLsp
         send_message("fail", params)
       end
 
-      #: (id: String, message: String?, uri: URI::Generic) -> void
-      def record_skip(id:, message:, uri:)
+      #: (id: String, uri: URI::Generic) -> void
+      def record_skip(id:, uri:)
         params = {
           id: id,
-          message: message,
           uri: uri.to_s,
         }
         send_message("skip", params)

--- a/lib/ruby_lsp/test_unit_test_runner.rb
+++ b/lib/ruby_lsp/test_unit_test_runner.rb
@@ -1,9 +1,14 @@
 # typed: true
 # frozen_string_literal: true
 
-require "test/unit"
-require "test/unit/ui/testrunner"
-require "ruby_lsp/test_reporter"
+begin
+  require "test/unit"
+  require "test/unit/ui/testrunner"
+rescue LoadError
+  return
+end
+
+require_relative "test_reporter"
 require "ruby_indexer/lib/ruby_indexer/uri"
 
 module RubyLsp
@@ -65,11 +70,7 @@ module RubyLsp
 
     #: (::Test::Unit::Pending pending) -> void
     def record_skip(pending)
-      TestReporter.record_skip(
-        id: @current_test_id,
-        message: pending.message,
-        uri: @current_uri,
-      )
+      TestReporter.record_skip(id: @current_test_id, uri: @current_uri)
     end
 
     #: (::Test::Unit::TestCase test) -> URI::Generic?
@@ -94,3 +95,4 @@ module RubyLsp
 end
 
 Test::Unit::AutoRunner.register_runner(:ruby_lsp) { |_auto_runner| RubyLsp::TestRunner }
+Test::Unit::AutoRunner.default_runner = :ruby_lsp

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -52,7 +52,6 @@ module RubyLsp
           "method" => "skip",
           "params" => {
             "id" => "SampleTest#test_that_is_pending",
-            "message" => "pending test",
             "uri" => uri,
           },
         },

--- a/test/test_unit_test_runner_test.rb
+++ b/test/test_unit_test_runner_test.rb
@@ -48,7 +48,6 @@ module RubyLsp
           "method" => "skip",
           "params" => {
             "id" => "SampleTest#test_that_is_pending",
-            "message" => "pending test",
             "uri" => uri,
           },
         },


### PR DESCRIPTION
### Motivation

Closes #3177

This PR contains the final adjustments to fully hook up the extension and server sides in executing tests and displaying the streaming results.

### Implementation

This PR is just a series of tiny adjustments to make everything fit together, so I commented on each change.

### Automated Tests

Adapted some existing tests.

### Manual Tests

1. Start the extension in development mode on this branch
2. On the second window, open the `ruby-lsp`'s gem code
3. Verify you can discover tests in the explorer
4. Verify you can run tests in the explorer and see the results reflected in the UI