### PR TITLE
Allow test run cancellation in Test Results panel

### DIFF
--- a/vscode/src/linkedCancellationSource.ts
+++ b/vscode/src/linkedCancellationSource.ts
@@ -1,0 +1,33 @@
+import * as vscode from "vscode";
+
+export class LinkedCancellationSource implements vscode.Disposable {
+  private readonly tokenSource = new vscode.CancellationTokenSource();
+  private readonly disposables: vscode.Disposable[] = [this.tokenSource];
+
+  constructor(
+    token: vscode.CancellationToken,
+    ...additionalTokens: vscode.CancellationToken[]
+  ) {
+    [token, ...additionalTokens].forEach((token) => {
+      const disposable = token.onCancellationRequested(() => {
+        this.tokenSource.cancel();
+      });
+
+      this.disposables.push(disposable);
+    });
+  }
+
+  dispose() {
+    this.disposables.forEach((disposable) => disposable.dispose());
+  }
+
+  isCancellationRequested() {
+    return this.tokenSource.token.isCancellationRequested;
+  }
+
+  onCancellationRequested(callback: () => void) {
+    this.disposables.push(
+      this.tokenSource.token.onCancellationRequested(callback),
+    );
+  }
+}

--- a/vscode/src/test/suite/linkendCancellationSource.test.ts
+++ b/vscode/src/test/suite/linkendCancellationSource.test.ts
@@ -1,0 +1,27 @@
+import * as assert from "assert";
+
+import * as vscode from "vscode";
+
+import { LinkedCancellationSource } from "../../linkedCancellationSource";
+
+suite("LinkedCancellationSource", () => {
+  test("isCancellationRequested", async () => {
+    const cancellationSource = new vscode.CancellationTokenSource();
+    const linkedCancellationSource = new LinkedCancellationSource(
+      cancellationSource.token,
+    );
+    let callbackCalled = false;
+
+    await new Promise<void>((resolve) => {
+      linkedCancellationSource.onCancellationRequested(() => {
+        callbackCalled = true;
+        resolve();
+      });
+
+      cancellationSource.cancel();
+    });
+
+    assert.ok(linkedCancellationSource.isCancellationRequested());
+    assert.ok(callbackCalled);
+  });
+});

--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -843,18 +843,19 @@ suite("TestController", () => {
         }),
       } as any;
 
+      const cancellationSource = new vscode.CancellationTokenSource();
       const runStub = {
         started: sinon.stub(),
         passed: sinon.stub(),
         enqueued: sinon.stub(),
         end: sinon.stub(),
+        token: cancellationSource.token,
       } as any;
       const createRunStub = sinon
         .stub(controller.testController, "createTestRun")
         .returns(runStub);
 
       const runRequest = new vscode.TestRunRequest([testItem]);
-      const cancellationSource = new vscode.CancellationTokenSource();
       await controller.runTest(runRequest, cancellationSource.token);
 
       assert.ok(runStub.enqueued.calledWith(testItem));
@@ -893,18 +894,19 @@ suite("TestController", () => {
         }),
       } as any;
 
+      const cancellationSource = new vscode.CancellationTokenSource();
       const runStub = {
         started: sinon.stub(),
         passed: sinon.stub(),
         enqueued: sinon.stub(),
         end: sinon.stub(),
+        token: cancellationSource.token,
       } as any;
       const createRunStub = sinon
         .stub(controller.testController, "createTestRun")
         .returns(runStub);
 
       const debug = new Debugger(context, () => workspace);
-      const cancellationSource = new vscode.CancellationTokenSource();
       const startDebuggingSpy = sinon.spy(vscode.debug, "startDebugging");
 
       const runRequest = new vscode.TestRunRequest(
@@ -968,6 +970,7 @@ suite("TestController", () => {
         }),
       } as any;
 
+      const cancellationSource = new vscode.CancellationTokenSource();
       const runStub = {
         started: sinon.stub(),
         passed: sinon.stub(),
@@ -975,6 +978,7 @@ suite("TestController", () => {
         end: sinon.stub(),
         addCoverage: sinon.stub(),
         appendOutput: sinon.stub(),
+        token: cancellationSource.token,
       } as any;
       const createRunStub = sinon
         .stub(controller.testController, "createTestRun")
@@ -985,7 +989,6 @@ suite("TestController", () => {
         [],
         controller.coverageProfile,
       );
-      const cancellationSource = new vscode.CancellationTokenSource();
       const fakeFileContents = Buffer.from(
         JSON.stringify({
           // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->
While manual testing https://github.com/Shopify/ruby-lsp/pull/3338, we discovered tests can also be stopped from the Test Results panel, and that button was not working properly. The test process would continue running because we were only cancelling the test item request, but not the test run itself.

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

- Introduced a new `LinkedCancellationSource` class that coordinates cancellation between multiple sources
- The class monitors both test request and test run cancellation tokens
- When either token is cancelled, `LinkedCancellationSource` triggers cancellation of the test process

<!-- ### Automated Tests

We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. 

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
