### PR TITLE
Improve support for hovering over a gem in Gemfile

### DIFF
--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -86,6 +86,14 @@ module RubyLsp
 
       #: (Prism::StringNode node) -> void
       def on_string_node_enter(node)
+        if @path && File.basename(@path) == GEMFILE_NAME
+          parent = @node_context.parent
+          if parent.is_a?(Prism::CallNode) && parent.name == :gem && parent.arguments&.arguments&.first == node
+            generate_gem_hover(parent)
+            return
+          end
+        end
+
         generate_heredoc_hover(node)
       end
 

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -87,9 +87,9 @@ module RubyLsp
       #: (Prism::StringNode node) -> void
       def on_string_node_enter(node)
         if @path && File.basename(@path) == GEMFILE_NAME
-          parent = @node_context.parent
-          if parent.is_a?(Prism::CallNode) && parent.name == :gem && parent.arguments&.arguments&.first == node
-            generate_gem_hover(parent)
+          call_node = @node_context.call_node
+          if call_node && call_node.name == :gem && call_node.arguments&.arguments&.first == node
+            generate_gem_hover(call_node)
             return
           end
         end
@@ -131,11 +131,6 @@ module RubyLsp
 
       #: (Prism::CallNode node) -> void
       def on_call_node_enter(node)
-        if @path && File.basename(@path) == GEMFILE_NAME && node.name == :gem
-          generate_gem_hover(node)
-          return
-        end
-
         return if @sorbet_level.true_or_higher? && self_receiver?(node)
 
         message = node.message

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -273,28 +273,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
     end
   end
 
-  def test_hovering_over_gemfile_dependency_using_gem_call
-    source = <<~RUBY
-      gem 'rake'
-    RUBY
-
-    with_server(source, URI("file:///Gemfile")) do |server, uri|
-      server.process_message(
-        id: 1,
-        method: "textDocument/hover",
-        params: { textDocument: { uri: uri }, position: { character: 0, line: 0 } },
-      )
-
-      response = server.pop_response.response
-      spec = Gem.loaded_specs["rake"]
-
-      assert_includes(response.contents.value, spec.name)
-      assert_includes(response.contents.value, spec.version.to_s)
-      assert_includes(response.contents.value, spec.homepage)
-    end
-  end
-
-  def test_hovering_over_gemfile_dependency_using_gem_name
+  def test_hovering_over_gemfile_dependency_name
     source = <<~RUBY
       gem 'rake'
     RUBY
@@ -307,8 +286,11 @@ class HoverExpectationsTest < ExpectationsTestRunner
       )
 
       response = server.pop_response.response
+      spec = Gem.loaded_specs["rake"]
 
-      assert_includes(response.contents.value, "rake")
+      assert_includes(response.contents.value, spec.name)
+      assert_includes(response.contents.value, spec.version.to_s)
+      assert_includes(response.contents.value, spec.homepage)
     end
   end
 


### PR DESCRIPTION
### Motivation

Currently you can hover over an entry in the `Gemfile` to reveal information about a gem, but this works only for the `gem` call and not the string containing the gem name.

### Implementation

Added behaviour to the `on_string_node_enter` callback.

### Automated Tests

Included

### Manual Tests

Can be verified with Ruby LSP's own Gemfile, using this branch.