### PR TITLE
Implement debug handler based on command resolution

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -342,6 +342,11 @@ class ExperimentalCapabilities implements StaticFeature {
   clear(): void {}
 }
 
+export interface ResolvedCommands {
+  commands: string[];
+  reporterPaths: string[] | undefined;
+}
+
 export default class Client extends LanguageClient implements ClientInterface {
   public readonly ruby: Ruby;
   public serverVersion?: string;
@@ -502,9 +507,7 @@ export default class Client extends LanguageClient implements ClientInterface {
     });
   }
 
-  async resolveTestCommands(
-    items: LspTestItem[],
-  ): Promise<{ commands: string[]; reporterPaths: string[] | undefined }> {
+  async resolveTestCommands(items: LspTestItem[]): Promise<ResolvedCommands> {
     return this.sendRequest("rubyLsp/resolveTestCommands", {
       items,
     });


### PR DESCRIPTION
### Motivation

Closes #3311

This PR implements a new handler for the debug profile based on the test command resolution mechanism we created.

### Implementation

Which profile is triggering the execution of the test explorer is included as part of the request parameter. This allows us to share the logic all the way after resolving test commands.

After that, we need to launch the debugger with the given commands instead of running them in the background like we do for the run profile.

### Note

We unfortunately cannot use our JSON reporters to update the explorer's UI in this case, because the debugger needs to use the stdio pipes to communicate with the editor. We can't try to create a JSON RPC connection with the underlying process as that breaks the debug adapter.

### Automated Tests

Added a test.

### Manual Tests

1. Launch the extension on this branch
2. Open the test explorer
3. Run some tests in debug mode
4. Verify the debugger is launched