### PR TITLE
Handle changing visibility post method definition

### DIFF
--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -924,6 +924,32 @@ module RubyIndexer
       RUBY
     end
 
+    def test_changing_visibility_post_definition
+      index(<<~RUBY)
+        class Foo
+          def bar; end
+          private :bar
+
+          def baz; end
+          protected :baz
+
+          private
+          def qux; end
+
+          public :qux
+        end
+      RUBY
+
+      entry = T.must(@index["bar"].first)
+      assert_predicate(entry, :private?)
+
+      entry = T.must(@index["baz"].first)
+      assert_predicate(entry, :protected?)
+
+      entry = T.must(@index["qux"].first)
+      assert_predicate(entry, :public?)
+    end
+
     private
 
     #: (Entry::Method entry, String call_string) -> void


### PR DESCRIPTION
### Motivation

I noticed we didn't handle changing method visibility post definition. This PR adds support for it.

### Implementation

The idea is to check if there are string or symbol arguments being passed and then change the visibility of the methods passed.

Otherwise, we continue doing the same as before.

### Automated Tests

Added a test.