### PR TITLE
Log full backtrace on diagnostic and formatting crashes

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -674,6 +674,10 @@ module RubyLsp
         "Formatting error: #{error.message}",
         type: Constant::MessageType::ERROR,
       ))
+      send_message(Notification.window_log_message(
+        "Formatting failed with\r\n: #{error.full_message}",
+        type: Constant::MessageType::ERROR,
+      ))
       send_empty_response(message[:id])
     end
 
@@ -917,6 +921,10 @@ module RubyLsp
     rescue StandardError, LoadError => error
       send_message(Notification.window_show_message(
         "Error running diagnostics: #{error.message}",
+        type: Constant::MessageType::ERROR,
+      ))
+      send_message(Notification.window_log_message(
+        "Diagnostics failed with\r\n: #{error.full_message}",
         type: Constant::MessageType::ERROR,
       ))
       send_empty_response(message[:id])


### PR DESCRIPTION
### Motivation

As suggested [here](https://github.com/Shopify/ruby-lsp/issues/3260#issuecomment-2695960573), we really should log the entire backtrace of formatting/diagnostic crashes - otherwise it's pretty difficult to figure out which cop broke and how.

### Implementation

Started sending a log message including the full backtrace.