### PR TITLE
Point to local executable directly instead of modifying PATH

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -137,6 +137,12 @@ function getLspExecutables(
       options: executableOptions,
     };
   } else {
+    const workspacePath = workspaceFolder.uri.fsPath;
+    const command =
+      path.basename(workspacePath) === "ruby-lsp" && os.platform() !== "win32"
+        ? path.join(workspacePath, "exe", "ruby-lsp")
+        : "ruby-lsp";
+
     const args = [];
 
     if (branch.length > 0) {
@@ -147,14 +153,9 @@ function getLspExecutables(
       args.push("--use-launcher");
     }
 
-    run = {
-      command: "ruby-lsp",
-      args,
-      options: executableOptions,
-    };
-
+    run = { command, args, options: executableOptions };
     debug = {
-      command: "ruby-lsp",
+      command,
       args: args.concat(["--debug"]),
       options: executableOptions,
     };

--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -193,20 +193,6 @@ export class Ruby implements RubyInterface {
     if (!this.error) {
       this.fetchRubyVersionInfo();
       await this.setupBundlePath();
-
-      // When working on the Ruby LSP itself, we want to use the local version of our executables rather than the ones
-      // globally installed. That allows us to catch mistakes made in the launch process before they are released
-      if (
-        path.basename(this.workspaceFolder.uri.fsPath) === "ruby-lsp" &&
-        os.platform() !== "win32"
-      ) {
-        const localExecutablesUri = vscode.Uri.joinPath(
-          this.workspaceFolder.uri,
-          "exe",
-        );
-
-        this._env.PATH = `${localExecutablesUri.fsPath}${path.delimiter}${this._env.PATH}`;
-      }
     }
   }
 

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-process-env */
 import * as assert from "assert";
 import * as path from "path";
-import os from "os";
 
 import * as vscode from "vscode";
 import sinon from "sinon";
@@ -174,47 +173,6 @@ suite("Ruby environment activation", () => {
 
     assert.deepStrictEqual(ruby.env, { BUNDLE_GEMFILE: ".ruby-lsp/Gemfile" });
   });
-
-  test("Adds local exe directory to PATH when working on the Ruby LSP itself", async () => {
-    if (os.platform() === "win32") {
-      // We don't mutate the path on Windows
-      return;
-    }
-
-    const manager = process.env.CI
-      ? ManagerIdentifier.None
-      : ManagerIdentifier.Chruby;
-
-    const configStub = sinon
-      .stub(vscode.workspace, "getConfiguration")
-      .returns({
-        get: (name: string) => {
-          if (name === "rubyVersionManager") {
-            return { identifier: manager };
-          } else if (name === "bundleGemfile") {
-            return "";
-          }
-
-          return undefined;
-        },
-      } as unknown as vscode.WorkspaceConfiguration);
-
-    const workspacePath = path.dirname(
-      path.dirname(path.dirname(path.dirname(__dirname))),
-    );
-    const lspFolder: vscode.WorkspaceFolder = {
-      uri: vscode.Uri.file(workspacePath),
-      name: path.basename(workspacePath),
-      index: 0,
-    };
-    const ruby = new Ruby(context, lspFolder, outputChannel, FAKE_TELEMETRY);
-    await ruby.activateRuby();
-
-    const firstEntry = ruby.env.PATH!.split(path.delimiter)[0];
-    assert.match(firstEntry, /ruby-lsp\/exe$/);
-
-    configStub.restore();
-  }).timeout(10000);
 
   test("Ignores untrusted workspace for telemetry", async () => {
     const telemetry = { ...FAKE_TELEMETRY, logError: sinon.stub() };


### PR DESCRIPTION
### Motivation

I accidentally noticed that we weren't using the local executable when working on the Ruby LSP repo. I remember testing out our previous approach of adding the `exe` directory to the PATH, but after some more testing it indeed doesn't work. Not sure what happened to be honest.

It's important that we use the local executable when working on the LSP so that we can catch problems with our bundle composition ahead of releasing things.

### Implementation

I removed that old change and switched to just pointing directly at the executable, which works as expected.