### PR TITLE
Add test run durations to status updates

### DIFF
--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -857,9 +857,9 @@ suite("TestController", () => {
       const cancellationSource = new vscode.CancellationTokenSource();
       await controller.runTest(runRequest, cancellationSource.token);
 
-      assert.ok(runStub.enqueued.calledWithExactly(testItem));
-      assert.ok(runStub.started.calledWithExactly(testItem));
-      assert.ok(runStub.passed.calledWithExactly(testItem));
+      assert.ok(runStub.enqueued.calledWith(testItem));
+      assert.ok(runStub.started.calledWith(testItem));
+      assert.ok(runStub.passed.calledWith(testItem));
       assert.ok(runStub.end.calledWithExactly());
 
       createRunStub.restore();
@@ -1008,9 +1008,9 @@ suite("TestController", () => {
       await controller.runTest(runRequest, cancellationSource.token);
       fsStub.restore();
 
-      assert.ok(runStub.enqueued.calledWithExactly(testItem));
-      assert.ok(runStub.started.calledWithExactly(testItem));
-      assert.ok(runStub.passed.calledWithExactly(testItem));
+      assert.ok(runStub.enqueued.calledWith(testItem));
+      assert.ok(runStub.started.calledWith(testItem));
+      assert.ok(runStub.passed.calledWith(testItem));
       assert.ok(runStub.end.calledWithExactly());
       assert.ok(
         runStub.appendOutput.calledWithExactly(


### PR DESCRIPTION
### Motivation

The explorer supports reporting how long a test run took. We can simply set that to the time difference between when a test began executing and when we received a final update for it (pass, error or fail).

### Implementation

The idea is to use a map of `test_id => started_timestamp`, so that we can retrieve when a test started and calculate the duration.

To avoid repeating the calculation multiple times, I created a tiny function inside the same scope to return the duration.

### Automated Tests

Adjusted our existing tests to not try to assert the duration since that would make them flaky.