### PR TITLE
Read initialize request from a file when retrying

### DIFF
--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -11,12 +11,19 @@ install_error = nil
 reboot = false
 
 workspace_uri = ARGV.first
+raw_initialize_path = File.join(".ruby-lsp", "raw_initialize")
 
 raw_initialize = if workspace_uri && !workspace_uri.start_with?("--")
   # If there's an argument without `--`, then it's the server asking to compose the bundle and passing to this
   # executable the workspace URI. We can't require gems at this point, so we built a fake initialize request manually
   reboot = true
   "{\"params\":{\"workspaceFolders\":[{\"uri\":\"#{workspace_uri}\"}]}}"
+elsif ARGV.include?("--retry")
+  # If we're trying to re-boot automatically, we can't try to read the same initialize request again from the pipe. We
+  # need to ensure that the retry mechanism always writes the request to a file, so that we can reuse it
+  content = File.read(raw_initialize_path)
+  File.delete(raw_initialize_path)
+  content
 else
   # Read the initialize request before even starting the server. We need to do this to figure out the workspace URI.
   # Editors are not required to spawn the language server process on the same directory as the workspace URI, so we need
@@ -89,7 +96,8 @@ rescue Bundler::GemNotFound, Bundler::GitError
   # scratch
   unless install_error || ARGV.include?("--retry")
     $stderr.puts("Initial bundle compose succeeded, but Bundler.setup failed. Trying to restart from scratch...")
-    exec(Gem.ruby, File.expand_path("ruby-lsp-launcher", __dir__), *ARGV, "--retry")
+    File.write(raw_initialize_path, raw_initialize)
+    exec(Gem.ruby, __FILE__, *ARGV, "--retry")
   end
 
   $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))

--- a/lib/ruby_lsp/scripts/compose_bundle.rb
+++ b/lib/ruby_lsp/scripts/compose_bundle.rb
@@ -13,8 +13,10 @@ def compose(raw_initialize)
   workspace_path ||= Dir.pwd
 
   env = RubyLsp::SetupBundler.new(workspace_path, launcher: true).setup!
-  File.write(
-    File.join(".ruby-lsp", "bundle_env"),
-    env.map { |k, v| "#{k}=#{v}" }.join("\n"),
-  )
+
+  File.open(File.join(".ruby-lsp", "bundle_env"), "w") do |f|
+    f.flock(File::LOCK_EX)
+    f.write(env.map { |k, v| "#{k}=#{v}" }.join("\n"))
+    f.flush
+  end
 end


### PR DESCRIPTION
### Motivation

I identified a bug in our retry mechanism while working on Core. The retry actually gets stuck every time because we try to read the initialize request from the stdin pipe a second time, but there's nothing to read so we're stuck forever in that read call.

### Implementation

To fix this, I started writing the initialize contents to a file only for the retry mechanism, so that we don't have to read it from the pipe again.

### Automated Tests

We didn't have tests for this, so I put in some extra effort to get a reliable one working. Essentially, the idea is to use an exclusive file lock on `bundle_env`, so that we can force pause the launch process immediately after bundle installing.

That gives us the opportunity to uninstall a gem between a successfully bundle install and the call to `Bundler.setup`, which reproduces the problem that the retry mechanism is intended for.

This new test properly hangs forever without the fix and passes afterwards.