### PR TITLE
Expand test directory command resolution with requires

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -32,7 +32,12 @@ module RubyLsp
             next unless path
 
             if tags.include?("test_dir")
-              full_files << "#{path}/**/*" if children.empty?
+              if children.empty?
+                full_files.concat(Dir.glob(
+                  "#{path}/**/{*_test,test_*}.rb",
+                  File::Constants::FNM_EXTGLOB | File::Constants::FNM_PATHNAME,
+                ))
+              end
             elsif tags.include?("test_file")
               full_files << path if children.empty?
             elsif tags.include?("test_group")
@@ -68,7 +73,10 @@ module RubyLsp
             end
           end
 
-          commands << "#{BASE_COMMAND} -Itest #{full_files.join(" ")}" unless full_files.empty?
+          unless full_files.empty?
+            commands << "#{BASE_COMMAND} -Itest -e \"ARGV.each { |f| require f }\" #{full_files.join(" ")}"
+          end
+
           commands
         end
 

--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -212,7 +212,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb /test/store_test.rb",
+            "bundle exec ruby -Itest -e \"ARGV.each { |f| require f }\" /test/server_test.rb /test/store_test.rb",
           ],
           result[:commands],
         )
@@ -221,6 +221,7 @@ module RubyLsp
 
     def test_resolve_test_command_entire_directories
       with_server do |server|
+        Dir.stubs(:glob).returns(["/other/test/fake_test.rb", "/other/test/fake_test2.rb"])
         server.process_message({
           id: 1,
           method: "rubyLsp/resolveTestCommands",
@@ -254,7 +255,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /other/test/**/* /test/server_test.rb /test/store_test.rb",
+            "bundle exec ruby -Itest -e \"ARGV.each { |f| require f }\" /other/test/fake_test.rb " \
+              "/other/test/fake_test2.rb /test/server_test.rb /test/store_test.rb",
           ],
           result[:commands],
         )
@@ -535,6 +537,7 @@ module RubyLsp
 
     def test_resolve_test_command_mix_of_directories_and_examples
       with_server do |server|
+        Dir.stubs(:glob).returns(["/test/unit/fake_test.rb", "/test/unit/fake_test2.rb"])
         server.process_message({
           id: 1,
           method: "rubyLsp/resolveTestCommands",
@@ -566,7 +569,8 @@ module RubyLsp
         assert_equal(
           [
             "bundle exec ruby -Itest /test/server_test.rb --name \"/^ServerTest#test_server$/\"",
-            "bundle exec ruby -Itest /test/unit/**/*",
+            "bundle exec ruby -Itest -e \"ARGV.each { |f| require f }\" /test/unit/fake_test.rb " \
+              "/test/unit/fake_test2.rb",
           ],
           result[:commands],
         )
@@ -1031,6 +1035,7 @@ module RubyLsp
 
     def test_resolve_test_command_mix_of_directories_and_examples
       with_server do |server|
+        Dir.stubs(:glob).returns(["/test/unit/fake_test.rb", "/test/unit/fake_test2.rb"])
         server.process_message({
           id: 1,
           method: "rubyLsp/resolveTestCommands",
@@ -1062,7 +1067,8 @@ module RubyLsp
         assert_equal(
           [
             "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest$/\" --name \"/test_server$/\"",
-            "bundle exec ruby -Itest /test/unit/**/*",
+            "bundle exec ruby -Itest -e \"ARGV.each { |f| require f }\" /test/unit/fake_test.rb " \
+              "/test/unit/fake_test2.rb",
           ],
           result[:commands],
         )


### PR DESCRIPTION
### Motivation

Our implementation of running all files in a directory was incorrect. You cannot use wildcards as part of the path because those are only expanded in the shell, not in a background command.

### Implementation

To my surprise, running `ruby -Itest test/file1_test.rb test/file2_test.rb` does not work. It consistently executes the first file and nothing else.

The only way I found to execute a bunch of test files together is to run only one them and require the rest (lol). Like this:

```shell
ruby -Itest -r./test/file1_test.rb test/file2_test.rb
```

If you know of another way to do this, please let me know. I couldn't find any alternatives that don't involve rake or other dependencies.

### Automated Tests

Adapted our tests to verify the right command.