### PR TITLE
Ensure store test is empty before resolving in tests

### DIFF
--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -429,6 +429,7 @@ suite("TestController", () => {
     };
 
     sandbox.stub(workspace, "lspClient").value(fakeClient);
+    storeTest.children.replace([]);
     await controller.testController.resolveHandler!(storeTest);
 
     const excludedExample = await controller.findTestItem(


### PR DESCRIPTION
This one test example is a bit flaky. When we invoke `resolveHandler(undefined)` to start discovering test items, the process will randomly pick a single file to resolve ahead of time to discover the test framework associated. If it picks the store test, we end up populating it before we switch the stub, which is not what we want.

We can make the tests significantly more robust by clearing the children of the store test file, which ensures that it will be resolved to what we expect.