### PR TITLE
Ensure colons are escaped when building URIs

### DIFF
--- a/lib/ruby_indexer/test/uri_test.rb
+++ b/lib/ruby_indexer/test/uri_test.rb
@@ -12,12 +12,12 @@ module RubyIndexer
 
     def test_from_path_on_windows
       uri = URI::Generic.from_path(path: "C:/some/windows/path/to/file.rb")
-      assert_equal("/C:/some/windows/path/to/file.rb", uri.path)
+      assert_equal("/C%3A/some/windows/path/to/file.rb", uri.path)
     end
 
     def test_from_path_on_windows_with_lowercase_drive
       uri = URI::Generic.from_path(path: "c:/some/windows/path/to/file.rb")
-      assert_equal("/c:/some/windows/path/to/file.rb", uri.path)
+      assert_equal("/c%3A/some/windows/path/to/file.rb", uri.path)
     end
 
     def test_to_standardized_path_on_unix
@@ -67,6 +67,19 @@ module RubyIndexer
 
       uri.add_require_path_from_load_entry("/some/unix/path")
       assert_equal("to/file", uri.require_path)
+    end
+
+    def test_from_path_escapes_colon_characters
+      uri = URI::Generic.from_path(path: "c:/some/windows/path with/spaces/file.rb")
+      assert_equal("c:/some/windows/path with/spaces/file.rb", uri.to_standardized_path)
+      assert_equal("file:///c%3A/some/windows/path%20with/spaces/file.rb", uri.to_s)
+    end
+
+    def test_from_path_with_unicode_characters
+      path = "/path/with/unicode/文件.rb"
+      uri = URI::Generic.from_path(path: path)
+      assert_equal(path, uri.to_standardized_path)
+      assert_equal("file:///path/with/unicode/%E6%96%87%E4%BB%B6.rb", uri.to_s)
     end
   end
 end


### PR DESCRIPTION
### Motivation

Closes #3285

The issue reported is that we're duplicating entries on Windows because one URI gets escaped and the other does not. The source of the problem is a difference between how Ruby escapes URIs and VS Code.

VS Code will always escape colon characters as `%3A`, but that's not the default behaviour for `URI::DEFAULT_PARSER.escape`. When we read URIs from disk, we're using the Ruby logic which generates one URI and then, when we receive requests from the editor for the same resource, we receive the escaped version of the URI.

```ruby
# What we get with Ruby
file:///C:/some/path.rb

# What we get from VS Code
file:///C%3A/some/path.rb
```

We need to ensure that we are escaping URIs in a way that's consistent with VS Code, otherwise we risk duplicating resources.

### Implementation

The URI implementation has a regex of unsafe characters, which it uses to decide what to escape and what to not escape.

To fix the problem, I just took that regex and removed colon from the list of safe characters, which then makes we produce the expected URIs during the initial indexing.

### Automated Tests

Added a test related to the bug and another one for unicode characters, which we were missing.