### PR TITLE
Consider local variables prefixed with underscore in grammar

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -109,7 +109,7 @@
           "name": "keyword.operator.assignment.augmented.ruby"
         }
       },
-      "match": "^\\s*([a-z]([A-Za-z0-9_])*)\\s*((&&|\\|\\|)=)",
+      "match": "^\\s*(_?[a-z]([A-Za-z0-9_])*)\\s*((&&|\\|\\|)=)",
       "comment": "A local variable and/or assignment"
     },
     {
@@ -124,7 +124,7 @@
           "name": "keyword.operator.assignment.augmented.ruby"
         }
       },
-      "match": "(?<!\\.)\\b(case|if|elsif|unless|until|while)\\b\\s*(\\()*?\\s*([a-z]([A-Za-z0-9_])*)\\s*((&&|\\|\\|)=)",
+      "match": "(?<!\\.)\\b(case|if|elsif|unless|until|while)\\b\\s*(\\()*?\\s*(_?[a-z]([A-Za-z0-9_])*)\\s*((&&|\\|\\|)=)",
       "comment": "A local variable and/or assignment in a condition"
     },
     {
@@ -136,7 +136,7 @@
           "name": "keyword.operator.assignment.augmented.ruby"
         }
       },
-      "match": "^\\s*([a-z]([A-Za-z0-9_])*)\\s*((\\+|\\*|-|\\/|%|\\*\\*|&|\\||\\^|<<|>>)=)",
+      "match": "^\\s*(_?[a-z]([A-Za-z0-9_])*)\\s*((\\+|\\*|-|\\/|%|\\*\\*|&|\\||\\^|<<|>>)=)",
       "comment": "A local variable operation assignment (+=, -=, *=, /=)"
     },
     {
@@ -151,7 +151,7 @@
           "name": "keyword.operator.assignment.augmented.ruby"
         }
       },
-      "match": "(?<!\\.)\\b(case|if|elsif|unless|until|while)\\b\\s*(\\()*?\\s*([a-z]([A-Za-z0-9_])*)\\s*((\\+|\\*|-|\\/|%|\\*\\*|&|\\||\\^|<<|>>)=)",
+      "match": "(?<!\\.)\\b(case|if|elsif|unless|until|while)\\b\\s*(\\()*?\\s*(_?[a-z]([A-Za-z0-9_])*)\\s*((\\+|\\*|-|\\/|%|\\*\\*|&|\\||\\^|<<|>>)=)",
       "comment": "A local variable operation assignment in a condition"
     },
     {
@@ -160,7 +160,7 @@
           "name": "variable.ruby"
         }
       },
-      "match": "^\\s*([a-z]([A-Za-z0-9_])*)\\s*(?==[^=>])",
+      "match": "^\\s*(_?[a-z]([A-Za-z0-9_])*)\\s*(?==[^=>])",
       "comment": "A local variable assignment"
     },
     {
@@ -172,7 +172,7 @@
           "name": "variable.ruby"
         }
       },
-      "match": "(?<!\\.)\\b(case|if|elsif|unless|until|while)\\b\\s*(\\()*?\\s*([a-z]([A-Za-z0-9_])*)\\s*=[^=>]",
+      "match": "(?<!\\.)\\b(case|if|elsif|unless|until|while)\\b\\s*(\\()*?\\s*(_?[a-z]([A-Za-z0-9_])*)\\s*=[^=>]",
       "comment": "A local variable assignment in a condition"
     },
     {

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -853,6 +853,17 @@ suite("Grammars", () => {
         const actualTokens = tokenizeRuby(ruby);
         assert.deepStrictEqual(actualTokens, expectedTokens);
       });
+
+      test("assignment with an underscore prefix", () => {
+        const ruby = "_local=1";
+        const expectedTokens = [
+          ["_local", ["source.ruby", "variable.ruby"]],
+          ["=", ["source.ruby", "keyword.operator.assignment.ruby"]],
+          ["1", ["source.ruby", "constant.numeric.ruby"]],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
     });
 
     function tokenizeRBS(rbs: string): [string, string[]][] {


### PR DESCRIPTION
### Motivation

Our grammar was not considering the underscore prefix as a possible local variable name, which made them by tokenized as constants.

### Implementation

We should allow for the optional underscore in front, so that people can ignore unused variables.

### Automated Tests

Added a scenario to cover this.