### PR TITLE
Do not include workspace name as part of relative path

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -829,7 +829,7 @@ export class TestController {
     firstLevelUri: vscode.Uri;
     secondLevelUri: vscode.Uri | undefined;
   }> {
-    const relativePath = vscode.workspace.asRelativePath(uri);
+    const relativePath = vscode.workspace.asRelativePath(uri, false);
     const pathParts = relativePath.split(path.sep);
     const dirPosition = this.testDirectoryPosition(pathParts);
     const firstLevelName = pathParts.slice(0, dirPosition + 1).join(path.sep);


### PR DESCRIPTION
### Motivation

I unfortunately made the same mistake and forgot to add `false` as the second argument to `asRelativePath`, which makes it ignore the workspace name and provide the actual file path.

It's unfortunate because we need to stub this method in tests, which means we don't catch these little things. This is why the explorer wasn't working on the LSP's own repo.