### PR TITLE
Troubleshooting silent Ruby LSP output channel docs hint

### DIFF
--- a/jekyll/troubleshooting.markdown
+++ b/jekyll/troubleshooting.markdown
@@ -193,10 +193,14 @@ assist.
 ### Check the VS Code output tab
 
 Many of the activation steps taken are logged in the `Ruby LSP` channel of VS Code's `Output` tab. Check the logs to see
-if any entries hint at what the issue might be. Did the extension select your preferred shell?
+if any entries hint at what the issue might be.
+
+Did the extension select your preferred shell?
 
 Did it select your preferred version manager? You can define which version manager to use with the
 `"rubyLsp.rubyVersionManager"` setting.
+
+No output in the `Ruby LSP` channel? Check the `Extension Host` channel for any errors related to extension startup.
 
 ### Enable logging
 


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

I was experiencing the following symptoms:
- `ruby-lsp` would fail to activate the ruby environment while being stuck on "Starting..."
- extension starting/stopping would seem non-responsive
- no output in Ruby LSP terminal channel
- no popup error messages of any kind from extension

Ultimately the problem was that my VSCode git feature was disabled and the `ruby-lsp` extension would "silently" fail to start. I was only able to discover this once I stumbled on the `Extension Host` output channel, after exhausting a lot of other debugging steps & time (reviewing existing github issues, documented diagnosis steps, etc, etc).

This PR aims to give the next person who may run into similar symptoms a bit more context that I was missing, as the nuance of how extensions function within VSCode is probably overlooked by many.

Note: If someone has ideas or wanted to point me in the correct direction for surfacing this git dependency/startup failure more natively through the extension/vscode, I could look into it. But, this diff seemed harmless enough to go ahead and submit regardless.
