### PR TITLE
Add server capability for full test discovery

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -294,6 +294,7 @@ module RubyLsp
             addon_detection: true,
             compose_bundle: true,
             go_to_relevant_file: true,
+            full_test_discovery: true,
           },
         ),
         serverInfo: {

--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -120,6 +120,14 @@ suite("TestController", () => {
         },
       ]),
       waitForIndexing: sinon.stub().resolves(),
+      initializeResult: {
+        capabilities: {
+          experimental: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            full_test_discovery: true,
+          },
+        },
+      },
     };
     workspace.lspClient = fakeClient as any;
     await controller.testController.resolveHandler!(undefined);
@@ -323,6 +331,14 @@ suite("TestController", () => {
         ];
       },
       waitForIndexing: sinon.stub().resolves(),
+      initializeResult: {
+        capabilities: {
+          experimental: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            full_test_discovery: true,
+          },
+        },
+      },
     };
     workspace.lspClient = fakeClient as any;
 
@@ -427,6 +443,14 @@ suite("TestController", () => {
         },
       ]),
       waitForIndexing: sinon.stub().resolves(),
+      initializeResult: {
+        capabilities: {
+          experimental: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            full_test_discovery: true,
+          },
+        },
+      },
     };
 
     workspace.lspClient = fakeClient as any;
@@ -470,6 +494,14 @@ suite("TestController", () => {
         },
       ]),
       waitForIndexing: sinon.stub().resolves(),
+      initializeResult: {
+        capabilities: {
+          experimental: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            full_test_discovery: true,
+          },
+        },
+      },
     };
 
     workspace.lspClient = fakeClient as any;
@@ -522,6 +554,14 @@ suite("TestController", () => {
         },
       ]),
       waitForIndexing: sinon.stub().resolves(),
+      initializeResult: {
+        capabilities: {
+          experimental: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            full_test_discovery: true,
+          },
+        },
+      },
     };
 
     workspace.lspClient = fakeClient as any;
@@ -624,6 +664,14 @@ suite("TestController", () => {
         },
       ]),
       waitForIndexing: sinon.stub().resolves(),
+      initializeResult: {
+        capabilities: {
+          experimental: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            full_test_discovery: true,
+          },
+        },
+      },
     };
 
     workspace.lspClient = fakeClient as any;
@@ -699,6 +747,14 @@ suite("TestController", () => {
         },
       ]),
       waitForIndexing: sinon.stub().resolves(),
+      initializeResult: {
+        capabilities: {
+          experimental: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            full_test_discovery: true,
+          },
+        },
+      },
     };
     workspace.lspClient = fakeClient as any;
     await controller.testController.resolveHandler!(serverTest);
@@ -791,6 +847,14 @@ suite("TestController", () => {
         },
       ]),
       waitForIndexing: sinon.stub().resolves(),
+      initializeResult: {
+        capabilities: {
+          experimental: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            full_test_discovery: true,
+          },
+        },
+      },
     };
     workspace.lspClient = fakeClient as any;
 
@@ -841,6 +905,14 @@ suite("TestController", () => {
           commands: [`node ${fakeServerPath}`],
           reporterPath: undefined,
         }),
+        initializeResult: {
+          capabilities: {
+            experimental: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              full_test_discovery: true,
+            },
+          },
+        },
       } as any;
 
       const cancellationSource = new vscode.CancellationTokenSource();
@@ -892,6 +964,14 @@ suite("TestController", () => {
           commands: [`ruby -e '1'`],
           reporterPath: undefined,
         }),
+        initializeResult: {
+          capabilities: {
+            experimental: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              full_test_discovery: true,
+            },
+          },
+        },
       } as any;
 
       const cancellationSource = new vscode.CancellationTokenSource();
@@ -968,6 +1048,14 @@ suite("TestController", () => {
           commands: [`node ${fakeServerPath}`],
           reporterPath: undefined,
         }),
+        initializeResult: {
+          capabilities: {
+            experimental: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              full_test_discovery: true,
+            },
+          },
+        },
       } as any;
 
       const cancellationSource = new vscode.CancellationTokenSource();

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -420,6 +420,19 @@ export class TestController {
         request.exclude,
       );
       const workspace = await this.getOrActivateWorkspace(workspaceFolder);
+
+      if (
+        !workspace.lspClient?.initializeResult?.capabilities.experimental
+          ?.full_test_discovery
+      ) {
+        run.appendOutput(
+          `The version of the Ruby LSP server being used by ${workspaceFolder.name} does not support the new
+           test explorer functionality. Please make sure you are using the latest version of the server.
+           See https://shopify.github.io/ruby-lsp/troubleshooting.html#outdated-version for more information.`,
+        );
+        break;
+      }
+
       const response =
         await workspace.lspClient?.resolveTestCommands(requestTestItems);
 
@@ -849,6 +862,19 @@ export class TestController {
         await this.gatherWorkspaceTests(workspaceFolder, item);
       } else if (!item.tags.some((tag) => tag === TEST_GROUP_TAG)) {
         const workspace = await this.getOrActivateWorkspace(workspaceFolder);
+
+        if (
+          !workspace.lspClient?.initializeResult?.capabilities.experimental
+            ?.full_test_discovery
+        ) {
+          await vscode.window.showWarningMessage(
+            `The version of the Ruby LSP server being used by ${workspaceFolder.name} does not support the new
+             test explorer functionality. Please make sure you are using the latest version of the server.
+             See https://shopify.github.io/ruby-lsp/troubleshooting.html#outdated-version for more information.`,
+          );
+          return;
+        }
+
         const lspClient = workspace.lspClient;
 
         if (lspClient) {


### PR DESCRIPTION
### Motivation

While we are rolling out the new test explorer, some folks will still have an outdated version of the server. We need to ensure we're using a capability to gate the new behaviour.

### Implementation

Added the capability in the server and started checking it in the extension. We can't perform either discovery or command resolution unless it's the latest server running.