### PR TITLE
Ensure parity between test-unit and minitest examples

### DIFF
--- a/test/fixtures/test_unit_example.rb
+++ b/test/fixtures/test_unit_example.rb
@@ -21,4 +21,10 @@ class SampleTest < Test::Unit::TestCase
   def test_that_raises
     raise "oops"
   end
+
+  def test_with_output
+    $stdout.puts "hello from $stdout.puts\nanother line"
+    puts "hello from puts\nanother line"
+    $stdout.write "hello from write\nanother line"
+  end
 end

--- a/test/test_unit_test_runner_test.rb
+++ b/test/test_unit_test_runner_test.rb
@@ -80,7 +80,40 @@ module RubyLsp
             "uri" => uri,
           },
         },
+        {
+          "method" => "start",
+          "params" => {
+            "id" => "SampleTest#test_with_output",
+            "uri" => uri,
+          },
+        },
+        {
+          "method" => "append_output",
+          "params" => {
+            "message" => "hello from $stdout.puts\r\nanother line\r\n",
+          },
+        },
+        {
+          "method" => "append_output",
+          "params" => {
+            "message" => "hello from puts\r\nanother line\r\n",
+          },
+        },
+        {
+          "method" => "append_output",
+          "params" => {
+            "message" => "hello from write\r\nanother line",
+          },
+        },
+        {
+          "method" => "pass",
+          "params" => {
+            "id" => "SampleTest#test_with_output",
+            "uri" => uri,
+          },
+        },
       ]
+      assert_equal(2 + 2 + 2 + 2 + 5, actual.size)
       assert_equal(expected, actual)
     end
   end


### PR DESCRIPTION
Match what we added in https://github.com/Shopify/ruby-lsp/pull/3286 for minitest.