### PR TITLE
Allow add-ons to resolve test commands

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -236,5 +236,13 @@ module RubyLsp
     # @overridable
     #: (ResponseBuilders::TestCollection response_builder, Prism::Dispatcher dispatcher, URI::Generic uri) -> void
     def create_discover_tests_listener(response_builder, dispatcher, uri); end
+
+    # Resolves the minimal set of commands required to execute the requested tests. Add-ons are responsible for only
+    # handling items related to the framework they add support for and have discovered themselves
+    # @overridable
+    #: (Array[Hash[Symbol, untyped]]) -> Array[String]
+    def resolve_test_commands(items)
+      []
+    end
   end
 end

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1459,11 +1459,16 @@ module RubyLsp
     #: (Hash[Symbol, untyped] message) -> void
     def resolve_test_commands(message)
       items = message.dig(:params, :items)
+      commands = Listeners::TestStyle.resolve_test_commands(items)
+
+      Addon.addons.each do |addon|
+        commands.concat(addon.resolve_test_commands(items))
+      end
 
       send_message(Result.new(
         id: message[:id],
         response: {
-          commands: Listeners::TestStyle.resolve_test_commands(items),
+          commands: commands,
           reporterPaths: [Listeners::TestStyle::MINITEST_REPORTER_PATH, Listeners::TestStyle::TEST_UNIT_REPORTER_PATH],
         },
       ))


### PR DESCRIPTION
### Motivation

Closes #3177

Add-ons need to be able to both discover test items and resolve the commands needed to execute them. This PR adds support for add-ons to resolve commands.

### Implementation

The idea is to have the add-ons only handle test items that were tagged by them, ignoring everything else. In this scenario, we should be able to simply concatenate all responses and avoid conflicts.

### Automated Tests

Added tests.