### PR TITLE
Use normal client name in OnTypeFormattingTest

### DIFF
--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -996,7 +996,7 @@ class OnTypeFormattingTest < Minitest::Test
       document,
       { line: 2, character: 4 },
       "\n",
-      "Visual Studio Code - Insiders",
+      "Visual Studio Code",
     ).perform
 
     assert_empty(edits)
@@ -1023,7 +1023,7 @@ class OnTypeFormattingTest < Minitest::Test
       document,
       { line: 1, character: 2 },
       "\n",
-      "Visual Studio Code - Insiders",
+      "Visual Studio Code",
     ).perform
 
     expected_edits = [


### PR DESCRIPTION
These tests aren't specific to VS Code Insiders so let's use the normal client name.

There is one remaining test which *is* specific to Insiders

(I noticed this when looking at https://github.com/Shopify/ruby-lsp/pull/3302)