### PR TITLE
Append custom reporter rather than replacing all

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
+++ b/lib/ruby_lsp/ruby_lsp_reporter_plugin.rb
@@ -16,7 +16,7 @@ module Minitest
       class << self
         #: (Hash[untyped, untyped]) -> void
         def minitest_plugin_init(_options)
-          Minitest.reporter.reporters = [RubyLspReporter.new]
+          Minitest.reporter.reporters << RubyLspReporter.new
         end
       end
 

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -9,7 +9,7 @@ module RubyLsp
       plugin_path = "lib/ruby_lsp/ruby_lsp_reporter_plugin.rb"
       # In Ruby 3.1, the require fails unless Bundler is set up.
       env = { "RUBYOPT" => "-rbundler/setup -r./#{plugin_path}" }
-      _stdin, stdout, stderr, wait_thr = T.unsafe(Open3).popen3(
+      _stdin, stdout, _stderr, _wait_thr = T.unsafe(Open3).popen3(
         env,
         "bundle",
         "exec",
@@ -17,7 +17,6 @@ module RubyLsp
         "-Itest",
         "test/fixtures/minitest_example.rb",
       )
-      flunk("command failed: #{stderr.read}") unless wait_thr.value.success?
 
       stdout.binmode
       stdout.sync = true
@@ -117,8 +116,10 @@ module RubyLsp
           },
         },
       ]
-      assert_equal(2 + 2 + 2 + 2 + 5, actual.size)
-      assert_equal(expected, actual)
+
+      expected.each do |message|
+        assert_includes(actual, message)
+      end
     end
 
     private


### PR DESCRIPTION
### Motivation

Depends on #3286

After we can handle any printing to stdout, then instead of getting rid of the original Minitest reporters, we can simply append ours.

That makes it so that the test results panel will be populated with what would be printed to the terminal, while at the same time updating the explorer with streaming JSON notifications.

### Implementation

Just switched from replace to append.