### PR TITLE
Only load from `cgi` what is required

### DIFF
--- a/lib/ruby_lsp/internal.rb
+++ b/lib/ruby_lsp/internal.rb
@@ -14,7 +14,7 @@ Bundler.ui.level = :silent
 
 require "json"
 require "uri"
-require "cgi"
+require "cgi/escape"
 require "set"
 require "strscan"
 require "prism"


### PR DESCRIPTION
### Motivation
In ruby 3.5 most of the functionality will require adding cgi as a dependency.

Only escape/unescape functions will remain, which is all that's needed here.. `cgi/escape` behaves as expected since Ruby 2.4.

https://bugs.ruby-lang.org/issues/21258.

### Implementation

Only load what is required.

### Automated Tests

Not much to test here.

### Manual Tests

Ran with ruby-dev, fixed other requires of `cgi` in other gems until no warning are emitted anymore.
