### PR TITLE
Strip HTML comments from RBS docs

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -293,7 +293,9 @@ module RubyIndexer
 
     #: ((RBS::AST::Declarations::Class | RBS::AST::Declarations::Module | RBS::AST::Declarations::Constant | RBS::AST::Declarations::Global | RBS::AST::Members::MethodDefinition | RBS::AST::Members::Alias) declaration) -> String?
     def comments_to_string(declaration)
-      declaration.comment&.string
+      # HTML comments are not rendered in VS Code, but they are in some other editors, so
+      # we need to strip them out.
+      declaration.comment&.string&.gsub(/<!--.*?-->/m, "")
     end
   end
 end


### PR DESCRIPTION
### Motivation

Ruby LSP supports hovering over a method to show its docs. For Ruby itself, these docs come from RBS, and may include HTML comments which are a kind of metadata.

VS Code ignores these HTML comments, but in other editors, such as Vim and Zed, they are displayed as part of the content, e.g.:

<img width="356" alt="Screenshot 2025-04-01 at 1 16 24 PM" src="https://github.com/user-attachments/assets/22e74fd9-302e-4a23-a36c-d925bd1c074a" />

This PR strips them out:

<img width="348" alt="Screenshot 2025-04-01 at 1 42 31 PM" src="https://github.com/user-attachments/assets/b3d08a02-c310-4ab3-af8f-8bec27f30097" />

### Implementation

I've added the removal behaviour where the indexing happens, but it may be better to do it at a higher level, e.g. on the hover request, so that the 'raw' comment is still available through the index in case it's needed for other purposes. Any opinions?

### Automated Tests

None yet - I will add once there is a consensus on the approach.

### Manual Tests

Hover over a method definition from RBS, such as `"".length`.

cc @adam12 who [reported](https://ruby-dx.slack.com/archives/C050D17S6FP/p1737144877686379) this in the Ruby DX Slack a while ago.