### PR TITLE
Add icon for GoToRelevantFile in vscode

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -54,14 +54,16 @@
           "group": "9_cutcopypaste"
         }
       ],
+      "editor/title": [
+        {
+          "command": "rubyLsp.goToRelevantFile",
+          "when": "rubyLsp.activated",
+          "group": "navigation"
+        }
+      ],
       "view/title": [
         {
           "command": "rubyLsp.fileOperation",
-          "when": "rubyLsp.activated && view == 'workbench.explorer.fileView'",
-          "group": "navigation"
-        },
-        {
-          "command": "rubyLsp.goToRelevantFile",
           "when": "rubyLsp.activated && view == 'workbench.explorer.fileView'",
           "group": "navigation"
         }
@@ -172,7 +174,8 @@
       {
         "command": "rubyLsp.goToRelevantFile",
         "title": "Go to relevant file (test <> source code)",
-        "category": "Ruby LSP"
+        "category": "Ruby LSP",
+        "icon": "$(arrow-swap)"
       },
       {
         "command": "rubyLsp.collectRubyLspInfo",


### PR DESCRIPTION
### Motivation

Add an icon (arrow swap) for GoToRelevantFile in vscode at the editor navigation bar. Also remove this function from the file explorer title bar, as it really does not belong there.


https://github.com/user-attachments/assets/b3420dbe-9fb0-4a0f-9bfa-a4b06b420e63


