### PR TITLE
Fix Index.constant_name crashing on dynamic constant paths

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -36,12 +36,10 @@ module RubyIndexer
 
       # Returns the unresolved name for a constant reference including all parts of a constant path, or `nil` if the
       # constant contains dynamic or incomplete parts
-      #: ((Prism::ConstantPathNode | Prism::ConstantReadNode | Prism::ConstantPathTargetNode | Prism::CallNode | Prism::MissingNode) node) -> String?
+      #: (Prism::Node) -> String?
       def constant_name(node)
         case node
-        when Prism::CallNode, Prism::MissingNode
-          nil
-        else
+        when Prism::ConstantPathNode, Prism::ConstantReadNode, Prism::ConstantPathTargetNode
           node.full_name
         end
       rescue Prism::ConstantPathNode::DynamicPartsInConstantPathError,

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -2185,6 +2185,13 @@ module RubyIndexer
 
       node = Prism.parse("class Foo; end").value.statements.body.first.constant_path
       assert_equal("Foo", Index.constant_name(node))
+
+      node = Prism.parse(<<~RUBY).value.statements.body.first.constant_path
+        class class Foo
+        end
+        end
+      RUBY
+      assert_nil(Index.constant_name(node))
     end
   end
 end


### PR DESCRIPTION
### Motivation

There was a bug in our implementation of constant_name, which we usually use to pass a module's or class' `constant_path`.

We were assuming only certain possible nodes inside, but the reality is that you can have pretty much anything inside.

### Implementation

We should consider it a generic `Prism::Node` and then treat only the cases we're interested in.

### Automated Tests

Added a test that reproduces an issue where a class' `constant_path` is another `Prism::ClassNode`, which happens if you have

```ruby
class class Foo
end
end
```