### PR TITLE
Replace T.unsafe with comment based RBS syntax

### DIFF
--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -1,37 +1,54 @@
 {
-    "version": "0.2",
-    "dictionaryDefinitions": [
-        {
-        "name": "project-words",
-        "path": "./project-words",
-        "addWords": true
-        }
-    ],
-    // cspell recognizes 'addon' as valid but we want to enforce 'add-on', but not within code
-    "words": [
-      "!addon"
-    ],
-    "ignoreRegExpList": [
-      "\\.addon",
-      "addon\\.",
-      "\\(addon\\)",
-      "@addon",
-      "_addon",
-      "addon\\w+",
-      "addon_",
-      "addon\"",
-      "addon =",
-      "$\\s+addon^",
-      "\\|addon\\|",
-      "addon$" // could have false positives but unlikely
-    ],
-    "language": "en",
-    "files": ["**/*.rb", "**/*.md", "**/*.markdown", "**/*.ts"],
-    "ignorePaths": [
-      "**/node_modules/**",
-      "vendor/**",
-      "coverage/**",
-      "test/fixtures/",
-    ],
-    "dictionaries": ["ruby", "en_US", "shell", "file-types", "project-words", "companies", "softwareTerms", "misc", "coding-terms"]
-  }
+  "version": "0.2",
+  "dictionaryDefinitions": [
+    {
+      "name": "project-words",
+      "path": "./project-words",
+      "addWords": true
+    }
+  ],
+  // cspell recognizes 'addon' as valid but we want to enforce 'add-on', but not within code
+  "words": [
+    "!addon"
+  ],
+  "ignoreRegExpList": [
+    "\\.addon",
+    "addon\\.",
+    "\\(addon\\)",
+    "\\(addon,",
+    "addon\\s+#: as",
+    "@addon",
+    "_addon",
+    "addon\\w+",
+    "addon_",
+    "addon\"",
+    "addon =",
+    "$\\s+addon^",
+    "\\|addon\\|",
+    "addon$" // could have false positives but unlikely
+  ],
+  "language": "en",
+  "files": [
+    "**/*.rb",
+    "**/*.md",
+    "**/*.markdown",
+    "**/*.ts"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "vendor/**",
+    "coverage/**",
+    "test/fixtures/"
+  ],
+  "dictionaries": [
+    "ruby",
+    "en_US",
+    "shell",
+    "file-types",
+    "project-words",
+    "companies",
+    "softwareTerms",
+    "misc",
+    "coding-terms"
+  ]
+}

--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -66,7 +66,7 @@ module RubyIndexer
       flags = File::FNM_PATHNAME | File::FNM_EXTGLOB
 
       uris = @included_patterns.flat_map do |pattern|
-        load_path_entry = T.let(nil, T.nilable(String))
+        load_path_entry = nil #: String?
 
         Dir.glob(File.join(@workspace_path, pattern), flags).map! do |path|
           # All entries for the same pattern match the same $LOAD_PATH entry. Since searching the $LOAD_PATH for every

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -1023,7 +1023,7 @@ module RubyIndexer
       # Otherwise, push all of the leading parts of the nesting that aren't redundant into the name. For example, if we
       # have a reference to `Foo::Bar` inside the `[Namespace, Foo]` nesting, then only the `Foo` part is redundant, but
       # we still need to include the `Namespace` part
-      T.unsafe(name_parts).unshift(*nesting[0...first_redundant_part])
+      name_parts.unshift(*nesting[0...first_redundant_part])
       name_parts.join("::")
     end
 

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -56,8 +56,13 @@ module RubyLsp
       @encoding = global_state.encoding #: Encoding
       @uri = uri #: URI::Generic
       @needs_parsing = true #: bool
-      @parse_result = T.unsafe(nil) #: ParseResultType
       @last_edit = nil #: Edit?
+
+      # Workaround to be able to type parse_result properly. It is immediately set when invoking parse!
+      @parse_result = ( # rubocop:disable Style/RedundantParentheses
+        nil #: as untyped
+      ) #: ParseResultType
+
       parse!
     end
 

--- a/lib/ruby_lsp/requests/code_action_resolve.rb
+++ b/lib/ruby_lsp/requests/code_action_resolve.rb
@@ -115,10 +115,10 @@ module RubyLsp
 
         # Find the node with the end line closest to the requested position, so that we can place the refactor
         # immediately after that closest node
-        closest_node = T.must(closest_statements.child_nodes.compact.min_by do |node|
+        closest_node = closest_statements.child_nodes.compact.min_by do |node|
           distance = source_range.dig(:start, :line) - (node.location.end_line - 1)
           distance <= 0 ? Float::INFINITY : distance
-        end)
+        end #: as !nil
 
         return Error::InvalidTargetRange if closest_node.is_a?(Prism::MissingNode)
 
@@ -380,16 +380,14 @@ module RubyLsp
 
         attribute_name = node.name[1..]
         indentation = " " * (closest_node.location.start_column + 2)
-        attribute_accessor_source = T.must(
-          case @code_action[:title]
-          when CodeActions::CREATE_ATTRIBUTE_READER
-            "#{indentation}attr_reader :#{attribute_name}\n\n"
-          when CodeActions::CREATE_ATTRIBUTE_WRITER
-            "#{indentation}attr_writer :#{attribute_name}\n\n"
-          when CodeActions::CREATE_ATTRIBUTE_ACCESSOR
-            "#{indentation}attr_accessor :#{attribute_name}\n\n"
-          end,
-        )
+        attribute_accessor_source = case @code_action[:title]
+        when CodeActions::CREATE_ATTRIBUTE_READER
+          "#{indentation}attr_reader :#{attribute_name}\n\n"
+        when CodeActions::CREATE_ATTRIBUTE_WRITER
+          "#{indentation}attr_writer :#{attribute_name}\n\n"
+        when CodeActions::CREATE_ATTRIBUTE_ACCESSOR
+          "#{indentation}attr_accessor :#{attribute_name}\n\n"
+        end #: as !nil
 
         target_start_line = closest_node.location.start_line
         target_range = {

--- a/lib/ruby_lsp/requests/selection_ranges.rb
+++ b/lib/ruby_lsp/requests/selection_ranges.rb
@@ -32,7 +32,7 @@ module RubyLsp
           next unless node
 
           range = Support::SelectionRange.new(range: range_from_location(node.location), parent: parent)
-          T.unsafe(queue).unshift(*node.child_nodes.map { |child| [child, range] })
+          queue.unshift(*node.child_nodes.map { |child| [child, range] })
           @ranges.unshift(range)
         end
 

--- a/lib/ruby_lsp/requests/show_syntax_tree.rb
+++ b/lib/ruby_lsp/requests/show_syntax_tree.rb
@@ -46,7 +46,7 @@ module RubyLsp
           if (start_char..end_char).cover?(loc.start_offset..loc.end_offset)
             found_nodes << node
           else
-            T.unsafe(queue).unshift(*node.child_nodes)
+            queue.unshift(*node.child_nodes)
           end
         end
 

--- a/lib/ruby_lsp/requests/support/source_uri.rb
+++ b/lib/ruby_lsp/requests/support/source_uri.rb
@@ -21,8 +21,10 @@ module URI
     # have the uri gem in their own bundle and thus not use a compatible version.
     PARSER = const_defined?(:RFC2396_PARSER) ? RFC2396_PARSER : DEFAULT_PARSER #: RFC2396_Parser
 
-    T.unsafe(self).alias_method(:gem_name, :host)
-    T.unsafe(self).alias_method(:line_number, :fragment)
+    self #: as untyped # rubocop:disable Style/RedundantSelf
+      .alias_method(:gem_name, :host)
+    self #: as untyped # rubocop:disable Style/RedundantSelf
+      .alias_method(:line_number, :fragment)
 
     #: String?
     attr_reader :gem_version

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -53,7 +53,7 @@ module RubyLsp
           # Add the next child_nodes to the queue to be processed. The order here is important! We want to move in the
           # same order as the visiting mechanism, which means searching the child nodes before moving on to the next
           # sibling
-          T.unsafe(queue).unshift(*candidate.child_nodes)
+          queue.unshift(*candidate.child_nodes)
 
           # Skip if the current node doesn't cover the desired position
           loc = candidate.location
@@ -195,7 +195,7 @@ module RubyLsp
         # Add the next child_nodes to the queue to be processed. The order here is important! We want to move in the
         # same order as the visiting mechanism, which means searching the child nodes before moving on to the next
         # sibling
-        T.unsafe(queue).unshift(*candidate.child_nodes)
+        queue.unshift(*candidate.child_nodes)
 
         # Skip if the current node doesn't cover the desired position
         loc = candidate.location

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1062,7 +1062,8 @@ module RubyLsp
       end
 
       Addon.file_watcher_addons.each do |addon|
-        T.unsafe(addon).workspace_did_change_watched_files(changes)
+        addon #: as untyped
+          .workspace_did_change_watched_files(changes)
       rescue => e
         send_log_message(
           "Error in #{addon.name} add-on while processing watched file notifications: #{e.full_message}",

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -260,7 +260,8 @@ module RubyLsp
       # The ENV can only be merged after checking if an update is required because we depend on the original value of
       # ENV["BUNDLE_GEMFILE"], which gets overridden after the merge
       should_update = should_bundle_update?
-      T.unsafe(ENV).merge!(env)
+      ENV #: as untyped
+        .merge!(env)
 
       unless should_update && !force_install
         Bundler::CLI::Install.new({ "no-cache" => true }).run

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -137,7 +137,12 @@ module RubyLsp
     #: -> Hash[Symbol, untyped]
     def to_hash
       hash = { method: @method }
-      hash[:params] = T.unsafe(@params).to_hash if @params
+
+      if @params
+        hash[:params] = @params #: as untyped
+          .to_hash
+      end
+
       hash
     end
   end
@@ -181,7 +186,12 @@ module RubyLsp
     #: -> Hash[Symbol, untyped]
     def to_hash
       hash = { id: @id, method: @method }
-      hash[:params] = T.unsafe(@params).to_hash if @params
+
+      if @params
+        hash[:params] = @params #: as untyped
+          .to_hash
+      end
+
       hash
     end
   end

--- a/sorbet/config
+++ b/sorbet/config
@@ -8,3 +8,4 @@
 --enable-experimental-requires-ancestor
 --enable-experimental-rbs-signatures
 --enable-experimental-rbs-assertions
+--suppress-error-code=7019

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -57,8 +57,8 @@ module RubyLsp
     def test_addons_are_automatically_tracked
       Addon.load_addons(@global_state, @outgoing_queue)
 
-      addon = Addon.addons.find { |addon| addon.is_a?(@addon) }
-      assert_equal(123, T.unsafe(addon).field)
+      addon = Addon.addons.find { |addon| addon.is_a?(@addon) } #: as untyped
+      assert_equal(123, addon.field)
     end
 
     def test_loading_addons_initializes_them
@@ -145,8 +145,8 @@ module RubyLsp
 
       Addon.load_addons(@global_state, @outgoing_queue)
 
-      addon = Addon.get("My Add-on", "0.1.0")
-      assert_equal({ something: false }, T.unsafe(addon).settings)
+      addon = Addon.get("My Add-on", "0.1.0") #: as untyped
+      assert_equal({ something: false }, addon.settings)
     end
 
     def test_depend_on_constraints
@@ -185,9 +185,9 @@ module RubyLsp
         })
         Addon.load_addons(@global_state, @outgoing_queue)
 
-        addon = Addon.get("Project Addon", "0.1.0")
+        addon = Addon.get("Project Addon", "0.1.0") #: as untyped
         assert_equal("Project Addon", addon.name)
-        assert_predicate(T.unsafe(addon), :hello)
+        assert_predicate(addon, :hello)
       end
     end
   end

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -257,7 +257,8 @@ module RubyLsp
       notifications = state.apply_options({ initializationOptions: { linters: ["rubocop"] } })
 
       log = notifications.find do |n|
-        n.method == "window/logMessage" && T.unsafe(n.params).message.include?("RuboCop v1.70.0")
+        params = n.params #: as untyped
+        n.method == "window/logMessage" && params.message.include?("RuboCop v1.70.0")
       end
       refute_nil(log)
       assert_equal(["rubocop"], state.instance_variable_get(:@linters))
@@ -270,7 +271,8 @@ module RubyLsp
       notifications = state.apply_options({ initializationOptions: { formatter: "rubocop" } })
 
       log = notifications.find do |n|
-        n.method == "window/logMessage" && T.unsafe(n.params).message.include?("RuboCop v1.70.0")
+        params = n.params #: as untyped
+        n.method == "window/logMessage" && params.message.include?("RuboCop v1.70.0")
       end
       refute_nil(log)
       assert_equal("rubocop", state.formatter)
@@ -283,7 +285,8 @@ module RubyLsp
       notifications = state.apply_options({ initializationOptions: { linters: ["rubocop"] } })
 
       log = notifications.find do |n|
-        n.method == "window/logMessage" && T.unsafe(n.params).message.include?("RuboCop v1.70.0")
+        params = n.params #: as untyped
+        n.method == "window/logMessage" && params.message.include?("RuboCop v1.70.0")
       end
       refute_nil(log)
       assert_equal(["rubocop_internal"], state.instance_variable_get(:@linters))
@@ -296,7 +299,8 @@ module RubyLsp
       notifications = state.apply_options({ initializationOptions: { formatter: "rubocop" } })
 
       log = notifications.find do |n|
-        n.method == "window/logMessage" && T.unsafe(n.params).message.include?("RuboCop v1.70.0")
+        params = n.params #: as untyped
+        n.method == "window/logMessage" && params.message.include?("RuboCop v1.70.0")
       end
       refute_nil(log)
       assert_equal("rubocop_internal", state.formatter)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -283,12 +283,13 @@ class IntegrationTest < Minitest::Test
       ["-I", File.expand_path(path)]
     end.uniq.flatten
 
-    stdin, stdout, stderr, wait_thr = T.unsafe(Open3).popen3(
-      extra_env,
-      Gem.ruby,
-      *load_path,
-      File.join(@root, "exe", exec),
-    )
+    stdin, stdout, stderr, wait_thr = Open3 #: as untyped
+      .popen3(
+        extra_env,
+        Gem.ruby,
+        *load_path,
+        File.join(@root, "exe", exec),
+      )
     stdin.sync = true
     stdin.binmode
     stdout.sync = true
@@ -320,7 +321,7 @@ class IntegrationTest < Minitest::Test
 
     # If the child process failed, it is really difficult to diagnose what's happening unless we read what was printed
     # to stderr
-    unless T.unsafe(wait_thr.value).success?
+    unless wait_thr.value.success?
       require "timeout"
 
       Timeout.timeout(5) do

--- a/test/requests/code_actions_formatting_test.rb
+++ b/test/requests/code_actions_formatting_test.rb
@@ -90,8 +90,7 @@ class CodeActionsFormattingTest < Minitest::Test
     # hashes here, so cast to untyped and only look at those.
     untyped_result = result #: untyped
     selected_action = untyped_result.find do |ca|
-      code_action = T.let(ca, T.untyped)
-      code_action.respond_to?(:[]) && code_action[:title] == code_action_title
+      ca.respond_to?(:[]) && ca[:title] == code_action_title
     end
 
     # transform edits from lsp to the format RubyLsp::Document wants them

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -301,7 +301,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
           end
         end
 
-        T.unsafe(klass).new(response_builder, uri, dispatcher)
+        klass.new(response_builder, uri, dispatcher)
       end
 
       def activate(global_state, outgoing_queue)

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1810,7 +1810,7 @@ class CompletionTest < Minitest::Test
           end
         end
 
-        T.unsafe(klass).new(response_builder, nesting, dispatcher, uri)
+        klass.new(response_builder, nesting, dispatcher, uri)
       end
 
       def activate(global_state, outgoing_queue); end

--- a/test/requests/definition_expectations_test.rb
+++ b/test/requests/definition_expectations_test.rb
@@ -1176,7 +1176,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
       # typed: strict
       class Foo
         def initialize
-          @something = T.let(123, Integer)
+          @something = 123 #: Integer
         end
 
         def baz
@@ -1300,7 +1300,7 @@ class DefinitionExpectationsTest < ExpectationsTestRunner
           end
         end
 
-        T.unsafe(klass).new(response_builder, uri, nesting, dispatcher)
+        klass.new(response_builder, uri, nesting, dispatcher)
       end
 
       def activate(global_state, outgoing_queue); end

--- a/test/requests/diagnostics_test.rb
+++ b/test/requests/diagnostics_test.rb
@@ -101,7 +101,7 @@ class DiagnosticsTest < Minitest::Test
       end
     end
 
-    @global_state.register_formatter("my-custom-formatter", T.unsafe(formatter_class).new)
+    @global_state.register_formatter("my-custom-formatter", formatter_class.new)
     @global_state.apply_options({
       initializationOptions: { linters: ["my-custom-formatter"] },
     })

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -160,7 +160,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
           end
         end
 
-        T.unsafe(klass).new(response_builder, dispatcher)
+        klass.new(response_builder, dispatcher)
       end
     end
   end

--- a/test/requests/formatting_test.rb
+++ b/test/requests/formatting_test.rb
@@ -151,7 +151,7 @@ class FormattingTest < Minitest::Test
       end
     end
 
-    @global_state.register_formatter("my-custom-formatter", T.unsafe(formatter_class).new)
+    @global_state.register_formatter("my-custom-formatter", formatter_class.new)
     assert_includes(formatted_document("my-custom-formatter"), "# formatter by my-custom-formatter")
   end
 

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -847,7 +847,7 @@ class HoverExpectationsTest < ExpectationsTestRunner
       class Child
         def initialize
           # Hello
-          @something = T.let(123, Integer)
+          @something = 123 #: Integer
         end
 
         def bar

--- a/test/requests/rename_test.rb
+++ b/test/requests/rename_test.rb
@@ -93,14 +93,12 @@ class RenameTest < Minitest::Test
       global_state: global_state,
     )
 
-    response = T.must(
-      RubyLsp::Requests::Rename.new(
-        global_state,
-        store,
-        document,
-        { position: { line: 3, character: 7 }, newName: "NewMe" },
-      ).perform,
-    )
+    response = RubyLsp::Requests::Rename.new(
+      global_state,
+      store,
+      document,
+      { position: { line: 3, character: 7 }, newName: "NewMe" },
+    ).perform #: as !nil
 
     untitled_change = response.document_changes[1]
     assert_equal("untitled:Untitled-1", untitled_change.text_document.uri)
@@ -131,14 +129,12 @@ class RenameTest < Minitest::Test
       uri: URI::Generic.from_path(path: path),
       global_state: global_state,
     )
-    workspace_edit = T.must(
-      RubyLsp::Requests::Rename.new(
-        global_state,
-        store,
-        document,
-        { position: position, newName: new_name },
-      ).perform,
-    )
+    workspace_edit = RubyLsp::Requests::Rename.new(
+      global_state,
+      store,
+      document,
+      { position: position, newName: new_name },
+    ).perform #: as !nil
 
     file_renames = workspace_edit.document_changes.filter_map do |text_edit_or_rename|
       next text_edit_or_rename unless text_edit_or_rename.is_a?(RubyLsp::Interface::TextDocumentEdit)

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -104,7 +104,7 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
           end
         end
 
-        T.unsafe(klass).new(response_builder, dispatcher)
+        klass.new(response_builder, dispatcher)
       end
 
       def activate(global_state, outgoing_queue); end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1485,8 +1485,8 @@ class ServerTest < Minitest::Test
   def wait_for_indexing
     message = @server.pop_response
     until message.is_a?(RubyLsp::Notification) && message.method == "$/progress" &&
-        T.unsafe(message).params.value.kind == "end"
-
+        message.params #: as untyped
+            .value.kind == "end"
       message = @server.pop_response
     end
   end
@@ -1547,10 +1547,10 @@ class ServerTest < Minitest::Test
 
   #: (Class desired_class, ?String? desired_method, ?id: Integer?) -> untyped
   def find_message(desired_class, desired_method = nil, id: nil)
-    message = @server.pop_response #: (RubyLsp::Result | RubyLsp::Message | RubyLsp::Error)
+    message = @server.pop_response
 
-    until message.is_a?(desired_class) && (!desired_method || T.unsafe(message).method == desired_method) &&
-        (!id || T.unsafe(message).id == id)
+    until message.is_a?(desired_class) && (!desired_method || message.method == desired_method) &&
+        (!id || message.id == id)
       message = @server.pop_response
 
       if message.is_a?(RubyLsp::Error) && desired_class != RubyLsp::Error

--- a/test/test_reporters/minitest_reporter_test.rb
+++ b/test/test_reporters/minitest_reporter_test.rb
@@ -12,7 +12,7 @@ module RubyLsp
       server = TCPServer.new("localhost", 0)
       port = server.addr[1].to_s
       events = []
-      socket = T.let(nil, T.nilable(Socket))
+      socket = nil #: Socket?
 
       receiver = Thread.new do
         socket = server.accept
@@ -32,18 +32,19 @@ module RubyLsp
         end
       end
 
-      _stdin, stdout, _stderr, wait_thr = T.unsafe(Open3).popen3(
-        {
-          "RUBYOPT" => "-rbundler/setup -r#{plugin_path}",
-          "RUBY_LSP_TEST_RUNNER" => "run",
-          "RUBY_LSP_REPORTER_PORT" => port,
-        },
-        "bundle",
-        "exec",
-        "ruby",
-        "-Itest",
-        "test/fixtures/minitest_example.rb",
-      )
+      _stdin, stdout, _stderr, wait_thr = Open3 #: as untyped
+        .popen3(
+          {
+            "RUBYOPT" => "-rbundler/setup -r#{plugin_path}",
+            "RUBY_LSP_TEST_RUNNER" => "run",
+            "RUBY_LSP_REPORTER_PORT" => port,
+          },
+          "bundle",
+          "exec",
+          "ruby",
+          "-Itest",
+          "test/fixtures/minitest_example.rb",
+        )
 
       receiver.join
       wait_thr.join

--- a/test/test_reporters/test_unit_reporter_test.rb
+++ b/test/test_reporters/test_unit_reporter_test.rb
@@ -14,7 +14,7 @@ module RubyLsp
       server = TCPServer.new("localhost", 0)
       port = server.addr[1].to_s
       events = []
-      socket = T.let(nil, T.nilable(Socket))
+      socket = nil #: Socket?
 
       receiver = Thread.new do
         socket = server.accept
@@ -34,19 +34,20 @@ module RubyLsp
         end
       end
 
-      _stdin, stdout, _stderr, wait_thr = T.unsafe(Open3).popen3(
-        {
-          "RUBYOPT" => "-rbundler/setup -r#{reporter_path}",
-          "RUBY_LSP_TEST_RUNNER" => "run",
-          "RUBY_LSP_REPORTER_PORT" => port,
-        },
-        "bundle",
-        "exec",
-        "ruby",
-        "-Itest",
-        test_path,
-        chdir: Bundler.root.to_s,
-      )
+      _stdin, stdout, _stderr, wait_thr = Open3 #: as untyped
+        .popen3(
+          {
+            "RUBYOPT" => "-rbundler/setup -r#{reporter_path}",
+            "RUBY_LSP_TEST_RUNNER" => "run",
+            "RUBY_LSP_REPORTER_PORT" => port,
+          },
+          "bundle",
+          "exec",
+          "ruby",
+          "-Itest",
+          test_path,
+          chdir: Bundler.root.to_s,
+        )
 
       wait_thr.join
       receiver.join


### PR DESCRIPTION
### Motivation

Replace `T.unsafe` with `#: as untyped`. I also replaced some extra cases of `T.let` and `T.must` that had been missed.

With this, the only thing left is `T.cast`.