### PR TITLE
Deduplicate code in testController.test.ts

### DIFF
--- a/vscode/src/test/suite/helpers.ts
+++ b/vscode/src/test/suite/helpers.ts
@@ -3,6 +3,8 @@ import path from "path";
 import os from "os";
 import fs from "fs";
 
+import * as vscode from "vscode";
+
 import { MAJOR, MINOR, RUBY_VERSION } from "../rubyVersion";
 
 export function createRubySymlinks() {
@@ -41,3 +43,22 @@ export function createRubySymlinks() {
     }
   }
 }
+
+export const LSP_WORKSPACE_PATH = path.dirname(
+  path.dirname(path.dirname(path.dirname(__dirname))),
+);
+export const LSP_WORKSPACE_URI = vscode.Uri.file(LSP_WORKSPACE_PATH);
+export const LSP_WORKSPACE_FOLDER: vscode.WorkspaceFolder = {
+  uri: LSP_WORKSPACE_URI,
+  name: path.basename(LSP_WORKSPACE_PATH),
+  index: 0,
+};
+export const CONTEXT = {
+  extensionMode: vscode.ExtensionMode.Test,
+  subscriptions: [],
+  workspaceState: {
+    get: (_name: string) => undefined,
+    update: (_name: string, _value: any) => Promise.resolve(),
+  },
+  extensionUri: vscode.Uri.joinPath(LSP_WORKSPACE_URI, "vscode"),
+} as unknown as vscode.ExtensionContext;


### PR DESCRIPTION
### Motivation

We ended up accumulating some duplicate setup as we built the new test explorer implementation tests.

Specifically, the way that we were stubbing the LSP client was duplicated everywhere. Additionally, we kept having issues of leaking stubs because we weren't using a Sinon sandbox.

### Implementation

I deduplicated much of the setup and switched to using a Sinon sandbox, which should hopefully make the tests a lot less flaky.