### PR TITLE
Support keyword arguments for signature help's active parameter

### DIFF
--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -100,6 +100,8 @@ module RubyLsp
           active_parameter_index += 1
         end
 
+        # if the incoming position is a keyword parameter,
+        # find the first keyword that is not in the current argument list
         if signature && keyword_parameter?(signature.parameters[active_parameter_index])
           active_parameter_index = determine_active_keyword_argument(signature, flat_arguments)
         end

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -24,6 +24,7 @@ module RubyLsp
         super()
 
         char_position, _ = document.find_index_by_position(position)
+        char_position -= 1
         delegate_request_if_needed!(global_state, document, char_position)
 
         node_context = RubyDocument.locate(
@@ -38,7 +39,14 @@ module RubyLsp
         @target = target #: Prism::Node?
         @dispatcher = dispatcher
         @response_builder = ResponseBuilders::SignatureHelp.new #: ResponseBuilders::SignatureHelp
-        Listeners::SignatureHelp.new(@response_builder, global_state, node_context, dispatcher, sorbet_level)
+        Listeners::SignatureHelp.new(
+          @response_builder,
+          global_state,
+          node_context,
+          dispatcher,
+          sorbet_level,
+          char_position,
+        )
       end
 
       # @override

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -14,7 +14,7 @@ module RubyLsp
         def provider
           # Identifier characters are automatically included, such as A-Z, a-z, 0-9, _, * or :
           Interface::SignatureHelpOptions.new(
-            trigger_characters: ["(", " ", ","],
+            trigger_characters: ["(", ","],
           )
         end
       end

--- a/test/requests/signature_help_test.rb
+++ b/test/requests/signature_help_test.rb
@@ -86,7 +86,7 @@ class SignatureHelpTest < Minitest::Test
     with_server(source) do |server, uri|
       server.process_message(id: 1, method: "textDocument/signatureHelp", params:  {
         textDocument: { uri: uri },
-        position: { line: 5, character: 9 },
+        position: { line: 5, character: 10 },
         context: {
           triggerCharacter: ",",
         },
@@ -114,7 +114,7 @@ class SignatureHelpTest < Minitest::Test
     with_server(source) do |server, uri|
       server.process_message(id: 1, method: "textDocument/signatureHelp", params:  {
         textDocument: { uri: uri },
-        position: { line: 5, character: 12 },
+        position: { line: 5, character: 13 },
         context: {
           triggerCharacter: ",",
           activeSignatureHelp: nil,
@@ -124,7 +124,7 @@ class SignatureHelpTest < Minitest::Test
       signature = result.signatures.first
 
       assert_equal("bar(a:, b:)", signature.label)
-      assert_equal(1, result.active_parameter)
+      assert_equal(0, result.active_parameter)
     end
   end
 
@@ -143,7 +143,7 @@ class SignatureHelpTest < Minitest::Test
     with_server(source) do |server, uri|
       server.process_message(id: 1, method: "textDocument/signatureHelp", params: {
         textDocument: { uri: uri },
-        position: { line: 5, character: 15 },
+        position: { line: 5, character: 16 },
         context: {
           triggerCharacter: ",",
           activeSignatureHelp: nil,
@@ -152,7 +152,7 @@ class SignatureHelpTest < Minitest::Test
       result = server.pop_response.response
       signature = result.signatures.first
       assert_equal("bar(a, b = <default>, c:, d:)", signature.label)
-      assert_equal(2, result.active_parameter)
+      assert_equal(3, result.active_parameter)
     end
   end
 
@@ -171,13 +171,13 @@ class SignatureHelpTest < Minitest::Test
     with_server(source) do |server, uri|
       server.process_message(id: 1, method: "textDocument/signatureHelp", params: {
         textDocument: { uri: uri },
-        position: { line: 5, character: 20 },
+        position: { line: 5, character: 21 },
         context: {},
       })
       result = server.pop_response.response
       signature = result.signatures.first
       assert_equal("bar(*a)", signature.label)
-      assert_equal(0, result.active_parameter)
+      assert_equal(signature.parameters.length, result.active_parameter)
     end
   end
 
@@ -196,7 +196,7 @@ class SignatureHelpTest < Minitest::Test
     with_server(source) do |server, uri|
       server.process_message(id: 1, method: "textDocument/signatureHelp", params: {
         textDocument: { uri: uri },
-        position: { line: 5, character: 9 },
+        position: { line: 5, character: 10 },
         context: {},
       })
       result = server.pop_response.response


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

The signature help's active parameter is not shown properly with keyword arguments, or when user is typing at the middle of argument list.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

* Support keyword arguments for signature help's active parameter
* check the current char position instead just check the end of argument node (because signature help is triggered by typing character)
* remove space from trigger characters because it's not helping very much
* give up showing active parameter, instead of showing an incorrect(?) one when things get too complex with `*`, `**`, `...`

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
Updated existing tests.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
