### PR TITLE
Ignore non Minitest or Test Unit items for resolve command

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -24,6 +24,7 @@ module RubyLsp
           until queue.empty?
             item = T.must(queue.shift)
             tags = Set.new(item[:tags])
+            next unless tags.include?("framework:minitest") || tags.include?("framework:test_unit")
 
             children = item[:children]
             uri = URI(item[:uri])
@@ -40,7 +41,7 @@ module RubyLsp
               unless children.any? && children.all? { |child| child[:tags].include?("test_group") }
                 aggregated_tests[path][item[:label]] = { tags: tags, examples: [] }
               end
-            elsif tags.include?("framework:minitest") || tags.include?("framework:test_unit")
+            else
               class_name, method_name = item[:id].split("#")
               aggregated_tests[path][class_name][:examples] << method_name
               aggregated_tests[path][class_name][:tags].merge(tags)

--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -195,14 +195,14 @@ module RubyLsp
                 id: "file:///test/server_test.rb",
                 uri: "file:///test/server_test.rb",
                 label: "/test/server_test.rb",
-                tags: ["test_file"],
+                tags: ["test_file", "framework:minitest"],
                 children: [],
               },
               {
                 id: "file:///test/store_test.rb",
                 uri: "file:///test/store_test.rb",
                 label: "/test/store_test.rb",
-                tags: ["test_file"],
+                tags: ["test_file", "framework:minitest"],
                 children: [],
               },
             ],
@@ -230,21 +230,21 @@ module RubyLsp
                 id: "file:///other/test",
                 uri: "file:///other/test",
                 label: "/other/test",
-                tags: ["test_dir"],
+                tags: ["test_dir", "framework:minitest"],
                 children: [],
               },
               {
                 id: "file:///test/server_test.rb",
                 uri: "file:///test/server_test.rb",
                 label: "/test/server_test.rb",
-                tags: ["test_file"],
+                tags: ["test_file", "framework:minitest"],
                 children: [],
               },
               {
                 id: "file:///test/store_test.rb",
                 uri: "file:///test/store_test.rb",
                 label: "/test/store_test.rb",
-                tags: ["test_file"],
+                tags: ["test_file", "framework:minitest"],
                 children: [],
               },
             ],
@@ -544,7 +544,7 @@ module RubyLsp
                 id: "file:///test/unit",
                 uri: "file:///test/unit",
                 label: "/test/unit",
-                tags: ["test_dir"],
+                tags: ["test_dir", "framework:minitest"],
                 children: [],
               },
               {
@@ -714,7 +714,7 @@ module RubyLsp
                   start: { line: 0, character: 0 },
                   end: { line: 30, character: 3 },
                 },
-                tags: ["test_uni", "test_group"],
+                tags: ["test_group", "framework:test_unit"],
                 children: [
                   {
                     id: "ServerTest#test_server",
@@ -1040,7 +1040,7 @@ module RubyLsp
                 id: "file:///test/unit",
                 uri: "file:///test/unit",
                 label: "/test/unit",
-                tags: ["test_dir"],
+                tags: ["test_dir", "framework:test_unit"],
                 children: [],
               },
               {
@@ -1066,6 +1066,70 @@ module RubyLsp
           ],
           result[:commands],
         )
+      end
+    end
+  end
+
+  class ResolveTestCommandsOtherFrameworksTest < Minitest::Test
+    def test_ignores_items_tagged_by_other_frameworks
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerTest",
+                uri: "file:///test/server_test.rb",
+                label: "ServerTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["framework:rails", "test_group"],
+                children: [
+                  {
+                    id: "ServerTest#test_server",
+                    uri: "file:///test/server_test.rb",
+                    label: "test_server",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["framework:rails"],
+                    children: [],
+                  },
+                ],
+              },
+              {
+                id: "StoreTest",
+                uri: "file:///test/store_test.rb",
+                label: "StoreTest",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["framework:rails", "test_group"],
+                children: [
+                  {
+                    id: "StoreTest#test_store",
+                    uri: "file:///test/store_test.rb",
+                    label: "test_store",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["framework:rails"],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_empty(result[:commands])
       end
     end
   end


### PR DESCRIPTION
### Motivation

We were using `partition` to separate Minitest and Test Unit tests items in order to resolve commands. However, this won't work once add-ons can contribute test items to discovery, we need to ignore anything that we don't want to handle.

### Implementation

Used `group_by` instead, so that we can ignore test items tagged with other frameworks.

### Automated Tests

Added a test.