### PR TITLE
Always set RUBYOPT when running tests in terminal

### DIFF
--- a/vscode/src/streamingRunner.ts
+++ b/vscode/src/streamingRunner.ts
@@ -156,14 +156,16 @@ export class StreamingRunner implements vscode.Disposable {
     }
 
     // Set the TCP port information every time even if there's an existing terminal. The user can close the editor
-    // window or reload extensions, which will assign a new port but maintain the same terminal
+    // window or reload extensions, which will assign a new port but maintain the same terminal.
+    //
+    // We also send RUBYOPT since that hooks up the custom LSP test reporters and the user's shell may override it
     if (process.platform === "win32") {
       terminal.sendText(
-        `$env:RUBY_LSP_REPORTER_PORT="${this.tcpPort}"; Clear-Host`,
+        `$env:RUBY_LSP_REPORTER_PORT="${this.tcpPort}"; $env:RUBYOPT="${env.RUBYOPT}"; Clear-Host`,
       );
     } else {
       terminal.sendText(
-        `export RUBY_LSP_REPORTER_PORT="${this.tcpPort}"; clear`,
+        `export RUBY_LSP_REPORTER_PORT="${this.tcpPort}"; export RUBYOPT="${env.RUBYOPT}"; clear`,
       );
     }
 


### PR DESCRIPTION
### Motivation

We were originally only setting the port variable on every terminal run, but that's not enough. We also need to ensure `RUBYOPT` is set because that hooks up our custom LSP test reporters.

For example, Shadowenv can erase that variable, leaving us unable to report results back to the extension.