### PR TITLE
Hook code lens with the new test discovery

### DIFF
--- a/lib/ruby_lsp/requests/support/test_item.rb
+++ b/lib/ruby_lsp/requests/support/test_item.rb
@@ -13,6 +13,12 @@ module RubyLsp
         #: String
         attr_reader :id, :label
 
+        #: URI::Generic
+        attr_reader :uri
+
+        #: Interface::Range
+        attr_reader :range
+
         #: (String id, String label, URI::Generic uri, Interface::Range range, Symbol framework) -> void
         def initialize(id, label, uri, range, framework:)
           @id = id

--- a/lib/ruby_lsp/response_builders/test_collection.rb
+++ b/lib/ruby_lsp/response_builders/test_collection.rb
@@ -8,15 +8,52 @@ module RubyLsp
 
       ResponseType = type_member { { fixed: Requests::Support::TestItem } }
 
+      #: Array[Interface::CodeLens]
+      attr_reader :code_lens
+
       #: -> void
       def initialize
         super
         @items = {} #: Hash[String, ResponseType]
+        @code_lens = [] #: Array[Interface::CodeLens]
       end
 
       #: (ResponseType item) -> void
       def add(item)
         @items[item.id] = item
+      end
+
+      #: (ResponseType item) -> void
+      def add_code_lens(item)
+        range = item.range
+        arguments = [item.uri.to_standardized_path, item.id]
+
+        @code_lens << Interface::CodeLens.new(
+          range: range,
+          command: Interface::Command.new(
+            title: "▶ Run",
+            command: "rubyLsp.runTest",
+            arguments: arguments,
+          ),
+        )
+
+        @code_lens << Interface::CodeLens.new(
+          range: range,
+          command: Interface::Command.new(
+            title: "▶ Run In Terminal",
+            command: "rubyLsp.runTestInTerminal",
+            arguments: arguments,
+          ),
+        )
+
+        @code_lens << Interface::CodeLens.new(
+          range: range,
+          command: Interface::Command.new(
+            title: "⚙ Debug",
+            command: "rubyLsp.debugTest",
+            arguments: arguments,
+          ),
+        )
       end
 
       #: (String id) -> ResponseType?

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -701,7 +701,7 @@ export default class Client extends LanguageClient implements ClientInterface {
 
         if (response) {
           const testLenses = response.filter(
-            (codeLens) => (codeLens as CodeLens).data.type === "test",
+            (codeLens) => (codeLens as CodeLens).data?.type === "test",
           ) as CodeLens[];
 
           if (testLenses.length) {


### PR DESCRIPTION
### Motivation

The code lenses were not yet fully hooked up with the new test discovery mechanism. This PR hooks it up using the same listeners used to discover tests.

### Implementation

To reuse the logic for discovering tests, my proposal is that the test collection builder starts accepting test code lenses. This allows us to capture test related code lenses with minimal changes.

It will also enable us to add a setting to disable the code lenses, which is something users have requested in the past.

Finally, add-ons can easily support this as well.