### PR TITLE
Accumulate streaming promises and await all before exiting

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -829,7 +829,7 @@ export class TestController {
     firstLevelUri: vscode.Uri;
     secondLevelUri: vscode.Uri | undefined;
   }> {
-    const relativePath = vscode.workspace.asRelativePath(uri);
+    const relativePath = vscode.workspace.asRelativePath(uri, false);
     const pathParts = relativePath.split(path.sep);
     const dirPosition = this.testDirectoryPosition(pathParts);
     const firstLevelName = pathParts.slice(0, dirPosition + 1).join(path.sep);


### PR DESCRIPTION
### Motivation

I found a better solution than sleeping to ensure we process all streaming updates before resolving the test run promise. We can instead accumulate all promises we receive and ensure they are all awaited before resolving the surrounding promise.

### Implementation

1. Created an array of promises
2. Started accumulate all asynchronous updates in the array. Made all updates synchronous (since pushing a promise into the array is not async)
3. When the test process exits, before we resolve the test run promise, we await all streaming update promises first, which guarantees that the UI is updated before we leave this method