### PR TITLE
Remove workspace from map when not eagerly activating

### DIFF
--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -211,6 +211,7 @@ export class RubyLsp {
     // When eagerly activating workspaces, we skip the ones that do not have a lockfile since they may not be a Ruby
     // workspace. Those cases are activated lazily below
     if (eager && !lockfileExists) {
+      this.workspacesBeingLaunched.delete(workspaceFolder.index);
       return;
     }
 


### PR DESCRIPTION
### Motivation

Closes #3189, closes #3253

When we return early from the workspace activation, we still need to remove the workspace from the map that guards against duplicate launches - otherwise that workspace will never be able to activate lazily later.

### Implementation

We need to ensure we clean up even in the early return.