### PR TITLE
Highlight multiline RBS signature syntax

### DIFF
--- a/vscode/grammars/rbs.injection.json
+++ b/vscode/grammars/rbs.injection.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "rbs-signature": {
-      "begin": "(?<![\"'/][^\"'/]*)(#:)",
+      "begin": "(?<![\"'/][^\"'/]*)(#(?::|\\|))",
       "beginCaptures": {
         "1": {
           "name": "comment.line.signature.rbs"

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -456,6 +456,35 @@ suite("Grammars", () => {
         assert.deepStrictEqual(actualTokens, expectedTokens);
       });
 
+      test("multi-line method signature with continuation (#|)", () => {
+        const ruby = "#: ()\n#| -> void";
+        const expectedTokens = [
+          ["#:", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
+          [" ", ["meta.type.signature.rbs"]],
+          [
+            "(",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
+          [
+            ")",
+            ["meta.type.signature.rbs", "punctuation.section.signature.rbs"],
+          ],
+          ["#|", ["meta.type.signature.rbs", "comment.line.signature.rbs"]],
+          [" ", ["meta.type.signature.rbs"]],
+          [
+            "->",
+            [
+              "meta.type.signature.rbs",
+              "punctuation.section.signature.return.rbs",
+            ],
+          ],
+          [" ", ["meta.type.signature.rbs"]],
+          ["void", ["meta.type.signature.rbs", "support.type.builtin.rbs"]],
+        ];
+        const actualTokens = tokenizeRBS(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+
       test("inline method signature with &", () => {
         const ruby = "#: [X] (X & Object) -> Class[X]";
         const expectedTokens = [


### PR DESCRIPTION
### Motivation

This PR adds support for multiline RBS signatures:

<img width="169" alt="image" src="https://github.com/user-attachments/assets/6f27ce70-7ae4-4cf7-a6b4-82f615d827cc" />

### Implementation

The implementation only allow lines to start with `#:` or `#|`.

This isn't ideal because it only accepts signatures just starting with a `#|` which isn't ideal:

<img width="169" alt="image" src="https://github.com/user-attachments/assets/a8d380a6-3ca6-445d-a53c-1d38331afcb4" />

I think we can improve in the future.
