### PR TITLE
Introduce Addon::notify to standardize error handling for add-ons

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -26,7 +26,7 @@ module RubyLsp
         Listeners::CodeLens.new(@response_builder, global_state, uri, dispatcher)
 
         Addon.addons.each do |addon|
-          addon.create_code_lens_listener(@response_builder, uri, dispatcher)
+          Addon.notify(addon, :create_code_lens_listener, @response_builder, uri, dispatcher)
         end
       end
 

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -74,7 +74,7 @@ module RubyLsp
         )
 
         Addon.addons.each do |addon|
-          addon.create_completion_listener(@response_builder, node_context, dispatcher, document.uri)
+          Addon.notify(addon, :create_completion_listener, @response_builder, node_context, dispatcher, document.uri)
         end
 
         matched = node_context.node

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -86,7 +86,7 @@ module RubyLsp
           )
 
           Addon.addons.each do |addon|
-            addon.create_definition_listener(@response_builder, document.uri, node_context, dispatcher)
+            Addon.notify(addon, :create_definition_listener, @response_builder, document.uri, node_context, dispatcher)
           end
         end
 

--- a/lib/ruby_lsp/requests/discover_tests.rb
+++ b/lib/ruby_lsp/requests/discover_tests.rb
@@ -40,7 +40,7 @@ module RubyLsp
           Listeners::SpecStyle.new(@response_builder, @global_state, @dispatcher, @document.uri)
 
           Addon.addons.each do |addon|
-            addon.create_discover_tests_listener(@response_builder, @dispatcher, @document.uri)
+            Addon.notify(addon, :create_discover_tests_listener, @response_builder, @dispatcher, @document.uri)
           end
 
           @dispatcher.visit(@document.parse_result.value)
@@ -58,7 +58,7 @@ module RubyLsp
             Listeners::SpecStyle.new(@response_builder, @global_state, @dispatcher, @document.uri)
 
             Addon.addons.each do |addon|
-              addon.create_discover_tests_listener(@response_builder, @dispatcher, @document.uri)
+              Addon.notify(addon, :create_discover_tests_listener, @response_builder, @dispatcher, @document.uri)
             end
 
             # Dispatch the events both for indexing the test file and discovering the tests. The order here is

--- a/lib/ruby_lsp/requests/document_symbol.rb
+++ b/lib/ruby_lsp/requests/document_symbol.rb
@@ -27,7 +27,7 @@ module RubyLsp
         Listeners::DocumentSymbol.new(@response_builder, uri, dispatcher)
 
         Addon.addons.each do |addon|
-          addon.create_document_symbol_listener(@response_builder, dispatcher)
+          Addon.notify(addon, :create_document_symbol_listener, @response_builder, dispatcher)
         end
       end
 

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -53,7 +53,7 @@ module RubyLsp
         @response_builder = ResponseBuilders::Hover.new #: ResponseBuilders::Hover
         Listeners::Hover.new(@response_builder, global_state, uri, node_context, dispatcher, sorbet_level)
         Addon.addons.each do |addon|
-          addon.create_hover_listener(@response_builder, node_context, dispatcher)
+          Addon.notify(addon, :create_hover_listener, @response_builder, node_context, dispatcher)
         end
 
         @dispatcher = dispatcher

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -87,7 +87,7 @@ module RubyLsp
         Listeners::SemanticHighlighting.new(dispatcher, @response_builder)
 
         Addon.addons.each do |addon|
-          addon.create_semantic_highlighting_listener(@response_builder, dispatcher)
+          Addon.notify(addon, :create_semantic_highlighting_listener, @response_builder, dispatcher)
         end
       end
 

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1056,12 +1056,7 @@ module RubyLsp
       end
 
       Addon.file_watcher_addons.each do |addon|
-        T.unsafe(addon).workspace_did_change_watched_files(changes)
-      rescue => e
-        send_log_message(
-          "Error in #{addon.name} add-on while processing watched file notifications: #{e.full_message}",
-          type: Constant::MessageType::ERROR,
-        )
+        Addon.notify(addon, :workspace_did_change_watched_files, changes)
       end
     end
 
@@ -1362,7 +1357,7 @@ module RubyLsp
       addon = Addon.addons.find { |addon| addon.name == addon_name }
       return unless addon
 
-      addon.handle_window_show_message_response(result[:title])
+      Addon.notify(addon, :handle_window_show_message_response, result[:title])
     end
 
     # NOTE: all servers methods are void because they can produce several messages for the client. The only reason this
@@ -1462,7 +1457,7 @@ module RubyLsp
       commands = Listeners::TestStyle.resolve_test_commands(items)
 
       Addon.addons.each do |addon|
-        commands.concat(addon.resolve_test_commands(items))
+        commands.concat(Addon.notify(addon, :resolve_test_commands, items))
       end
 
       send_message(Result.new(


### PR DESCRIPTION
Wraps calls to add-on actions with error handling so that they don't bring down the server.

<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation
Closes #3315 
<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests
Yes
<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
