### PR TITLE
Apply debug env customizations on top of Ruby environment

### DIFF
--- a/vscode/src/debugger.ts
+++ b/vscode/src/debugger.ts
@@ -113,8 +113,8 @@ export class Debugger
     if (debugConfiguration.env) {
       // If the user has their own debug launch configurations, we still need to inject the Ruby environment
       debugConfiguration.env = Object.assign(
-        debugConfiguration.env,
         workspace.ruby.env,
+        debugConfiguration.env,
       );
     } else {
       debugConfiguration.env = workspace.ruby.env;

--- a/vscode/src/test/suite/debugger.test.ts
+++ b/vscode/src/test/suite/debugger.test.ts
@@ -70,7 +70,9 @@ suite("Debugger", () => {
 
   test("Resolve configuration injects Ruby environment", async () => {
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
-    const ruby = { env: { bogus: "hello!" } } as unknown as Ruby;
+    const ruby = {
+      env: { bogus: "hello!", overrideMe: "oldValue" },
+    } as unknown as Ruby;
     const workspaceFolder = {
       name: "fake",
       uri: vscode.Uri.file("fake"),
@@ -90,10 +92,14 @@ suite("Debugger", () => {
         request: "launch",
         // eslint-disable-next-line no-template-curly-in-string
         program: "ruby ${file}",
+        env: {
+          overrideMe: "newValue",
+        },
       },
     );
 
-    assert.strictEqual(ruby.env, configs.env);
+    assert.strictEqual(configs.env.bogus, "hello!");
+    assert.strictEqual(configs.env.overrideMe, "newValue");
     debug.dispose();
     context.subscriptions.forEach((subscription) => subscription.dispose());
   });


### PR DESCRIPTION
### Motivation

Closes #3265

When merging the Ruby environment with the debug configurations environment, we inverted the order of operations. We have to apply the Ruby environment first and then the one coming from debug configs, otherwise the user can't customize anything.

### Implementation

Fixed the order.

### Automated Tests

Improved our existing test.