### PR TITLE
Connect code lens buttons to the new explorer

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -529,6 +529,7 @@ export class TestController {
   // Public for testing purposes. Finds a test item based on its ID and URI
   async findTestItem(id: string, uri: vscode.Uri) {
     if (this.testController.items.size === 0) {
+      // Discover and test items immediately if the test explorer hasn't been expanded
       await this.resolveHandler(undefined);
     }
 


### PR DESCRIPTION
### Motivation

We had forgotten about hooking up the code lens buttons with the new test explorer implementation. This PR hooks those up!

### Implementation

With the new implementation, all profiles are always executed by the same method. So I created a new command implementation that will just invoke that method using the appropriate profile.

### Manual tests

1. Start the extension on this branch
2. Open a test file
3. Click some code lens buttons
4. Verify that the tests run and results are reported to the explorer