### PR TITLE
Modify LinkedCancellationSource for asymmetric token cancellation

### DIFF
--- a/vscode/src/linkedCancellationSource.ts
+++ b/vscode/src/linkedCancellationSource.ts
@@ -2,23 +2,20 @@ import * as vscode from "vscode";
 
 export class LinkedCancellationSource implements vscode.Disposable {
   private readonly tokenSource = new vscode.CancellationTokenSource();
-  private readonly disposables: vscode.Disposable[] = [this.tokenSource];
 
   constructor(
     token: vscode.CancellationToken,
     ...additionalTokens: vscode.CancellationToken[]
   ) {
     [token, ...additionalTokens].forEach((token) => {
-      const disposable = token.onCancellationRequested(() => {
+      token.onCancellationRequested(() => {
         this.tokenSource.cancel();
       });
-
-      this.disposables.push(disposable);
     });
   }
 
   dispose() {
-    this.disposables.forEach((disposable) => disposable.dispose());
+    this.tokenSource.dispose();
   }
 
   isCancellationRequested() {
@@ -26,8 +23,6 @@ export class LinkedCancellationSource implements vscode.Disposable {
   }
 
   onCancellationRequested(callback: () => void) {
-    this.disposables.push(
-      this.tokenSource.token.onCancellationRequested(callback),
-    );
+    this.tokenSource.token.onCancellationRequested(callback);
   }
 }

--- a/vscode/src/test/suite/linkendCancellationSource.test.ts
+++ b/vscode/src/test/suite/linkendCancellationSource.test.ts
@@ -1,10 +1,22 @@
 import * as assert from "assert";
 
 import * as vscode from "vscode";
+import sinon from "sinon";
+import { beforeEach, afterEach } from "mocha";
 
 import { LinkedCancellationSource } from "../../linkedCancellationSource";
 
 suite("LinkedCancellationSource", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   test("isCancellationRequested", async () => {
     const cancellationSource = new vscode.CancellationTokenSource();
     const linkedCancellationSource = new LinkedCancellationSource(
@@ -23,5 +35,23 @@ suite("LinkedCancellationSource", () => {
 
     assert.ok(linkedCancellationSource.isCancellationRequested());
     assert.ok(callbackCalled);
+  });
+
+  test("dispose only disposes of the token source ", () => {
+    const cancellationSource = new vscode.CancellationTokenSource();
+    const spy = sandbox.stub();
+    sandbox.stub(cancellationSource, "token").get(() => ({
+      onCancellationRequested: () => {
+        return { dispose: spy };
+      },
+      isCancellationRequested: () => false,
+    }));
+
+    const linkedCancellationSource = new LinkedCancellationSource(
+      cancellationSource.token,
+    );
+
+    linkedCancellationSource.dispose();
+    assert.ok(spy.notCalled);
   });
 });


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

<!-- ### Motivation

 Closes # -->

To support continuous test runs, we need to modify the `LinkedCancellationSource` class to decouple cancellation behaviours between tokens. Previously, cancellation was bidirectionally linked, meaning cancellation of any token would propagate to all linked tokens.

For continuous runs, we need asymmetric cancellation behaviour: we want to propagate cancellation from request tokens to our run token, but not have cancellation propagate back from the run token to the request token.

Continuous test run support will be implemented in #3451
<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

<!--### Implementation

 How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

<!-- ### Automated Tests

We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

<!--### Manual Tests

 Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
