### PR TITLE
Use map compact instead of filter_map in activation script

### DIFF
--- a/vscode/activation.rb
+++ b/vscode/activation.rb
@@ -1,6 +1,7 @@
-env = ENV.filter_map do |k, v|
+# Using .map.compact just so that it doesn't crash immediately on Ruby 2.6
+env = ENV.map do |k, v|
   utf_8_value = v.dup.force_encoding(Encoding::UTF_8)
   "#{k}RUBY_LSP_VS#{utf_8_value}" if utf_8_value.valid_encoding?
-end
+end.compact
 env.unshift(RUBY_VERSION, Gem.path.join(","), !!defined?(RubyVM::YJIT))
 STDERR.print("RUBY_LSP_ACTIVATION_SEPARATOR#{env.join("RUBY_LSP_FS")}RUBY_LSP_ACTIVATION_SEPARATOR")


### PR DESCRIPTION
### Motivation

The activation script is failing when no Shadowenv environment is activated because it then falls back to system Ruby (2.6) and `filter_map` doesn't exist in it.

There are better long term solutions to this, like trying to fallback to chruby when Shadowenv fails or offering other options, but for now I would really like to remove these errors from telemetry since we finally managed to fix the encoding related problems too.

### Implementation

Switched to map/compact instead of `filter_map`.