### PR TITLE
Allow cancelling test runs

### DIFF
--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -995,7 +995,8 @@ suite("TestController", () => {
         .returns(runStub);
 
       const runRequest = new vscode.TestRunRequest([testItem]);
-      await controller.runTest(runRequest, {} as any);
+      const cancellationSource = new vscode.CancellationTokenSource();
+      await controller.runTest(runRequest, cancellationSource.token);
 
       assert.ok(runStub.enqueued.calledWithExactly(testItem));
       assert.ok(runStub.started.calledWithExactly(testItem));


### PR DESCRIPTION
### Motivation

We hadn't added any handling for the test run cancellation token, which meant that users are unable to cancel test execution. When running a large group of tests, this can be pretty inconvenient as the user has to wait until all of them finish or reload the window.

This PR allows cancelling test runs.

### Implementation

There are only two parts to cancelling them:

1. If the user requests a cancellation in the middle of running the test command, then we have to stop everything, cleanup and resolve the promise to stop execution
2. Then we need to prevent trying to run any of the next test commands, if there were multiple enqueued to run

That's it.

### Manual tests

1. Start the extension on this branch
2. Run a large test through the explorer (index_test.rb is a good option)
3. Click the stop button
4. Verify that tests stopped with a message saying that the run was cancelled