### PR TITLE
VS Code: Add customBinaryPath option

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -395,6 +395,10 @@
           "description": "A shell command to activate the right Ruby version or add a custom Ruby bin folder to the PATH. Only used if rubyVersionManager is set to 'custom'",
           "type": "string"
         },
+        "rubyLsp.customBinaryPath": {
+          "description": "A path to a custom Ruby LSP binary executable",
+          "type": "string"
+        },
         "rubyLsp.formatter": {
           "description": "Which tool the Ruby LSP should use for formatting files",
           "type": "string",

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -99,6 +99,7 @@ function getLspExecutables(
   const config = vscode.workspace.getConfiguration("rubyLsp");
   const branch: string = config.get("branch")!;
   const customBundleGemfile: string = config.get("bundleGemfile")!;
+  const customBinPath: string = config.get("customBinaryPath")!;
   const useBundlerCompose: boolean = config.get("useBundlerCompose")!;
   const bypassTypechecker: boolean = config.get("bypassTypechecker")!;
 
@@ -110,9 +111,23 @@ function getLspExecutables(
     shell: true,
   };
 
+  // If there's a user defined custom binary path, run it and just trust that it is `ruby-lsp` compatible.
+  if (customBinPath) {
+    run = {
+      command: customBinPath,
+      args: [],
+      options: executableOptions,
+    };
+
+    debug = {
+      command: customBinPath,
+      args: ["--debug"],
+      options: executableOptions,
+    };
+  }
   // If there's a user defined custom bundle, we run the LSP with `bundle exec` and just trust the user configured
   // their bundle. Otherwise, we run the global install of the LSP and use our composed bundle logic in the server
-  if (customBundleGemfile.length > 0) {
+  else if (customBundleGemfile.length > 0) {
     run = {
       command: "bundle",
       args: ["exec", "ruby-lsp"],


### PR DESCRIPTION
### Motivation

This option allows to provide any compatible binary to be used as `ruby-lsp` exec. This is especially useful for containerized development with VS Code running on the host machine (i.e., not using Dev Containers or Remote Containers). A typical use case is the applications using `dip` (and [ruby-on-whales](https://evilmartians.com/chronicles/ruby-on-whales-docker-for-ruby-rails-development)) (see #2919). However, the ability to customize the binary path has many more potential applications.

_Motivation continues..._

I've been using a similar approach with Zed for a while (it already provides this option). The trick is to use a thin Bash wrapper to run `ruby-lsp` anywhere. Mine looks as follows:

```sh
#!/bin/bash

cd $(dirname $0)/..

dip ruby-lsp $@
```

That's it.

With this change, we can configure `rubyLsp.customBinaryPath` to point to a custom executable (say, ".dockerdev/ruby-lsp"), and benefit from LSP features even without having Ruby LSP (and even Ruby) installed locally (let me omit some Docker-specific tricks used to make it work, not relevant to the proposal).

### Implementation

- Added new configuration option to `package.json`: `customBinaryPath`
- Updated `client.ts` to use the new option if present to generate commands configuration.

### Automated Tests

None. Couldn't find any tests for similar functionality (commands configuration). Would love to have some guidance here. 

### Manual Tests

Packaged and installed the forked version locally and verified that LSP works.