### PR TITLE
Prefix framework tags with `framework:`

### DIFF
--- a/lib/ruby_lsp/listeners/spec_style.rb
+++ b/lib/ruby_lsp/listeners/spec_style.rb
@@ -71,7 +71,7 @@ module RubyLsp
             description,
             @uri,
             range_from_node(node),
-            tags: [:minitest],
+            framework: :minitest,
           )
           @response_builder.add(test_item)
         else
@@ -103,7 +103,7 @@ module RubyLsp
           description,
           @uri,
           range_from_node(node),
-          tags: [:minitest],
+          framework: :minitest,
         )
         parent_test_group.add(test_item)
       end

--- a/lib/ruby_lsp/requests/support/test_item.rb
+++ b/lib/ruby_lsp/requests/support/test_item.rb
@@ -13,14 +13,14 @@ module RubyLsp
         #: String
         attr_reader :id, :label
 
-        #: (String id, String label, URI::Generic uri, Interface::Range range, Array[Symbol] tags) -> void
-        def initialize(id, label, uri, range, tags: [])
+        #: (String id, String label, URI::Generic uri, Interface::Range range, Symbol framework) -> void
+        def initialize(id, label, uri, range, framework:)
           @id = id
           @label = label
           @uri = uri
           @range = range
-          @tags = tags
-          @children = T.let({}, T::Hash[String, TestItem])
+          @tags = ["framework:#{framework}"] #: Array[String]
+          @children = {} #: Hash[String, TestItem]
         end
 
         #: (TestItem item) -> void
@@ -36,11 +36,6 @@ module RubyLsp
         #: -> Array[TestItem]
         def children
           @children.values
-        end
-
-        #: (Symbol) -> bool
-        def tag?(tag)
-          @tags.include?(tag)
         end
 
         #: -> Hash[Symbol, untyped]

--- a/test/requests/discover_tests_test.rb
+++ b/test/requests/discover_tests_test.rb
@@ -375,7 +375,7 @@ module RubyLsp
                   class_name,
                   @uri,
                   range_from_node(node),
-                  tags: [:custom_addon],
+                  framework: :custom_addon,
                 )
 
                 @response_builder.add(@current_class)
@@ -396,7 +396,7 @@ module RubyLsp
                 test_name,
                 @uri,
                 range_from_node(node),
-                tags: [:custom_addon],
+                framework: :custom_addon,
               ))
             end
           end
@@ -418,7 +418,7 @@ module RubyLsp
 
     def assert_all_items_tagged_with(items, tag)
       items.each do |item|
-        assert_includes(item[:tags], tag)
+        assert_includes(item[:tags], "framework:#{tag}")
         children = item[:children]
         assert_all_items_tagged_with(children, tag) unless children.empty?
       end

--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -20,7 +20,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [
                   {
                     id: "ServerTest#test_server",
@@ -30,7 +30,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["minitest"],
+                    tags: ["framework:minitest"],
                     children: [],
                   },
                 ],
@@ -43,7 +43,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [
                   {
                     id: "StoreTest#test_store",
@@ -53,7 +53,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["minitest"],
+                    tags: ["framework:minitest"],
                     children: [],
                   },
                 ],
@@ -88,7 +88,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [],
               },
               {
@@ -99,7 +99,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [
                   {
                     id: "StoreTest#test_store",
@@ -109,7 +109,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["minitest"],
+                    tags: ["framework:minitest"],
                     children: [],
                   },
                 ],
@@ -144,7 +144,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [
                   {
                     id: "ServerTest#test_server",
@@ -154,7 +154,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["minitest"],
+                    tags: ["framework:minitest"],
                     children: [],
                   },
                   {
@@ -165,7 +165,7 @@ module RubyLsp
                       start: { line: 12, character: 2 },
                       end: { line: 30, character: 3 },
                     },
-                    tags: ["minitest"],
+                    tags: ["framework:minitest"],
                     children: [],
                   },
                 ],
@@ -276,7 +276,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [],
               },
               {
@@ -287,7 +287,7 @@ module RubyLsp
                   start: { line: 32, character: 0 },
                   end: { line: 60, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [],
               },
             ],
@@ -319,7 +319,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [
                   {
                     id: "ServerTest#test_server",
@@ -329,7 +329,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["minitest"],
+                    tags: ["framework:minitest"],
                     children: [],
                   },
                   {
@@ -340,7 +340,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["minitest"],
+                    tags: ["framework:minitest"],
                     children: [],
                   },
                 ],
@@ -353,7 +353,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [],
               },
               {
@@ -364,7 +364,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [
                   {
                     id: "StoreTest#test_store",
@@ -374,7 +374,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["minitest"],
+                    tags: ["framework:minitest"],
                     children: [],
                   },
                 ],
@@ -410,7 +410,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [
                   {
                     id: "<dynamic_reference>::ServerTest#test_server",
@@ -420,7 +420,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["minitest"],
+                    tags: ["framework:minitest"],
                     children: [],
                   },
                 ],
@@ -433,7 +433,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [],
               },
             ],
@@ -462,7 +462,7 @@ module RubyLsp
                 id: "CompletionTest#test_with_typed_false",
                 label: "test_with_typed_false",
                 uri: "file:///test/requests/completion_test.rb",
-                tags: ["debug", "minitest"],
+                tags: ["debug", "framework:minitest"],
                 children: [],
                 range: { start: { line: 704, character: 2 }, end: { line: 728, character: 5 } },
               },
@@ -470,7 +470,7 @@ module RubyLsp
                 id: "CompletionTest#test_with_typed_true",
                 label: "test_with_typed_true",
                 uri: "file:///test/requests/completion_test.rb",
-                tags: ["debug", "minitest"],
+                tags: ["debug", "framework:minitest"],
                 children: [],
                 range: { start: { line: 730, character: 2 }, end: { line: 754, character: 5 } },
               },
@@ -504,7 +504,7 @@ module RubyLsp
                   start: { line: 10, character: 2 },
                   end: { line: 20, character: 3 },
                 },
-                tags: ["minitest", "test_group"],
+                tags: ["framework:minitest", "test_group"],
                 children: [
                   {
                     id: "ServerTest::MainTest::NestedTest",
@@ -514,7 +514,7 @@ module RubyLsp
                       start: { line: 12, character: 4 },
                       end: { line: 14, character: 5 },
                     },
-                    tags: ["minitest", "test_group"],
+                    tags: ["framework:minitest", "test_group"],
                     children: [],
                   },
                 ],
@@ -555,7 +555,7 @@ module RubyLsp
                   start: { line: 1, character: 2 },
                   end: { line: 10, character: 3 },
                 },
-                tags: ["minitest"],
+                tags: ["framework:minitest"],
                 children: [],
               },
             ],
@@ -590,7 +590,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [
                   {
                     id: "ServerTest#test_server",
@@ -600,7 +600,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["test_unit"],
+                    tags: ["framework:test_unit"],
                     children: [],
                   },
                 ],
@@ -613,7 +613,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [
                   {
                     id: "StoreTest#test_store",
@@ -623,7 +623,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["test_unit"],
+                    tags: ["framework:test_unit"],
                     children: [],
                   },
                 ],
@@ -658,7 +658,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [],
               },
               {
@@ -669,7 +669,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [
                   {
                     id: "StoreTest#test_store",
@@ -679,7 +679,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["test_unit"],
+                    tags: ["framework:test_unit"],
                     children: [],
                   },
                 ],
@@ -724,7 +724,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["test_unit"],
+                    tags: ["framework:test_unit"],
                     children: [],
                   },
                   {
@@ -735,7 +735,7 @@ module RubyLsp
                       start: { line: 12, character: 2 },
                       end: { line: 30, character: 3 },
                     },
-                    tags: ["test_unit"],
+                    tags: ["framework:test_unit"],
                     children: [],
                   },
                 ],
@@ -770,7 +770,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [],
               },
               {
@@ -781,7 +781,7 @@ module RubyLsp
                   start: { line: 32, character: 0 },
                   end: { line: 60, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [],
               },
             ],
@@ -814,7 +814,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [
                   {
                     id: "ServerTest#test_server",
@@ -824,7 +824,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["test_unit"],
+                    tags: ["framework:test_unit"],
                     children: [],
                   },
                   {
@@ -835,7 +835,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["test_unit"],
+                    tags: ["framework:test_unit"],
                     children: [],
                   },
                 ],
@@ -848,7 +848,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [],
               },
               {
@@ -859,7 +859,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [
                   {
                     id: "StoreTest#test_store",
@@ -869,7 +869,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["test_unit"],
+                    tags: ["framework:test_unit"],
                     children: [],
                   },
                 ],
@@ -906,7 +906,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [
                   {
                     id: "<dynamic_reference>::ServerTest#test_server",
@@ -916,7 +916,7 @@ module RubyLsp
                       start: { line: 1, character: 2 },
                       end: { line: 10, character: 3 },
                     },
-                    tags: ["test_unit"],
+                    tags: ["framework:test_unit"],
                     children: [],
                   },
                 ],
@@ -929,7 +929,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [],
               },
             ],
@@ -958,7 +958,7 @@ module RubyLsp
                 id: "CompletionTest#test_with_typed_false",
                 label: "test_with_typed_false",
                 uri: "file:///test/requests/completion_test.rb",
-                tags: ["debug", "test_unit"],
+                tags: ["debug", "framework:test_unit"],
                 children: [],
                 range: { start: { line: 704, character: 2 }, end: { line: 728, character: 5 } },
               },
@@ -966,7 +966,7 @@ module RubyLsp
                 id: "CompletionTest#test_with_typed_true",
                 label: "test_with_typed_true",
                 uri: "file:///test/requests/completion_test.rb",
-                tags: ["debug", "test_unit"],
+                tags: ["debug", "framework:test_unit"],
                 children: [],
                 range: { start: { line: 730, character: 2 }, end: { line: 754, character: 5 } },
               },
@@ -1000,7 +1000,7 @@ module RubyLsp
                   start: { line: 10, character: 2 },
                   end: { line: 20, character: 3 },
                 },
-                tags: ["test_unit", "test_group"],
+                tags: ["framework:test_unit", "test_group"],
                 children: [
                   {
                     id: "ServerTest::MainTest::NestedTest",
@@ -1010,7 +1010,7 @@ module RubyLsp
                       start: { line: 12, character: 4 },
                       end: { line: 14, character: 5 },
                     },
-                    tags: ["test_unit", "test_group"],
+                    tags: ["framework:test_unit", "test_group"],
                     children: [],
                   },
                 ],
@@ -1051,7 +1051,7 @@ module RubyLsp
                   start: { line: 1, character: 2 },
                   end: { line: 10, character: 3 },
                 },
-                tags: ["test_unit"],
+                tags: ["framework:test_unit"],
                 children: [],
               },
             ],

--- a/test/response_builders/test_collection_test.rb
+++ b/test/response_builders/test_collection_test.rb
@@ -15,8 +15,8 @@ module RubyLsp
 
     def test_allows_building_hierarchy_of_tests
       builder = ResponseBuilders::TestCollection.new
-      test_item = Requests::Support::TestItem.new("my-id", "Test label", @uri, @range)
-      nested_item = Requests::Support::TestItem.new("nested-id", "Nested label", @uri, @range)
+      test_item = Requests::Support::TestItem.new("my-id", "Test label", @uri, @range, framework: :minitest)
+      nested_item = Requests::Support::TestItem.new("nested-id", "Nested label", @uri, @range, framework: :minitest)
 
       builder.add(test_item)
       test_item.add(nested_item)
@@ -30,16 +30,28 @@ module RubyLsp
 
     def test_overrides_if_trying_to_add_item_with_same_id
       builder = ResponseBuilders::TestCollection.new
-      test_item = Requests::Support::TestItem.new("my-id", "Test label", @uri, @range)
-      nested_item = Requests::Support::TestItem.new("nested-id", "Nested label", @uri, @range)
+      test_item = Requests::Support::TestItem.new("my-id", "Test label", @uri, @range, framework: :minitest)
+      nested_item = Requests::Support::TestItem.new("nested-id", "Nested label", @uri, @range, framework: :minitest)
 
       builder.add(test_item)
       test_item.add(nested_item)
 
-      builder.add(Requests::Support::TestItem.new("my-id", "Other title, but same ID", @uri, @range))
+      builder.add(Requests::Support::TestItem.new(
+        "my-id",
+        "Other title, but same ID",
+        @uri,
+        @range,
+        framework: :minitest,
+      ))
       assert_equal("Other title, but same ID", T.must(builder["my-id"]).label)
 
-      test_item.add(Requests::Support::TestItem.new("nested-id", "Other title, but same ID", @uri, @range))
+      test_item.add(Requests::Support::TestItem.new(
+        "nested-id",
+        "Other title, but same ID",
+        @uri,
+        @range,
+        framework: :minitest,
+      ))
       assert_equal("Other title, but same ID", T.must(test_item["nested-id"]).label)
     end
 


### PR DESCRIPTION
### Motivation

Prefix framework tags with `framework:` so that we can more easily differentiate this tag from all of the others we need to add in the extension side.

### Why not a new field?

We had considered making this a separate field, but there's one issue. VS Code's test items don't allow for custom properties of any kind and we need to be able to store this information in them so that we can reuse it.

Instead of trying to do something super involved, like trying to use custom test items in the explorer, I think we're better off with a convention here.

### Implementation

Started prefixing the test item framework tag with `framework:`.

### Automated Tests

Adjusted existing tests.