### PR TITLE
Only emit shutdown event after processing coverage

### DIFF
--- a/test/test_reporters/lsp_reporter_test.rb
+++ b/test/test_reporters/lsp_reporter_test.rb
@@ -52,5 +52,14 @@ module RubyLsp
         LspReporter.instance.gather_coverage_results,
       )
     end
+
+    def test_shutdown_does_nothing_in_coverage_mode
+      ENV["RUBY_LSP_TEST_RUNNER"] = "coverage"
+      io = LspReporter.instance.instance_variable_get(:@io)
+      io.expects(:close).never
+      LspReporter.instance.shutdown
+    ensure
+      ENV.delete("RUBY_LSP_TEST_RUNNER")
+    end
   end
 end


### PR DESCRIPTION
### Motivation

On `run` and `debug` modes, as soon as the test suite is complete, we emit the `finish` event to let the extension side know that we're done.

However, that's not true for `coverage` mode, because we still want to process the data first and write to the file. Currently, on large codebases, that takes a bit of time. What ends up happening is that we:

1. Tell the extension we finished running tests
2. Start processing coverage data
3. The extension tries to read the data we're still processing
4. boom

### Implementation

We only want to emit the `finish` event when we're done with coverage. I added an `internal_shutdown` method to allow us to differentiate easily. The idea is for this one to be private to the `LspReporter` implementation, while `shutdown` is the public API intended to be used by specific reporter implementations (e.g.: Minitest, RSpec).

### Automated Tests

Added a simple test.