### PR TITLE
Show message if we cannot find related files

### DIFF
--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -728,8 +728,12 @@ export class RubyLsp {
             uri,
           );
 
-        if (response) {
+        if (response && response.locations.length > 0) {
           return openUris(response.locations);
+        } else {
+          await vscode.window.showInformationMessage(
+            "Couldn't find relevant files",
+          );
         }
       }),
     ];


### PR DESCRIPTION
### Motivation

If we don't find any relevant files to jump, the server returns an empty array and we end up showing an empty list for the user to pick from. The UX is a bit confusing, especially since you can't pick anything from the empty list.

This PR just changes so that we show a little popup mentioning we couldn't find relevant files to jump to.