### PR TITLE
Automatically discover children of workspace test items

### DIFF
--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -198,7 +198,9 @@ suite("TestController", () => {
 
     workspaceStubs.push(
       sandbox.stub(vscode.workspace, "getWorkspaceFolder").callsFake((uri) => {
-        return workspaces.find((workspace) => workspace.uri === uri);
+        return workspaces.find((workspace) =>
+          uri.fsPath.startsWith(workspace.uri.fsPath),
+        );
       }),
     );
   }
@@ -573,6 +575,22 @@ suite("TestController", () => {
 
     await controller.findTestItem("ServerTest", serverTestUri);
     assert.ok(serverTest.children.size > 0);
+  });
+
+  test("finding an item inside a workspace test item automatically discovers children", async () => {
+    const firstWorkspace = createWorkspaceWithTestFile();
+    const secondWorkspace = createWorkspaceWithTestFile();
+
+    stubWorkspaceOperations(
+      firstWorkspace.workspaceFolder,
+      secondWorkspace.workspaceFolder,
+    );
+
+    const serverTest = await controller.findTestItem(
+      "ServerTest::NestedTest#test_something",
+      firstWorkspace.testFileUri,
+    );
+    assert.ok(serverTest);
   });
 
   test("running a test", async () => {

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -1173,9 +1173,14 @@ export class TestController {
     if (workspaceFolders.length > 1) {
       workspaceFolder = vscode.workspace.getWorkspaceFolder(uri)!;
 
-      initialCollection = initialCollection.get(
+      const workspaceTestItem = initialCollection.get(
         workspaceFolder.uri.toString(),
-      )!.children;
+      );
+      initialCollection = workspaceTestItem!.children;
+
+      if (initialCollection.size === 0) {
+        await this.resolveHandler(workspaceTestItem);
+      }
     }
 
     // Get the hierarchy levels and find the appropriate test item


### PR DESCRIPTION
### Motivation

Part of the reason why code lens wasn't working in the new test explorer is because we weren't auto discovering children of workspace test items (and the LSP repo itself has multiple workspaces).

### Implementation

Just like we auto discover the workspace items themselves, we need to also do the same for their children.

Note that this only necessary when there are multiple workspaces. With a single one, we eagerly discover.

### Automated Tests

Added a test that fails before the fix.