### PR TITLE
Add refresh support to the test explorer

### DIFF
--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -898,4 +898,22 @@ suite("TestController", () => {
     assert.ok(runStub.passed.calledWith(testItem));
     assert.ok(runStub.end.calledWithExactly());
   }).timeout(10000);
+
+  test("refresh handler clears all items and starts from scratch", async () => {
+    await controller.testController.resolveHandler!(undefined);
+    assert.ok(controller.testController.items.size > 0);
+
+    const replaceSpy = sandbox.spy(controller.testController.items, "replace");
+    const resolveHandlerStub = sandbox.stub().resolves(true);
+    controller.testController.resolveHandler = resolveHandlerStub;
+
+    const source = new vscode.CancellationTokenSource();
+    await controller.testController.refreshHandler!(source.token);
+
+    assert.ok(replaceSpy.calledOnce);
+    assert.ok(replaceSpy.calledWith([]));
+    assert.ok(resolveHandlerStub.calledOnce);
+
+    source.dispose();
+  });
 });

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -86,6 +86,7 @@ export class TestController {
 
     if (this.fullDiscovery) {
       this.testController.resolveHandler = this.resolveHandler.bind(this);
+      this.testController.refreshHandler = this.refreshHandler.bind(this);
     }
 
     this.testCommands = new WeakMap<vscode.TestItem, string>();
@@ -508,6 +509,12 @@ export class TestController {
 
   get streamingPort() {
     return this.runner.tcpPort;
+  }
+
+  private async refreshHandler(_token: vscode.CancellationToken) {
+    this.testController.items.replace([]);
+    this.testController.invalidateTestResults();
+    await this.testController.resolveHandler!(undefined);
   }
 
   private async handleTests(


### PR DESCRIPTION
### Motivation

Adding refresh support to the test explorer is pretty straight forward, so I think it's worth doing in terms of completeness. It also gives users the chance to re-discover tests if by any chance something goes wrong during discovery.

### Implementation

All we have to do is delete all test items and then trigger discovery from scratch. I also invalidated previous test results as a part of it.

### Automated Tests

Added a test.