### PR TITLE
Automatically discover dynamically defined tests

### DIFF
--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -916,4 +916,53 @@ suite("TestController", () => {
 
     source.dispose();
   });
+
+  test("findTestItem creates items automatically when line is passed", async () => {
+    assert.strictEqual(
+      "ServerTest",
+      (await controller.findTestItem("ServerTest", serverTestUri))!.id,
+    );
+    assert.strictEqual(
+      "ServerTest::NestedTest",
+      (await controller.findTestItem("ServerTest::NestedTest", serverTestUri))!
+        .id,
+    );
+
+    const dynamicallyDefinedTest = await controller.findTestItem(
+      "ServerTest#test_dynamically_defined",
+      serverTestUri,
+      32,
+    );
+
+    assert.ok(dynamicallyDefinedTest);
+    assert.strictEqual(
+      "ServerTest#test_dynamically_defined",
+      dynamicallyDefinedTest.id,
+    );
+    assert.strictEqual("dynamic test", dynamicallyDefinedTest.description);
+    assert.strictEqual(
+      "★ test_dynamically_defined",
+      dynamicallyDefinedTest.label,
+    );
+
+    const dynamicallyDefinedNestedTest = await controller.findTestItem(
+      "ServerTest::NestedTest#test_nested_dynamically_defined",
+      serverTestUri,
+      32,
+    );
+
+    assert.ok(dynamicallyDefinedNestedTest);
+    assert.strictEqual(
+      "ServerTest::NestedTest#test_nested_dynamically_defined",
+      dynamicallyDefinedNestedTest.id,
+    );
+    assert.strictEqual(
+      "dynamic test",
+      dynamicallyDefinedNestedTest.description,
+    );
+    assert.strictEqual(
+      "★ test_nested_dynamically_defined",
+      dynamicallyDefinedNestedTest.label,
+    );
+  });
 });


### PR DESCRIPTION
### Motivation

Closes #3422

This PR starts creating test items on demand when status updates are received and

1. We cannot find the test item in question
2. The line information was passed

That way, we can consider it a dynamically defined test and automatically add items to the tree.

### Implementation

At the very end of searching for test items, I added a check to see if the line number was passed. If it was, we create a dynamic test item and return it.

### Automated Tests

Added a test.