### PR TITLE
Avoid recursion when collecting prefix tree node values

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/prefix_tree.rb
@@ -138,10 +138,11 @@ module RubyIndexer
       #: -> Array[Value]
       def collect
         result = []
-        result << @value if @leaf
+        stack = [self]
 
-        @children.each_value do |node|
-          result.concat(node.collect)
+        while (node = stack.pop)
+          result << node.value if node.leaf
+          stack.concat(node.children.values)
         end
 
         result

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -140,7 +140,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_equal(["path/foo", "path/other_foo"], @index.search_require_paths("path").map(&:require_path))
+      assert_equal(["path/other_foo", "path/foo"], @index.search_require_paths("path").map(&:require_path))
     end
 
     def test_searching_for_entries_based_on_prefix
@@ -157,10 +157,10 @@ module RubyIndexer
       RUBY
 
       results = @index.prefix_search("Foo", []).map { |entries| entries.map(&:name) }
-      assert_equal([["Foo::Bizw", "Foo::Bizw"], ["Foo::Bizt"]], results)
+      assert_equal([["Foo::Bizt"], ["Foo::Bizw", "Foo::Bizw"]], results)
 
       results = @index.prefix_search("Biz", ["Foo"]).map { |entries| entries.map(&:name) }
-      assert_equal([["Foo::Bizw", "Foo::Bizw"], ["Foo::Bizt"]], results)
+      assert_equal([["Foo::Bizt"], ["Foo::Bizw", "Foo::Bizw"]], results)
     end
 
     def test_resolve_normalizes_top_level_names
@@ -2128,7 +2128,7 @@ module RubyIndexer
         end
       RUBY
 
-      abc, adf = @index.instance_variable_completion_candidates("@", "Child::<Class:Child>")
+      adf, abc = @index.instance_variable_completion_candidates("@", "Child::<Class:Child>")
 
       refute_nil(abc)
       refute_nil(adf)

--- a/lib/ruby_indexer/test/prefix_tree_test.rb
+++ b/lib/ruby_indexer/test/prefix_tree_test.rb
@@ -25,10 +25,10 @@ module RubyIndexer
       tree = PrefixTree[String].new
       ["foo", "bar", "baz"].each { |item| tree.insert(item, item) }
 
-      assert_equal(["foo", "bar", "baz"], tree.search(""))
-      assert_equal(["bar", "baz"], tree.search("b"))
+      assert_equal(["baz", "bar", "foo"], tree.search(""))
+      assert_equal(["baz", "bar"], tree.search("b"))
       assert_equal(["foo"], tree.search("fo"))
-      assert_equal(["bar", "baz"], tree.search("ba"))
+      assert_equal(["baz", "bar"], tree.search("ba"))
       assert_equal(["baz"], tree.search("baz"))
       assert_empty(tree.search("qux"))
     end
@@ -80,17 +80,17 @@ module RubyIndexer
 
       assert_equal(
         [
-          "foo/bar/support/selection",
-          "foo/bar/support/semantic",
-          "foo/bar/support/syntax",
-          "foo/bar/support/source",
+          "foo/bar/support/formatting",
+          "foo/bar/support/prefix",
+          "foo/bar/support/highlight",
+          "foo/bar/support/diagnostic",
+          "foo/bar/support/rails",
           "foo/bar/support/runner",
           "foo/bar/support/runner2",
-          "foo/bar/support/rails",
-          "foo/bar/support/diagnostic",
-          "foo/bar/support/highlight",
-          "foo/bar/support/prefix",
-          "foo/bar/support/formatting",
+          "foo/bar/support/source",
+          "foo/bar/support/syntax",
+          "foo/bar/support/semantic",
+          "foo/bar/support/selection",
         ],
         tree.search("foo/bar/support"),
       )
@@ -99,7 +99,7 @@ module RubyIndexer
     def test_deletion
       tree = PrefixTree[String].new
       ["foo/bar", "foo/baz"].each { |item| tree.insert(item, item) }
-      assert_equal(["foo/bar", "foo/baz"], tree.search("foo"))
+      assert_equal(["foo/baz", "foo/bar"], tree.search("foo"))
 
       tree.delete("foo/bar")
       assert_empty(tree.search("foo/bar"))

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -618,9 +618,9 @@ class CompletionTest < Minitest::Test
         })
 
         result = server.pop_response.response
-        assert_equal(["qux1", "qux2"], result.map(&:label))
-        assert_equal(["qux1", "qux2"], result.map(&:filter_text))
-        assert_equal(["qux1", "qux2"], result.map { |completion| completion.text_edit.new_text })
+        assert_equal(["qux2", "qux1"], result.map(&:label))
+        assert_equal(["qux2", "qux1"], result.map(&:filter_text))
+        assert_equal(["qux2", "qux1"], result.map { |completion| completion.text_edit.new_text })
         assert_equal(["fake.rb", "fake.rb"], result.map { _1.label_details.description })
       end
     end
@@ -646,9 +646,9 @@ class CompletionTest < Minitest::Test
         })
 
         result = server.pop_response.response
-        assert_equal(["bar", "baz"], result.map(&:label))
-        assert_equal(["bar", "baz"], result.map(&:filter_text))
-        assert_equal(["bar", "baz"], result.map { |completion| completion.text_edit.new_text })
+        assert_equal(["baz", "bar"], result.map(&:label))
+        assert_equal(["baz", "bar"], result.map(&:filter_text))
+        assert_equal(["baz", "bar"], result.map { |completion| completion.text_edit.new_text })
         assert_equal([9, 9], result.map { |completion| completion.text_edit.range.start.character })
       end
     end
@@ -787,7 +787,7 @@ class CompletionTest < Minitest::Test
         })
 
         result = server.pop_response.response
-        assert_equal(["module", "method1", "method2"], result.map(&:label))
+        assert_equal(["module", "method2", "method1"], result.map(&:label))
       end
     end
   end
@@ -1053,7 +1053,7 @@ class CompletionTest < Minitest::Test
       })
 
       result = server.pop_response.response
-      assert_equal(["$qar", "$qaz", "$qux", "$quux", "$qorge", "$qoo"], result.map(&:label))
+      assert_equal(["$qoo", "$qorge", "$quux", "$qux", "$qaz", "$qar"], result.map(&:label))
 
       server.process_message(id: 1, method: "textDocument/completion", params: {
         textDocument: { uri: uri },
@@ -1061,7 +1061,7 @@ class CompletionTest < Minitest::Test
       })
 
       result = server.pop_response.response
-      assert_equal(["$LOADED_FEATURES", "$LOAD_PATH"], result.map(&:label))
+      assert_equal(["$LOAD_PATH", "$LOADED_FEATURES"], result.map(&:label))
       assert_equal(["global_variables.rbs", "global_variables.rbs"], result.map { _1.label_details.description })
 
       server.process_message(id: 1, method: "textDocument/completion", params: {
@@ -1181,7 +1181,7 @@ class CompletionTest < Minitest::Test
       })
 
       result = server.pop_response.response
-      assert_equal(["@@bar", "@@baz"], result.map(&:label))
+      assert_equal(["@@baz", "@@bar"], result.map(&:label))
     end
   end
 
@@ -1248,7 +1248,7 @@ class CompletionTest < Minitest::Test
       })
 
       result = server.pop_response.response
-      assert_equal(["@@a", "@@b", "@@c", "@@d"], result.map(&:label))
+      assert_equal(["@@d", "@@c", "@@b", "@@a"], result.map(&:label))
     end
   end
 
@@ -1319,7 +1319,7 @@ class CompletionTest < Minitest::Test
       })
 
       result = server.pop_response.response
-      assert_equal(["@a", "@b"], result.map(&:label))
+      assert_equal(["@b", "@a"], result.map(&:label))
     end
   end
 
@@ -1372,7 +1372,7 @@ class CompletionTest < Minitest::Test
       })
 
       result = server.pop_response.response
-      assert_equal(["baz", "bar"], result.map(&:label))
+      assert_equal(["bar", "baz"], result.map(&:label))
 
       server.process_message(id: 1, method: "textDocument/completion", params: {
         textDocument: { uri: uri },
@@ -1380,7 +1380,7 @@ class CompletionTest < Minitest::Test
       })
 
       result = server.pop_response.response
-      assert_equal(["begin", "break", "baz", "bar"], result.map(&:label))
+      assert_equal(["begin", "break", "bar", "baz"], result.map(&:label))
     end
   end
 
@@ -1416,7 +1416,7 @@ class CompletionTest < Minitest::Test
       })
 
       result = server.pop_response.response
-      assert_equal(["@a", "@b", "@c"], result.map(&:label))
+      assert_equal(["@c", "@b", "@a"], result.map(&:label))
 
       server.process_message(id: 1, method: "textDocument/completion", params: {
         textDocument: { uri: uri },
@@ -1424,7 +1424,7 @@ class CompletionTest < Minitest::Test
       })
 
       result = server.pop_response.response
-      assert_equal(["@a", "@b", "@c"], result.map(&:label))
+      assert_equal(["@c", "@b", "@a"], result.map(&:label))
     end
   end
 
@@ -1449,7 +1449,7 @@ class CompletionTest < Minitest::Test
         position: { line: 8, character: 5 },
       })
       result = server.pop_response.response
-      assert_equal(["begin", "break", "bar", "baz"], result.map(&:label))
+      assert_equal(["begin", "break", "baz", "bar"], result.map(&:label))
     end
   end
 


### PR DESCRIPTION
### Motivation

I noticed we were using recursion to accumulate all of the values in a prefix tree node and its children. Recursion can be quite slow, so I took a stab at removing it with a queue mechanism.

### Implementation

The idea is to accumulate nodes in the queue and then pop one by one, adding to the result when appropriate.

On my benchmarks with a small sized tree, this approach is 2x faster than using recursion.

**Note**: we now push the values into the result in a slightly different order. I updated the tests to match. Notice that this makes no difference for our usages for completion since the editor is expected to sort the entries based on the `sortText` property.