### PR TITLE
Avoiding rejecting promise if test command failed

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -1016,22 +1016,13 @@ export class TestController {
       });
 
       // Handle the execution end
-      testProcess.on("exit", (code) => {
+      testProcess.on("exit", () => {
         Promise.all(promises)
           .then(() => {
             disposables.forEach((disposable) => disposable.dispose());
             connection.end();
             connection.dispose();
-
-            if (code === 0) {
-              resolve();
-            } else {
-              reject(
-                new Error(
-                  `Test process exited with code ${code}\n${errorMessage}`,
-                ),
-              );
-            }
+            resolve();
           })
           .catch((err) => {
             reject(err);


### PR DESCRIPTION
### Motivation

When we execute a test that fails, the command will exit with a code different than zero. However, that's expected, since the tests failed.

We shouldn't reject the promise if the tests failed (only if some of the test controller's internals did). Otherwise, the explorer won't finalize the run properly.

### Implementation

We just need to resolve every time regardless of what the exit code was.