### PR TITLE
Use no-cache option when bundle installing

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -269,7 +269,7 @@ module RubyLsp
       T.unsafe(ENV).merge!(env)
 
       unless should_update && !force_install
-        Bundler::CLI::Install.new({}).run
+        Bundler::CLI::Install.new({ "no-cache" => true }).run
         correct_relative_remote_paths if @custom_lockfile.exist?
         return env
       end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -246,6 +246,26 @@ class IntegrationTest < Minitest::Test
     end
   end
 
+  def test_launch_mode_with_bundle_package
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~RUBY)
+        source "https://rubygems.org"
+        gem "stringio"
+      RUBY
+
+      Bundler.with_unbundled_env do
+        system("bundle", "install")
+        system("bundle", "package")
+
+        cached_gems = Dir.glob("#{dir}/vendor/cache/*.gem")
+        refute_empty(cached_gems)
+
+        launch(dir)
+        assert_empty(Dir.glob("#{dir}/vendor/cache/*.gem") - cached_gems)
+      end
+    end
+  end
+
   private
 
   def launch(workspace_path, exec = "ruby-lsp-launcher", extra_env = {})

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -693,7 +693,7 @@ class SetupBundlerTest < Minitest::Test
 
             mock_install = mock("install")
             mock_install.expects(:run)
-            Bundler::CLI::Install.expects(:new).with({}).returns(mock_install)
+            Bundler::CLI::Install.expects(:new).with({ "no-cache" => true }).returns(mock_install)
             RubyLsp::SetupBundler.new(dir, launcher: true).setup!
           end
         end
@@ -868,7 +868,7 @@ class SetupBundlerTest < Minitest::Test
             mock_install = mock("install")
             mock_install.expects(:run)
             require "bundler/cli/install"
-            Bundler::CLI::Install.expects(:new).with({}).returns(mock_install)
+            Bundler::CLI::Install.expects(:new).with({ "no-cache" => true }).returns(mock_install)
 
             RubyLsp::SetupBundler.new(dir, launcher: true).setup!
           end


### PR DESCRIPTION
### Motivation

My previous fix (#3277) unfortunately didn't work. If we exclude the `BUNDLE_CACHE_ALL` setting, bundle install will still cache them. We need to pass the `no-cache` option to avoid it.

### Implementation

Start using `no-cache` when bundle installing.

### Automated Tests

Added an integration test, which reproduces the issue as expected.