### PR TITLE
Fix RBS highlighting in Ruby regexes

### DIFF
--- a/vscode/grammars/rbs.injection.json
+++ b/vscode/grammars/rbs.injection.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "rbs-signature": {
-      "begin": "(?<![\"'/][^\"'/]*)(#:)",
+      "begin": "(?<![\"'/][^\"'/]*)(#(?::|\\|))",
       "beginCaptures": {
         "1": {
           "name": "comment.line.signature.rbs"

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -456,6 +456,35 @@ suite("Grammars", () => {
         assert.deepStrictEqual(actualTokens, expectedTokens);
       });
 
+      test("multi-line method signature with continuation (#|)", () => {
+        const ruby = "#: ()\n#| -> void";
+        const expectedTokens = [
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
+          [" ", ["meta.type.signature.rbs"]],
+          [
+            "(",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
+          [
+            ")",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
+          ["#|", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
+          [" ", ["meta.type.signature.rbs"]],
+          [
+            "->",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.signature.return.rbs",
+            ],
+          ],
+          [" ", ["meta.type.signature.rbs"]],
+          ["void", ["meta.type.signature.rbs", "support.type.builtin.rbs"]],
+        ];
+        const actualTokens = tokenizeRBS(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+
       test("inline method signature with &", () => {
         const ruby = "#: [X] (X & Object) -> Class[X]";
         const expectedTokens = [


### PR DESCRIPTION
Before:

<img width="223" alt="image" src="https://github.com/user-attachments/assets/1f4e4eda-b62f-4ec8-ac21-0e91b3cda4af" />

After:

<img width="223" alt="image" src="https://github.com/user-attachments/assets/463d4db1-e672-484b-8094-1ed00a0fa3c5" />
