### PR TITLE
Automatically discover children for test files that weren't expanded

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -387,6 +387,12 @@ export class TestController {
       return testFileItem;
     }
 
+    // If we're trying to find a test item inside a file that has never been expanded, then we never discovered its
+    // children and need to do so before trying to access them
+    if (testFileItem.children.size === 0) {
+      await this.resolveHandler(testFileItem);
+    }
+
     // If we find an exact match for this ID, then return it right away
     const groupOrItem = testFileItem.children.get(id);
     if (groupOrItem) {


### PR DESCRIPTION
### Motivation

I noticed that executing entire test directories through the explorer wasn't working. This is due to #3335 and the aspect that we were not automatically discovering the children of test files if they were never expanded.

That meant that, we had no knowledge of their children existing, but when running the tests we are reporting results for those children we know nothing about.

We need to automatically resolve children for test files that haven't been expanded otherwise the items we need to update don't exist.

### Implementation

It's just a matter of invoking our resolve handler if there are no children in the test file item.

### Automated Tests

Added a test.