### PR TITLE
Introduce test file watcher

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -121,6 +121,7 @@ export class TestController {
         if (terminal === this.terminal) this.terminal = undefined;
       }),
       testFileWatcher,
+      nestedTestDirWatcher,
       testFileWatcher.onDidCreate(async (uri) => {
         const workspace = vscode.workspace.getWorkspaceFolder(uri);
 
@@ -149,6 +150,18 @@ export class TestController {
             testFile.children.replace([]);
             await this.resolveHandler(testFile);
           }
+        }
+      }),
+      nestedTestDirWatcher.onDidDelete(async (uri) => {
+        const pathParts = uri.fsPath.split(path.sep);
+        if (pathParts.includes(".git")) {
+          return;
+        }
+
+        const parentItem = await this.getParentTestItem(uri);
+
+        if (parentItem) {
+          parentItem.children.delete(uri.toString());
         }
       }),
       testFileWatcher.onDidDelete(async (uri) => {

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -101,6 +101,10 @@ export class TestController {
       DEBUG_TAG,
     );
 
+    const testFileWatcher = vscode.workspace.createFileSystemWatcher(
+      "**/{test,spec,features}/**/{*_test.rb,test_*.rb,*_spec.rb,*.feature}",
+    );
+
     context.subscriptions.push(
       this.testController,
       this.testDebugProfile,

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -739,17 +739,26 @@ export class TestController {
         firstLevel,
       );
 
-      // Finally, add the test file to whatever is the final collection, which may be the first level test directory or
-      // a second level like models
-      const testItem = this.testController.createTestItem(
-        uri.toString(),
-        fileName,
-        uri,
-      );
-      testItem.canResolveChildren = true;
-      testItem.tags = [TEST_FILE_TAG, DEBUG_TAG];
-      finalCollection.add(testItem);
+      // Add the test file to the appropriate collection
+      this.addTestFileItem(uri, fileName, finalCollection);
     }
+  }
+
+  private addTestFileItem(
+    uri: vscode.Uri,
+    fileName: string,
+    collection: vscode.TestItemCollection,
+  ) {
+    // Finally, add the test file to whatever is the final collection, which may be the first level test directory or
+    // a second level like models
+    const testItem = this.testController.createTestItem(
+      uri.toString(),
+      fileName,
+      uri,
+    );
+    testItem.canResolveChildren = true;
+    testItem.tags = [TEST_FILE_TAG, DEBUG_TAG];
+    collection.add(testItem);
   }
 
   private getOrCreateFirstLevelItem(

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -125,6 +125,13 @@ export class TestController {
           }
         }
       }),
+      testFileWatcher.onDidDelete(async (uri) => {
+        const item = await this.getParentTestItem(uri);
+
+        if (item) {
+          item.children.delete(uri.toString());
+        }
+      }),
     );
   }
 

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -113,6 +113,24 @@ export class TestController {
         if (terminal === this.terminal) this.terminal = undefined;
       }),
       testFileWatcher,
+      testFileWatcher.onDidCreate(async (uri) => {
+        const workspace = vscode.workspace.getWorkspaceFolder(uri);
+
+        if (!workspace || !vscode.workspace.workspaceFolders) {
+          return;
+        }
+
+        const initialCollection =
+          vscode.workspace.workspaceFolders.length === 1
+            ? this.testController.items
+            : this.testController.items.get(workspace.uri.toString())?.children;
+
+        if (!initialCollection) {
+          return;
+        }
+
+        await this.addTestItemsForFile(uri, workspace, initialCollection);
+      }),
       testFileWatcher.onDidChange(async (uri) => {
         const item = await this.getParentTestItem(uri);
 

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -711,37 +711,45 @@ export class TestController {
     const pattern = this.testPattern(workspaceFolder);
 
     for (const uri of await vscode.workspace.findFiles(pattern)) {
-      const fileName = path.basename(uri.fsPath);
-      const relativePath = vscode.workspace.asRelativePath(uri, false);
-      const pathParts = relativePath.split(path.sep);
-
-      if (this.shouldSkipTestFile(fileName, pathParts)) {
-        continue;
-      }
-
-      // Find the position of the `test/spec/feature` directory. There may be many in applications that are divided by
-      // components, so we want to show each individual test directory as a separate item
-      const dirPosition = this.testDirectoryPosition(pathParts);
-
-      // Get or create the first level test directory item
-      const { firstLevel, firstLevelUri } = this.getOrCreateFirstLevelItem(
-        pathParts,
-        dirPosition,
-        workspaceFolder,
-        initialCollection,
-      );
-
-      // Get or create the second level test directory item if applicable
-      const finalCollection = await this.getOrCreateSecondLevelItem(
-        pathParts,
-        dirPosition,
-        firstLevelUri,
-        firstLevel,
-      );
-
-      // Add the test file to the appropriate collection
-      this.addTestFileItem(uri, fileName, finalCollection);
+      await this.addTestItemsForFile(uri, workspaceFolder, initialCollection);
     }
+  }
+
+  private async addTestItemsForFile(
+    uri: vscode.Uri,
+    workspaceFolder: vscode.WorkspaceFolder,
+    collection: vscode.TestItemCollection,
+  ) {
+    const fileName = path.basename(uri.fsPath);
+    const relativePath = vscode.workspace.asRelativePath(uri, false);
+    const pathParts = relativePath.split(path.sep);
+
+    if (this.shouldSkipTestFile(fileName, pathParts)) {
+      return;
+    }
+
+    // Find the position of the `test/spec/feature` directory. There may be many in applications that are divided by
+    // components, so we want to show each individual test directory as a separate item
+    const dirPosition = this.testDirectoryPosition(pathParts);
+
+    // Get or create the first level test directory item
+    const { firstLevel, firstLevelUri } = this.getOrCreateFirstLevelItem(
+      pathParts,
+      dirPosition,
+      workspaceFolder,
+      collection,
+    );
+
+    // Get or create the second level test directory item if applicable
+    const finalCollection = await this.getOrCreateSecondLevelItem(
+      pathParts,
+      dirPosition,
+      firstLevelUri,
+      firstLevel,
+    );
+
+    // Add the test file to the appropriate collection
+    this.addTestFileItem(uri, fileName, finalCollection);
   }
 
   private addTestFileItem(

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -12,8 +12,8 @@ import { LspTestItem, ServerTestItem } from "./client";
 
 const asyncExec = promisify(exec);
 
-const TEST_FILE_PATTERN =
-  "**/{test,spec,features}/**/{*_test.rb,test_*.rb,*_spec.rb,*.feature}";
+const NESTED_TEST_DIR_PATTERN = "**/{test,spec,features}/**/";
+const TEST_FILE_PATTERN = `${NESTED_TEST_DIR_PATTERN}{*_test.rb,test_*.rb,*_spec.rb,*.feature}`;
 
 interface CodeLensData {
   type: string;
@@ -106,6 +106,12 @@ export class TestController {
 
     const testFileWatcher =
       vscode.workspace.createFileSystemWatcher(TEST_FILE_PATTERN);
+    const nestedTestDirWatcher = vscode.workspace.createFileSystemWatcher(
+      NESTED_TEST_DIR_PATTERN,
+      true,
+      true,
+      false,
+    );
 
     context.subscriptions.push(
       this.testController,

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -722,22 +722,14 @@ export class TestController {
       // Find the position of the `test/spec/feature` directory. There may be many in applications that are divided by
       // components, so we want to show each individual test directory as a separate item
       const dirPosition = this.testDirectoryPosition(pathParts);
-      const firstLevelName = pathParts.slice(0, dirPosition + 1).join(path.sep);
-      const firstLevelUri = vscode.Uri.joinPath(
-        workspaceFolder.uri,
-        firstLevelName,
-      );
 
-      let firstLevel = initialCollection.get(firstLevelUri.toString());
-      if (!firstLevel) {
-        firstLevel = this.testController.createTestItem(
-          firstLevelUri.toString(),
-          firstLevelName,
-          firstLevelUri,
-        );
-        firstLevel.tags = [TEST_DIR_TAG, DEBUG_TAG];
-        initialCollection.add(firstLevel);
-      }
+      // Get or create the first level test directory item
+      const { firstLevel, firstLevelUri } = this.getOrCreateFirstLevelItem(
+        pathParts,
+        dirPosition,
+        workspaceFolder,
+        initialCollection,
+      );
 
       // In Rails apps, it's also very common to divide the test directory into a second hierarchy level, like models or
       // controllers. Here we try to find out if there is a second level, allowing users to run all tests for models for
@@ -781,6 +773,32 @@ export class TestController {
       testItem.tags = [TEST_FILE_TAG, DEBUG_TAG];
       finalCollection.add(testItem);
     }
+  }
+
+  private getOrCreateFirstLevelItem(
+    pathParts: string[],
+    dirPosition: number,
+    workspaceFolder: vscode.WorkspaceFolder,
+    initialCollection: vscode.TestItemCollection,
+  ): { firstLevel: vscode.TestItem; firstLevelUri: vscode.Uri } {
+    const firstLevelName = pathParts.slice(0, dirPosition + 1).join(path.sep);
+    const firstLevelUri = vscode.Uri.joinPath(
+      workspaceFolder.uri,
+      firstLevelName,
+    );
+
+    let firstLevel = initialCollection.get(firstLevelUri.toString());
+    if (!firstLevel) {
+      firstLevel = this.testController.createTestItem(
+        firstLevelUri.toString(),
+        firstLevelName,
+        firstLevelUri,
+      );
+      firstLevel.tags = [TEST_DIR_TAG, DEBUG_TAG];
+      initialCollection.add(firstLevel);
+    }
+
+    return { firstLevel, firstLevelUri };
   }
 
   private shouldSkipTestFile(fileName: string, pathParts: string[]) {

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -112,8 +112,8 @@ export class TestController {
       vscode.window.onDidCloseTerminal((terminal: vscode.Terminal): void => {
         if (terminal === this.terminal) this.terminal = undefined;
       }),
-      vscode.workspace.onDidSaveTextDocument(async (document) => {
-        const uri = document.uri;
+      testFileWatcher,
+      testFileWatcher.onDidChange(async (uri) => {
         const item = await this.getParentTestItem(uri);
 
         if (item) {
@@ -863,9 +863,13 @@ export class TestController {
         secondLevelName,
       );
 
-      const fileStat = await vscode.workspace.fs.stat(secondLevelUri);
-      if (fileStat.type === vscode.FileType.Directory) {
-        return { firstLevelUri, secondLevelUri };
+      try {
+        const fileStat = await vscode.workspace.fs.stat(secondLevelUri);
+        if (fileStat.type === vscode.FileType.Directory) {
+          return { firstLevelUri, secondLevelUri };
+        }
+      } catch (error: any) {
+        // Do nothing
       }
     }
 

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -713,7 +713,7 @@ export class TestController {
     for (const uri of await vscode.workspace.findFiles(pattern)) {
       const fileName = path.basename(uri.fsPath);
 
-      if (fileName === "test_helper.rb") {
+      if (this.shouldSkipTestFile(fileName)) {
         continue;
       }
 
@@ -788,6 +788,14 @@ export class TestController {
       testItem.tags = [TEST_FILE_TAG, DEBUG_TAG];
       finalCollection.add(testItem);
     }
+  }
+
+  private shouldSkipTestFile(fileName: string): boolean {
+    if (fileName === "test_helper.rb") {
+      return true;
+    }
+
+    return false;
   }
 
   private testPattern(workspaceFolder: vscode.WorkspaceFolder) {

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -12,6 +12,9 @@ import { LspTestItem, ServerTestItem } from "./client";
 
 const asyncExec = promisify(exec);
 
+const TEST_FILE_PATTERN =
+  "**/{test,spec,features}/**/{*_test.rb,test_*.rb,*_spec.rb,*.feature}";
+
 interface CodeLensData {
   type: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -101,9 +104,8 @@ export class TestController {
       DEBUG_TAG,
     );
 
-    const testFileWatcher = vscode.workspace.createFileSystemWatcher(
-      "**/{test,spec,features}/**/{*_test.rb,test_*.rb,*_spec.rb,*.feature}",
-    );
+    const testFileWatcher =
+      vscode.workspace.createFileSystemWatcher(TEST_FILE_PATTERN);
 
     context.subscriptions.push(
       this.testController,
@@ -868,10 +870,7 @@ export class TestController {
   }
 
   private testPattern(workspaceFolder: vscode.WorkspaceFolder) {
-    return new vscode.RelativePattern(
-      workspaceFolder,
-      "**/{test,spec,features}/**/{*_test.rb,test_*.rb,*_spec.rb,*.feature}",
-    );
+    return new vscode.RelativePattern(workspaceFolder, TEST_FILE_PATTERN);
   }
 
   private testDirectoryPosition(pathParts: string[]) {


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

Closes #3174 

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Currently, when test files are created or deleted, the test explorer doesn't automatically update to reflect these changes, requiring manual intervention or workspace reload to see the updates.

We need to make sure that, when there are changes to our files, the test explorer is aware of these changes automatically.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

Leveraged file system watchers to monitor test file changes:

- Uses the existing glob pattern `**/{test,spec,features}/**/{*_test.rb,test_*.rb,*_spec.rb,*.feature}`
- Handles four events:
  - `testFileWatcher.onDidCreate`: Adds new test files, nested appropriately, in the test explorer
  - `testFileWatcher.onDidChange`: Refreshes test items when a test file is modified
  - `testFileWatcher.onDidDelete`: Removes deleted test files from the test explorer
  - `nestedTestDirWatcher.onDidDelete`: Removes deleted test directories from the test explorer

Refactored the test hierarchy detection logic:
  - Extracted `detectHierarchyLevels` to analyze and return hierarchy information without modifying collections
  - Added `getOrCreateHierarchyLevels` to ensure test items exist based on the detected hierarchy
  - Added `addTestFileItem`: Handles individual test file item creation
  - Added `shouldSkipTestFile` to filter out helper files and fixtures

Open to suggestions on method naming 😄 

<!-- ### Automated Tests

We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. 

### Manual Tests

Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
