### PR TITLE
Allow disabling the Sorbet detection via config

### DIFF
--- a/jekyll/editors.markdown
+++ b/jekyll/editors.markdown
@@ -78,7 +78,8 @@ configuration languages (JSON, Lua, ELisp, etc.).
       "inlayHint": {
         "implicitHashValue": true,
         "implicitRescue": true
-      }
+      },
+      "typeCheckerIntegration": "defer"
     },
     "indexing": {
       "excludedPatterns": ["path/to/excluded/file.rb"],


### PR DESCRIPTION
### Motivation

When configuring editors other than VS Code (e.g. Zed or Emacs), sometimes running multiple LSPs isn't an option. This means that Sorbet-enabled projects aren't able to run both Ruby LSP and Sorbet LSP.

In those cases, it's convenient to be able to disable the deference for some features to the type checker LSP. Prior to this change, you could accomplish this by setting the `RUBY_LSP_BYPASS_TYPECHECKER` environment variable, which works but isn't the easiest thing to do in all cases (e.g. you can't launch Zed from Spotlight unless you globally set this value, which then disables Sorbet deference in _all_ projects).

Instead of hiding this behavior behind an environment variable, this change makes it configurable via an initialization option.

### Implementation

This change introduces a new initialization option for disabling the automatic detection of a type checker. This behavior was initially implemented through an environment variable (which this change maintains for backwards-compatibility), but that isn't the easiest thing to configure.

By making it a part of initialization, we can now declaratively set the flag with all other configuration for the server.

I went with the naming of "defer" and "bypass" because the default behavior is to defer some functionality to the type checker and the alternative is to bypass with it. While these are communicative, I'm unsure if they're discoverable.

### Automated Tests

I added all cases for this behavior to the `GlobalState` test suite.

### Manual Tests

Use this configuration in a Sorbet-enabled project:

```json
{
  "initializationOptions": {
    "featuresConfiguration": {
      "typeCheckerIntegration": "bypass"
    }
  }
}
```

and observe that Ruby LSP handles go-to-symbol and workspace symbols.