### PR TITLE
Include line numbers when reporting test start event

### DIFF
--- a/lib/ruby_lsp/test_reporters/lsp_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/lsp_reporter.rb
@@ -59,9 +59,9 @@ module RubyLsp
       @io.close
     end
 
-    #: (id: String, uri: URI::Generic) -> void
-    def start_test(id:, uri:)
-      send_message("start", id: id, uri: uri.to_s)
+    #: (id: String, uri: URI::Generic, ?line: Integer?) -> void
+    def start_test(id:, uri:, line: nil)
+      send_message("start", id: id, uri: uri.to_s, line: line)
     end
 
     #: (id: String, uri: URI::Generic) -> void
@@ -82,6 +82,17 @@ module RubyLsp
     #: (id: String, message: String?, uri: URI::Generic) -> void
     def record_error(id:, message:, uri:)
       send_message("error", id: id, message: message, uri: uri.to_s)
+    end
+
+    #: (Method | UnboundMethod) -> [URI::Generic, Integer?]?
+    def uri_and_line_for(method_object)
+      file_path, line = method_object.source_location
+      return unless file_path
+      return if file_path.start_with?("(eval at ")
+
+      uri = URI::Generic.from_path(path: File.expand_path(file_path))
+      zero_based_line = line ? line - 1 : nil
+      [uri, zero_based_line]
     end
 
     # Gather the results returned by Coverage.result and format like the VS Code test explorer expects

--- a/lib/ruby_lsp/test_reporters/test_unit_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/test_unit_reporter.rb
@@ -26,12 +26,12 @@ module RubyLsp
     def test_started(test)
       super
 
-      current_test = test
-      @current_uri = uri_for_test(current_test)
-      return unless @current_uri
+      uri, line = LspReporter.instance.uri_and_line_for(test.method(test.method_name))
+      return unless uri
 
-      @current_test_id = "#{current_test.class.name}##{current_test.method_name}"
-      LspReporter.instance.start_test(id: @current_test_id, uri: @current_uri)
+      @current_uri = uri
+      @current_test_id = "#{test.class.name}##{test.method_name}"
+      LspReporter.instance.start_test(id: @current_test_id, uri: @current_uri, line: line)
     end
 
     #: (::Test::Unit::TestCase test) -> void
@@ -60,18 +60,6 @@ module RubyLsp
     #: (Float) -> void
     def finished(elapsed_time)
       LspReporter.instance.shutdown
-    end
-
-    #: (::Test::Unit::TestCase test) -> URI::Generic?
-    def uri_for_test(test)
-      location = test.method(test.method_name).source_location
-      return unless location
-
-      file, _line = location
-      return if file.start_with?("(eval at ")
-
-      absolute_path = File.expand_path(file, Dir.pwd)
-      URI::Generic.from_path(path: absolute_path)
     end
 
     #: -> void

--- a/test/test_reporters/minitest_reporter_test.rb
+++ b/test/test_reporters/minitest_reporter_test.rb
@@ -56,6 +56,7 @@ module RubyLsp
           "params" => {
             "id" => "SampleTest#test_that_fails",
             "uri" => uri,
+            "line" => 14,
           },
         },
         {
@@ -71,6 +72,7 @@ module RubyLsp
           "params" => {
             "id" => "SampleTest#test_that_is_pending",
             "uri" => uri,
+            "line" => 18,
           },
         },
         {
@@ -85,6 +87,7 @@ module RubyLsp
           "params" => {
             "id" => "SampleTest#test_that_passes",
             "uri" => uri,
+            "line" => 9,
           },
         },
         {
@@ -99,6 +102,7 @@ module RubyLsp
           "params" => {
             "id" => "SampleTest#test_that_raises",
             "uri" => uri,
+            "line" => 22,
           },
         },
         {
@@ -114,6 +118,7 @@ module RubyLsp
           "params" => {
             "id" => "SampleTest#test_with_output",
             "uri" => uri,
+            "line" => 26,
           },
         },
         {

--- a/test/test_reporters/test_unit_reporter_test.rb
+++ b/test/test_reporters/test_unit_reporter_test.rb
@@ -59,6 +59,7 @@ module RubyLsp
           "params" => {
             "id" => "SampleTest#test_that_fails",
             "uri" => uri,
+            "line" => 11,
           },
         },
         {
@@ -74,6 +75,7 @@ module RubyLsp
           "params" => {
             "id" => "SampleTest#test_that_is_pending",
             "uri" => uri,
+            "line" => 15,
           },
         },
         {
@@ -88,6 +90,7 @@ module RubyLsp
           "params" => {
             "id" => "SampleTest#test_that_passes",
             "uri" => uri,
+            "line" => 6,
           },
         },
         {
@@ -102,6 +105,7 @@ module RubyLsp
           "params" => {
             "id" => "SampleTest#test_that_raises",
             "uri" => uri,
+            "line" => 19,
           },
         },
         {


### PR DESCRIPTION
### Motivation

First step for #3422

The minimum we need to auto discover dynamic tests is the line number, so that we can use that for the test item's range information.

We need our LSP test reporter to include that so that the extension can use it.

### Implementation

Started making it possible to report the line in which a test was executed. Made the Minitest and Test Unit reporters include that.

### Automated Tests

Updated tests to reflect the new line information.