### PR TITLE
Remove T::Enum for SorbetLevel

### DIFF
--- a/lib/ruby_lsp/listeners/signature_help.rb
+++ b/lib/ruby_lsp/listeners/signature_help.rb
@@ -6,7 +6,7 @@ module RubyLsp
     class SignatureHelp
       include Requests::Support::Common
 
-      #: (ResponseBuilders::SignatureHelp response_builder, GlobalState global_state, NodeContext node_context, Prism::Dispatcher dispatcher, RubyDocument::SorbetLevel sorbet_level) -> void
+      #: (ResponseBuilders::SignatureHelp response_builder, GlobalState global_state, NodeContext node_context, Prism::Dispatcher dispatcher, SorbetLevel sorbet_level) -> void
       def initialize(response_builder, global_state, node_context, dispatcher, sorbet_level)
         @sorbet_level = sorbet_level
         @response_builder = response_builder
@@ -19,7 +19,7 @@ module RubyLsp
 
       #: (Prism::CallNode node) -> void
       def on_call_node_enter(node)
-        return if sorbet_level_true_or_higher?(@sorbet_level)
+        return if @sorbet_level.true_or_higher?
 
         message = node.message
         return unless message

--- a/lib/ruby_lsp/requests/completion.rb
+++ b/lib/ruby_lsp/requests/completion.rb
@@ -21,7 +21,7 @@ module RubyLsp
         end
       end
 
-      #: ((RubyDocument | ERBDocument) document, GlobalState global_state, Hash[Symbol, untyped] params, RubyDocument::SorbetLevel sorbet_level, Prism::Dispatcher dispatcher) -> void
+      #: ((RubyDocument | ERBDocument) document, GlobalState global_state, Hash[Symbol, untyped] params, SorbetLevel sorbet_level, Prism::Dispatcher dispatcher) -> void
       def initialize(document, global_state, params, sorbet_level, dispatcher)
         super()
         @target = nil #: Prism::Node?

--- a/lib/ruby_lsp/requests/definition.rb
+++ b/lib/ruby_lsp/requests/definition.rb
@@ -11,7 +11,7 @@ module RubyLsp
     class Definition < Request
       extend T::Generic
 
-      #: ((RubyDocument | ERBDocument) document, GlobalState global_state, Hash[Symbol, untyped] position, Prism::Dispatcher dispatcher, RubyDocument::SorbetLevel sorbet_level) -> void
+      #: ((RubyDocument | ERBDocument) document, GlobalState global_state, Hash[Symbol, untyped] position, Prism::Dispatcher dispatcher, SorbetLevel sorbet_level) -> void
       def initialize(document, global_state, position, dispatcher, sorbet_level)
         super()
         @response_builder = ResponseBuilders::CollectionResponseBuilder

--- a/lib/ruby_lsp/requests/hover.rb
+++ b/lib/ruby_lsp/requests/hover.rb
@@ -19,7 +19,7 @@ module RubyLsp
 
       ResponseType = type_member { { fixed: T.nilable(Interface::Hover) } }
 
-      #: ((RubyDocument | ERBDocument) document, GlobalState global_state, Hash[Symbol, untyped] position, Prism::Dispatcher dispatcher, RubyDocument::SorbetLevel sorbet_level) -> void
+      #: ((RubyDocument | ERBDocument) document, GlobalState global_state, Hash[Symbol, untyped] position, Prism::Dispatcher dispatcher, SorbetLevel sorbet_level) -> void
       def initialize(document, global_state, position, dispatcher, sorbet_level)
         super()
 

--- a/lib/ruby_lsp/requests/signature_help.rb
+++ b/lib/ruby_lsp/requests/signature_help.rb
@@ -19,7 +19,7 @@ module RubyLsp
         end
       end
 
-      #: ((RubyDocument | ERBDocument) document, GlobalState global_state, Hash[Symbol, untyped] position, Hash[Symbol, untyped]? context, Prism::Dispatcher dispatcher, RubyDocument::SorbetLevel sorbet_level) -> void
+      #: ((RubyDocument | ERBDocument) document, GlobalState global_state, Hash[Symbol, untyped] position, Hash[Symbol, untyped]? context, Prism::Dispatcher dispatcher, SorbetLevel sorbet_level) -> void
       def initialize(document, global_state, position, context, dispatcher, sorbet_level) # rubocop:disable Metrics/ParameterLists
         super()
 

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -159,11 +159,6 @@ module RubyLsp
             Constant::SymbolKind::FIELD
           end
         end
-
-        #: (RubyDocument::SorbetLevel sorbet_level) -> bool
-        def sorbet_level_true_or_higher?(sorbet_level)
-          sorbet_level == RubyDocument::SorbetLevel::True || sorbet_level == RubyDocument::SorbetLevel::Strict
-        end
       end
     end
   end

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -23,16 +23,6 @@ module RubyLsp
       :private_class_method,
     ].freeze
 
-    class SorbetLevel < T::Enum
-      enums do
-        None = new("none")
-        Ignore = new("ignore")
-        False = new("false")
-        True = new("true")
-        Strict = new("strict")
-      end
-    end
-
     class << self
       #: (Prism::Node node, Integer char_position, code_units_cache: (^(Integer arg0) -> Integer | Prism::CodeUnitsCache), ?node_types: Array[singleton(Prism::Node)]) -> NodeContext
       def locate(node, char_position, code_units_cache:, node_types: [])
@@ -157,26 +147,6 @@ module RubyLsp
     #: -> LanguageId
     def language_id
       LanguageId::Ruby
-    end
-
-    #: -> SorbetLevel
-    def sorbet_level
-      sigil = parse_result.magic_comments.find do |comment|
-        comment.key == "typed"
-      end&.value
-
-      case sigil
-      when "ignore"
-        SorbetLevel::Ignore
-      when "false"
-        SorbetLevel::False
-      when "true"
-        SorbetLevel::True
-      when "strict", "strong"
-        SorbetLevel::Strict
-      else
-        SorbetLevel::None
-      end
     end
 
     #: (Hash[Symbol, untyped] range, ?node_types: Array[singleton(Prism::Node)]) -> Prism::Node?

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -797,12 +797,16 @@ module RubyLsp
       )
     end
 
-    #: (Document[untyped] document) -> RubyDocument::SorbetLevel
+    #: (Document[untyped] document) -> SorbetLevel
     def sorbet_level(document)
-      return RubyDocument::SorbetLevel::Ignore unless @global_state.has_type_checker
-      return RubyDocument::SorbetLevel::Ignore unless document.is_a?(RubyDocument)
+      return SorbetLevel.ignore unless document.is_a?(RubyDocument)
+      return SorbetLevel.ignore unless @global_state.has_type_checker
 
-      document.sorbet_level
+      sigil = document.parse_result.magic_comments.find do |comment|
+        comment.key == "typed"
+      end&.value
+
+      SorbetLevel.new(sigil)
     end
 
     #: (Hash[Symbol, untyped] message) -> void

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -259,4 +259,47 @@ module RubyLsp
       @configuration[:enableAll] || @configuration[feature]
     end
   end
+
+  class SorbetLevel
+    class << self
+      #: -> SorbetLevel
+      def ignore
+        new("ignore")
+      end
+    end
+
+    #: (String?) -> void
+    def initialize(sigil)
+      @level = case sigil
+      when "ignore"
+        :ignore
+      when "false"
+        :false
+      when "true"
+        :true
+      when "strict", "strong"
+        :strict
+      else
+        :none
+      end #: Symbol
+    end
+
+    #: -> bool
+    def ignore? = @level == :ignore
+
+    #: -> bool
+    def false? = @level == :false
+
+    #: -> bool
+    def true? = @level == :true
+
+    #: -> bool
+    def strict? = @level == :strict
+
+    #: -> bool
+    def none? = @level == :none
+
+    #: -> bool
+    def true_or_higher? = @level == :true || @level == :strict
+  end
 end

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -656,66 +656,6 @@ class RubyDocumentTest < Minitest::Test
     assert_equal(value, document.cache_get("textDocument/semanticHighlighting"))
   end
 
-  def test_no_sigil
-    document = RubyLsp::RubyDocument.new(
-      source: +"# frozen_string_literal: true",
-      version: 1,
-      uri: @uri,
-      global_state: @global_state,
-    )
-    assert_equal(RubyLsp::RubyDocument::SorbetLevel::None, document.sorbet_level)
-  end
-
-  def test_sigil_ignore
-    document = RubyLsp::RubyDocument.new(source: +"# typed: ignore", version: 1, uri: @uri, global_state: @global_state)
-    assert_equal(RubyLsp::RubyDocument::SorbetLevel::Ignore, document.sorbet_level)
-  end
-
-  def test_sigil_false
-    document = RubyLsp::RubyDocument.new(source: +"# typed: false", version: 1, uri: @uri, global_state: @global_state)
-    assert_equal(RubyLsp::RubyDocument::SorbetLevel::False, document.sorbet_level)
-  end
-
-  def test_sigil_true
-    document = RubyLsp::RubyDocument.new(source: +"# typed: true", version: 1, uri: @uri, global_state: @global_state)
-    assert_equal(RubyLsp::RubyDocument::SorbetLevel::True, document.sorbet_level)
-  end
-
-  def test_sigil_strict
-    document = RubyLsp::RubyDocument.new(source: +"# typed: strict", version: 1, uri: @uri, global_state: @global_state)
-    assert_equal(RubyLsp::RubyDocument::SorbetLevel::Strict, document.sorbet_level)
-  end
-
-  def test_sigil_strong
-    document = RubyLsp::RubyDocument.new(source: +"# typed: strong", version: 1, uri: @uri, global_state: @global_state)
-    assert_equal(RubyLsp::RubyDocument::SorbetLevel::Strict, document.sorbet_level)
-  end
-
-  def test_sorbet_sigil_only_in_magic_comment
-    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
-      # typed: false
-
-      def foo
-        some_string = "# typed: true"
-      end
-
-      # Shouldn't be tricked by the following comment:
-      # ```
-      # # typed: strict
-      #
-      # def main; end
-      # ```
-      def bar; end
-
-      def baz
-        <<-CODE
-          # typed: strong
-        CODE
-      end
-    RUBY
-    assert_equal(RubyLsp::RubyDocument::SorbetLevel::False, document.sorbet_level)
-  end
-
   def test_locating_compact_namespace_declaration
     document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       class Foo::Bar


### PR DESCRIPTION
### Motivation

Continuing the work from #3442

This PR removes the `T::Enum` that we were using for the Sorbet level.

### Implementation

I created a new object so that we don't have to check for equality against symbols everywhere.