### PR TITLE
Fix paths to custom test reporters

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -118,8 +118,8 @@ module RubyLsp
 
       include Requests::Support::Common
 
-      MINITEST_REPORTER_PATH = T.let(File.expand_path("ruby_lsp_reporter_plugin.rb", __dir__), String)
-      TEST_UNIT_REPORTER_PATH = T.let(File.expand_path("test_unit_test_runner.rb", __dir__), String)
+      MINITEST_REPORTER_PATH = T.let(File.expand_path("../ruby_lsp_reporter_plugin.rb", __dir__), String)
+      TEST_UNIT_REPORTER_PATH = T.let(File.expand_path("../test_unit_test_runner.rb", __dir__), String)
       ACCESS_MODIFIERS = [:public, :private, :protected].freeze
       DYNAMIC_REFERENCE_MARKER = "<dynamic_reference>"
       BASE_COMMAND = T.let(

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1464,6 +1464,21 @@ class ServerTest < Minitest::Test
     end
   end
 
+  def test_resolve_test_commands_returns_custom_reporters
+    @server.process_message({
+      id: 1,
+      method: "rubyLsp/resolveTestCommands",
+      params: {
+        items: [],
+      },
+    })
+    result = find_message(RubyLsp::Result, id: 1)
+    reporters = result.response[:reporterPaths]
+
+    assert_includes(reporters, File.expand_path("../lib/ruby_lsp/ruby_lsp_reporter_plugin.rb", __dir__))
+    assert_includes(reporters, File.expand_path("../lib/ruby_lsp/test_unit_test_runner.rb", __dir__))
+  end
+
   private
 
   def wait_for_indexing


### PR DESCRIPTION
### Motivation

I forgot to update the file paths when I moved the constants.

### Implementation

Adjusted the paths to point to the right files.

### Automated Tests

Added a test so that we don't make this mistake again.