### PR TITLE
Differentiate between regular termination and cancellation

### DIFF
--- a/vscode/src/streamingRunner.ts
+++ b/vscode/src/streamingRunner.ts
@@ -85,7 +85,7 @@ export class StreamingRunner implements vscode.Disposable {
       linkedCancellationSource.onCancellationRequested(async () => {
         this.run!.appendOutput("\r\nTest run cancelled.");
         abortController.abort();
-        await this.finalize();
+        await this.finalize(true);
       });
 
       if (mode === Mode.Run) {
@@ -248,8 +248,8 @@ export class StreamingRunner implements vscode.Disposable {
     return server;
   }
 
-  private async finalize() {
-    if (this.currentWorkspace) {
+  private async finalize(cancellation: boolean) {
+    if (cancellation && this.currentWorkspace) {
       // If the tests are being executed in a terminal, send a CTRL+C signal to stop them
       const terminal = this.terminals.get(
         `${this.currentWorkspace.workspaceFolder.name}: test`,
@@ -294,9 +294,8 @@ export class StreamingRunner implements vscode.Disposable {
 
     // Handle the JSON events being emitted by the tests
     this.disposables.push(
-      this.connection.onNotification(
-        NOTIFICATION_TYPES.finish,
-        this.finalize.bind(this),
+      this.connection.onNotification(NOTIFICATION_TYPES.finish, () =>
+        this.finalize(false),
       ),
     );
 


### PR DESCRIPTION
### Motivation

We need to differentiate the finalization of a test run based on whether the tests simply finished running vs the user cancelling them manually.

For the run in terminal profile, we do not want to send a CTRL + C if the tests simply finished running normally as that will mark even successful runs with exit code 1.

### Implementation

Added a parameter to finalize, so that we can differentiate. Stopped sending CTRL + C on cancellations.