### PR TITLE
Remove T::Enum for language ID

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -3,14 +3,6 @@
 
 module RubyLsp
   class Document
-    class LanguageId < T::Enum
-      enums do
-        Ruby = new("ruby")
-        ERB = new("erb")
-        RBS = new("rbs")
-      end
-    end
-
     extend T::Sig
     extend T::Helpers
     extend T::Generic
@@ -71,7 +63,7 @@ module RubyLsp
       self.class == other.class && uri == other.uri && @source == other.source
     end
 
-    sig { abstract.returns(LanguageId) }
+    sig { abstract.returns(Symbol) }
     def language_id; end
 
     #: [T] (String request_name) { (Document[ParseResultType] document) -> T } -> T

--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -46,9 +46,9 @@ module RubyLsp
     end
 
     # @override
-    #: -> LanguageId
+    #: -> Symbol
     def language_id
-      LanguageId::ERB
+      :erb
     end
 
     #: (Hash[Symbol, untyped] position, ?node_types: Array[singleton(Prism::Node)]) -> NodeContext

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -8,7 +8,7 @@ module RubyLsp
 
       MAX_NUMBER_OF_DEFINITION_CANDIDATES_WITHOUT_RECEIVER = 10
 
-      #: (ResponseBuilders::CollectionResponseBuilder[(Interface::Location | Interface::LocationLink)] response_builder, GlobalState global_state, Document::LanguageId language_id, URI::Generic uri, NodeContext node_context, Prism::Dispatcher dispatcher, SorbetLevel sorbet_level) -> void
+      #: (ResponseBuilders::CollectionResponseBuilder[(Interface::Location | Interface::LocationLink)] response_builder, GlobalState global_state, Symbol language_id, URI::Generic uri, NodeContext node_context, Prism::Dispatcher dispatcher, SorbetLevel sorbet_level) -> void
       def initialize(response_builder, global_state, language_id, uri, node_context, dispatcher, sorbet_level) # rubocop:disable Metrics/ParameterLists
         @response_builder = response_builder
         @global_state = global_state
@@ -62,7 +62,7 @@ module RubyLsp
 
         # Until we can properly infer the receiver type in erb files (maybe with ruby-lsp-rails),
         # treating method calls' type as `nil` will allow users to get some completion support first
-        if @language_id == Document::LanguageId::ERB && inferrer_receiver_type&.name == "Object"
+        if @language_id == :erb && inferrer_receiver_type&.name == "Object"
           inferrer_receiver_type = nil
         end
 

--- a/lib/ruby_lsp/rbs_document.rb
+++ b/lib/ruby_lsp/rbs_document.rb
@@ -36,9 +36,9 @@ module RubyLsp
     end
 
     # @override
-    #: -> LanguageId
+    #: -> Symbol
     def language_id
-      LanguageId::RBS
+      :rbs
     end
   end
 end

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -144,9 +144,9 @@ module RubyLsp
     end
 
     # @override
-    #: -> LanguageId
+    #: -> Symbol
     def language_id
-      LanguageId::Ruby
+      :ruby
     end
 
     #: (Hash[Symbol, untyped] range, ?node_types: Array[singleton(Prism::Node)]) -> Prism::Node?

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -387,11 +387,11 @@ module RubyLsp
         text_document = message.dig(:params, :textDocument)
         language_id = case text_document[:languageId]
         when "erb", "eruby"
-          Document::LanguageId::ERB
+          :erb
         when "rbs"
-          Document::LanguageId::RBS
+          :rbs
         else
-          Document::LanguageId::Ruby
+          :ruby
         end
 
         document = @store.set(

--- a/lib/ruby_lsp/store.rb
+++ b/lib/ruby_lsp/store.rb
@@ -38,11 +38,11 @@ module RubyLsp
       ext = File.extname(path)
       language_id = case ext
       when ".erb", ".rhtml"
-        Document::LanguageId::ERB
+        :erb
       when ".rbs"
-        Document::LanguageId::RBS
+        :rbs
       else
-        Document::LanguageId::Ruby
+        :ruby
       end
 
       set(uri: uri, source: File.binread(path), version: 0, language_id: language_id)
@@ -51,12 +51,12 @@ module RubyLsp
       raise NonExistingDocumentError, uri.to_s
     end
 
-    #: (uri: URI::Generic, source: String, version: Integer, language_id: Document::LanguageId) -> Document[untyped]
+    #: (uri: URI::Generic, source: String, version: Integer, language_id: Symbol) -> Document[untyped]
     def set(uri:, source:, version:, language_id:)
       @state[uri.to_s] = case language_id
-      when Document::LanguageId::ERB
+      when :erb
         ERBDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
-      when Document::LanguageId::RBS
+      when :rbs
         RBSDocument.new(source: source, version: version, uri: uri, global_state: @global_state)
       else
         RubyDocument.new(source: source, version: version, uri: uri, global_state: @global_state)

--- a/test/requests/rename_test.rb
+++ b/test/requests/rename_test.rb
@@ -84,7 +84,7 @@ class RenameTest < Minitest::Test
       end
     RUBY
     global_state.index.index_single(untitled_uri, untitled_source)
-    store.set(uri: untitled_uri, source: untitled_source, version: 1, language_id: RubyLsp::Document::LanguageId::Ruby)
+    store.set(uri: untitled_uri, source: untitled_source, version: 1, language_id: :ruby)
 
     document = RubyLsp::RubyDocument.new(
       source: source,

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -11,7 +11,7 @@ class StoreTest < Minitest::Test
       uri: URI::Generic.from_path(path: "/foo/bar.rb"),
       source: "def foo; end",
       version: 1,
-      language_id: RubyLsp::Document::LanguageId::Ruby,
+      language_id: :ruby,
     )
   end
 
@@ -56,7 +56,7 @@ class StoreTest < Minitest::Test
 
   def test_handling_uris_with_spaces
     uri = URI("file:///foo%20bar/baz.rb")
-    @store.set(uri: uri, source: "def foo; end", version: 1, language_id: RubyLsp::Document::LanguageId::Ruby)
+    @store.set(uri: uri, source: "def foo; end", version: 1, language_id: :ruby)
 
     assert_equal(
       RubyLsp::RubyDocument.new(source: "def foo; end", version: 1, uri: uri, global_state: @global_state),
@@ -66,7 +66,7 @@ class StoreTest < Minitest::Test
 
   def test_handling_uris_for_unsaved_files
     uri = URI("untitled:Untitled-1")
-    @store.set(uri: uri, source: "def foo; end", version: 1, language_id: RubyLsp::Document::LanguageId::Ruby)
+    @store.set(uri: uri, source: "def foo; end", version: 1, language_id: :ruby)
 
     assert_equal(
       RubyLsp::RubyDocument.new(source: "def foo; end", version: 1, uri: uri, global_state: @global_state),
@@ -81,8 +81,8 @@ class StoreTest < Minitest::Test
     path = "/foo/bar.rb"
     file_uri = URI("file://#{path}")
     git_uri = URI("git://#{path}")
-    @store.set(uri: file_uri, source: "def foo; end", version: 1, language_id: RubyLsp::Document::LanguageId::Ruby)
-    @store.set(uri: git_uri, source: "def foo; end", version: 1, language_id: RubyLsp::Document::LanguageId::Ruby)
+    @store.set(uri: file_uri, source: "def foo; end", version: 1, language_id: :ruby)
+    @store.set(uri: git_uri, source: "def foo; end", version: 1, language_id: :ruby)
 
     refute_same(@store.get(file_uri), @store.get(git_uri))
 
@@ -158,7 +158,7 @@ class StoreTest < Minitest::Test
     assert_equal(1, counter)
 
     # After the entry in the storage is updated, the cache is invalidated
-    @store.set(uri: uri, source: "def bar; end", version: 1, language_id: RubyLsp::Document::LanguageId::Ruby)
+    @store.set(uri: uri, source: "def bar; end", version: 1, language_id: :ruby)
     5.times do
       @store.cache_fetch(uri, "textDocument/foldingRange") do
         counter += 1
@@ -170,7 +170,7 @@ class StoreTest < Minitest::Test
 
   def test_push_edits
     uri = URI("file:///foo/bar.rb")
-    @store.set(uri: uri, source: +"def bar; end", version: 1, language_id: RubyLsp::Document::LanguageId::Ruby)
+    @store.set(uri: uri, source: +"def bar; end", version: 1, language_id: :ruby)
 
     # Write puts 'a' in incremental edits
     @store.push_edits(


### PR DESCRIPTION
### Motivation

This PR removes the last `T::Enum` from our codebase, the one for language ID.

### Implementation

Swapped it for symbols.