### PR TITLE
Avoid resetting framework tag if finding a file with no tests

### DIFF
--- a/vscode/src/streamingRunner.ts
+++ b/vscode/src/streamingRunner.ts
@@ -297,10 +297,10 @@ export class StreamingRunner implements vscode.Disposable {
       this.connection.dispose();
     }
 
-    if (this.run!.name === "on_demand_run_in_terminal") {
-      this.run!.end();
+    if (this.run && this.run.name === "on_demand_run_in_terminal") {
+      this.run.end();
+      this.run = undefined;
     }
-    this.run = undefined;
 
     this.executionPromise!.resolve();
   }

--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -965,4 +965,56 @@ suite("TestController", () => {
       dynamicallyDefinedNestedTest.label,
     );
   });
+
+  test("finding a file with no tests inside doesn't reset framework tag", async () => {
+    const discoverTestsStub = sandbox
+      .stub()
+      .onFirstCall()
+      .resolves([
+        {
+          id: "StoreTest",
+          uri: storeTestUri.toString(),
+          label: "StoreTest",
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 30, character: 3 },
+          },
+          tags: ["framework:minitest"],
+          children: [
+            {
+              id: "StoreTest#test_store",
+              uri: storeTestUri.toString(),
+              label: "test_store",
+              range: {
+                start: { line: 1, character: 2 },
+                end: { line: 10, character: 3 },
+              },
+              tags: ["framework:minitest"],
+              children: [],
+            },
+          ],
+        },
+      ])
+      .onSecondCall()
+      .resolves([]);
+
+    const fakeClient = {
+      discoverTests: discoverTestsStub,
+      waitForIndexing: sinon.stub().resolves(),
+      initializeResult: {
+        capabilities: {
+          experimental: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            full_test_discovery: true,
+          },
+        },
+      },
+    };
+
+    sandbox.stub(workspace, "lspClient").value(fakeClient);
+
+    await assert.doesNotReject(async () => {
+      await controller.testController.resolveHandler!(undefined);
+    });
+  });
 });


### PR DESCRIPTION
### Motivation

When discovering tests, we may end up finding a file that looks like a test, but doesn't actually define any inside. For example, `test_config.rb`.

When we find those, the children for the file will be empty, which means there will be no framework tag to associate with its parent items.

We should not reset a previously discovered framework tag when this happens and we should remove this file from the tree - since you can't actually execute it.

### Implementation

1. Started reusing the previous tag if no new ones were found
2. If we try to eager resolve a test file and it has no children, then we can remove the item from the tree
3. I also noticed a logic bug where we were returning the first level test item as the second level if we couldn't find any second levels for the hierarchy. This is wrong and we should just return `undefined`
4. Finally, I started checking if `test.run` is present before finalizing it because under certain conditions it may actually reach that point being `undefined`


### Automated Tests

Added a test.