### PR TITLE
Add coverage data collection to the test reporter

### DIFF
--- a/lib/ruby_lsp/test_reporter.rb
+++ b/lib/ruby_lsp/test_reporter.rb
@@ -67,6 +67,85 @@ module RubyLsp
         send_message("append_output", params)
       end
 
+      # Gather the results returned by Coverage.result and format like the VS Code test explorer expects
+      #
+      # Coverage result format:
+      #
+      # Lines are reported in order as an array where each number is the number of times it was executed. For example,
+      # the following says that line 0 was executed 1 time and line 1 executed 3 times: [1, 3].
+      # Nil values represent lines for which coverage is not available, like empty lines, comments or keywords like
+      # `else`
+      #
+      # Branches are a hash containing the name of the branch and the location where it is found in tuples with the
+      # following elements: [NAME, ID, START_LINE, START_COLUMN, END_LINE, END_COLUMN] as the keys and the value is the
+      # number of times it was executed
+      #
+      # Methods are a similar hash [ClassName, :method_name, START_LINE, START_COLUMN, END_LINE, END_COLUMN] => NUMBER
+      # OF EXECUTIONS
+      #
+      # Example:
+      # {
+      #   "file_path" => {
+      #     "lines" => [1, 2, 3, nil],
+      #     "branches" => {
+      #       ["&.", 0, 6, 21, 6, 65] => { [:then, 1, 6, 21, 6, 65] => 0, [:else, 5, 7, 0, 7, 87] => 1 }
+      #     },
+      #     "methods" => {
+      #       ["Foo", :bar, 6, 21, 6, 65] => 0
+      #     }
+      # }
+      #: () -> Hash[String, StatementCoverage]
+      def gather_coverage_results
+        # Ignore coverage results inside dependencies
+        bundle_path = Bundler.bundle_path.to_s
+        default_gems_path = File.dirname(RbConfig::CONFIG["rubylibdir"])
+
+        result = Coverage.result.reject do |file_path, _coverage_info|
+          file_path.start_with?(bundle_path) ||
+            file_path.start_with?(default_gems_path) ||
+            file_path.start_with?("eval")
+        end
+
+        result.to_h do |file_path, coverage_info|
+          # Format the branch coverage information as VS Code expects it and then group it based on the start line of
+          # the conditional that causes the branching. We need to match each line coverage data with the branches that
+          # spawn from that line
+          branch_by_line = coverage_info[:branches]
+            .flat_map do |branch, data|
+              branch_name, _branch_id, branch_start_line, _branch_start_col, _branch_end_line, _branch_end_col = branch
+
+              data.map do |then_or_else, execution_count|
+                name, _id, start_line, start_column, end_line, end_column = then_or_else
+
+                {
+                  groupingLine: branch_start_line,
+                  executed: execution_count,
+                  location: {
+                    start: { line: start_line, character: start_column },
+                    end: { line: end_line, character: end_column },
+                  },
+                  label: "#{branch_name} #{name}",
+                }
+              end
+            end
+            .group_by { |branch| branch[:groupingLine] }
+
+          # Format the line coverage information, gathering any branch coverage data associated with that line
+          data = coverage_info[:lines].filter_map.with_index do |execution_count, line_index|
+            next if execution_count.nil?
+
+            {
+              executed: execution_count,
+              location: { line: line_index, character: 0 },
+              branches: branch_by_line[line_index] || [],
+            }
+          end
+
+          # The expected format is URI => { executed: number_of_times_executed, location: { ... }, branches: [ ... ] }
+          [URI::Generic.from_path(path: File.expand_path(file_path)).to_s, data]
+        end
+      end
+
       private
 
       #: (method_name: String?, params: Hash[String, untyped]) -> void
@@ -109,6 +188,20 @@ module RubyLsp
   end
 end
 
-# We wrap the default output stream so that we can capture anything written to stdout and emit it as part of
-# the JSON event stream.
-$> = RubyLsp::TestReporter::IOWrapper.new($stdout)
+if ENV["RUBY_LSP_TEST_RUNNER"]
+  # We wrap the default output stream so that we can capture anything written to stdout and emit it as part of the JSON
+  # event stream.
+  $> = RubyLsp::TestReporter::IOWrapper.new($stdout)
+
+  if ENV["RUBY_LSP_TEST_RUNNER"] == "coverage"
+    # Auto start coverage when running tests under that profile. This avoids the user from having to configure coverage
+    # manually for their project or adding extra dependencies
+    require "coverage"
+    Coverage.start(:all)
+
+    at_exit do
+      coverage_results = RubyLsp::TestReporter.gather_coverage_results
+      File.write(File.join(".ruby-lsp", "coverage_result.json"), coverage_results.to_json)
+    end
+  end
+end

--- a/sorbet/rbi/shims/test_reporter.rbi
+++ b/sorbet/rbi/shims/test_reporter.rbi
@@ -1,0 +1,15 @@
+# typed: true
+
+module RubyLsp::TestReporter
+  # https://code.visualstudio.com/api/references/vscode-api#Position
+  Position = T.type_alias { { line: Integer, character: Integer } }
+
+  # https://code.visualstudio.com/api/references/vscode-api#Range
+  Range = T.type_alias { { start: Position, end: Position } }
+
+  # https://code.visualstudio.com/api/references/vscode-api#BranchCoverage
+  BranchCoverage = T.type_alias { { executed: Integer, label: String, location: Range } }
+
+  # https://code.visualstudio.com/api/references/vscode-api#StatementCoverage
+  StatementCoverage = T.type_alias { { executed: Integer, location: Position, branches: T::Array[BranchCoverage] } }
+end

--- a/test/minitest_test_runner_test.rb
+++ b/test/minitest_test_runner_test.rb
@@ -8,7 +8,7 @@ module RubyLsp
     def test_minitest_output
       plugin_path = "lib/ruby_lsp/ruby_lsp_reporter_plugin.rb"
       # In Ruby 3.1, the require fails unless Bundler is set up.
-      env = { "RUBYOPT" => "-rbundler/setup -r./#{plugin_path}" }
+      env = { "RUBYOPT" => "-rbundler/setup -r./#{plugin_path}", "RUBY_LSP_TEST_RUNNER" => "run" }
       _stdin, stdout, _stderr, _wait_thr = T.unsafe(Open3).popen3(
         env,
         "bundle",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ require "mocha/minitest"
 # `Minitest::Reporters.use!` overrides our reporter customizations and breaks the integrations.
 #
 # We also don't need debug related things
-unless ENV["RUBY_LSP_TEST_RUNNER"] == "true"
+unless ENV["RUBY_LSP_TEST_RUNNER"]
   SORBET_PATHS = Gem.loaded_specs["sorbet-runtime"].full_require_paths.freeze #: Array[String]
 
   # Define breakpoint methods without actually activating the debugger

--- a/test/test_reporter_test.rb
+++ b/test/test_reporter_test.rb
@@ -1,0 +1,56 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+require "coverage"
+require "ruby_lsp/test_reporter"
+
+module RubyLsp
+  class TestReporterTest < Minitest::Test
+    def test_coverage_results_are_formatted_as_vscode_expects
+      path = "/path/to/file.rb"
+      Coverage.expects(:result).returns({
+        path => {
+          lines: [1, 2, 3, nil],
+          branches: {
+            ["&.", 0, 2, 2, 3, 6] => { [:then, 1, 2, 2, 2, 6] => 0, [:else, 3, 3, 2, 3, 6] => 1 },
+          },
+        },
+      })
+
+      uri = URI::Generic.from_path(path: File.expand_path(path)).to_s
+
+      assert_equal(
+        {
+          uri =>
+            [
+              { executed: 1, location: { line: 0, character: 0 }, branches: [] },
+              { executed: 2, location: { line: 1, character: 0 }, branches: [] },
+              {
+                executed: 3,
+                location: { line: 2, character: 0 },
+                branches:
+                [
+                  {
+                    groupingLine: 2,
+                    executed: 0,
+                    location:
+                          { start: { line: 2, character: 2 }, end: { line: 2, character: 6 } },
+                    label: "&. then",
+                  },
+                  {
+                    groupingLine: 2,
+                    executed: 1,
+                    location:
+                    { start: { line: 3, character: 2 }, end: { line: 3, character: 6 } },
+                    label: "&. else",
+                  },
+                ],
+              },
+            ],
+        },
+        TestReporter.gather_coverage_results,
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

First step for #1800

This PR adds the capability to our test reporter to collect coverage using Ruby's built-in coverage API.

### Implementation

The coverage API is pretty convenient. You invoke `Coverage.start` to begin collecting and then `Coverage.result` returns the data.

The implementation is essentially just that. The rest is simply transforming the coverage data that comes from the Ruby API into the format that VS Code expects, so that we don't need any handling on the extension side.

### Automated Tests

Added a test.