### PR TITLE
Replace T.must with comment based syntax

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -94,7 +94,7 @@ module RubyIndexer
       # Remove user specified patterns
       bundle_path = Bundler.settings["path"]&.gsub(/[\\]+/, "/")
       uris.reject! do |indexable|
-        path = T.must(indexable.full_path)
+        path = indexable.full_path #: as !nil
         next false if test_files_ignored_from_exclusion?(path, bundle_path)
 
         excluded_patterns.any? { |pattern| File.fnmatch?(pattern, path, flags) }

--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -135,7 +135,7 @@ module RubyIndexer
         existing_entries = T.cast(@index[real_nesting.join("::")], T.nilable(T::Array[Entry::SingletonClass]))
 
         if existing_entries
-          entry = T.must(existing_entries.first)
+          entry = existing_entries.first #: as !nil
           entry.update_singleton_information(
             Location.from_prism_location(node.location, @code_units_cache),
             Location.from_prism_location(expression.location, @code_units_cache),
@@ -509,7 +509,10 @@ module RubyIndexer
         parent_class_name,
       )
 
-      advance_namespace_stack(T.must(nesting.last), entry)
+      advance_namespace_stack(
+        nesting.last, #: as !nil
+        entry,
+      )
     end
 
     #: { (Index index, Entry::Namespace base) -> void } -> void
@@ -927,7 +930,7 @@ module RubyIndexer
 
     #: -> VisibilityScope
     def current_visibility_scope
-      T.must(@visibility_stack.last)
+      @visibility_stack.last #: as !nil
     end
 
     #: (Prism::ParametersNode? parameters_node) -> Array[Entry::Parameter]

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -52,9 +52,11 @@ module RubyIndexer
     #: -> String
     def file_name
       if @uri.scheme == "untitled"
-        T.must(@uri.opaque)
+        @uri.opaque #: as !nil
       else
-        File.basename(T.must(file_path))
+        File.basename(
+          file_path, #: as !nil
+        )
       end
     end
 

--- a/lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb
@@ -78,7 +78,7 @@ module RubyIndexer
       return unless node
 
       # Remove the node from the tree and then go up the parents to remove any of them with empty children
-      parent = T.must(node.parent) #: Node[Value]?
+      parent = node.parent #: Node[Value]?
 
       while parent
         parent.children.delete(node.key)

--- a/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
@@ -282,7 +282,11 @@ module RubyIndexer
     #: (Prism::CallNode node) -> void
     def on_call_node_enter(node)
       if @target.is_a?(MethodTarget) && (name = node.name.to_s) == @target.method_name
-        @references << Reference.new(name, T.must(node.message_loc), declaration: false)
+        @references << Reference.new(
+          name,
+          node.message_loc, #: as !nil
+          declaration: false,
+        )
       end
     end
 

--- a/lib/ruby_indexer/test/class_variables_test.rb
+++ b/lib/ruby_indexer/test/class_variables_test.rb
@@ -14,8 +14,8 @@ module RubyIndexer
 
       assert_entry("@@bar", Entry::ClassVariable, "/fake/path/foo.rb:1-2:1-7")
 
-      entry = T.must(@index["@@bar"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@@bar"]&.first #: as Entry::ClassVariable
+      owner = entry.owner #: as !nil
       assert_instance_of(Entry::Class, owner)
       assert_equal("Foo", owner.name)
     end
@@ -50,13 +50,13 @@ module RubyIndexer
       assert_entry("@@foo", Entry::ClassVariable, "/fake/path/foo.rb:1-2:1-7")
       assert_entry("@@bar", Entry::ClassVariable, "/fake/path/foo.rb:1-9:1-14")
 
-      entry = T.must(@index["@@foo"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@@foo"]&.first #: as Entry::ClassVariable
+      owner = entry.owner #: as !nil
       assert_instance_of(Entry::Class, owner)
       assert_equal("Foo", owner.name)
 
-      entry = T.must(@index["@@bar"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@@bar"]&.first #: as Entry::ClassVariable
+      owner = entry.owner #: as !nil
       assert_instance_of(Entry::Class, owner)
       assert_equal("Foo", owner.name)
     end
@@ -83,10 +83,10 @@ module RubyIndexer
 
     def test_top_level_class_variable
       index(<<~RUBY)
-        @foo = 123
+        @@foo = 123
       RUBY
 
-      entry = T.must(@index["@foo"]&.first)
+      entry = @index["@@foo"]&.first #: as Entry::ClassVariable
       assert_nil(entry.owner)
     end
 
@@ -99,8 +99,8 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["@@bar"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@@bar"]&.first #: as Entry::ClassVariable
+      owner = entry.owner #: as !nil
       assert_instance_of(Entry::Class, owner)
       assert_equal("Foo", owner.name)
     end
@@ -114,8 +114,8 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["@@bar"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@@bar"]&.first #: as Entry::ClassVariable
+      owner = entry.owner #: as !nil
       assert_instance_of(Entry::Class, owner)
       assert_equal("Foo", owner.name)
     end
@@ -131,8 +131,8 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["@@bar"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@@bar"]&.first #: as Entry::ClassVariable
+      owner = entry.owner #: as !nil
       assert_instance_of(Entry::Class, owner)
       assert_equal("Foo", owner.name)
     end

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -223,10 +223,12 @@ module RubyIndexer
         class Bar; end
       RUBY
 
-      foo_entry = @index["Foo"].first
+      foo_entry = @index["Foo"] #: as !nil
+        .first #: as !nil
       assert_equal("This is a Foo comment\nThis is another Foo comment", foo_entry.comments)
 
-      bar_entry = @index["Bar"].first
+      bar_entry = @index["Bar"] #: as !nil
+        .first #: as !nil
       assert_equal("This Bar comment has 1 line padding", bar_entry.comments)
     end
 
@@ -236,7 +238,7 @@ module RubyIndexer
         class Foo
         end
       RUBY
-      assert(@index["Foo"].first)
+      assert(@index["Foo"]&.first)
     end
 
     def test_comments_can_be_attached_to_a_namespaced_class
@@ -249,10 +251,12 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = @index["Foo"].first
+      foo_entry = @index["Foo"] #: as !nil
+        .first #: as !nil
       assert_equal("This is a Foo comment\nThis is another Foo comment", foo_entry.comments)
 
-      bar_entry = @index["Foo::Bar"].first
+      bar_entry = @index["Foo::Bar"] #: as !nil
+        .first #: as !nil
       assert_equal("This is a Bar comment", bar_entry.comments)
     end
 
@@ -265,11 +269,9 @@ module RubyIndexer
         class Foo; end
       RUBY
 
-      first_foo_entry = @index["Foo"][0]
-      assert_equal("This is a Foo comment", first_foo_entry.comments)
-
-      second_foo_entry = @index["Foo"][1]
-      assert_equal("This is another Foo comment", second_foo_entry.comments)
+      first_foo_entry, second_foo_entry = @index["Foo"] #: as !nil
+      assert_equal("This is a Foo comment", first_foo_entry&.comments)
+      assert_equal("This is another Foo comment", second_foo_entry&.comments)
     end
 
     def test_comments_removes_the_leading_pound_and_space
@@ -281,10 +283,12 @@ module RubyIndexer
         class Bar; end
       RUBY
 
-      first_foo_entry = @index["Foo"][0]
+      first_foo_entry = @index["Foo"] #: as !nil
+        .first #: as !nil
       assert_equal("This is a Foo comment", first_foo_entry.comments)
 
-      second_foo_entry = @index["Bar"][0]
+      second_foo_entry = @index["Bar"] #: as !nil
+        .first #: as !nil
       assert_equal("This is a Bar comment", second_foo_entry.comments)
     end
 
@@ -301,14 +305,17 @@ module RubyIndexer
         end
       RUBY
 
-      b_const = @index["A::B"].first
+      b_const = @index["A::B"] #: as !nil
+        .first
       assert_predicate(b_const, :private?)
 
-      c_const = @index["A::C"].first
+      c_const = @index["A::C"] #: as !nil
+        .first
       assert_predicate(c_const, :private?)
 
-      d_const = @index["A::D"].first
-      assert_equal(Entry::Visibility::PUBLIC, d_const.visibility)
+      d_const = @index["A::D"] #: as !nil
+        .first
+      assert_predicate(d_const, :public?)
     end
 
     def test_keeping_track_of_super_classes
@@ -331,16 +338,20 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo"].first)
+      foo = @index["Foo"] #: as !nil
+        .first #: as Entry::Class
       assert_equal("Bar", foo.parent_class)
 
-      baz = T.must(@index["Baz"].first)
+      baz = @index["Baz"] #: as !nil
+        .first #: as Entry::Class
       assert_equal("::Object", baz.parent_class)
 
-      qux = T.must(@index["Something::Qux"].first)
+      qux = @index["Something::Qux"] #: as !nil
+        .first #: as Entry::Class
       assert_equal("::Baz", qux.parent_class)
 
-      final_thing = T.must(@index["FinalThing"].first)
+      final_thing = @index["FinalThing"] #: as !nil
+        .first #: as Entry::Class
       assert_equal("Something::Baz", final_thing.parent_class)
     end
 
@@ -380,13 +391,16 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo"][0])
+      foo = @index["Foo"] #: as !nil
+        .first #: as Entry::Class
       assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.mixin_operation_module_names)
 
-      qux = T.must(@index["Foo::Qux"][0])
+      qux = @index["Foo::Qux"] #: as !nil
+        .first #: as Entry::Class
       assert_equal(["Corge", "Corge", "Baz"], qux.mixin_operation_module_names)
 
-      constant_path_references = T.must(@index["ConstantPathReferences"][0])
+      constant_path_references = @index["ConstantPathReferences"] #: as !nil
+        .first #: as Entry::Class
       assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.mixin_operation_module_names)
     end
 
@@ -426,13 +440,16 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo"][0])
+      foo = @index["Foo"] #: as !nil
+        .first #: as Entry::Class
       assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.mixin_operation_module_names)
 
-      qux = T.must(@index["Foo::Qux"][0])
+      qux = @index["Foo::Qux"] #: as !nil
+        .first #: as Entry::Class
       assert_equal(["Corge", "Corge", "Baz"], qux.mixin_operation_module_names)
 
-      constant_path_references = T.must(@index["ConstantPathReferences"][0])
+      constant_path_references = @index["ConstantPathReferences"] #: as !nil
+        .first #: as Entry::Class
       assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.mixin_operation_module_names)
     end
 
@@ -472,13 +489,16 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo::<Class:Foo>"][0])
+      foo = @index["Foo::<Class:Foo>"] #: as !nil
+        .first #: as Entry::Class
       assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.mixin_operation_module_names)
 
-      qux = T.must(@index["Foo::Qux::<Class:Qux>"][0])
+      qux = @index["Foo::Qux::<Class:Qux>"] #: as !nil
+        .first #: as Entry::Class
       assert_equal(["Corge", "Corge", "Baz"], qux.mixin_operation_module_names)
 
-      constant_path_references = T.must(@index["ConstantPathReferences::<Class:ConstantPathReferences>"][0])
+      constant_path_references = @index["ConstantPathReferences::<Class:ConstantPathReferences>"] #: as !nil
+        .first #: as Entry::Class
       assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.mixin_operation_module_names)
     end
 
@@ -492,7 +512,8 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo::<Class:Foo>"].first)
+      foo = @index["Foo::<Class:Foo>"] #: as !nil
+        .first #: as Entry::SingletonClass
       assert_equal(4, foo.location.start_line)
       assert_equal("Some extra comments", foo.comments)
     end
@@ -506,7 +527,8 @@ module RubyIndexer
         end
       RUBY
 
-      singleton = T.must(@index["Foo::<Class:bar>"].first)
+      singleton = @index["Foo::<Class:bar>"] #: as !nil
+        .first #: as Entry::SingletonClass
 
       # Even though this is not correct, we consider any dynamic singleton class block as a regular singleton class.
       # That pattern cannot be properly analyzed statically and assuming that it's always a regular singleton simplifies
@@ -539,7 +561,8 @@ module RubyIndexer
         end
       RUBY
 
-      foo = T.must(@index["Foo"].first)
+      foo = @index["Foo"] #: as !nil
+        .first #: as Entry::Class
       refute_equal(foo.location, foo.name_location)
 
       name_location = foo.name_location
@@ -548,7 +571,8 @@ module RubyIndexer
       assert_equal(6, name_location.start_column)
       assert_equal(9, name_location.end_column)
 
-      bar = T.must(@index["Bar"].first)
+      bar = @index["Bar"] #: as !nil
+        .first #: as Entry::Module
       refute_equal(bar.location, bar.name_location)
 
       name_location = bar.name_location
@@ -625,7 +649,8 @@ module RubyIndexer
 
       @index.index_file(uri, collect_comments: false)
 
-      entry = @index["RubyLsp::NodeContext"].first
+      entry = @index["RubyLsp::NodeContext"] #: as !nil
+        .first #: as !nil
 
       assert_equal(<<~COMMENTS.chomp, entry.comments)
         This class allows listeners to access contextual information about a node in the AST, such as its parent,
@@ -644,7 +669,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index["Foo"].first
+      entry = @index["Foo"]&.first #: as !nil
       assert_empty(entry.comments)
     end
 
@@ -663,8 +688,8 @@ module RubyIndexer
       # Verify we indexed the correct name
       assert_entry("Foo::Bar::<Class:Bar>", Entry::SingletonClass, "/fake/path/foo.rb:1-2:3-5")
 
-      method = @index["baz"]&.first
-      assert_equal("Foo::Bar::<Class:Bar>", method.owner.name)
+      method = @index["baz"]&.first #: as Entry::Method
+      assert_equal("Foo::Bar::<Class:Bar>", method.owner&.name)
     end
 
     def test_lazy_comments_with_spaces_are_properly_attributed
@@ -681,7 +706,7 @@ module RubyIndexer
       File.write(path, source)
       @index.index_single(URI::Generic.from_path(path: path), source, collect_comments: false)
 
-      entry = @index["Foo"].first
+      entry = @index["Foo"]&.first #: as !nil
 
       begin
         assert_equal(<<~COMMENTS.chomp, entry.comments)
@@ -706,7 +731,7 @@ module RubyIndexer
       File.write(path, source)
       @index.index_single(URI::Generic.from_path(path: path), source, collect_comments: false)
 
-      entry = @index["Foo"].first
+      entry = @index["Foo"]&.first #: as !nil
 
       begin
         assert_equal(<<~COMMENTS.chomp, entry.comments)
@@ -733,7 +758,7 @@ module RubyIndexer
       File.write(path, source)
       @index.index_single(URI::Generic.from_path(path: path), source, collect_comments: false)
 
-      entry = @index["Foo"].first
+      entry = @index["Foo"]&.first #: as !nil
 
       begin
         assert_empty(entry.comments)

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -97,10 +97,12 @@ module RubyIndexer
       path = Pathname.new(RbConfig::CONFIG["rubylibdir"]).join("extra_file.txt").to_s
       FileUtils.touch(path)
 
-      uris = @config.indexable_uris
-      assert(uris.none? { |uri| uri.full_path == path })
-    ensure
-      FileUtils.rm(T.must(path))
+      begin
+        uris = @config.indexable_uris
+        assert(uris.none? { |uri| uri.full_path == path })
+      ensure
+        FileUtils.rm(path)
+      end
     end
 
     def test_paths_are_unique

--- a/lib/ruby_indexer/test/constant_test.rb
+++ b/lib/ruby_indexer/test/constant_test.rb
@@ -94,17 +94,17 @@ module RubyIndexer
         A::BAZ = 1
       RUBY
 
-      foo_comment = @index["FOO"].first.comments
-      assert_equal("FOO comment", foo_comment)
+      foo = @index["FOO"]&.first #: as !nil
+      assert_equal("FOO comment", foo.comments)
 
-      a_foo_comment = @index["A::FOO"].first.comments
-      assert_equal("A::FOO comment", a_foo_comment)
+      a_foo = @index["A::FOO"]&.first #: as !nil
+      assert_equal("A::FOO comment", a_foo.comments)
 
-      bar_comment = @index["BAR"].first.comments
-      assert_equal("::BAR comment", bar_comment)
+      bar = @index["BAR"]&.first #: as !nil
+      assert_equal("::BAR comment", bar.comments)
 
-      a_baz_comment = @index["A::BAZ"].first.comments
-      assert_equal("A::BAZ comment", a_baz_comment)
+      a_baz = @index["A::BAZ"]&.first #: as !nil
+      assert_equal("A::BAZ comment", a_baz.comments)
     end
 
     def test_variable_path_constants_are_ignored
@@ -129,13 +129,13 @@ module RubyIndexer
         end
       RUBY
 
-      b_const = @index["A::B"].first
+      b_const = @index["A::B"]&.first #: as !nil
       assert_predicate(b_const, :private?)
 
-      c_const = @index["A::C"].first
+      c_const = @index["A::C"]&.first #: as !nil
       assert_predicate(c_const, :private?)
 
-      d_const = @index["A::D"].first
+      d_const = @index["A::D"]&.first #: as !nil
       assert_predicate(d_const, :public?)
     end
 
@@ -162,13 +162,13 @@ module RubyIndexer
         end
       RUBY
 
-      a_const = @index["A::B::CONST_A"].first
+      a_const = @index["A::B::CONST_A"]&.first #: as !nil
       assert_predicate(a_const, :private?)
 
-      b_const = @index["A::B::CONST_B"].first
+      b_const = @index["A::B::CONST_B"]&.first #: as !nil
       assert_predicate(b_const, :private?)
 
-      c_const = @index["A::B::CONST_C"].first
+      c_const = @index["A::B::CONST_C"]&.first #: as !nil
       assert_predicate(c_const, :private?)
     end
 
@@ -186,10 +186,10 @@ module RubyIndexer
         A::B.private_constant(:CONST_B)
       RUBY
 
-      a_const = @index["A::B::CONST_A"].first
+      a_const = @index["A::B::CONST_A"]&.first #: as !nil
       assert_predicate(a_const, :private?)
 
-      b_const = @index["A::B::CONST_B"].first
+      b_const = @index["A::B::CONST_B"]&.first #: as !nil
       assert_predicate(b_const, :private?)
     end
 
@@ -207,12 +207,12 @@ module RubyIndexer
         SECOND = A::FIRST
       RUBY
 
-      unresolve_entry = @index["A::FIRST"].first
+      unresolve_entry = @index["A::FIRST"]&.first #: as Entry::UnresolvedConstantAlias
       assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("B::C", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::FIRST", []).first
+      resolved_entry = @index.resolve("A::FIRST", [])&.first #: as Entry::ConstantAlias
       assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::B::C", resolved_entry.target)
     end
@@ -233,25 +233,25 @@ module RubyIndexer
         end
       RUBY
 
-      unresolve_entry = @index["A::ALIAS"].first
+      unresolve_entry = @index["A::ALIAS"]&.first #: as Entry::UnresolvedConstantAlias
       assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("B", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("ALIAS", ["A"]).first
+      resolved_entry = @index.resolve("ALIAS", ["A"])&.first #: as Entry::ConstantAlias
       assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::B", resolved_entry.target)
 
-      resolved_entry = @index.resolve("ALIAS::C", ["A"]).first
+      resolved_entry = @index.resolve("ALIAS::C", ["A"])&.first #: as Entry::Module
       assert_instance_of(Entry::Module, resolved_entry)
       assert_equal("A::B::C", resolved_entry.name)
 
-      unresolve_entry = @index["Other::ONE_MORE"].first
+      unresolve_entry = @index["Other::ONE_MORE"]&.first #: as Entry::UnresolvedConstantAlias
       assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["Other"], unresolve_entry.nesting)
       assert_equal("A::ALIAS", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("Other::ONE_MORE::C", []).first
+      resolved_entry = @index.resolve("Other::ONE_MORE::C", [])&.first
       assert_instance_of(Entry::Module, resolved_entry)
     end
 
@@ -266,55 +266,55 @@ module RubyIndexer
       RUBY
 
       # B and C
-      unresolve_entry = @index["A::B"].first
+      unresolve_entry = @index["A::B"]&.first #: as Entry::UnresolvedConstantAlias
       assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("C", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::B", []).first
+      resolved_entry = @index.resolve("A::B", [])&.first #: as Entry::ConstantAlias
       assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::C", resolved_entry.target)
 
-      constant = @index["A::C"].first
+      constant = @index["A::C"]&.first #: as Entry::Constant
       assert_instance_of(Entry::Constant, constant)
 
       # D and E
-      unresolve_entry = @index["A::D"].first
+      unresolve_entry = @index["A::D"]&.first #: as Entry::UnresolvedConstantAlias
       assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("E", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::D", []).first
+      resolved_entry = @index.resolve("A::D", [])&.first #: as Entry::ConstantAlias
       assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::E", resolved_entry.target)
 
       # F and G::H
-      unresolve_entry = @index["A::F"].first
+      unresolve_entry = @index["A::F"]&.first #: as Entry::UnresolvedConstantAlias
       assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("G::H", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::F", []).first
+      resolved_entry = @index.resolve("A::F", [])&.first #: as Entry::ConstantAlias
       assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::G::H", resolved_entry.target)
 
       # I::J, K::L and M
-      unresolve_entry = @index["A::I::J"].first
+      unresolve_entry = @index["A::I::J"]&.first #: as Entry::UnresolvedConstantAlias
       assert_instance_of(Entry::UnresolvedConstantAlias, unresolve_entry)
       assert_equal(["A"], unresolve_entry.nesting)
       assert_equal("K::L", unresolve_entry.target)
 
-      resolved_entry = @index.resolve("A::I::J", []).first
+      resolved_entry = @index.resolve("A::I::J", [])&.first #: as Entry::ConstantAlias
       assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::K::L", resolved_entry.target)
 
       # When we are resolving A::I::J, we invoke `resolve("K::L", ["A"])`, which recursively resolves A::K::L too.
       # Therefore, both A::I::J and A::K::L point to A::M by the end of the previous resolve invocation
-      resolved_entry = @index["A::K::L"].first
+      resolved_entry = @index["A::K::L"]&.first #: as Entry::ConstantAlias
       assert_instance_of(Entry::ConstantAlias, resolved_entry)
       assert_equal("A::M", resolved_entry.target)
 
-      constant = @index["A::M"].first
+      constant = @index["A::M"]&.first
       assert_instance_of(Entry::Constant, constant)
     end
 

--- a/lib/ruby_indexer/test/enhancements_test.rb
+++ b/lib/ruby_indexer/test/enhancements_test.rb
@@ -108,7 +108,7 @@ module RubyIndexer
           return unless association_name.is_a?(Prism::SymbolNode)
 
           @listener.add_method(
-            T.must(association_name.value),
+            association_name.value, #: as !nil
             association_name.location,
             [],
           )

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -15,11 +15,11 @@ module RubyIndexer
         end
       RUBY
 
-      entries = @index["Foo"]
+      entries = @index["Foo"] #: as !nil
       assert_equal(2, entries.length)
 
       @index.delete(URI::Generic.from_path(path: "/fake/path/other_foo.rb"))
-      entries = @index["Foo"]
+      entries = @index["Foo"] #: as !nil
       assert_equal(1, entries.length)
     end
 
@@ -29,7 +29,7 @@ module RubyIndexer
         end
       RUBY
 
-      entries = @index["Foo"]
+      entries = @index["Foo"] #: as !nil
       assert_equal(1, entries.length)
 
       @index.delete(URI::Generic.from_path(path: "/fake/path/foo.rb"))
@@ -52,21 +52,21 @@ module RubyIndexer
         end
       RUBY
 
-      entries = @index.resolve("Something", ["Foo", "Baz"])
+      entries = @index.resolve("Something", ["Foo", "Baz"]) #: as !nil
       refute_empty(entries)
-      assert_equal("Foo::Baz::Something", entries.first.name)
+      assert_equal("Foo::Baz::Something", entries.first&.name)
 
-      entries = @index.resolve("Bar", ["Foo"])
+      entries = @index.resolve("Bar", ["Foo"]) #: as !nil
       refute_empty(entries)
-      assert_equal("Foo::Bar", entries.first.name)
+      assert_equal("Foo::Bar", entries.first&.name)
 
-      entries = @index.resolve("Bar", ["Foo", "Baz"])
+      entries = @index.resolve("Bar", ["Foo", "Baz"]) #: as !nil
       refute_empty(entries)
-      assert_equal("Foo::Bar", entries.first.name)
+      assert_equal("Foo::Bar", entries.first&.name)
 
-      entries = @index.resolve("Foo::Bar", ["Foo", "Baz"])
+      entries = @index.resolve("Foo::Bar", ["Foo", "Baz"]) #: as !nil
       refute_empty(entries)
-      assert_equal("Foo::Bar", entries.first.name)
+      assert_equal("Foo::Bar", entries.first&.name)
 
       assert_nil(@index.resolve("DoesNotExist", ["Foo"]))
     end
@@ -86,9 +86,9 @@ module RubyIndexer
         end
       RUBY
 
-      entries = @index["::Foo::Baz::Something"]
+      entries = @index["::Foo::Baz::Something"] #: as !nil
       refute_empty(entries)
-      assert_equal("Foo::Baz::Something", entries.first.name)
+      assert_equal("Foo::Baz::Something", entries.first&.name)
     end
 
     def test_fuzzy_search
@@ -172,15 +172,15 @@ module RubyIndexer
         end
       RUBY
 
-      entries = @index.resolve("::Foo::Bar", [])
+      entries = @index.resolve("::Foo::Bar", []) #: as !nil
       refute_nil(entries)
 
-      assert_equal("Foo::Bar", entries.first.name)
+      assert_equal("Foo::Bar", entries.first&.name)
 
-      entries = @index.resolve("::Bar", ["Foo"])
+      entries = @index.resolve("::Bar", ["Foo"]) #: as !nil
       refute_nil(entries)
 
-      assert_equal("Bar", entries.first.name)
+      assert_equal("Bar", entries.first&.name)
     end
 
     def test_resolving_aliases_to_non_existing_constants_with_conflicting_names
@@ -195,7 +195,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index.resolve("BAZ", ["Foo", "Bar"]).first
+      entry = @index.resolve("BAZ", ["Foo", "Bar"])&.first
       refute_nil(entry)
 
       assert_instance_of(Entry::UnresolvedConstantAlias, entry)
@@ -233,9 +233,10 @@ module RubyIndexer
         end
       RUBY
 
-      entries = T.must(@index.resolve_method("baz", "Foo::Bar"))
-      assert_equal("baz", entries.first.name)
-      assert_equal("Foo::Bar", T.must(entries.first.owner).name)
+      entries = @index.resolve_method("baz", "Foo::Bar") #: as !nil
+      assert_equal("baz", entries.first&.name)
+      owner = entries.first&.owner #: as !nil
+      assert_equal("Foo::Bar", owner.name)
     end
 
     def test_resolve_method_with_class_name_conflict
@@ -248,9 +249,10 @@ module RubyIndexer
         end
       RUBY
 
-      entries = T.must(@index.resolve_method("Array", "Foo"))
-      assert_equal("Array", entries.first.name)
-      assert_equal("Foo", T.must(entries.first.owner).name)
+      entries = @index.resolve_method("Array", "Foo") #: as !nil
+      assert_equal("Array", entries.first&.name)
+      owner = entries.first&.owner #: as !nil
+      assert_equal("Foo", owner.name)
     end
 
     def test_resolve_method_attribute
@@ -260,9 +262,10 @@ module RubyIndexer
         end
       RUBY
 
-      entries = T.must(@index.resolve_method("bar", "Foo"))
-      assert_equal("bar", entries.first.name)
-      assert_equal("Foo", T.must(entries.first.owner).name)
+      entries = @index.resolve_method("bar", "Foo") #: as !nil
+      assert_equal("bar", entries.first&.name)
+      owner = entries.first&.owner #: as !nil
+      assert_equal("Foo", owner.name)
     end
 
     def test_resolve_method_with_two_definitions
@@ -278,15 +281,17 @@ module RubyIndexer
         end
       RUBY
 
-      first_entry, second_entry = T.must(@index.resolve_method("bar", "Foo"))
+      first_entry, second_entry = @index.resolve_method("bar", "Foo") #: as !nil
 
-      assert_equal("bar", first_entry.name)
-      assert_equal("Foo", T.must(first_entry.owner).name)
-      assert_includes(first_entry.comments, "Hello from first `bar`")
+      assert_equal("bar", first_entry&.name)
+      owner = first_entry&.owner #: as !nil
+      assert_equal("Foo", owner.name)
+      assert_includes(first_entry&.comments, "Hello from first `bar`")
 
-      assert_equal("bar", second_entry.name)
-      assert_equal("Foo", T.must(second_entry.owner).name)
-      assert_includes(second_entry.comments, "Hello from second `bar`")
+      assert_equal("bar", second_entry&.name)
+      owner = second_entry&.owner #: as !nil
+      assert_equal("Foo", owner.name)
+      assert_includes(second_entry&.comments, "Hello from second `bar`")
     end
 
     def test_resolve_method_inherited_only
@@ -300,9 +305,8 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.resolve_method("baz", "Foo", inherited_only: true).first)
-
-      assert_equal("Bar", T.must(entry.owner).name)
+      entry = @index.resolve_method("baz", "Foo", inherited_only: true)&.first #: as !nil
+      assert_equal("Bar", entry.owner&.name)
     end
 
     def test_resolve_method_inherited_only_for_prepended_module
@@ -338,7 +342,7 @@ module RubyIndexer
       entries = @index.prefix_search("qz")
       refute_empty(entries)
 
-      entry = T.must(T.must(entries.first).first)
+      entry = entries.first&.first #: as !nil
       assert_equal("qzx", entry.name)
     end
 
@@ -739,13 +743,13 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.resolve_method("baz", "Wow")&.first)
+      entry = @index.resolve_method("baz", "Wow")&.first #: as !nil
       assert_equal("baz", entry.name)
-      assert_equal("Foo", T.must(entry.owner).name)
+      assert_equal("Foo", entry.owner&.name)
 
-      entry = T.must(@index.resolve_method("qux", "Wow")&.first)
+      entry = @index.resolve_method("qux", "Wow")&.first #: as !nil
       assert_equal("qux", entry.name)
-      assert_equal("Bar", T.must(entry.owner).name)
+      assert_equal("Bar", entry.owner&.name)
     end
 
     def test_resolving_an_inherited_method_lands_on_first_match
@@ -765,12 +769,12 @@ module RubyIndexer
         end
       RUBY
 
-      entries = T.must(@index.resolve_method("qux", "Wow"))
+      entries = @index.resolve_method("qux", "Wow") #: as !nil
       assert_equal(1, entries.length)
 
-      entry = T.must(entries.first)
+      entry = entries.first #: as !nil
       assert_equal("qux", entry.name)
-      assert_equal("Foo", T.must(entry.owner).name)
+      assert_equal("Foo", entry.owner&.name)
     end
 
     def test_handle_change_clears_ancestor_cache_if_tree_changed
@@ -800,7 +804,8 @@ module RubyIndexer
             end
           RUBY
 
-          @index.handle_change(uri, File.read(T.must(uri.full_path)))
+          path = uri.full_path #: as !nil
+          @index.handle_change(uri, File.read(path))
           assert_empty(@index.instance_variable_get(:@ancestors))
           assert_equal(["Bar", "Object", "Kernel", "BasicObject"], @index.linearized_ancestors_of("Bar"))
         end
@@ -837,7 +842,8 @@ module RubyIndexer
             end
           RUBY
 
-          @index.handle_change(uri, File.read(T.must(uri.full_path)))
+          path = uri.full_path #: as !nil
+          @index.handle_change(uri, File.read(path))
           refute_empty(@index.instance_variable_get(:@ancestors))
           assert_equal(["Bar", "Foo", "Object", "Kernel", "BasicObject"], @index.linearized_ancestors_of("Bar"))
         end
@@ -870,7 +876,8 @@ module RubyIndexer
             end
           RUBY
 
-          @index.handle_change(uri, File.read(T.must(uri.full_path)))
+          path = uri.full_path #: as !nil
+          @index.handle_change(uri, File.read(path))
           assert_empty(@index.instance_variable_get(:@ancestors))
           assert_equal(["Bar", "Object", "Kernel", "BasicObject"], @index.linearized_ancestors_of("Bar"))
         end
@@ -904,7 +911,7 @@ module RubyIndexer
         CONST = 4
       RUBY
 
-      entry = T.must(@index.resolve("CONST", ["Namespace", "Bar"])&.first)
+      entry = @index.resolve("CONST", ["Namespace", "Bar"])&.first #: as !nil
       assert_equal(14, entry.location.start_line)
     end
 
@@ -925,10 +932,10 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.resolve("Foo::CONST::TARGET", [])&.first)
+      entry = @index.resolve("Foo::CONST::TARGET", [])&.first #: as !nil
       assert_equal(2, entry.location.start_line)
 
-      entry = T.must(@index.resolve("Namespace::Bar::CONST::TARGET", [])&.first)
+      entry = @index.resolve("Namespace::Bar::CONST::TARGET", [])&.first #: as !nil
       assert_equal(2, entry.location.start_line)
     end
 
@@ -946,10 +953,10 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.resolve("CONST", ["Namespace", "Child"])&.first)
+      entry = @index.resolve("CONST", ["Namespace", "Child"])&.first #: as !nil
       assert_equal(2, entry.location.start_line)
 
-      entry = T.must(@index.resolve("Namespace::Child::CONST", [])&.first)
+      entry = @index.resolve("Namespace::Child::CONST", [])&.first #: as !nil
       assert_equal(5, entry.location.start_line)
     end
 
@@ -975,13 +982,13 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.resolve("CONST", ["Foo"])&.first)
+      entry = @index.resolve("CONST", ["Foo"])&.first #: as !nil
       assert_equal(6, entry.location.start_line)
 
-      entry = T.must(@index.resolve("Foo::CONST", [])&.first)
+      entry = @index.resolve("Foo::CONST", [])&.first #: as !nil
       assert_equal(6, entry.location.start_line)
 
-      entry = T.must(@index.resolve("Bar::CONST", [])&.first)
+      entry = @index.resolve("Bar::CONST", [])&.first #: as !nil
       assert_equal(15, entry.location.start_line)
     end
 
@@ -1005,7 +1012,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.resolve("CONST", ["First", "Second"])&.first)
+      entry = @index.resolve("CONST", ["First", "Second"])&.first #: as !nil
       assert_equal(6, entry.location.start_line)
     end
 
@@ -1017,11 +1024,11 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = T.must(@index.resolve("FOO", ["Namespace"])&.first)
+      foo_entry = @index.resolve("FOO", ["Namespace"])&.first #: as !nil
       assert_equal(2, foo_entry.location.start_line)
       assert_instance_of(Entry::ConstantAlias, foo_entry)
 
-      bar_entry = T.must(@index.resolve("BAR", ["Namespace"])&.first)
+      bar_entry = @index.resolve("BAR", ["Namespace"])&.first #: as !nil
       assert_equal(3, bar_entry.location.start_line)
       assert_instance_of(Entry::ConstantAlias, bar_entry)
     end
@@ -1035,15 +1042,15 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = T.must(@index.resolve("FOO", ["Namespace"])&.first)
+      foo_entry = @index.resolve("FOO", ["Namespace"])&.first #: as !nil
       assert_equal(2, foo_entry.location.start_line)
       assert_instance_of(Entry::ConstantAlias, foo_entry)
 
-      bar_entry = T.must(@index.resolve("BAR", ["Namespace"])&.first)
+      bar_entry = @index.resolve("BAR", ["Namespace"])&.first #: as !nil
       assert_equal(3, bar_entry.location.start_line)
       assert_instance_of(Entry::ConstantAlias, bar_entry)
 
-      baz_entry = T.must(@index.resolve("BAZ", ["Namespace"])&.first)
+      baz_entry = @index.resolve("BAZ", ["Namespace"])&.first #: as !nil
       assert_equal(4, baz_entry.location.start_line)
       assert_instance_of(Entry::ConstantAlias, baz_entry)
     end
@@ -1065,7 +1072,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.resolve("Other::ALIAS::CONST", ["Third"])&.first)
+      entry = @index.resolve("Other::ALIAS::CONST", ["Third"])&.first #: as !nil
       assert_kind_of(Entry::Constant, entry)
       assert_equal("Original::Something::CONST", entry.name)
     end
@@ -1080,7 +1087,7 @@ module RubyIndexer
         FOO::CONST
       RUBY
 
-      entry = T.must(@index.resolve("FOO::CONST", [])&.first)
+      entry = @index.resolve("FOO::CONST", [])&.first #: as !nil
       assert_kind_of(Entry::Constant, entry)
       assert_equal("Foo::CONST", entry.name)
     end
@@ -1091,7 +1098,7 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = T.must(@index.resolve("Foo::Bar", [])&.first)
+      foo_entry = @index.resolve("Foo::Bar", [])&.first #: as !nil
       assert_equal(1, foo_entry.location.start_line)
       assert_instance_of(Entry::Class, foo_entry)
     end
@@ -1117,7 +1124,7 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = T.must(@index.resolve("A::B::Foo::CONST", ["A", "B"])&.first)
+      foo_entry = @index.resolve("A::B::Foo::CONST", ["A", "B"])&.first #: as !nil
       assert_equal(2, foo_entry.location.start_line)
     end
 
@@ -1135,7 +1142,7 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = T.must(@index.resolve("Entry::CONST", ["Namespace", "Index"])&.first)
+      foo_entry = @index.resolve("Entry::CONST", ["Namespace", "Index"])&.first #: as !nil
       assert_equal(3, foo_entry.location.start_line)
     end
 
@@ -1154,7 +1161,7 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = T.must(@index.resolve("CONST", ["Namespace", "Index"])&.first)
+      foo_entry = @index.resolve("CONST", ["Namespace", "Index"])&.first #: as !nil
       assert_equal(6, foo_entry.location.start_line)
     end
 
@@ -1171,7 +1178,7 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = T.must(@index.resolve("CONST", ["Namespace", "Index"])&.first)
+      foo_entry = @index.resolve("CONST", ["Namespace", "Index"])&.first #: as !nil
       assert_equal(1, foo_entry.location.start_line)
     end
 
@@ -1190,9 +1197,9 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.instance_variable_completion_candidates("@", "Bar")&.first)
+      entry = @index.instance_variable_completion_candidates("@", "Bar").first #: as !nil
       assert_equal("@bar", entry.name)
-      assert_equal("Bar", T.must(entry.owner).name)
+      assert_equal("Bar", entry.owner&.name)
     end
 
     def test_resolving_a_qualified_reference
@@ -1213,7 +1220,7 @@ module RubyIndexer
         end
       RUBY
 
-      foo_entry = T.must(@index.resolve("Third::CONST", ["Foo"])&.first)
+      foo_entry = @index.resolve("Third::CONST", ["Foo"])&.first #: as !nil
       assert_equal(9, foo_entry.location.start_line)
     end
 
@@ -1226,9 +1233,9 @@ module RubyIndexer
         class Object; end
       RUBY
 
-      entries = @index["Object"]
+      entries = @index["Object"] #: as !nil
       assert_equal(2, entries.length)
-      reopened_entry = entries.last
+      reopened_entry = entries.last #: as Entry::Class
       assert_equal("::BasicObject", reopened_entry.parent_class)
       assert_equal(["Object", "Kernel", "BasicObject"], @index.linearized_ancestors_of("Object"))
     end
@@ -1238,9 +1245,9 @@ module RubyIndexer
         class BasicObject; end
       RUBY
 
-      entries = @index["BasicObject"]
+      entries = @index["BasicObject"] #: as !nil
       assert_equal(2, entries.length)
-      reopened_entry = entries.last
+      reopened_entry = entries.last #: as Entry::Class
       assert_nil(reopened_entry.parent_class)
       assert_equal(["BasicObject"], @index.linearized_ancestors_of("BasicObject"))
     end
@@ -1318,10 +1325,9 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index.resolve_method("found_me!", "Foo::Bar::<Class:Bar>::Baz::<Class:Baz>")&.first
+      entry = @index.resolve_method("found_me!", "Foo::Bar::<Class:Bar>::Baz::<Class:Baz>")&.first #: as !nil
       refute_nil(entry)
-
-      assert_equal("found_me!", T.must(entry).name)
+      assert_equal("found_me!", entry.name)
     end
 
     def test_resolving_constants_in_singleton_contexts
@@ -1344,9 +1350,9 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index.resolve("CONST", ["Foo", "Bar", "<Class:Bar>", "Baz", "<Class:Baz>"])&.first
+      entry = @index.resolve("CONST", ["Foo", "Bar", "<Class:Bar>", "Baz", "<Class:Baz>"])&.first #: as !nil
       refute_nil(entry)
-      assert_equal(9, T.must(entry).location.start_line)
+      assert_equal(9, entry.location.start_line)
     end
 
     def test_resolving_instance_variables_in_singleton_contexts
@@ -1366,17 +1372,17 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index.resolve_instance_variable("@a", "Foo::Bar::<Class:Bar>")&.first
+      entry = @index.resolve_instance_variable("@a", "Foo::Bar::<Class:Bar>")&.first #: as !nil
       refute_nil(entry)
-      assert_equal("@a", T.must(entry).name)
+      assert_equal("@a", entry.name)
 
-      entry = @index.resolve_instance_variable("@b", "Foo::Bar::<Class:Bar>")&.first
+      entry = @index.resolve_instance_variable("@b", "Foo::Bar::<Class:Bar>")&.first #: as !nil
       refute_nil(entry)
-      assert_equal("@b", T.must(entry).name)
+      assert_equal("@b", entry.name)
 
-      entry = @index.resolve_instance_variable("@c", "Foo::Bar::<Class:Bar>::<Class:<Class:Bar>>")&.first
+      entry = @index.resolve_instance_variable("@c", "Foo::Bar::<Class:Bar>::<Class:<Class:Bar>>")&.first #: as !nil
       refute_nil(entry)
-      assert_equal("@c", T.must(entry).name)
+      assert_equal("@c", entry.name)
     end
 
     def test_instance_variable_completion_in_singleton_contexts
@@ -1422,7 +1428,7 @@ module RubyIndexer
 
       results = @index.fuzzy_search("Zwq")
       assert_equal(1, results.length)
-      assert_equal("Zwq", results.first.name)
+      assert_equal("Zwq", results.first&.name)
     end
 
     def test_resolving_method_aliases
@@ -1444,39 +1450,39 @@ module RubyIndexer
       RUBY
 
       # baz
-      methods = @index.resolve_method("baz", "Bar")
+      methods = @index.resolve_method("baz", "Bar") #: as !nil
       refute_nil(methods)
 
-      entry = T.must(methods.first)
+      entry = methods.first #: as Entry::MethodAlias
       assert_kind_of(Entry::MethodAlias, entry)
       assert_equal("bar", entry.target.name)
-      assert_equal("Foo", T.must(entry.target.owner).name)
+      assert_equal("Foo", entry.target.owner&.name)
 
       # qux
-      methods = @index.resolve_method("qux", "Bar")
+      methods = @index.resolve_method("qux", "Bar") #: as !nil
       refute_nil(methods)
 
-      entry = T.must(methods.first)
+      entry = methods.first #: as Entry::MethodAlias
       assert_kind_of(Entry::MethodAlias, entry)
       assert_equal("hello", entry.target.name)
-      assert_equal("Bar", T.must(entry.target.owner).name)
+      assert_equal("Bar", entry.target.owner&.name)
 
       # double
-      methods = @index.resolve_method("double", "Bar")
+      methods = @index.resolve_method("double", "Bar") #: as !nil
       refute_nil(methods)
 
-      entry = T.must(methods.first)
+      entry = methods.first #: as Entry::MethodAlias
       assert_kind_of(Entry::MethodAlias, entry)
 
-      target = entry.target
+      target = entry.target #: as Entry::MethodAlias
       assert_equal("double_alias", target.name)
       assert_kind_of(Entry::MethodAlias, target)
-      assert_equal("Foo", T.must(target.owner).name)
+      assert_equal("Foo", target.owner&.name)
 
       final_target = target.target
       assert_equal("bar", final_target.name)
       assert_kind_of(Entry::Method, final_target)
-      assert_equal("Foo", T.must(final_target.owner).name)
+      assert_equal("Foo", final_target.owner&.name)
     end
 
     def test_resolving_circular_method_aliases
@@ -1490,7 +1496,7 @@ module RubyIndexer
       methods = @index.resolve_method("bar", "Foo")
       assert_nil(methods)
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first
       assert_kind_of(Entry::UnresolvedMethodAlias, entry)
     end
 
@@ -1505,7 +1511,7 @@ module RubyIndexer
       methods = @index.resolve_method("bar", "Foo")
       assert_nil(methods)
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first
       assert_kind_of(Entry::UnresolvedMethodAlias, entry)
     end
 
@@ -1521,18 +1527,18 @@ module RubyIndexer
         end
       RUBY
 
-      methods = @index.resolve_method("decorated_name", "Foo")
+      methods = @index.resolve_method("decorated_name", "Foo") #: as !nil
       refute_nil(methods)
 
-      entry = T.must(methods.first)
+      entry = methods.first #: as Entry::MethodAlias
       assert_kind_of(Entry::MethodAlias, entry)
 
       target = entry.target
       assert_equal("name", target.name)
       assert_kind_of(Entry::Accessor, target)
-      assert_equal("Foo", T.must(target.owner).name)
+      assert_equal("Foo", target.owner&.name)
 
-      other_decorated_name = T.must(@index["decorated_name"].find { |e| e.is_a?(Entry::UnresolvedMethodAlias) })
+      other_decorated_name = @index["decorated_name"]&.find { |e| e.is_a?(Entry::UnresolvedMethodAlias) }
       assert_kind_of(Entry::UnresolvedMethodAlias, other_decorated_name)
     end
 
@@ -1557,7 +1563,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.first_unqualified_const("Bar")&.first)
+      entry = @index.first_unqualified_const("Bar")&.first #: as !nil
       assert_equal("Foo::Bar", entry.name)
     end
 
@@ -1574,7 +1580,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index.first_unqualified_const("Type")&.first)
+      entry = @index.first_unqualified_const("Type")&.first #: as !nil
       assert_equal("Namespace::Type", entry.name)
     end
 
@@ -1591,7 +1597,7 @@ module RubyIndexer
 
       entries = @index.method_completion_candidates("bar", "Baz")
       assert_equal(["bar"], entries.map(&:name))
-      assert_equal("Baz", T.must(entries.first.owner).name)
+      assert_equal("Baz", entries.first&.owner&.name)
     end
 
     def test_completion_does_not_duplicate_methods_overridden_by_aliases
@@ -1607,7 +1613,7 @@ module RubyIndexer
 
       entries = @index.method_completion_candidates("bar", "Baz")
       assert_equal(["bar"], entries.map(&:name))
-      assert_equal("Baz", T.must(entries.first.owner).name)
+      assert_equal("Baz", entries.first&.owner&.name)
     end
 
     def test_decorated_parameters
@@ -1618,11 +1624,10 @@ module RubyIndexer
         end
       RUBY
 
-      methods = @index.resolve_method("bar", "Foo")
+      methods = @index.resolve_method("bar", "Foo") #: as !nil
       refute_nil(methods)
 
-      entry = T.must(methods.first)
-
+      entry = methods.first #: as Entry::Method
       assert_equal("(a, b = <default>, c: <default>)", entry.decorated_parameters)
     end
 
@@ -1634,11 +1639,10 @@ module RubyIndexer
         end
       RUBY
 
-      methods = @index.resolve_method("bar", "Foo")
+      methods = @index.resolve_method("bar", "Foo") #: as !nil
       refute_nil(methods)
 
-      entry = T.must(methods.first)
-
+      entry = methods.first #: as Entry::Method
       assert_equal("()", entry.decorated_parameters)
     end
 
@@ -1707,9 +1711,9 @@ module RubyIndexer
       RUBY
 
       ["bar", "baz"].product(["Foo", "Foo::<Class:Foo>"]).each do |method, receiver|
-        entry = @index.resolve_method(method, receiver)&.first
+        entry = @index.resolve_method(method, receiver)&.first #: as !nil
         refute_nil(entry)
-        assert_equal(method, T.must(entry).name)
+        assert_equal(method, entry.name)
       end
 
       assert_equal(
@@ -1888,7 +1892,7 @@ module RubyIndexer
         end
       RUBY
 
-      method = @index.resolve_method("==", "Foo").first
+      method = @index.resolve_method("==", "Foo")&.first #: as Entry::Method
       assert_kind_of(Entry::Method, method)
       assert_equal("==", method.name)
 
@@ -1906,13 +1910,13 @@ module RubyIndexer
         end
       RUBY
 
-      entries = @index.entries_for("file:///fake/path/foo.rb", Entry)
+      entries = @index.entries_for("file:///fake/path/foo.rb", Entry) #: as !nil
       assert_equal(["Foo", "Bar", "my_def", "Bar::<Class:Bar>", "my_singleton_def"], entries.map(&:name))
 
-      entries = @index.entries_for("file:///fake/path/foo.rb", RubyIndexer::Entry::Namespace)
+      entries = @index.entries_for("file:///fake/path/foo.rb", RubyIndexer::Entry::Namespace) #: as !nil
       assert_equal(["Foo", "Bar", "Bar::<Class:Bar>"], entries.map(&:name))
 
-      entries = @index.entries_for("file:///fake/path/foo.rb")
+      entries = @index.entries_for("file:///fake/path/foo.rb") #: as !nil
       assert_equal(["Foo", "Bar", "my_def", "Bar::<Class:Bar>", "my_singleton_def"], entries.map(&:name))
     end
 
@@ -1945,14 +1949,14 @@ module RubyIndexer
       result = @index.constant_completion_candidates("X", ["Namespace", "Baz"])
 
       result.each do |entries|
-        name = entries.first.name
+        name = entries.first&.name
         assert(entries.all? { |e| e.name == name })
       end
 
-      assert_equal(["Namespace::XQRK", "Bar::XQRK", "XQRK"], result.map { |entries| entries.first.name })
+      assert_equal(["Namespace::XQRK", "Bar::XQRK", "XQRK"], result.map { |entries| entries.first&.name })
 
       result = @index.constant_completion_candidates("::X", ["Namespace", "Baz"])
-      assert_equal(["XQRK"], result.map { |entries| entries.first.name })
+      assert_equal(["XQRK"], result.map { |entries| entries.first&.name })
     end
 
     def test_constant_completion_candidates_for_empty_name
@@ -1967,7 +1971,7 @@ module RubyIndexer
       RUBY
 
       result = @index.constant_completion_candidates("Baz::", [])
-      assert_includes(result.map { |entries| entries.first.name }, "Foo::Bar")
+      assert_includes(result.map { |entries| entries.first&.name }, "Foo::Bar")
     end
 
     def test_follow_alias_namespace
@@ -2025,7 +2029,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index.resolve("Namespace::Foo::CONST", ["First", "Namespace", "Foo", "InnerNamespace"])&.first
+      entry = @index.resolve("Namespace::Foo::CONST", ["First", "Namespace", "Foo", "InnerNamespace"])&.first #: as !nil
       assert_equal("Parent::CONST", entry.name)
       assert_instance_of(Entry::Constant, entry)
     end
@@ -2093,7 +2097,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index["Foo"]&.first
+      entry = @index["Foo"]&.first #: as !nil
       refute_nil(entry, "Expected indexer to be able to handle unsaved URIs")
       assert_equal("untitled:Untitled-1", entry.uri.to_s)
       assert_equal("Untitled-1", entry.file_name)
@@ -2105,7 +2109,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index["Foo"]&.first
+      entry = @index["Foo"]&.first #: as !nil
       refute_nil(entry, "Expected indexer to be able to handle unsaved URIs")
       assert_equal("I added this comment!", entry.comments)
     end
@@ -2129,8 +2133,8 @@ module RubyIndexer
       refute_nil(abc)
       refute_nil(adf)
 
-      assert_equal("@@abc", abc.name)
-      assert_equal("@@adf", adf.name)
+      assert_equal("@@abc", abc&.name)
+      assert_equal("@@adf", adf&.name)
     end
 
     def test_class_variable_completion_from_singleton_context
@@ -2156,7 +2160,7 @@ module RubyIndexer
         end
       RUBY
 
-      candidates = @index.resolve_class_variable("@@hello", "Foo::<Class:Foo>")
+      candidates = @index.resolve_class_variable("@@hello", "Foo::<Class:Foo>") #: as !nil
       refute_empty(candidates)
 
       assert_equal("@@hello", candidates.first&.name)

--- a/lib/ruby_indexer/test/instance_variables_test.rb
+++ b/lib/ruby_indexer/test/instance_variables_test.rb
@@ -19,10 +19,10 @@ module RubyIndexer
 
       assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
 
-      entry = T.must(@index["@a"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::Class, owner)
-      assert_equal("Foo::Bar", owner.name)
+      assert_equal("Foo::Bar", owner&.name)
     end
 
     def test_instance_variable_with_multibyte_characters
@@ -51,10 +51,10 @@ module RubyIndexer
 
       assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
 
-      entry = T.must(@index["@a"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::Class, owner)
-      assert_equal("Foo::Bar", owner.name)
+      assert_equal("Foo::Bar", owner&.name)
     end
 
     def test_instance_variable_operator_write
@@ -71,10 +71,10 @@ module RubyIndexer
 
       assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
 
-      entry = T.must(@index["@a"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::Class, owner)
-      assert_equal("Foo::Bar", owner.name)
+      assert_equal("Foo::Bar", owner&.name)
     end
 
     def test_instance_variable_or_write
@@ -91,10 +91,10 @@ module RubyIndexer
 
       assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
 
-      entry = T.must(@index["@a"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::Class, owner)
-      assert_equal("Foo::Bar", owner.name)
+      assert_equal("Foo::Bar", owner&.name)
     end
 
     def test_instance_variable_target
@@ -112,15 +112,15 @@ module RubyIndexer
       assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:4-6:4-8")
       assert_entry("@b", Entry::InstanceVariable, "/fake/path/foo.rb:4-10:4-12")
 
-      entry = T.must(@index["@a"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::Class, owner)
-      assert_equal("Foo::Bar", owner.name)
+      assert_equal("Foo::Bar", owner&.name)
 
-      entry = T.must(@index["@b"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@b"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::Class, owner)
-      assert_equal("Foo::Bar", owner.name)
+      assert_equal("Foo::Bar", owner&.name)
     end
 
     def test_empty_name_instance_variables
@@ -156,24 +156,24 @@ module RubyIndexer
 
       assert_entry("@a", Entry::InstanceVariable, "/fake/path/foo.rb:2-4:2-6")
 
-      entry = T.must(@index["@a"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::Bar::<Class:Bar>", owner.name)
+      assert_equal("Foo::Bar::<Class:Bar>", owner&.name)
 
       assert_entry("@b", Entry::InstanceVariable, "/fake/path/foo.rb:6-8:6-10")
 
-      entry = T.must(@index["@b"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@b"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::Bar::<Class:Bar>", owner.name)
+      assert_equal("Foo::Bar::<Class:Bar>", owner&.name)
 
       assert_entry("@c", Entry::InstanceVariable, "/fake/path/foo.rb:9-6:9-8")
 
-      entry = T.must(@index["@c"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@c"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::Bar::<Class:Bar>::<Class:<Class:Bar>>", owner.name)
+      assert_equal("Foo::Bar::<Class:Bar>::<Class:<Class:Bar>>", owner&.name)
     end
 
     def test_top_level_instance_variables
@@ -181,7 +181,7 @@ module RubyIndexer
         @a = 123
       RUBY
 
-      entry = T.must(@index["@a"]&.first)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
       assert_nil(entry.owner)
     end
 
@@ -194,10 +194,10 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["@a"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::<Class:Foo>", owner.name)
+      assert_equal("Foo::<Class:Foo>", owner&.name)
     end
 
     def test_instance_variable_inside_dynamic_method_declaration
@@ -211,10 +211,10 @@ module RubyIndexer
 
       # If the surrounding method is being defined on any dynamic value that isn't `self`, then we attribute the
       # instance variable to the wrong owner since there's no way to understand that statically
-      entry = T.must(@index["@a"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::Class, owner)
-      assert_equal("Foo", owner.name)
+      assert_equal("Foo", owner&.name)
     end
 
     def test_module_function_does_not_impact_instance_variables
@@ -231,10 +231,10 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["@a"]&.first)
-      owner = T.must(entry.owner)
+      entry = @index["@a"]&.first #: as Entry::InstanceVariable
+      owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::<Class:Foo>", owner.name)
+      assert_equal("Foo::<Class:Foo>", owner&.name)
     end
   end
 end

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -47,9 +47,9 @@ module RubyIndexer
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
 
-      entry = T.must(@index["bar"].first)
-      owner = T.must(entry.owner)
-      assert_equal("Foo::<Class:Foo>", owner.name)
+      entry = @index["bar"]&.first #: as Entry::Method
+      owner = entry.owner
+      assert_equal("Foo::<Class:Foo>", owner&.name)
       assert_instance_of(Entry::SingletonClass, owner)
     end
 
@@ -79,11 +79,11 @@ module RubyIndexer
         end
       RUBY
 
-      assert_equal(2, @index["bar"].length)
-      first_entry = T.must(@index["bar"].first)
-      assert_equal("Foo::self::Bar", first_entry.owner.name)
-      second_entry = T.must(@index["bar"].last)
-      assert_equal("Bar", second_entry.owner.name)
+      assert_equal(2, @index["bar"]&.length)
+      first_entry = @index["bar"]&.first #: as Entry::Method
+      assert_equal("Foo::self::Bar", first_entry.owner&.name)
+      second_entry = @index["bar"]&.last #: as Entry::Method
+      assert_equal("Bar", second_entry.owner&.name)
     end
 
     def test_visibility_tracking
@@ -135,19 +135,19 @@ module RubyIndexer
       RUBY
 
       ["foo", "bar"].each do |keyword|
-        entries = T.must(@index[keyword])
+        entries = @index[keyword] #: as Array[Entry::Method]
         # should receive two entries because module_function creates a singleton method
         # for the Test module and a private method for classes include the Test module
         assert_equal(entries.size, 2)
         first_entry, second_entry = *entries
         # The first entry points to the location of the module_function call
-        assert_equal("Test", first_entry.owner.name)
-        assert_instance_of(Entry::Module, first_entry.owner)
+        assert_equal("Test", first_entry&.owner&.name)
+        assert_instance_of(Entry::Module, first_entry&.owner)
         assert_predicate(first_entry, :private?)
         # The second entry points to the public singleton method
-        assert_equal("Test::<Class:Test>", second_entry.owner.name)
-        assert_instance_of(Entry::SingletonClass, second_entry.owner)
-        assert_equal(Entry::Visibility::PUBLIC, second_entry.visibility)
+        assert_equal("Test::<Class:Test>", second_entry&.owner&.name)
+        assert_instance_of(Entry::SingletonClass, second_entry&.owner)
+        assert_equal(Entry::Visibility::PUBLIC, second_entry&.visibility)
       end
     end
 
@@ -168,13 +168,13 @@ module RubyIndexer
       RUBY
 
       ["foo", "bar"].each do |keyword|
-        entries = T.must(@index[keyword])
+        entries = @index[keyword] #: as Array[Entry::Method]
         assert_equal(1, entries.size)
         entry = entries.first
         assert_predicate(entry, :private?)
       end
 
-      entries = T.must(@index["baz"])
+      entries = @index["baz"] #: as Array[Entry::Method]
       assert_equal(1, entries.size)
       entry = entries.first
       assert_predicate(entry, :public?)
@@ -197,13 +197,13 @@ module RubyIndexer
       RUBY
 
       ["foo", "bar"].each do |keyword|
-        entries = T.must(@index[keyword])
+        entries = @index[keyword] #: as Array[Entry::Method]
         assert_equal(1, entries.size)
         entry = entries.first
         assert_predicate(entry, :private?)
       end
 
-      entries = T.must(@index["baz"])
+      entries = @index["baz"] #: as Array[Entry::Method]
       assert_equal(1, entries.size)
       entry = entries.first
       assert_predicate(entry, :public?)
@@ -220,12 +220,12 @@ module RubyIndexer
         end
       RUBY
 
-      entries = T.must(@index["foo"])
+      entries = @index["foo"] #: as Array[Entry::Method]
       assert_equal(1, entries.size)
       entry = entries.first
       assert_predicate(entry, :private?)
 
-      entries = T.must(@index["bar"])
+      entries = @index["bar"] #: as Array[Entry::Method]
       assert_equal(1, entries.size)
       entry = entries.first
       assert_predicate(entry, :public?)
@@ -251,17 +251,17 @@ module RubyIndexer
         end
       RUBY
 
-      foo_comment = @index["Foo"].first.comments
-      assert_equal("Documentation for Foo", foo_comment)
+      foo = @index["Foo"]&.first #: as !nil
+      assert_equal("Documentation for Foo", foo.comments)
 
-      bar_comment = @index["bar"].first.comments
-      assert_equal("####################\nDocumentation for bar\n####################\n", bar_comment)
+      bar = @index["bar"]&.first #: as !nil
+      assert_equal("####################\nDocumentation for bar\n####################\n", bar.comments)
 
-      baz_comment = @index["baz"].first.comments
-      assert_equal("Documentation for baz", baz_comment)
+      baz = @index["baz"]&.first #: as !nil
+      assert_equal("Documentation for baz", baz.comments)
 
-      ban_comment = @index["ban"].first.comments
-      assert_empty(ban_comment)
+      ban = @index["ban"]&.first #: as !nil
+      assert_empty(ban.comments)
     end
 
     def test_method_with_parameters
@@ -273,11 +273,11 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(1, parameters.length)
       parameter = parameters.first
-      assert_equal(:a, parameter.name)
+      assert_equal(:a, parameter&.name)
       assert_instance_of(Entry::RequiredParameter, parameter)
     end
 
@@ -290,11 +290,11 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(1, parameters.length)
       parameter = parameters.first
-      assert_equal(:"(a, (b, ))", parameter.name)
+      assert_equal(:"(a, (b, ))", parameter&.name)
       assert_instance_of(Entry::RequiredParameter, parameter)
     end
 
@@ -307,11 +307,11 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(1, parameters.length)
       parameter = parameters.first
-      assert_equal(:a, parameter.name)
+      assert_equal(:a, parameter&.name)
       assert_instance_of(Entry::OptionalParameter, parameter)
     end
 
@@ -324,15 +324,15 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(2, parameters.length)
       a, b = parameters
 
-      assert_equal(:a, a.name)
+      assert_equal(:a, a&.name)
       assert_instance_of(Entry::KeywordParameter, a)
 
-      assert_equal(:b, b.name)
+      assert_equal(:b, b&.name)
       assert_instance_of(Entry::OptionalKeywordParameter, b)
     end
 
@@ -345,15 +345,15 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(2, parameters.length)
       a, b = parameters
 
-      assert_equal(:a, a.name)
+      assert_equal(:a, a&.name)
       assert_instance_of(Entry::RestParameter, a)
 
-      assert_equal(:b, b.name)
+      assert_equal(:b, b&.name)
       assert_instance_of(Entry::KeywordRestParameter, b)
     end
 
@@ -371,34 +371,34 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(2, parameters.length)
       a, b = parameters
 
-      assert_equal(:a, a.name)
+      assert_equal(:a, a&.name)
       assert_instance_of(Entry::RestParameter, a)
 
-      assert_equal(:b, b.name)
+      assert_equal(:b, b&.name)
       assert_instance_of(Entry::RequiredParameter, b)
 
-      entry = T.must(@index["baz"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["baz"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(2, parameters.length)
       a, b = parameters
 
-      assert_equal(:a, a.name)
+      assert_equal(:a, a&.name)
       assert_instance_of(Entry::KeywordRestParameter, a)
 
-      assert_equal(:b, b.name)
+      assert_equal(:b, b&.name)
       assert_instance_of(Entry::RequiredParameter, b)
 
-      entry = T.must(@index["qux"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["qux"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(2, parameters.length)
       _a, second = parameters
 
-      assert_equal(:"(b, c)", second.name)
+      assert_equal(:"(b, c)", second&.name)
       assert_instance_of(Entry::RequiredParameter, second)
     end
 
@@ -411,10 +411,10 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(1, parameters.length)
-      param = parameters.first
+      param = parameters.first #: as Entry::Parameter
 
       assert_equal(:"(a, *b)", param.name)
       assert_instance_of(Entry::RequiredParameter, param)
@@ -431,17 +431,17 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
-      param = parameters.first
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
+      param = parameters.first #: as Entry::Parameter
       assert_equal(:block, param.name)
       assert_instance_of(Entry::BlockParameter, param)
 
-      entry = T.must(@index["baz"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["baz"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(1, parameters.length)
 
-      param = parameters.first
+      param = parameters.first #: as Entry::Parameter
       assert_equal(Entry::BlockParameter::DEFAULT_NAME, param.name)
       assert_instance_of(Entry::BlockParameter, param)
     end
@@ -455,15 +455,15 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(2, parameters.length)
       first, second = parameters
 
-      assert_equal(Entry::RestParameter::DEFAULT_NAME, first.name)
+      assert_equal(Entry::RestParameter::DEFAULT_NAME, first&.name)
       assert_instance_of(Entry::RestParameter, first)
 
-      assert_equal(Entry::KeywordRestParameter::DEFAULT_NAME, second.name)
+      assert_equal(Entry::KeywordRestParameter::DEFAULT_NAME, second&.name)
       assert_instance_of(Entry::KeywordRestParameter, second)
     end
 
@@ -476,8 +476,8 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:2-5")
-      entry = T.must(@index["bar"].first)
-      parameters = entry.signatures.first.parameters
+      entry = @index["bar"]&.first #: as Entry::Method
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_empty(parameters)
     end
 
@@ -492,17 +492,17 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
       assert_instance_of(Entry::Method, entry, "Expected `bar` to be indexed")
 
-      parameters = entry.signatures.first.parameters
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(1, parameters.length)
       assert_instance_of(Entry::ForwardingParameter, parameters.first)
 
-      entry = T.must(@index["baz"].first)
+      entry = @index["baz"]&.first #: as Entry::Method
       assert_instance_of(Entry::Method, entry, "Expected `baz` to be indexed")
 
-      parameters = entry.signatures.first.parameters
+      parameters = entry.signatures.first&.parameters #: as Array[Entry::Parameter]
       assert_equal(2, parameters.length)
       assert_instance_of(Entry::RequiredParameter, parameters[0])
       assert_instance_of(Entry::ForwardingParameter, parameters[1])
@@ -516,8 +516,8 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
-      owner_name = T.must(entry.owner).name
+      entry = @index["bar"]&.first #: as Entry::Method
+      owner_name = entry.owner&.name
 
       assert_equal("Foo", owner_name)
     end
@@ -533,9 +533,9 @@ module RubyIndexer
       RUBY
 
       assert_entry("bar", Entry::Accessor, "/fake/path/foo.rb:2-15:2-18")
-      assert_equal("Hello there", @index["bar"].first.comments)
+      assert_equal("Hello there", @index["bar"]&.first&.comments)
       assert_entry("other", Entry::Accessor, "/fake/path/foo.rb:2-21:2-26")
-      assert_equal("Hello there", @index["other"].first.comments)
+      assert_equal("Hello there", @index["other"]&.first&.comments)
       assert_entry("baz=", Entry::Accessor, "/fake/path/foo.rb:3-15:3-18")
       assert_entry("qux", Entry::Accessor, "/fake/path/foo.rb:4-17:4-20")
       assert_entry("qux=", Entry::Accessor, "/fake/path/foo.rb:4-17:4-20")
@@ -565,14 +565,14 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.cast(@index["first_method"]&.first, Entry::Method)
-      assert_equal("Foo", T.must(entry.owner).name)
+      entry = @index["first_method"]&.first #: as Entry::Method
+      assert_equal("Foo", entry.owner&.name)
 
-      entry = T.cast(@index["second_method"]&.first, Entry::Method)
-      assert_equal("Foo::Bar", T.must(entry.owner).name)
+      entry = @index["second_method"]&.first #: as Entry::Method
+      assert_equal("Foo::Bar", entry.owner&.name)
 
-      entry = T.cast(@index["third_method"]&.first, Entry::Method)
-      assert_equal("Foo", T.must(entry.owner).name)
+      entry = @index["third_method"]&.first #: as Entry::Method
+      assert_equal("Foo", entry.owner&.name)
     end
 
     def test_keeps_track_of_aliases
@@ -609,15 +609,15 @@ module RubyIndexer
       assert_entry("bar", Entry::Method, "/fake/path/foo.rb:1-2:1-19")
       assert_entry("baz", Entry::Method, "/fake/path/foo.rb:4-4:4-16")
 
-      bar_owner = T.must(T.must(@index["bar"].first).owner)
-      baz_owner = T.must(T.must(@index["baz"].first).owner)
+      bar = @index["bar"]&.first #: as Entry::Method
+      baz = @index["baz"]&.first #: as Entry::Method
 
-      assert_instance_of(Entry::SingletonClass, bar_owner)
-      assert_instance_of(Entry::SingletonClass, baz_owner)
+      assert_instance_of(Entry::SingletonClass, bar.owner)
+      assert_instance_of(Entry::SingletonClass, baz.owner)
 
       # Regardless of whether the method was added through `self.something` or `class << self`, the owner object must be
       # the exact same
-      assert_same(bar_owner, baz_owner)
+      assert_same(bar.owner, baz.owner)
     end
 
     def test_name_location_points_to_method_identifier_location
@@ -630,7 +630,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
       refute_equal(entry.location, entry.name_location)
 
       name_location = entry.name_location
@@ -648,7 +648,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
 
       # Matching calls
       assert_signature_matches(entry, "bar()")
@@ -682,7 +682,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
 
       # All calls match a forwarding parameter
       assert_signature_matches(entry, "bar(1)")
@@ -708,7 +708,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
 
       # All calls with at least one positional argument match
       assert_signature_matches(entry, "bar(1)")
@@ -734,7 +734,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
 
       # All calls with at least one positional argument match
       assert_signature_matches(entry, "bar()")
@@ -762,7 +762,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
 
       # All calls with at least one positional argument match
       assert_signature_matches(entry, "bar(1)")
@@ -789,7 +789,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
 
       assert_signature_matches(entry, "bar(...)")
       assert_signature_matches(entry, "bar()")
@@ -817,7 +817,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
 
       assert_signature_matches(entry, "bar(...)")
       assert_signature_matches(entry, "bar()")
@@ -841,10 +841,10 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
       assert_signature_matches(entry, "bar(a: 1)")
 
-      entry = T.must(@index["baz"].first)
+      entry = @index["baz"]&.first #: as Entry::Method
       assert_signature_matches(entry, "baz(1)")
     end
 
@@ -864,27 +864,27 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
       assert_predicate(entry, :public?)
-      assert_equal("Foo", T.must(entry.owner).name)
+      assert_equal("Foo", entry.owner&.name)
 
-      instance_baz, singleton_baz = T.must(@index["baz"])
+      instance_baz, singleton_baz = @index["baz"] #: as Array[Entry::Method]
       assert_predicate(instance_baz, :private?)
-      assert_equal("Foo", T.must(instance_baz.owner).name)
+      assert_equal("Foo", instance_baz&.owner&.name)
 
       assert_predicate(singleton_baz, :public?)
-      assert_equal("Foo::<Class:Foo>", T.must(singleton_baz.owner).name)
+      assert_equal("Foo::<Class:Foo>", singleton_baz&.owner&.name)
 
       # After invoking `public`, the state of `module_function` is reset
-      instance_qux, singleton_qux = T.must(@index["qux"])
+      instance_qux, singleton_qux = @index["qux"] #: as Array[Entry::Method]
       assert_nil(singleton_qux)
       assert_predicate(instance_qux, :public?)
-      assert_equal("Foo", T.must(instance_baz.owner).name)
+      assert_equal("Foo", instance_baz&.owner&.name)
 
       # Attributes are not turned into class methods, they do become private
-      instance_attribute, singleton_attribute = @index["attribute"]
+      instance_attribute, singleton_attribute = @index["attribute"] #: as Array[Entry::Method]
       assert_nil(singleton_attribute)
-      assert_equal("Foo", T.must(instance_attribute.owner).name)
+      assert_equal("Foo", instance_attribute&.owner&.name)
       assert_predicate(instance_attribute, :private?)
     end
 
@@ -900,13 +900,13 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
       assert_predicate(entry, :public?)
-      assert_equal("Foo", T.must(entry.owner).name)
+      assert_equal("Foo", entry.owner&.name)
 
-      entry = T.must(@index["baz"].first)
+      entry = @index["baz"]&.first #: as Entry::Method
       assert_predicate(entry, :public?)
-      assert_equal("Foo", T.must(entry.owner).name)
+      assert_equal("Foo", entry.owner&.name)
     end
 
     def test_making_several_class_methods_private
@@ -940,13 +940,13 @@ module RubyIndexer
         end
       RUBY
 
-      entry = T.must(@index["bar"].first)
+      entry = @index["bar"]&.first #: as Entry::Method
       assert_predicate(entry, :private?)
 
-      entry = T.must(@index["baz"].first)
+      entry = @index["baz"]&.first #: as Entry::Method
       assert_predicate(entry, :protected?)
 
-      entry = T.must(@index["qux"].first)
+      entry = @index["qux"]&.first #: as Entry::Method
       assert_predicate(entry, :public?)
     end
 
@@ -954,14 +954,14 @@ module RubyIndexer
 
     #: (Entry::Method entry, String call_string) -> void
     def assert_signature_matches(entry, call_string)
-      sig = T.must(entry.signatures.first)
+      sig = entry.signatures.first #: as !nil
       arguments = parse_prism_args(call_string)
       assert(sig.matches?(arguments), "Expected #{call_string} to match #{entry.name}#{entry.decorated_parameters}")
     end
 
     #: (Entry::Method entry, String call_string) -> void
     def refute_signature_matches(entry, call_string)
-      sig = T.must(entry.signatures.first)
+      sig = entry.signatures.first #: as !nil
       arguments = parse_prism_args(call_string)
       refute(sig.matches?(arguments), "Expected #{call_string} to not match #{entry.name}#{entry.decorated_parameters}")
     end

--- a/lib/ruby_indexer/test/rbs_indexer_test.rb
+++ b/lib/ruby_indexer/test/rbs_indexer_test.rb
@@ -6,16 +6,16 @@ require_relative "test_case"
 module RubyIndexer
   class RBSIndexerTest < TestCase
     def test_index_core_classes
-      entries = @index["Array"]
+      entries = @index["Array"] #: as !nil
       refute_nil(entries)
       # Array is a class but also an instance method on Kernel
       assert_equal(2, entries.length)
-      entry = entries.find { |entry| entry.is_a?(RubyIndexer::Entry::Class) }
+      entry = entries.find { |entry| entry.is_a?(Entry::Class) } #: as Entry::Class
       assert_match(%r{/gems/rbs-.*/core/array.rbs}, entry.file_path)
       assert_equal("array.rbs", entry.file_name)
       assert_equal("Object", entry.parent_class)
       assert_equal(1, entry.mixin_operations.length)
-      enumerable_include = entry.mixin_operations.first
+      enumerable_include = entry.mixin_operations.first #: as !nil
       assert_equal("Enumerable", enumerable_include.module_name)
 
       # Using fixed positions would be fragile, so let's just check some basics.
@@ -26,10 +26,10 @@ module RubyIndexer
     end
 
     def test_index_core_modules
-      entries = @index["Kernel"]
+      entries = @index["Kernel"] #: as !nil
       refute_nil(entries)
       assert_equal(1, entries.length)
-      entry = entries.first
+      entry = entries.first #: as Entry::Module
       assert_match(%r{/gems/rbs-.*/core/kernel.rbs}, entry.file_path)
       assert_equal("kernel.rbs", entry.file_name)
 
@@ -41,30 +41,23 @@ module RubyIndexer
     end
 
     def test_index_core_constants
-      entries = @index["RUBY_VERSION"]
+      entries = @index["RUBY_VERSION"] #: as !nil
       refute_nil(entries)
       assert_equal(1, entries.length)
 
-      # Complex::I is defined as `Complex::I = ...`
-      entries = @index["Complex::I"]
+      entries = @index["Complex::I"] #: as !nil
       refute_nil(entries)
       assert_equal(1, entries.length)
 
-      # Encoding::US_ASCII is defined as
-      # ```
-      # module Encoding
-      #   US_ASCII = ...
-      #   ...
-      # ````
-      entries = @index["Encoding::US_ASCII"]
+      entries = @index["Encoding::US_ASCII"] #: as !nil
       refute_nil(entries)
       assert_equal(1, entries.length)
     end
 
     def test_index_methods
-      entries = @index["initialize"]
+      entries = @index["initialize"] #: as Array[Entry::Method]
       refute_nil(entries)
-      entry = entries.find { |entry| entry.owner.name == "Array" }
+      entry = entries.find { |entry| entry.owner&.name == "Array" } #: as Entry::Method
       assert_match(%r{/gems/rbs-.*/core/array.rbs}, entry.file_path)
       assert_equal("array.rbs", entry.file_name)
       assert_equal(Entry::Visibility::PUBLIC, entry.visibility)
@@ -77,11 +70,11 @@ module RubyIndexer
     end
 
     def test_index_global_declaration
-      entries = @index["$DEBUG"]
+      entries = @index["$DEBUG"] #: as Array[Entry::GlobalVariable]
       refute_nil(entries)
       assert_equal(1, entries.length)
 
-      entry = entries.first
+      entry = entries.first #: as Entry::GlobalVariable
 
       assert_instance_of(Entry::GlobalVariable, entry)
       assert_equal("$DEBUG", entry.name)
@@ -91,10 +84,10 @@ module RubyIndexer
     end
 
     def test_attaches_correct_owner_to_singleton_methods
-      entries = @index["basename"]
+      entries = @index["basename"] #: as Array[Entry::Method]
       refute_nil(entries)
 
-      owner = entries.first.owner
+      owner = entries.first&.owner #: as Entry::SingletonClass
       assert_instance_of(Entry::SingletonClass, owner)
       assert_equal("File::<Class:File>", owner.name)
     end
@@ -103,47 +96,47 @@ module RubyIndexer
       # NOTE: RBS does not store the name location for classes, modules or methods. This behavior is not exactly what
       # we would like, but for now we assign the same location to both
 
-      entries = @index["Array"]
+      entries = @index["Array"] #: as Array[Entry::Class]
       refute_nil(entries)
-      entry = entries.find { |entry| entry.is_a?(Entry::Class) }
+      entry = entries.find { |entry| entry.is_a?(Entry::Class) } #: as Entry::Class
 
       assert_same(entry.location, entry.name_location)
     end
 
     def test_rbs_method_with_required_positionals
-      entries = @index["crypt"]
+      entries = @index["crypt"] #: as Array[Entry::Method]
       assert_equal(1, entries.length)
 
-      entry = entries.first
+      entry = entries.first #: as Entry::Method
       signatures = entry.signatures
       assert_equal(1, signatures.length)
 
-      first_signature = signatures.first
+      first_signature = signatures.first #: as Entry::Signature
 
       # (::string salt_str) -> ::String
 
       assert_equal(1, first_signature.parameters.length)
       assert_kind_of(Entry::RequiredParameter, first_signature.parameters[0])
-      assert_equal(:salt_str, first_signature.parameters[0].name)
+      assert_equal(:salt_str, first_signature.parameters[0]&.name)
     end
 
     def test_rbs_method_with_unnamed_required_positionals
-      entries = @index["try_convert"]
-      entry = entries.find { |entry| entry.owner.name == "Array::<Class:Array>" }
+      entries = @index["try_convert"] #: as Array[Entry::Method]
+      entry = entries.find { |entry| entry.owner&.name == "Array::<Class:Array>" } #: as Entry::Method
 
-      parameters = entry.signatures[0].parameters
+      parameters = entry.signatures[0]&.parameters #: as Array[Entry::Parameter]
 
       assert_equal([:arg0], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
     end
 
     def test_rbs_method_with_optional_positionals
-      entries = @index["polar"]
-      entry = entries.find { |entry| entry.owner.name == "Complex::<Class:Complex>" }
+      entries = @index["polar"] #: as Array[Entry::Method]
+      entry = entries.find { |entry| entry.owner&.name == "Complex::<Class:Complex>" } #: as Entry::Method
 
       # def self.polar: (Numeric, ?Numeric) -> Complex
 
-      parameters = entry.signatures[0].parameters
+      parameters = entry.signatures[0]&.parameters #: as Array[Entry::Parameter]
 
       assert_equal([:arg0, :arg1], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
@@ -151,27 +144,27 @@ module RubyIndexer
     end
 
     def test_rbs_method_with_optional_parameter
-      entries = @index["chomp"]
+      entries = @index["chomp"] #: as Array[Entry::Method]
       assert_equal(1, entries.length)
 
-      entry = entries.first
+      entry = entries.first #: as Entry::Method
       signatures = entry.signatures
       assert_equal(1, signatures.length)
 
-      first_signature = signatures.first
+      first_signature = signatures.first #: as Entry::Signature
 
       # (?::string? separator) -> ::String
 
       assert_equal(1, first_signature.parameters.length)
       assert_kind_of(Entry::OptionalParameter, first_signature.parameters[0])
-      assert_equal(:separator, first_signature.parameters[0].name)
+      assert_equal(:separator, first_signature.parameters[0]&.name)
     end
 
     def test_rbs_method_with_required_and_optional_parameters
-      entries = @index["gsub"]
+      entries = @index["gsub"] #: as Array[Entry::Method]
       assert_equal(1, entries.length)
 
-      entry = entries.first
+      entry = entries.first #: as Entry::Method
 
       signatures = entry.signatures
       assert_equal(3, signatures.length)
@@ -180,37 +173,37 @@ module RubyIndexer
       # | (::Regexp | ::string pattern) -> ::Enumerator[::String, ::String]
       # | (::Regexp | ::string pattern) { (::String match) -> ::_ToS } -> ::String
 
-      parameters = signatures[0].parameters
+      parameters = signatures[0]&.parameters #: as !nil
       assert_equal([:pattern, :replacement], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
       assert_kind_of(Entry::RequiredParameter, parameters[1])
 
-      parameters = signatures[1].parameters
+      parameters = signatures[1]&.parameters #: as !nil
       assert_equal([:pattern], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
 
-      parameters = signatures[2].parameters
+      parameters = signatures[2]&.parameters #: as !nil
       assert_equal([:pattern, :"<anonymous block>"], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
       assert_kind_of(Entry::BlockParameter, parameters[1])
     end
 
     def test_rbs_anonymous_block_parameter
-      entries = @index["open"]
-      entry = entries.find { |entry| entry.owner.name == "File::<Class:File>" }
+      entries = @index["open"] #: as Array[Entry::Method]
+      entry = entries.find { |entry| entry.owner&.name == "File::<Class:File>" } #: as Entry::Method
 
       assert_equal(2, entry.signatures.length)
 
       # (::String name, ?::String mode, ?::Integer perm) -> ::IO?
       # | [T] (::String name, ?::String mode, ?::Integer perm) { (::IO) -> T } -> T
 
-      parameters = entry.signatures[0].parameters
+      parameters = entry.signatures[0]&.parameters #: as !nil
       assert_equal([:file_name, :mode, :perm], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
       assert_kind_of(Entry::OptionalParameter, parameters[1])
       assert_kind_of(Entry::OptionalParameter, parameters[2])
 
-      parameters = entry.signatures[1].parameters
+      parameters = entry.signatures[1]&.parameters #: as !nil
       assert_equal([:file_name, :mode, :perm, :"<anonymous block>"], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
       assert_kind_of(Entry::OptionalParameter, parameters[1])
@@ -219,10 +212,10 @@ module RubyIndexer
     end
 
     def test_rbs_method_with_rest_positionals
-      entries = @index["count"]
-      entry = entries.find { |entry| entry.owner.name == "String" }
+      entries = @index["count"] #: as Array[Entry::Method]
+      entry = entries.find { |entry| entry.owner&.name == "String" } #: as Entry::Method
 
-      parameters = entry.signatures.first.parameters
+      parameters = entry.signatures.first&.parameters #: as !nil
       assert_equal(1, entry.signatures.length)
 
       # (::String::selector selector_0, *::String::selector more_selectors) -> ::Integer
@@ -233,8 +226,8 @@ module RubyIndexer
     end
 
     def test_rbs_method_with_trailing_positionals
-      entries = @index["select"] # https://ruby-doc.org/3.3.3/IO.html#method-c-select
-      entry = entries.find { |entry| entry.owner.name == "IO::<Class:IO>" }
+      entries = @index["select"] #: as Array[Entry::Method]
+      entry = entries.find { |entry| entry.owner&.name == "IO::<Class:IO>" } #: as !nil
 
       signatures = entry.signatures
       assert_equal(2, signatures.length)
@@ -242,13 +235,13 @@ module RubyIndexer
       # def self.select: [X, Y, Z] (::Array[X & io]? read_array, ?::Array[Y & io]? write_array, ?::Array[Z & io]? error_array) -> [ Array[X], Array[Y], Array[Z] ] # rubocop:disable Layout/LineLength
       #   | [X, Y, Z] (::Array[X & io]? read_array, ?::Array[Y & io]? write_array, ?::Array[Z & io]? error_array, Time::_Timeout? timeout) -> [ Array[X], Array[Y], Array[Z] ]? # rubocop:disable Layout/LineLength
 
-      parameters = signatures[0].parameters
+      parameters = signatures[0]&.parameters #: as !nil
       assert_equal([:read_array, :write_array, :error_array], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
       assert_kind_of(Entry::OptionalParameter, parameters[1])
       assert_kind_of(Entry::OptionalParameter, parameters[2])
 
-      parameters = signatures[1].parameters
+      parameters = signatures[1]&.parameters #: as !nil
       assert_equal([:read_array, :write_array, :error_array, :timeout], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
       assert_kind_of(Entry::OptionalParameter, parameters[1])
@@ -257,8 +250,8 @@ module RubyIndexer
     end
 
     def test_rbs_method_with_optional_keywords
-      entries = @index["step"]
-      entry = entries.find { |entry| entry.owner.name == "Numeric" }
+      entries = @index["step"] #: as Array[Entry::Method]
+      entry = entries.find { |entry| entry.owner&.name == "Numeric" } #: as !nil
 
       signatures = entry.signatures
       assert_equal(4, signatures.length)
@@ -268,24 +261,24 @@ module RubyIndexer
       # | (?by: ::Numeric, ?to: ::Numeric) { (::Numeric) -> void } -> self
       # | (?by: ::Numeric, ?to: ::Numeric) -> ::Enumerator[::Numeric, self]
 
-      parameters = signatures[0].parameters
+      parameters = signatures[0]&.parameters #: as !nil
       assert_equal([:limit, :step, :"<anonymous block>"], parameters.map(&:name))
       assert_kind_of(Entry::OptionalParameter, parameters[0])
       assert_kind_of(Entry::OptionalParameter, parameters[1])
       assert_kind_of(Entry::BlockParameter, parameters[2])
 
-      parameters = signatures[1].parameters
+      parameters = signatures[1]&.parameters #: as !nil
       assert_equal([:limit, :step], parameters.map(&:name))
       assert_kind_of(Entry::OptionalParameter, parameters[0])
       assert_kind_of(Entry::OptionalParameter, parameters[1])
 
-      parameters = signatures[2].parameters
+      parameters = signatures[2]&.parameters #: as !nil
       assert_equal([:by, :to, :"<anonymous block>"], parameters.map(&:name))
       assert_kind_of(Entry::OptionalKeywordParameter, parameters[0])
       assert_kind_of(Entry::OptionalKeywordParameter, parameters[1])
       assert_kind_of(Entry::BlockParameter, parameters[2])
 
-      parameters = signatures[3].parameters
+      parameters = signatures[3]&.parameters #: as !nil
       assert_equal([:by, :to], parameters.map(&:name))
       assert_kind_of(Entry::OptionalKeywordParameter, parameters[0])
       assert_kind_of(Entry::OptionalKeywordParameter, parameters[1])
@@ -308,14 +301,14 @@ module RubyIndexer
     end
 
     def test_rbs_method_with_rest_keywords
-      entries = @index["method_missing"]
-      entry = entries.find { |entry| entry.owner.name == "BasicObject" }
+      entries = @index["method_missing"] #: as Array[Entry::Method]
+      entry = entries.find { |entry| entry.owner&.name == "BasicObject" } #: as !nil
       signatures = entry.signatures
       assert_equal(1, signatures.length)
 
       # (Symbol, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> untyped
 
-      parameters = signatures[0].parameters
+      parameters = signatures[0]&.parameters #: as !nil
       assert_equal([:arg0, :"<anonymous splat>", :"<anonymous keyword splat>"], parameters.map(&:name))
       assert_kind_of(Entry::RequiredParameter, parameters[0])
       assert_kind_of(Entry::RestParameter, parameters[1])
@@ -348,24 +341,24 @@ module RubyIndexer
     def test_signature_alias
       # In RBS, an alias means that two methods have the same signature.
       # It does not mean the same thing as a Ruby alias.
-      any_entries = @index["any?"]
+      any_entries = @index["any?"] #: as Array[Entry::UnresolvedMethodAlias]
 
-      assert_equal(["Array", "Enumerable", "Hash"], any_entries.map { _1.owner.name })
+      assert_equal(["Array", "Enumerable", "Hash"], any_entries.map { _1.owner&.name })
 
-      entry = any_entries.find { |entry| entry.owner.name == "Array" }
+      entry = any_entries.find { |entry| entry.owner&.name == "Array" } #: as !nil
 
       assert_kind_of(RubyIndexer::Entry::UnresolvedMethodAlias, entry)
       assert_equal("any?", entry.name)
       assert_equal("all?", entry.old_name)
-      assert_equal("Array", entry.owner.name)
-      assert(entry.file_path.end_with?("core/array.rbs"))
+      assert_equal("Array", entry.owner&.name)
+      assert(entry.file_path&.end_with?("core/array.rbs"))
       refute_empty(entry.comments)
     end
 
     def test_indexing_untyped_functions
-      entries = @index.resolve_method("call", "Method")
+      entries = @index.resolve_method("call", "Method") #: as Array[Entry::Method]
 
-      parameters = entries.first.signatures.first.parameters
+      parameters = entries.first&.signatures&.first&.parameters #: as !nil
       assert_equal(1, parameters.length)
       assert_instance_of(Entry::ForwardingParameter, parameters.first)
     end
@@ -379,7 +372,8 @@ module RubyIndexer
       indexer = RubyIndexer::RBSIndexer.new(index)
       pathname = Pathname.new("/file.rbs")
       indexer.process_signature(pathname, declarations)
-      entry = T.must(index[method_name]).first
+      entry = index[method_name] #: as !nil
+        .first
       T.cast(entry, Entry::Method).signatures
     end
   end

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -18,11 +18,11 @@ module RubyIndexer
     end
 
     def assert_entry(expected_name, type, expected_location, visibility: nil)
-      entries = @index[expected_name]
+      entries = @index[expected_name] #: as !nil
       refute_nil(entries, "Expected #{expected_name} to be indexed")
       refute_empty(entries, "Expected #{expected_name} to be indexed")
 
-      entry = entries.first
+      entry = entries.first #: as !nil
       assert_instance_of(type, entry, "Expected #{expected_name} to be a #{type}")
 
       location = entry.location

--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -111,7 +111,9 @@ module RubyLsp
               push_char(" ")
             end
           else
-            push_char(T.must(char))
+            push_char(
+              char, #: as !nil
+            )
           end
         when "-"
           if @inside_ruby && next_char == "%" &&
@@ -120,7 +122,9 @@ module RubyLsp
             push_char("   ")
             @inside_ruby = false
           else
-            push_char(T.must(char))
+            push_char(
+              char, #: as !nil
+            )
           end
         when "%"
           if @inside_ruby && next_char == ">"
@@ -128,7 +132,9 @@ module RubyLsp
             @current_pos += 1
             push_char("  ")
           else
-            push_char(T.must(char))
+            push_char(
+              char, #: as !nil
+            )
           end
         when "\r"
           @ruby << char
@@ -143,7 +149,9 @@ module RubyLsp
           @ruby << char
           @host_language << char
         else
-          push_char(T.must(char))
+          push_char(
+            char, #: as !nil
+          )
         end
       end
 

--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -185,7 +185,7 @@ module RubyLsp
 
     #: -> String
     def workspace_path
-      T.must(@workspace_uri.to_standardized_path)
+      @workspace_uri.to_standardized_path #: as !nil
     end
 
     #: -> String

--- a/lib/ruby_lsp/listeners/code_lens.rb
+++ b/lib/ruby_lsp/listeners/code_lens.rb
@@ -208,7 +208,7 @@ module RubyLsp
 
       #: (?group_stack: Array[String], ?spec_name: String?, ?method_name: String?) -> String
       def generate_test_command(group_stack: [], spec_name: nil, method_name: nil)
-        path = T.must(@path)
+        path = @path #: as !nil
         command = BASE_COMMAND
         command += " -Itest" if File.fnmatch?("**/test/**/*", path, File::FNM_PATHNAME)
         command += " -Ispec" if File.fnmatch?("**/spec/**/*", path, File::FNM_PATHNAME)
@@ -233,7 +233,7 @@ module RubyLsp
           # the best we can do is match everything to the right of it.
           # Tests are classes, dynamic references are only a thing for modules,
           # so there must be something to the left of the available path.
-          dynamic_stack = T.must(group_stack[last_dynamic_reference_index + 1..])
+          dynamic_stack = group_stack[last_dynamic_reference_index + 1..] #: as !nil
 
           if method_name
             " --name " + "/::#{Shellwords.escape(dynamic_stack.join("::")) + "#" + Shellwords.escape(method_name)}$/"
@@ -257,7 +257,7 @@ module RubyLsp
 
       #: (Array[String] group_stack, String? method_name) -> String
       def generate_test_unit_command(group_stack, method_name)
-        group_name = T.must(group_stack.last)
+        group_name = group_stack.last #: as !nil
         command = " --testcase " + "/#{Shellwords.escape(group_name)}/"
 
         if method_name

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -382,7 +382,7 @@ module RubyLsp
 
         # We should only allow jumping to the definition of private constants if the constant is defined in the same
         # namespace as the reference
-        first_entry = T.must(entries.first)
+        first_entry = entries.first #: as !nil
         return if first_entry.private? && first_entry.name != "#{@node_context.fully_qualified_name}::#{value}"
 
         entries.each do |entry|

--- a/lib/ruby_lsp/listeners/document_link.rb
+++ b/lib/ruby_lsp/listeners/document_link.rb
@@ -107,7 +107,9 @@ module RubyLsp
 
         uri = T.cast(
           begin
-            URI(T.must(match[0]))
+            URI(
+              match[0], #: as !nil
+            )
           rescue URI::Error
             nil
           end,

--- a/lib/ruby_lsp/listeners/document_symbol.rb
+++ b/lib/ruby_lsp/listeners/document_symbol.rb
@@ -318,7 +318,7 @@ module RubyLsp
           name: name,
           kind: Constant::SymbolKind::METHOD,
           range_location: new_name_node.location,
-          selection_range_location: T.must(new_name_node.value_loc),
+          selection_range_location: new_name_node.value_loc, #: as !nil
         )
       end
 
@@ -357,7 +357,7 @@ module RubyLsp
               name: name,
               kind: Constant::SymbolKind::FIELD,
               range_location: argument.location,
-              selection_range_location: T.must(argument.value_loc),
+              selection_range_location: argument.value_loc, #: as !nil
             )
           elsif argument.is_a?(Prism::StringNode)
             name = argument.content
@@ -391,7 +391,7 @@ module RubyLsp
             name: name,
             kind: Constant::SymbolKind::METHOD,
             range_location: new_name_argument.location,
-            selection_range_location: T.must(new_name_argument.value_loc),
+            selection_range_location: new_name_argument.value_loc, #: as !nil
           )
         elsif new_name_argument.is_a?(Prism::StringNode)
           name = new_name_argument.content

--- a/lib/ruby_lsp/listeners/folding_ranges.rb
+++ b/lib/ruby_lsp/listeners/folding_ranges.rb
@@ -193,8 +193,10 @@ module RubyLsp
           next if chunk.length == 1
 
           @response_builder << Interface::FoldingRange.new(
-            start_line: T.must(chunk.first).location.start_line - 1,
-            end_line: T.must(chunk.last).location.end_line - 1,
+            start_line: chunk.first #: as !nil
+              .location.start_line - 1,
+            end_line: chunk.last #: as !nil
+              .location.end_line - 1,
             kind: "comment",
           )
         end
@@ -204,8 +206,10 @@ module RubyLsp
       def emit_requires_range
         if @requires.length > 1
           @response_builder << Interface::FoldingRange.new(
-            start_line: T.must(@requires.first).location.start_line - 1,
-            end_line: T.must(@requires.last).location.end_line - 1,
+            start_line: @requires.first #: as !nil
+              .location.start_line - 1,
+            end_line: @requires.last #: as !nil
+              .location.end_line - 1,
             kind: "imports",
           )
         end

--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -299,7 +299,7 @@ module RubyLsp
         methods = @index.resolve_method(message, type.name, inherited_only: inherited_only)
         return unless methods
 
-        first_method = T.must(methods.first)
+        first_method = methods.first #: as !nil
 
         title = "#{message}#{first_method.decorated_parameters}"
         title << first_method.formatted_signatures
@@ -365,7 +365,7 @@ module RubyLsp
 
         # We should only show hover for private constants if the constant is defined in the same namespace as the
         # reference
-        first_entry = T.must(entries.first)
+        first_entry = entries.first #: as !nil
         return if first_entry.private? && first_entry.name != "#{@node_context.fully_qualified_name}::#{name}"
 
         categorized_markdown_from_index_entries(name, entries).each do |category, content|

--- a/lib/ruby_lsp/listeners/semantic_highlighting.rb
+++ b/lib/ruby_lsp/listeners/semantic_highlighting.rb
@@ -67,12 +67,18 @@ module RubyLsp
         return if special_method?(message)
 
         if Requests::Support::Sorbet.annotation?(node)
-          @response_builder.add_token(T.must(node.message_loc), :type)
+          @response_builder.add_token(
+            node.message_loc, #: as !nil
+            :type,
+          )
         elsif !node.receiver && !node.opening_loc
           # If the node has a receiver, then the syntax is not ambiguous and semantic highlighting is not necessary to
           # determine that the token is a method call. The only ambiguous case is method calls with implicit self
           # receiver and no parenthesis, which may be confused with local variables
-          @response_builder.add_token(T.must(node.message_loc), :method)
+          @response_builder.add_token(
+            node.message_loc, #: as !nil
+            :method,
+          )
         end
       end
 
@@ -98,7 +104,7 @@ module RubyLsp
 
       #: (Prism::DefNode node) -> void
       def on_def_node_leave(node)
-        @current_scope = T.must(@current_scope.parent)
+        @current_scope = @current_scope.parent #: as !nil
       end
 
       #: (Prism::BlockNode node) -> void
@@ -108,7 +114,7 @@ module RubyLsp
 
       #: (Prism::BlockNode node) -> void
       def on_block_node_leave(node)
-        @current_scope = T.must(@current_scope.parent)
+        @current_scope = @current_scope.parent #: as !nil
       end
 
       #: (Prism::BlockLocalVariableNode node) -> void
@@ -301,7 +307,8 @@ module RubyLsp
         # For each capture name we find in the regexp, look for a local in the current_scope
         Regexp.new(content, Regexp::FIXEDENCODING).names.each do |name|
           # The +3 is to compensate for the "(?<" part of the capture name
-          capture_name_offset = T.must(content.index("(?<#{name}>")) + 3
+          capture_name_index = content.index("(?<#{name}>") #: as !nil
+          capture_name_offset = capture_name_index + 3
           local_var_loc = loc.copy(start_offset: loc.start_offset + capture_name_offset, length: name.length)
 
           local = @current_scope.lookup(name)

--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -69,7 +69,11 @@ module RubyLsp
           signature.matches?(arguments)
         end || 0
 
-        parameter_length = [T.must(signatures[active_sig_index]).parameters.length - 1, 0].max
+        parameter_length = [
+          signatures[active_sig_index] #: as !nil
+            .parameters.length - 1,
+          0,
+        ].max
         active_parameter = (arguments.length - 1).clamp(0, parameter_length)
 
         # If there are arguments, then we need to check if there's a trailing comma after the end of the last argument

--- a/lib/ruby_lsp/listeners/spec_style.rb
+++ b/lib/ruby_lsp/listeners/spec_style.rb
@@ -148,7 +148,7 @@ module RubyLsp
       def in_spec_context?
         return true if @nesting.empty?
 
-        T.must(@spec_class_stack.last)
+        @spec_class_stack.last #: as !nil
       end
     end
   end

--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -22,7 +22,7 @@ module RubyLsp
           queue = items.dup
 
           until queue.empty?
-            item = T.must(queue.shift)
+            item = queue.shift #: as !nil
             tags = Set.new(item[:tags])
             next unless tags.include?("framework:minitest") || tags.include?("framework:test_unit")
 

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -97,7 +97,7 @@ module RubyLsp
         return Error::EmptySelection if source_range[:start] == source_range[:end]
 
         start_index, end_index = @document.find_index_by_position(source_range[:start], source_range[:end])
-        extracted_source = T.must(@document.source[start_index...end_index])
+        extracted_source = @document.source[start_index...end_index] #: as !nil
 
         # Find the closest statements node, so that we place the refactor in a valid position
         node_context = RubyDocument
@@ -153,7 +153,8 @@ module RubyLsp
           indentation_line = lines[indentation_line_number]
           return Error::InvalidTargetRange unless indentation_line
 
-          indentation = T.must(indentation_line[/\A */]).size
+          indentation = indentation_line[/\A */] #: as !nil
+            .size
 
           target_range = {
             start: { line: target_line, character: indentation },
@@ -195,7 +196,7 @@ module RubyLsp
         return Error::EmptySelection if source_range[:start] == source_range[:end]
 
         start_index, end_index = @document.find_index_by_position(source_range[:start], source_range[:end])
-        extracted_source = T.must(@document.source[start_index...end_index])
+        extracted_source = @document.source[start_index...end_index] #: as !nil
 
         # Find the closest method declaration node, so that we place the refactor in a valid position
         node_context = RubyDocument.locate(

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -54,7 +54,7 @@ module RubyLsp
           end
         end
 
-        first_entry = T.must(entries.first)
+        first_entry = entries.first #: as !nil
 
         if first_entry.is_a?(RubyIndexer::Entry::Member)
           label = +"#{label}#{first_entry.decorated_parameters}"

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -37,8 +37,8 @@ module RubyLsp
 
         if should_refine_target?(parent, target)
           target = determine_target(
-            T.must(target),
-            T.must(parent),
+            target, #: as !nil
+            parent, #: as !nil
             position,
           )
         elsif position_outside_target?(position, target)

--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -51,7 +51,9 @@ module RubyLsp
           # But if it's a RBS signature starting with `#:`, we'll ignore it
           # so users can immediately continue typing the method definition
           if (comment_match = @previous_line.match(/^#(?!:)(\s*)/))
-            handle_comment_line(T.must(comment_match[1]))
+            handle_comment_line(
+              comment_match[1], #: as !nil
+            )
           elsif @document.syntax_error?
             match = /(<<((-|~)?))(?<quote>['"`]?)(?<delimiter>\w+)\k<quote>/.match(@previous_line)
             heredoc_delimiter = match && match.named_captures["delimiter"]
@@ -76,7 +78,7 @@ module RubyLsp
         current_line = @lines[@position[:line]]
         return unless /((?<=do)|(?<={))\s+\|/.match?(current_line)
 
-        line = T.must(current_line)
+        line = current_line #: as !nil
 
         # If the user inserts the closing pipe manually to the end of the block argument, we need to avoid adding
         # an additional one and remove the previous one.  This also helps to remove the user who accidentally

--- a/lib/ruby_lsp/requests/prepare_type_hierarchy.rb
+++ b/lib/ruby_lsp/requests/prepare_type_hierarchy.rb
@@ -49,8 +49,7 @@ module RubyLsp
 
         # While the spec allows for multiple entries, VSCode seems to only support one
         # We'll just return the first one for now
-        first_entry = T.must(entries.first)
-
+        first_entry = entries.first #: as !nil
         range = range_from_location(first_entry.location)
 
         [

--- a/lib/ruby_lsp/requests/references.rb
+++ b/lib/ruby_lsp/requests/references.rb
@@ -106,7 +106,8 @@ module RubyLsp
           entries = @global_state.index.resolve(name, node_context.nesting)
           return unless entries
 
-          fully_qualified_name = T.must(entries.first).name
+          fully_qualified_name = entries.first #: as !nil
+            .name
           RubyIndexer::ReferenceFinder::ConstTarget.new(fully_qualified_name)
         when
           Prism::InstanceVariableAndWriteNode,

--- a/lib/ruby_lsp/requests/semantic_highlighting.rb
+++ b/lib/ruby_lsp/requests/semantic_highlighting.rb
@@ -43,8 +43,8 @@ module RubyLsp
           # Filter the tokens based on the first different position. This must happen at this stage, before we try to
           # find the next position from the end or else we risk confusing sets of token that may have different lengths,
           # but end with the exact same token
-          old_tokens = T.must(previous_tokens[first_different_position...])
-          new_tokens = T.must(current_tokens[first_different_position...])
+          old_tokens = previous_tokens[first_different_position...] #: as !nil
+          new_tokens = current_tokens[first_different_position...] #: as !nil
 
           # Then search from the end to find the first token that doesn't match. Since the user is normally editing the
           # middle of the file, this will minimize the number of edits since the end of the token array has not changed
@@ -53,8 +53,8 @@ module RubyLsp
           end || 0
 
           # Filter the old and new tokens to only the section that will be replaced/inserted/deleted
-          old_tokens = T.must(old_tokens[...old_tokens.length - first_different_token_from_end])
-          new_tokens = T.must(new_tokens[...new_tokens.length - first_different_token_from_end])
+          old_tokens = old_tokens[...old_tokens.length - first_different_token_from_end] #: as !nil
+          new_tokens = new_tokens[...new_tokens.length - first_different_token_from_end] #: as !nil
 
           # And we send back a single edit, replacing an entire section for the new tokens
           Interface::SemanticTokensDelta.new(

--- a/lib/ruby_lsp/requests/show_syntax_tree.rb
+++ b/lib/ruby_lsp/requests/show_syntax_tree.rb
@@ -29,7 +29,7 @@ module RubyLsp
 
       #: -> String
       def ast_for_range
-        range = T.must(@range)
+        range = @range #: as !nil
         start_char, end_char = @document.find_index_by_position(range[:start], range[:end])
 
         queue = @tree.statements.body.dup

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -54,7 +54,9 @@ module RubyLsp
         #: (String file_path) -> bool?
         def not_in_dependencies?(file_path)
           BUNDLE_PATH &&
-            !file_path.start_with?(T.must(BUNDLE_PATH)) &&
+            !file_path.start_with?(
+              BUNDLE_PATH, #: as !nil
+            ) &&
             !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])
         end
 

--- a/lib/ruby_lsp/requests/support/rubocop_formatter.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_formatter.rb
@@ -21,7 +21,7 @@ module RubyLsp
         # @override
         #: (URI::Generic uri, RubyDocument document) -> String?
         def run_formatting(uri, document)
-          filename = T.must(uri.to_standardized_path || uri.opaque)
+          filename = uri.to_standardized_path || uri.opaque #: as !nil
 
           # Invoke RuboCop with just this file in `paths`
           @format_runner.run(filename, document.source)
@@ -38,7 +38,7 @@ module RubyLsp
         # @override
         #: (URI::Generic uri, RubyDocument document) -> Array[Interface::Diagnostic]?
         def run_diagnostic(uri, document)
-          filename = T.must(uri.to_standardized_path || uri.opaque)
+          filename = uri.to_standardized_path || uri.opaque #: as !nil
           # Invoke RuboCop with just this file in `paths`
           @diagnostic_runner.run(filename, document.source)
 

--- a/lib/ruby_lsp/response_builders/document_symbol.rb
+++ b/lib/ruby_lsp/response_builders/document_symbol.rb
@@ -38,13 +38,14 @@ module RubyLsp
 
       #: -> (SymbolHierarchyRoot | Interface::DocumentSymbol)
       def last
-        T.must(@stack.last)
+        @stack.last #: as !nil
       end
 
       # @override
       #: -> Array[Interface::DocumentSymbol]
       def response
-        T.must(@stack.first).children
+        @stack.first #: as !nil
+          .children
       end
     end
   end

--- a/lib/ruby_lsp/response_builders/hover.rb
+++ b/lib/ruby_lsp/response_builders/hover.rb
@@ -35,7 +35,7 @@ module RubyLsp
       # @override
       #: -> ResponseType
       def response
-        result = T.must(@response[:title])
+        result = @response[:title] #: as !nil
         result << "\n" << @response[:links] if @response[:links]
         result << "\n" << @response[:documentation] if @response[:documentation]
 

--- a/lib/ruby_lsp/response_builders/semantic_highlighting.rb
+++ b/lib/ruby_lsp/response_builders/semantic_highlighting.rb
@@ -64,7 +64,7 @@ module RubyLsp
             start_line: location.start_line,
             start_code_unit_column: location.cached_start_code_units_column(@code_units_cache),
             length: length,
-            type: T.must(TOKEN_TYPES[type]),
+            type: TOKEN_TYPES[type], #: as !nil
             modifier: modifiers_indices,
           ),
         )

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -223,7 +223,8 @@ module RubyLsp
       configured_features = options.dig(:initializationOptions, :enabledFeatures)
 
       configured_hints = options.dig(:initializationOptions, :featuresConfiguration, :inlayHint)
-      T.must(@store.features_configuration.dig(:inlayHint)).configuration.merge!(configured_hints) if configured_hints
+      @store.features_configuration.dig(:inlayHint) #: as !nil
+        .configuration.merge!(configured_hints) if configured_hints
 
       enabled_features = case configured_features
       when Array
@@ -488,7 +489,11 @@ module RubyLsp
       document_symbol = Requests::DocumentSymbol.new(uri, dispatcher)
       document_link = Requests::DocumentLink.new(uri, parse_result.comments, dispatcher)
       code_lens = Requests::CodeLens.new(@global_state, uri, dispatcher)
-      inlay_hint = Requests::InlayHints.new(document, T.must(@store.features_configuration.dig(:inlayHint)), dispatcher)
+      inlay_hint = Requests::InlayHints.new(
+        document,
+        @store.features_configuration.dig(:inlayHint), #: as !nil
+        dispatcher,
+      )
 
       if document.is_a?(RubyDocument) && document.should_index?
         # Re-index the file as it is modified. This mode of indexing updates entries only. Require path trees are only
@@ -815,7 +820,7 @@ module RubyLsp
         return
       end
 
-      hints_configurations = T.must(@store.features_configuration.dig(:inlayHint))
+      hints_configurations = @store.features_configuration.dig(:inlayHint) #: as !nil
       dispatcher = Prism::Dispatcher.new
 
       unless document.is_a?(RubyDocument) || document.is_a?(ERBDocument)
@@ -1393,7 +1398,9 @@ module RubyLsp
           Open3.capture3(
             Gem.ruby,
             "-I",
-            File.dirname(T.must(__dir__)),
+            File.dirname(
+              __dir__, #: as !nil
+            ),
             File.expand_path("../../exe/ruby-lsp-launcher", __dir__),
             @global_state.workspace_uri.to_s,
             chdir: @global_state.workspace_path,

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -405,12 +405,15 @@ module RubyLsp
     def correct_relative_remote_paths
       content = @custom_lockfile.read
       content.gsub!(/remote: (.*)/) do |match|
-        path = T.must(Regexp.last_match)[1]
+        last_match = Regexp.last_match #: as !nil
+        path = last_match[1]
 
         # We should only apply the correction if the remote is a relative path. It might also be a URI, like
         # `https://rubygems.org` or an absolute path, in which case we shouldn't do anything
         if path && !URI(path).scheme
-          "remote: #{File.expand_path(path, T.must(@gemfile).dirname)}"
+          bundle_dir = @gemfile #: as !nil
+            .dirname
+          "remote: #{File.expand_path(path, bundle_dir)}"
         else
           match
         end

--- a/lib/ruby_lsp/static_docs.rb
+++ b/lib/ruby_lsp/static_docs.rb
@@ -3,7 +3,14 @@
 
 module RubyLsp
   # The path to the `static_docs` directory, where we keep long-form static documentation
-  STATIC_DOCS_PATH = File.join(File.dirname(File.dirname(T.must(__dir__))), "static_docs") #: String
+  STATIC_DOCS_PATH = File.join(
+    File.dirname(
+      File.dirname(
+        __dir__, #: as !nil
+      ),
+    ),
+    "static_docs",
+  ) #: String
 
   # A map of keyword => short documentation to be displayed on hover or completion
   KEYWORD_DOCS = {

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -46,7 +46,7 @@ module RubyLsp
       end
 
       set(uri: uri, source: File.binread(path), version: 0, language_id: language_id)
-      T.must(@state[uri.to_s])
+      @state[uri.to_s] #: as !nil
     rescue Errno::ENOENT
       raise NonExistingDocumentError, uri.to_s
     end
@@ -65,7 +65,8 @@ module RubyLsp
 
     #: (uri: URI::Generic, edits: Array[Hash[Symbol, untyped]], version: Integer) -> void
     def push_edits(uri:, edits:, version:)
-      T.must(@state[uri.to_s]).push_edits(edits, version: version)
+      @state[uri.to_s] #: as !nil
+        .push_edits(edits, version: version)
     end
 
     #: -> void

--- a/lib/ruby_lsp/type_inferrer.rb
+++ b/lib/ruby_lsp/type_inferrer.rb
@@ -177,7 +177,10 @@ module RubyLsp
       # Returns the attached version of this type by removing the `<Class:...>` part from its name
       #: -> Type
       def attached
-        Type.new(T.must(@name.split("::")[..-2]).join("::"))
+        Type.new(
+          @name.split("::")[..-2] #: as !nil
+          .join("::"),
+        )
       end
     end
 

--- a/sorbet/rbi/shims/test_case.rbi
+++ b/sorbet/rbi/shims/test_case.rbi
@@ -1,0 +1,7 @@
+# typed: true
+
+class RubyIndexer::TestCase < Minitest::Test
+  def initialize
+    @index = nil #: RubyIndexer::Index # rubocop:disable Layout/LeadingCommentSpace
+  end
+end

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -42,14 +42,16 @@ module RubyLsp
       Addon.load_addons(@global_state, @outgoing_queue)
       server = RubyLsp::Server.new
 
-      capture_subprocess_io do
-        server.process_message({ method: "initialized" })
-      end
+      begin
+        capture_subprocess_io do
+          server.process_message({ method: "initialized" })
+        end
 
-      addon_instance = T.must(Addon.addons.find { |addon| addon.is_a?(@addon) })
-      assert_predicate(addon_instance, :activated)
-    ensure
-      T.must(server).run_shutdown
+        addon_instance = Addon.addons.find { |addon| addon.is_a?(@addon) } #: as !nil
+        assert_predicate(addon_instance, :activated)
+      ensure
+        server.run_shutdown
+      end
     end
 
     def test_addons_are_automatically_tracked
@@ -83,7 +85,7 @@ module RubyLsp
       end
 
       Addon.load_addons(@global_state, @outgoing_queue)
-      error_addon = T.must(Addon.addons.find(&:error?))
+      error_addon = Addon.addons.find(&:error?) #: as !nil
 
       assert_predicate(error_addon, :error?)
       assert_equal(<<~MESSAGE, error_addon.formatted_errors)

--- a/test/erb_document_test.rb
+++ b/test/erb_document_test.rb
@@ -130,7 +130,11 @@ class ERBDocumentTest < Minitest::Test
     # Locate the `each` call from block
     node_context = document.locate_node({ line: 0, character: 17 })
     assert_instance_of(Prism::BlockNode, node_context.node)
-    assert_equal(:each, T.must(node_context.call_node).name)
+    assert_equal(
+      :each,
+      node_context.call_node #: as !nil
+        .name,
+    )
 
     # Locate the `title` invocation
     node_context = document.locate_node({ line: 1, character: 15 })

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -39,8 +39,9 @@ class IntegrationTest < Minitest::Test
 
     assert_equal(0, status.exitstatus, stderr)
 
-    activation_string = T.must(/RUBY_LSP_ACTIVATION_SEPARATOR(.*)RUBY_LSP_ACTIVATION_SEPARATOR/m.match(stderr))[1]
-    version, gem_path, yjit, *fields = T.must(activation_string).split("RUBY_LSP_FS")
+    match = /RUBY_LSP_ACTIVATION_SEPARATOR(.*)RUBY_LSP_ACTIVATION_SEPARATOR/m.match(stderr) #: as !nil
+    activation_string = match[1] #: as !nil
+    version, gem_path, yjit, *fields = activation_string.split("RUBY_LSP_FS")
 
     assert_equal(RUBY_VERSION, version)
     refute_nil(gem_path)
@@ -68,8 +69,9 @@ class IntegrationTest < Minitest::Test
 
     assert_equal(0, status.exitstatus, stderr)
 
-    activation_string = T.must(/RUBY_LSP_ACTIVATION_SEPARATOR(.*)RUBY_LSP_ACTIVATION_SEPARATOR/m.match(stderr))[1]
-    version, gem_path, yjit, *fields = T.must(activation_string).split("RUBY_LSP_FS")
+    match = /RUBY_LSP_ACTIVATION_SEPARATOR(.*)RUBY_LSP_ACTIVATION_SEPARATOR/m.match(stderr) #: as !nil
+    activation_string = match[1] #: as !nil
+    version, gem_path, yjit, *fields = activation_string.split("RUBY_LSP_FS")
 
     assert_equal(RUBY_VERSION, version)
     refute_nil(gem_path)

--- a/test/requests/code_actions_formatting_test.rb
+++ b/test/requests/code_actions_formatting_test.rb
@@ -79,11 +79,11 @@ class CodeActionsFormattingTest < Minitest::Test
 
     diagnostics = RubyLsp::Requests::Diagnostics.new(global_state, document).perform
     # The source of the returned attributes may be RuboCop or Prism. Prism diagnostics don't have a code.
-    rubocop_diagnostics = T.must(diagnostics).select { _1.attributes[:source] == "RuboCop" }
-    diagnostic = T.must(T.must(rubocop_diagnostics).find { |d| d.attributes[:code] && (d.code == diagnostic_code) })
+    rubocop_diagnostics = diagnostics&.select { _1.attributes[:source] == "RuboCop" }
+    diagnostic = rubocop_diagnostics&.find { |d| d.attributes[:code] && (d.code == diagnostic_code) } #: as !nil
     range = diagnostic.range.to_hash.transform_values(&:to_hash)
     result = RubyLsp::Requests::CodeActions.new(document, range, {
-      diagnostics: [JSON.parse(T.must(diagnostic).to_json, symbolize_names: true)],
+      diagnostics: [JSON.parse(diagnostic.to_json, symbolize_names: true)],
     }).perform
 
     # CodeActions#run returns Array<CodeAction, Hash>. We're interested in the

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -36,15 +36,17 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     assert_equal(6, response.size)
 
-    assert_equal("▶ Run In Terminal", T.must(response[1]).command.title)
+    assert_equal("▶ Run In Terminal", response[1]&.command&.title)
     assert_equal(
       "bundle exec ruby -Itest /test/fake.rb --name \"/^FooTest(#|::)/\"",
-      T.must(response[1]).command.arguments[2],
+      response[1] #: as !nil
+        .command.arguments[2],
     )
-    assert_equal("▶ Run In Terminal", T.must(response[4]).command.title)
+    assert_equal("▶ Run In Terminal", response[4]&.command&.title)
     assert_equal(
       "bundle exec ruby -Itest /test/fake.rb --name FooTest#test_bar",
-      T.must(response[4]).command.arguments[2],
+      response[4] #: as !nil
+        .command.arguments[2],
     )
   end
 
@@ -68,20 +70,23 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     assert_equal(9, response.size)
 
-    assert_equal("▶ Run In Terminal", T.must(response[1]).command.title)
+    assert_equal("▶ Run In Terminal", response[1]&.command&.title)
     assert_equal(
       "bundle exec ruby -Ispec /spec/fake.rb --name \"/^FooTest(#|::)/\"",
-      T.must(response[1]).command.arguments[2],
+      response[1] #: as !nil
+        .command.arguments[2],
     )
-    assert_equal("▶ Run In Terminal", T.must(response[4]).command.title)
+    assert_equal("▶ Run In Terminal", response[4]&.command&.title)
     assert_equal(
       "bundle exec ruby -Ispec /spec/fake.rb --name \"/^FooTest::a(#|::)/\"",
-      T.must(response[4]).command.arguments[2],
+      response[4] #: as !nil
+        .command.arguments[2],
     )
-    assert_equal("▶ Run In Terminal", T.must(response[7]).command.title)
+    assert_equal("▶ Run In Terminal", response[7]&.command&.title)
     assert_equal(
       "bundle exec ruby -Ispec /spec/fake.rb --name \"/^FooTest::a#test_0001_b$/\"",
-      T.must(response[7]).command.arguments[2],
+      response[7] #: as !nil
+        .command.arguments[2],
     )
   end
 
@@ -123,12 +128,17 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
 
     assert_equal(6, response.size)
 
-    assert_equal("▶ Run In Terminal", T.must(response[1]).command.title)
-    assert_equal("bundle exec ruby -Itest /test/fake.rb --testcase /FooTest/", T.must(response[1]).command.arguments[2])
-    assert_equal("▶ Run In Terminal", T.must(response[4]).command.title)
+    assert_equal("▶ Run In Terminal", response[1]&.command&.title)
+    assert_equal(
+      "bundle exec ruby -Itest /test/fake.rb --testcase /FooTest/",
+      response[1] #: as !nil
+        .command.arguments[2],
+    )
+    assert_equal("▶ Run In Terminal", response[4]&.command&.title)
     assert_equal(
       "bundle exec ruby -Itest /test/fake.rb --testcase /FooTest/ --name test_bar",
-      T.must(response[4]).command.arguments[2],
+      response[4] #: as !nil
+        .command.arguments[2],
     )
   end
 

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -31,7 +31,10 @@ class CompletionResolveTest < Minitest::Test
       expected = existing_item.merge(
         documentation: Interface::MarkupContent.new(
           kind: "markdown",
-          value: markdown_from_index_entries("Foo::Bar", T.must(server.global_state.index["Foo::Bar"])),
+          value: markdown_from_index_entries(
+            "Foo::Bar",
+            server.global_state.index["Foo::Bar"], #: as !nil
+          ),
         ),
       )
       assert_match(/This is a class that does things/, result[:documentation].value)
@@ -197,7 +200,10 @@ class CompletionResolveTest < Minitest::Test
       contents = result[:documentation].value
 
       assert_match("```ruby\nyield\n```", contents)
-      assert_match(T.must(RubyLsp::KEYWORD_DOCS["yield"]), contents)
+      assert_match(
+        RubyLsp::KEYWORD_DOCS["yield"], #: as !nil
+        contents,
+      )
       assert_match("[Read more](#{RubyLsp::STATIC_DOCS_PATH}/yield.md)", contents)
     end
   end

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -30,8 +30,9 @@ class CompletionTest < Minitest::Test
     source = <<~RUBY
       require "#{prefix}"
     RUBY
-    end_char = T.must(source.rindex('"'))
-    start_position = { line: 0, character: T.must(source.index('"')) + 1 }
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
     end_position = { line: 0, character: end_char }
 
     with_server(source) do |server, uri|
@@ -61,8 +62,9 @@ class CompletionTest < Minitest::Test
     source = <<~RUBY
       require("#{prefix}")
     RUBY
-    end_char = T.must(source.rindex('"'))
-    start_position = { line: 0, character: T.must(source.index('"')) + 1 }
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
     end_position = { line: 0, character: end_char }
 
     with_server(source) do |server, uri|
@@ -92,8 +94,9 @@ class CompletionTest < Minitest::Test
     source = <<~RUBY
       Kernel.require "#{prefix}"
     RUBY
-    end_char = T.must(source.rindex('"'))
-    start_position = { line: 0, character: T.must(source.index('"')) + 1 }
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
     end_position = { line: 0, character: end_char }
 
     with_server(source) do |server, uri|
@@ -123,8 +126,9 @@ class CompletionTest < Minitest::Test
     source = <<~RUBY
       require "#{prefix}"
     RUBY
-    end_char = T.must(source.rindex('"'))
-    start_position = { line: 0, character: T.must(source.index('"')) + 1 }
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
     end_position = { line: 0, character: end_char }
 
     with_server(source) do |server, uri|
@@ -793,8 +797,9 @@ class CompletionTest < Minitest::Test
     source = <<~RUBY
       require_relative "#{prefix}"
     RUBY
-    end_char = T.must(source.rindex('"'))
-    start_position = { line: 0, character: T.must(source.index('"')) + 1 }
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
     end_position = { line: 0, character: end_char }
 
     with_server(source) do |server|
@@ -834,8 +839,9 @@ class CompletionTest < Minitest::Test
     source = <<~RUBY
       require_relative("#{prefix}")
     RUBY
-    end_char = T.must(source.rindex('"'))
-    start_position = { line: 0, character: T.must(source.index('"')) + 1 }
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
     end_position = { line: 0, character: end_char }
 
     with_server(source) do |server|
@@ -878,8 +884,9 @@ class CompletionTest < Minitest::Test
     source = <<~RUBY
       Kernel.require_relative "#{prefix}"
     RUBY
-    end_char = T.must(source.rindex('"'))
-    start_position = { line: 0, character: T.must(source.index('"')) + 1 }
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
     end_position = { line: 0, character: end_char }
 
     with_server(source) do |server|
@@ -918,8 +925,9 @@ class CompletionTest < Minitest::Test
     source = <<~RUBY
       Kernel.require_relative "b"
     RUBY
-    end_char = T.must(source.rindex('"'))
-    start_position = { line: 0, character: T.must(source.index('"')) + 1 }
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
     end_position = { line: 0, character: end_char }
 
     with_server(source) do |server|
@@ -961,8 +969,9 @@ class CompletionTest < Minitest::Test
       require_relative "#{prefix}"
     RUBY
 
-    end_char = T.must(source.rindex('"'))
-    start_position = { line: 0, character: T.must(source.index('"')) + 1 }
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
     end_position = { line: 0, character: end_char }
 
     with_server(source) do |server|

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -312,7 +312,8 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
         },
       })
       index = server.global_state.index
-      index.index_single(URI::Generic.from_path(path: T.must(second_uri.to_standardized_path)), second_source)
+      path = second_uri.to_standardized_path #: as !nil
+      index.index_single(URI::Generic.from_path(path: path), second_source)
 
       server.process_message(
         id: 1,

--- a/test/requests/diagnostics_expectations_test.rb
+++ b/test/requests/diagnostics_expectations_test.rb
@@ -34,7 +34,7 @@ class DiagnosticsExpectationsTest < ExpectationsTestRunner
     assert_empty(stdout)
 
     # On Windows, RuboCop will complain that the file is missing a carriage return at the end. We need to ignore these
-    T.must(result).reject { |diagnostic| diagnostic.source == "RuboCop" && diagnostic.code == "Layout/EndOfLine" }
+    result&.reject { |diagnostic| diagnostic.source == "RuboCop" && diagnostic.code == "Layout/EndOfLine" }
   end
 
   def assert_expectations(source, expected)

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -34,10 +34,14 @@ class DiagnosticsTest < Minitest::Test
       def foo
     RUBY
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(@global_state, document).perform)
+    diagnostics = RubyLsp::Requests::Diagnostics.new(@global_state, document).perform #: as !nil
 
     assert_equal(2, diagnostics.length)
-    assert_equal("expected an `end` to close the `def` statement", T.must(diagnostics.last).message)
+    assert_equal(
+      "expected an `end` to close the `def` statement",
+      diagnostics.last #: as !nil
+        .message,
+    )
   end
 
   def test_empty_diagnostics_without_rubocop
@@ -54,8 +58,7 @@ class DiagnosticsTest < Minitest::Test
 
     @global_state.instance_variable_get(:@supported_formatters).delete("rubocop_internal")
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(@global_state, document).perform)
-
+    diagnostics = RubyLsp::Requests::Diagnostics.new(@global_state, document).perform #: as !nil
     assert_empty(diagnostics)
   ensure
     # Restore the class
@@ -69,8 +72,7 @@ class DiagnosticsTest < Minitest::Test
       end
     RUBY
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(@global_state, document).perform)
-
+    diagnostics = RubyLsp::Requests::Diagnostics.new(@global_state, document).perform #: as !nil
     refute_empty(diagnostics)
   end
 
@@ -104,7 +106,7 @@ class DiagnosticsTest < Minitest::Test
       initializationOptions: { linters: ["my-custom-formatter"] },
     })
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(@global_state, document).perform)
+    diagnostics = RubyLsp::Requests::Diagnostics.new(@global_state, document).perform #: as !nil
     assert(diagnostics.find { |d| d.message == "Hello from custom formatter" })
   end
 
@@ -116,11 +118,11 @@ class DiagnosticsTest < Minitest::Test
       b /a/
     RUBY
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(@global_state, document).perform)
-    assert_match("ambiguous first argument", T.must(diagnostics[0]).message)
-    assert_match("ambiguous first argument", T.must(diagnostics[1]).message)
-    assert_match("ambiguous `*`", T.must(diagnostics[2]).message)
-    assert_match("ambiguous `/`", T.must(diagnostics[3]).message)
+    diagnostics = RubyLsp::Requests::Diagnostics.new(@global_state, document).perform #: as !nil
+    assert_match("ambiguous first argument", diagnostics[0]&.message)
+    assert_match("ambiguous first argument", diagnostics[1]&.message)
+    assert_match("ambiguous `*`", diagnostics[2]&.message)
+    assert_match("ambiguous `/`", diagnostics[3]&.message)
   end
 
   def test_END_inside_method_definition_warning
@@ -128,8 +130,8 @@ class DiagnosticsTest < Minitest::Test
       def m; END{}; end
     RUBY
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(@global_state, document).perform)
-    assert_equal("END in method; use at_exit", T.must(diagnostics[0]).message)
+    diagnostics = RubyLsp::Requests::Diagnostics.new(@global_state, document).perform #: as !nil
+    assert_equal("END in method; use at_exit", diagnostics[0]&.message)
   end
 
   def test_syntax_error_diagnostic
@@ -137,11 +139,11 @@ class DiagnosticsTest < Minitest::Test
       def foo
     RUBY
 
-    diagnostics = T.must(RubyLsp::Requests::Diagnostics.new(@global_state, document).perform)
-    assert_equal("expected a delimiter to close the parameters", T.must(diagnostics[0]).message)
+    diagnostics = RubyLsp::Requests::Diagnostics.new(@global_state, document).perform #: as !nil
+    assert_equal("expected a delimiter to close the parameters", diagnostics[0]&.message)
     assert_equal(
       "unexpected end-of-input, assuming it is closing the parent top level context",
-      T.must(diagnostics[1]).message,
+      diagnostics[1]&.message,
     )
   end
 end

--- a/test/requests/discover_tests_test.rb
+++ b/test/requests/discover_tests_test.rb
@@ -172,31 +172,33 @@ module RubyLsp
         end
       RUBY
 
-      with_server do |server, uri|
-        server.global_state.index.index_single(uri, <<~RUBY)
-          module Test
-            module Unit
-              class TestCase; end
+      begin
+        with_server do |server, uri|
+          server.global_state.index.index_single(uri, <<~RUBY)
+            module Test
+              module Unit
+                class TestCase; end
+              end
             end
-          end
-        RUBY
+          RUBY
 
-        server.process_message(
-          id: 1,
-          method: "rubyLsp/discoverTests",
-          params: { textDocument: { uri: URI::Generic.from_path(path: path) } },
-        )
+          server.process_message(
+            id: 1,
+            method: "rubyLsp/discoverTests",
+            params: { textDocument: { uri: URI::Generic.from_path(path: path) } },
+          )
 
-        items = get_response(server)
-        assert_equal(
-          ["FooTest"],
-          items.map { |i| i[:label] },
-        )
-        assert_equal(["test_something"], items[0][:children].map { |i| i[:label] })
-        assert_all_items_tagged_with(items, :test_unit)
+          items = get_response(server)
+          assert_equal(
+            ["FooTest"],
+            items.map { |i| i[:label] },
+          )
+          assert_equal(["test_something"], items[0][:children].map { |i| i[:label] })
+          assert_all_items_tagged_with(items, :test_unit)
+        end
+      ensure
+        FileUtils.rm(path)
       end
-    ensure
-      FileUtils.rm(T.must(path))
     end
 
     def test_does_not_raise_on_duplicate_test_ids

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -26,11 +26,11 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
 
     assert_equal(5, response.size)
 
-    assert_equal("@foo", T.must(response[0]).name)
-    assert_equal("@bar", T.must(response[1]).name)
-    assert_equal("@baz", T.must(response[2]).name)
-    assert_equal("@qux", T.must(response[3]).name)
-    assert_equal("@quux", T.must(response[4]).name)
+    assert_equal("@foo", response[0]&.name)
+    assert_equal("@bar", response[1]&.name)
+    assert_equal("@baz", response[2]&.name)
+    assert_equal("@qux", response[3]&.name)
+    assert_equal("@quux", response[4]&.name)
   end
 
   def test_instance_variable_with_destructuring_assignment
@@ -49,11 +49,11 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
 
     assert_equal(5, response.size)
 
-    assert_equal("@a", T.must(response[0]).name)
-    assert_equal("@b", T.must(response[1]).name)
-    assert_equal("@c", T.must(response[2]).name)
-    assert_equal("@d", T.must(response[3]).name)
-    assert_equal("@e", T.must(response[4]).name)
+    assert_equal("@a", response[0]&.name)
+    assert_equal("@b", response[1]&.name)
+    assert_equal("@c", response[2]&.name)
+    assert_equal("@d", response[3]&.name)
+    assert_equal("@e", response[4]&.name)
   end
 
   def test_labels_blank_names
@@ -70,7 +70,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
     response = listener.perform
 
     assert_equal(1, response.size)
-    assert_equal("<blank>", T.must(response.first).name)
+    assert_equal("<blank>", response.first&.name)
   end
 
   def test_document_symbol_addons

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -929,7 +929,10 @@ class HoverExpectationsTest < ExpectationsTestRunner
 
       contents = server.pop_response.response.contents.value
       assert_match("```ruby\nyield\n```", contents)
-      assert_match(T.must(RubyLsp::KEYWORD_DOCS["yield"]), contents)
+      assert_match(
+        RubyLsp::KEYWORD_DOCS["yield"], #: as !nil
+        contents,
+      )
       assert_match("[Read more](#{RubyLsp::STATIC_DOCS_PATH}/yield.md)", contents)
     end
   end

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -45,7 +45,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_adding_missing_curly_brace_in_string_interpolation
@@ -81,7 +81,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_adding_missing_pipe
@@ -117,7 +117,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_pipe_is_not_added_in_regular_or_pipe
@@ -143,7 +143,7 @@ class OnTypeFormattingTest < Minitest::Test
       "|",
       "Visual Studio Code",
     ).perform
-    assert_empty(T.must(edits))
+    assert_empty(edits)
   end
 
   def test_pipe_is_removed_if_user_adds_manually_after_completion
@@ -186,7 +186,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
     assert_equal("[].each do ||", document.source)
 
     # Push the third pipe manually after the completion happened
@@ -214,7 +214,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_pipe_is_removed_if_user_adds_manually_after_block_argument
@@ -257,7 +257,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_comment_continuation
@@ -289,7 +289,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "#    ",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_comment_continuation_does_not_apply_to_rbs_signatures
@@ -401,7 +401,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "#    ",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_comment_continuation_when_inserting_new_line_in_the_middle
@@ -436,7 +436,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "# ",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_breaking_line_between_keyword_and_more_content
@@ -477,7 +477,7 @@ class OnTypeFormattingTest < Minitest::Test
       },
     ]
 
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_breaking_line_between_keyword_when_there_is_content_on_the_next_line
@@ -540,7 +540,7 @@ class OnTypeFormattingTest < Minitest::Test
       },
     ]
 
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_auto_indent_after_end_keyword
@@ -568,7 +568,7 @@ class OnTypeFormattingTest < Minitest::Test
       },
     ]
 
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_auto_indent_after_end_keyword_with_complex_body
@@ -604,7 +604,7 @@ class OnTypeFormattingTest < Minitest::Test
       },
     ]
 
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_auto_indent_after_end_keyword_does_not_add_extra_indentation
@@ -628,7 +628,7 @@ class OnTypeFormattingTest < Minitest::Test
       },
     ]
 
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_breaking_line_if_a_keyword_is_part_of_method_call
@@ -674,7 +674,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_adding_heredoc_delimiter
@@ -714,7 +714,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_plain_heredoc_completion
@@ -754,7 +754,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_quoted_heredoc_completion
@@ -794,7 +794,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_completing_end_token_inside_parameters
@@ -825,7 +825,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_completing_end_token_inside_brackets
@@ -856,7 +856,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_no_snippet_if_not_vs_code
@@ -892,7 +892,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "end",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_includes_snippets_on_vscode_insiders
@@ -932,7 +932,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_includes_snippets_on_cursor
@@ -972,7 +972,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_includes_snippets_on_vscodium
@@ -1012,7 +1012,7 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 
   def test_does_not_confuse_class_parameter_with_keyword
@@ -1080,6 +1080,6 @@ class OnTypeFormattingTest < Minitest::Test
         newText: "$0",
       },
     ]
-    assert_equal(expected_edits.to_json, T.must(edits).to_json)
+    assert_equal(expected_edits.to_json, edits.to_json)
   end
 end

--- a/test/requests/range_formatting_test.rb
+++ b/test/requests/range_formatting_test.rb
@@ -46,7 +46,7 @@ class RangeFormattingTest < Minitest::Test
   private
 
   def expect_formatted_range(range, expected)
-    edits = T.must(RubyLsp::Requests::RangeFormatting.new(@global_state, @document, { range: range }).perform)
+    edits = RubyLsp::Requests::RangeFormatting.new(@global_state, @document, { range: range }).perform #: as !nil
 
     @document.push_edits(
       edits.map do |edit|

--- a/test/requests/workspace_symbol_test.rb
+++ b/test/requests/workspace_symbol_test.rb
@@ -19,16 +19,16 @@ class WorkspaceSymbolTest < Minitest::Test
     RUBY
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "Foo").perform.first
-    assert_equal("Foo", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
+    assert_equal("Foo", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::CLASS, result&.kind)
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "Bar").perform.first
-    assert_equal("Bar", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::NAMESPACE, T.must(result).kind)
+    assert_equal("Bar", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::NAMESPACE, result&.kind)
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "CONST").perform.first
-    assert_equal("CONSTANT", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::CONSTANT, T.must(result).kind)
+    assert_equal("CONSTANT", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::CONSTANT, result&.kind)
   end
 
   def test_fuzzy_matches_symbols
@@ -40,16 +40,16 @@ class WorkspaceSymbolTest < Minitest::Test
     RUBY
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "Floo").perform.first
-    assert_equal("Foo", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
+    assert_equal("Foo", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::CLASS, result&.kind)
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "Bear").perform.first
-    assert_equal("Bar", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::NAMESPACE, T.must(result).kind)
+    assert_equal("Bar", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::NAMESPACE, result&.kind)
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "CONF").perform.first
-    assert_equal("CONSTANT", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::CONSTANT, T.must(result).kind)
+    assert_equal("CONSTANT", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::CONSTANT, result&.kind)
   end
 
   def test_symbols_include_container_name
@@ -60,9 +60,9 @@ class WorkspaceSymbolTest < Minitest::Test
     RUBY
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "Foo::Bar").perform.first
-    assert_equal("Foo::Bar", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
-    assert_equal("Foo", T.must(result).container_name)
+    assert_equal("Foo::Bar", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::CLASS, result&.kind)
+    assert_equal("Foo", result&.container_name)
   end
 
   def test_does_not_include_symbols_from_dependencies
@@ -82,7 +82,7 @@ class WorkspaceSymbolTest < Minitest::Test
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "Foo::CONSTANT").perform
     assert_equal(1, result.length)
-    assert_equal("Foo", T.must(result.first).name)
+    assert_equal("Foo", result.first&.name)
   end
 
   def test_returns_method_symbols
@@ -96,16 +96,16 @@ class WorkspaceSymbolTest < Minitest::Test
     RUBY
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "bar").perform.first
-    assert_equal("bar", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::METHOD, T.must(result).kind)
+    assert_equal("bar", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::METHOD, result&.kind)
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "initialize").perform.first
-    assert_equal("initialize", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::CONSTRUCTOR, T.must(result).kind)
+    assert_equal("initialize", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::CONSTRUCTOR, result&.kind)
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "baz").perform.first
-    assert_equal("baz", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::PROPERTY, T.must(result).kind)
+    assert_equal("baz", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::PROPERTY, result&.kind)
   end
 
   def test_returns_symbols_from_unsaved_files
@@ -114,7 +114,7 @@ class WorkspaceSymbolTest < Minitest::Test
     RUBY
 
     result = RubyLsp::Requests::WorkspaceSymbol.new(@global_state, "Foo").perform.first
-    assert_equal("Foo", T.must(result).name)
-    assert_equal(RubyLsp::Constant::SymbolKind::CLASS, T.must(result).kind)
+    assert_equal("Foo", result&.name)
+    assert_equal(RubyLsp::Constant::SymbolKind::CLASS, result&.kind)
   end
 end

--- a/test/response_builders/test_collection_test.rb
+++ b/test/response_builders/test_collection_test.rb
@@ -21,9 +21,9 @@ module RubyLsp
       builder.add(test_item)
       test_item.add(nested_item)
 
-      item = builder["my-id"]
+      item = builder["my-id"] #: as !nil
       assert(item)
-      assert(T.must(item)["nested-id"])
+      assert(item["nested-id"])
 
       builder.response.map(&:to_hash).each { |item| assert_expected_fields(item) }
     end
@@ -43,7 +43,11 @@ module RubyLsp
         @range,
         framework: :minitest,
       ))
-      assert_equal("Other title, but same ID", T.must(builder["my-id"]).label)
+      assert_equal(
+        "Other title, but same ID",
+        builder["my-id"] #: as !nil
+          .label,
+      )
 
       test_item.add(Requests::Support::TestItem.new(
         "nested-id",
@@ -52,7 +56,11 @@ module RubyLsp
         @range,
         framework: :minitest,
       ))
-      assert_equal("Other title, but same ID", T.must(test_item["nested-id"]).label)
+      assert_equal(
+        "Other title, but same ID",
+        test_item["nested-id"] #: as !nil
+          .label,
+      )
     end
 
     private

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -451,7 +451,8 @@ class RubyDocumentTest < Minitest::Test
     assert_instance_of(Prism::ConstantPathNode, node_context.parent)
     assert_equal(
       "ActiveRecord",
-      T.must(T.cast(node_context.parent, Prism::ConstantPathNode).child_nodes.first).location.slice,
+      T.cast(node_context.parent, Prism::ConstantPathNode).child_nodes.first #: as !nil
+        .location.slice,
     )
 
     # Locate the `Base` class
@@ -504,11 +505,11 @@ class RubyDocumentTest < Minitest::Test
     RUBY
 
     node_context = document.locate_node({ line: 3, character: 14 })
-    assert_equal(":foo", T.must(node_context.node).slice)
-    assert_equal(:hello, T.must(node_context.call_node).name)
+    assert_equal(":foo", node_context.node&.slice)
+    assert_equal(:hello, node_context.call_node&.name)
 
     node_context = document.locate_node({ line: 4, character: 8 })
-    assert_equal(":bar", T.must(node_context.node).slice)
+    assert_equal(":bar", node_context.node&.slice)
     assert_nil(node_context.call_node)
   end
 
@@ -524,8 +525,8 @@ class RubyDocumentTest < Minitest::Test
     RUBY
 
     node_context = document.locate_node({ line: 3, character: 22 })
-    assert_equal(":foo", T.must(node_context.node).slice)
-    assert_equal(:hello, T.must(node_context.call_node).name)
+    assert_equal(":foo", node_context.node&.slice)
+    assert_equal(:hello, node_context.call_node&.name)
   end
 
   def test_locate_returns_call_node_for_blocks
@@ -536,7 +537,7 @@ class RubyDocumentTest < Minitest::Test
     RUBY
 
     node_context = document.locate_node({ line: 1, character: 4 })
-    assert_equal(:foo, T.must(node_context.call_node).name)
+    assert_equal(:foo, node_context.call_node&.name)
   end
 
   def test_locate_returns_call_node_ZZZ
@@ -549,7 +550,7 @@ class RubyDocumentTest < Minitest::Test
     RUBY
 
     node_context = document.locate_node({ line: 2, character: 6 })
-    assert_equal(:foo, T.must(node_context.call_node).name)
+    assert_equal(:foo, node_context.call_node&.name)
   end
 
   def test_locate_returns_correct_nesting_when_specifying_target_classes
@@ -697,11 +698,11 @@ class RubyDocumentTest < Minitest::Test
 
     node_context = document.locate_node({ line: 0, character: 11 })
     assert_empty(node_context.nesting)
-    assert_equal("Foo::Bar", T.must(node_context.node).slice)
+    assert_equal("Foo::Bar", node_context.node&.slice)
 
     node_context = document.locate_node({ line: 3, character: 6 })
     assert_empty(node_context.nesting)
-    assert_equal("Baz", T.must(node_context.node).slice)
+    assert_equal("Baz", node_context.node&.slice)
   end
 
   def test_locating_singleton_contexts
@@ -816,7 +817,7 @@ class RubyDocumentTest < Minitest::Test
     range = { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } }
     document.push_edits([{ range: range, text: "d" }], version: 2)
 
-    last_edit = T.must(document.last_edit)
+    last_edit = document.last_edit #: as !nil
     assert_instance_of(RubyLsp::Document::Insert, last_edit)
     assert_equal(range, last_edit.range)
 
@@ -824,7 +825,7 @@ class RubyDocumentTest < Minitest::Test
     range = { start: { line: 1, character: 0 }, end: { line: 1, character: 1 } }
     document.push_edits([{ range: range, text: "def" }], version: 3)
 
-    last_edit = T.must(document.last_edit)
+    last_edit = document.last_edit #: as !nil
     assert_instance_of(RubyLsp::Document::Replace, last_edit)
     assert_equal(range, last_edit.range)
 
@@ -832,7 +833,7 @@ class RubyDocumentTest < Minitest::Test
     range = { start: { line: 1, character: 0 }, end: { line: 1, character: 3 } }
     document.push_edits([{ range: range, text: "" }], version: 4)
 
-    last_edit = T.must(document.last_edit)
+    last_edit = document.last_edit #: as !nil
     assert_instance_of(RubyLsp::Document::Delete, last_edit)
     assert_equal(range, last_edit.range)
 

--- a/test/scope_test.rb
+++ b/test/scope_test.rb
@@ -8,7 +8,7 @@ class ScopeTest < Minitest::Test
     scope = RubyLsp::Scope.new
     scope.add("foo", :parameter)
 
-    assert_equal(:parameter, T.must(scope.lookup("foo")).type)
+    assert_equal(:parameter, scope.lookup("foo")&.type)
   end
 
   def test_finding_parameter_in_parent_scope
@@ -16,7 +16,7 @@ class ScopeTest < Minitest::Test
     parent.add("foo", :parameter)
 
     scope = RubyLsp::Scope.new(parent)
-    assert_equal(:parameter, T.must(scope.lookup("foo")).type)
+    assert_equal(:parameter, scope.lookup("foo")&.type)
   end
 
   def test_not_finding_parameter


### PR DESCRIPTION
### Motivation

Migrate all of our `T.must` usage to the comment based RBS syntax.