### PR TITLE
Remove T::Enum for entry visibility

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -3,14 +3,6 @@
 
 module RubyIndexer
   class Entry
-    class Visibility < T::Enum
-      enums do
-        PUBLIC = new(:public)
-        PROTECTED = new(:protected)
-        PRIVATE = new(:private)
-      end
-    end
-
     #: String
     attr_reader :name
 
@@ -22,7 +14,7 @@ module RubyIndexer
 
     alias_method :name_location, :location
 
-    #: Visibility
+    #: Symbol
     attr_accessor :visibility
 
     #: (String name, URI::Generic uri, Location location, String? comments) -> void
@@ -30,23 +22,23 @@ module RubyIndexer
       @name = name
       @uri = uri
       @comments = comments
-      @visibility = Visibility::PUBLIC #: Visibility
+      @visibility = :public #: Symbol
       @location = location
     end
 
     #: -> bool
     def public?
-      visibility == Visibility::PUBLIC
+      @visibility == :public
     end
 
     #: -> bool
     def protected?
-      visibility == Visibility::PROTECTED
+      @visibility == :protected
     end
 
     #: -> bool
     def private?
-      visibility == Visibility::PRIVATE
+      @visibility == :private
     end
 
     #: -> String
@@ -306,7 +298,7 @@ module RubyIndexer
       #: Entry::Namespace?
       attr_reader :owner
 
-      #: (String name, URI::Generic uri, Location location, String? comments, Visibility visibility, Entry::Namespace? owner) -> void
+      #: (String name, URI::Generic uri, Location location, String? comments, Symbol visibility, Entry::Namespace? owner) -> void
       def initialize(name, uri, location, comments, visibility, owner) # rubocop:disable Metrics/ParameterLists
         super(name, uri, location, comments)
         @visibility = visibility
@@ -358,7 +350,7 @@ module RubyIndexer
       #: Location
       attr_reader :name_location
 
-      #: (String name, URI::Generic uri, Location location, Location name_location, String? comments, Array[Signature] signatures, Visibility visibility, Entry::Namespace? owner) -> void
+      #: (String name, URI::Generic uri, Location location, Location name_location, String? comments, Array[Signature] signatures, Symbol visibility, Entry::Namespace? owner) -> void
       def initialize(name, uri, location, name_location, comments, signatures, visibility, owner) # rubocop:disable Metrics/ParameterLists
         super(name, uri, location, comments, visibility, owner)
         @signatures = signatures

--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -107,15 +107,6 @@ module RubyIndexer
       location = to_ruby_indexer_location(member.location)
       comments = comments_to_string(member)
 
-      visibility = case member.visibility
-      when :private
-        Entry::Visibility::PRIVATE
-      when :protected
-        Entry::Visibility::PROTECTED
-      else
-        Entry::Visibility::PUBLIC
-      end
-
       real_owner = member.singleton? ? @index.existing_or_new_singleton_class(owner.name) : owner
       signatures = signatures(member)
       @index.add(Entry::Method.new(
@@ -125,7 +116,7 @@ module RubyIndexer
         location,
         comments,
         signatures,
-        visibility,
+        member.visibility || :public,
         real_owner,
       ))
     end

--- a/lib/ruby_indexer/lib/ruby_indexer/visibility_scope.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/visibility_scope.rb
@@ -8,7 +8,7 @@ module RubyIndexer
     class << self
       #: -> instance
       def module_function_scope
-        new(module_func: true, visibility: Entry::Visibility::PRIVATE)
+        new(module_func: true, visibility: :private)
       end
 
       #: -> instance
@@ -17,14 +17,14 @@ module RubyIndexer
       end
     end
 
-    #: Entry::Visibility
+    #: Symbol
     attr_reader :visibility
 
     #: bool
     attr_reader :module_func
 
-    #: (?visibility: Entry::Visibility, ?module_func: bool) -> void
-    def initialize(visibility: Entry::Visibility::PUBLIC, module_func: false)
+    #: (?visibility: Symbol, ?module_func: bool) -> void
+    def initialize(visibility: :public, module_func: false)
       @visibility = visibility
       @module_func = module_func
     end

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -100,9 +100,9 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("foo", Entry::Method, "/fake/path/foo.rb:1-10:2-5", visibility: Entry::Visibility::PRIVATE)
-      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:4-2:4-14", visibility: Entry::Visibility::PUBLIC)
-      assert_entry("baz", Entry::Method, "/fake/path/foo.rb:8-2:8-14", visibility: Entry::Visibility::PROTECTED)
+      assert_entry("foo", Entry::Method, "/fake/path/foo.rb:1-10:2-5", visibility: :private)
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:4-2:4-14", visibility: :public)
+      assert_entry("baz", Entry::Method, "/fake/path/foo.rb:8-2:8-14", visibility: :protected)
     end
 
     def test_visibility_tracking_with_nested_class_or_modules
@@ -120,9 +120,9 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("foo", Entry::Method, "/fake/path/foo.rb:3-2:3-14", visibility: Entry::Visibility::PRIVATE)
-      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:6-4:6-16", visibility: Entry::Visibility::PUBLIC)
-      assert_entry("baz", Entry::Method, "/fake/path/foo.rb:9-2:9-14", visibility: Entry::Visibility::PRIVATE)
+      assert_entry("foo", Entry::Method, "/fake/path/foo.rb:3-2:3-14", visibility: :private)
+      assert_entry("bar", Entry::Method, "/fake/path/foo.rb:6-4:6-16", visibility: :public)
+      assert_entry("baz", Entry::Method, "/fake/path/foo.rb:9-2:9-14", visibility: :private)
     end
 
     def test_visibility_tracking_with_module_function
@@ -147,7 +147,7 @@ module RubyIndexer
         # The second entry points to the public singleton method
         assert_equal("Test::<Class:Test>", second_entry&.owner&.name)
         assert_instance_of(Entry::SingletonClass, second_entry&.owner)
-        assert_equal(Entry::Visibility::PUBLIC, second_entry&.visibility)
+        assert_equal(:public, second_entry&.visibility)
       end
     end
 

--- a/lib/ruby_indexer/test/rbs_indexer_test.rb
+++ b/lib/ruby_indexer/test/rbs_indexer_test.rb
@@ -60,7 +60,7 @@ module RubyIndexer
       entry = entries.find { |entry| entry.owner&.name == "Array" } #: as Entry::Method
       assert_match(%r{/gems/rbs-.*/core/array.rbs}, entry.file_path)
       assert_equal("array.rbs", entry.file_name)
-      assert_equal(Entry::Visibility::PUBLIC, entry.visibility)
+      assert_equal(:public, entry.visibility)
 
       # Using fixed positions would be fragile, so let's just check some basics.
       assert_operator(entry.location.start_line, :>, 0)

--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -11,6 +11,13 @@ module RubyIndexer
       @default_indexed_entries = @index.instance_variable_get(:@entries).dup
     end
 
+    def teardown
+      entries = @index.instance_variable_get(:@entries).values.flatten
+      entries.each do |entry|
+        assert_includes([:public, :private, :protected], entry.visibility)
+      end
+    end
+
     private
 
     def index(source, uri: URI::Generic.from_path(path: "/fake/path/foo.rb"))
@@ -31,7 +38,6 @@ module RubyIndexer
           ":#{location.end_line - 1}-#{location.end_column}"
 
       assert_equal(expected_location, location_string)
-
       assert_equal(visibility, entry.visibility) if visibility
     end
 

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -512,7 +512,7 @@ module RubyLsp
         external_references = @node_context.fully_qualified_name != type.name
 
         @index.method_completion_candidates(method_name, type.name).each do |entry|
-          next if entry.visibility != RubyIndexer::Entry::Visibility::PUBLIC && external_references
+          next if entry.visibility != :public && external_references
 
           entry_name = entry.name
           owner_name = entry.owner&.name


### PR DESCRIPTION
### Motivation

Next step after #3439

This PR removes the `T::Enum` used to represent visibility.

### Implementation

I used symbols to represent it instead. I didn't create a constant for the valid values of visibility because I thought that would be overkill, but let me know if you feel differently.