### PR TITLE
Resolve test code lenses lazily for better performance

### DIFF
--- a/lib/ruby_lsp/requests/code_lens.rb
+++ b/lib/ruby_lsp/requests/code_lens.rb
@@ -14,7 +14,7 @@ module RubyLsp
       class << self
         #: -> Interface::CodeLensOptions
         def provider
-          Interface::CodeLensOptions.new(resolve_provider: false)
+          Interface::CodeLensOptions.new(resolve_provider: true)
         end
       end
 

--- a/lib/ruby_lsp/response_builders/test_collection.rb
+++ b/lib/ruby_lsp/response_builders/test_collection.rb
@@ -31,29 +31,17 @@ module RubyLsp
 
         @code_lens << Interface::CodeLens.new(
           range: range,
-          command: Interface::Command.new(
-            title: "▶ Run",
-            command: "rubyLsp.runTest",
-            arguments: arguments,
-          ),
+          data: { arguments: arguments, kind: "run_test" },
         )
 
         @code_lens << Interface::CodeLens.new(
           range: range,
-          command: Interface::Command.new(
-            title: "▶ Run in terminal",
-            command: "rubyLsp.runTestInTerminal",
-            arguments: arguments,
-          ),
+          data: { arguments: arguments, kind: "run_test_in_terminal" },
         )
 
         @code_lens << Interface::CodeLens.new(
           range: range,
-          command: Interface::Command.new(
-            title: "⚙ Debug",
-            command: "rubyLsp.debugTest",
-            arguments: arguments,
-          ),
+          data: { arguments: arguments, kind: "debug_test" },
         )
       end
 

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -32,6 +32,8 @@ module RubyLsp
         text_document_document_link(message)
       when "textDocument/codeLens"
         text_document_code_lens(message)
+      when "codeLens/resolve"
+        code_lens_resolve(message)
       when "textDocument/semanticTokens/full"
         text_document_semantic_tokens_full(message)
       when "textDocument/semanticTokens/full/delta"
@@ -1511,6 +1513,27 @@ module RubyLsp
           commands: commands,
           reporterPaths: [Listeners::TestStyle::MINITEST_REPORTER_PATH, Listeners::TestStyle::TEST_UNIT_REPORTER_PATH],
         },
+      ))
+    end
+
+    #: (Hash[Symbol, untyped] message) -> void
+    def code_lens_resolve(message)
+      code_lens = message[:params]
+      args = code_lens.dig(:data, :arguments)
+
+      case code_lens.dig(:data, :kind)
+      when "run_test"
+        code_lens[:command] = Interface::Command.new(title: "▶ Run", command: "rubyLsp.runTest", arguments: args)
+      when "run_test_in_terminal"
+        code_lens[:command] =
+          Interface::Command.new(title: "▶ Run in terminal", command: "rubyLsp.runTestInTerminal", arguments: args)
+      when "debug_test"
+        code_lens[:command] = Interface::Command.new(title: "⚙ Debug", command: "rubyLsp.debugTest", arguments: args)
+      end
+
+      send_message(Result.new(
+        id: message[:id],
+        response: code_lens,
       ))
     end
   end

--- a/test/requests/discover_tests_test.rb
+++ b/test/requests/discover_tests_test.rb
@@ -129,51 +129,51 @@ module RubyLsp
         assert_equal(9, items.length)
 
         # MyTest
-        assert_equal("▶ Run", items[0].command.title)
+        assert_equal("run_test", items[0].data[:kind])
         assert_equal(
           { start: { line: 1, character: 2 }, end: { line: 1, character: 3 } },
           JSON.parse(items[0].range.to_json, symbolize_names: true),
         )
-        assert_equal("▶ Run in terminal", items[1].command.title)
+        assert_equal("run_test_in_terminal", items[1].data[:kind])
         assert_equal(
           { start: { line: 1, character: 2 }, end: { line: 1, character: 3 } },
           JSON.parse(items[1].range.to_json, symbolize_names: true),
         )
-        assert_equal("⚙ Debug", items[2].command.title)
+        assert_equal("debug_test", items[2].data[:kind])
         assert_equal(
           { start: { line: 1, character: 2 }, end: { line: 1, character: 3 } },
           JSON.parse(items[2].range.to_json, symbolize_names: true),
         )
 
         # test_something
-        assert_equal("▶ Run", items[3].command.title)
+        assert_equal("run_test", items[3].data[:kind])
         assert_equal(
           { start: { line: 2, character: 4 }, end: { line: 2, character: 5 } },
           JSON.parse(items[3].range.to_json, symbolize_names: true),
         )
-        assert_equal("▶ Run in terminal", items[4].command.title)
+        assert_equal("run_test_in_terminal", items[4].data[:kind])
         assert_equal(
           { start: { line: 2, character: 4 }, end: { line: 2, character: 5 } },
           JSON.parse(items[4].range.to_json, symbolize_names: true),
         )
-        assert_equal("⚙ Debug", items[5].command.title)
+        assert_equal("debug_test", items[5].data[:kind])
         assert_equal(
           { start: { line: 2, character: 4 }, end: { line: 2, character: 5 } },
           JSON.parse(items[5].range.to_json, symbolize_names: true),
         )
 
         # test_something_else
-        assert_equal("▶ Run", items[6].command.title)
+        assert_equal("run_test", items[6].data[:kind])
         assert_equal(
           { start: { line: 4, character: 4 }, end: { line: 4, character: 5 } },
           JSON.parse(items[6].range.to_json, symbolize_names: true),
         )
-        assert_equal("▶ Run in terminal", items[7].command.title)
+        assert_equal("run_test_in_terminal", items[7].data[:kind])
         assert_equal(
           { start: { line: 4, character: 4 }, end: { line: 4, character: 5 } },
           JSON.parse(items[7].range.to_json, symbolize_names: true),
         )
-        assert_equal("⚙ Debug", items[8].command.title)
+        assert_equal("debug_test", items[8].data[:kind])
         assert_equal(
           { start: { line: 4, character: 4 }, end: { line: 4, character: 5 } },
           JSON.parse(items[8].range.to_json, symbolize_names: true),

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1527,6 +1527,72 @@ class ServerTest < Minitest::Test
     assert_empty(@server.global_state.index.instance_variable_get(:@ancestors))
   end
 
+  def test_code_lens_resolve_populates_run_test_command
+    arguments = ["/workspace/test/foo_test.rb", "FooTest#test_something"]
+    @server.process_message({
+      id: 1,
+      method: "codeLens/resolve",
+      params: {
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        data: {
+          kind: "run_test",
+          arguments: arguments,
+        },
+      },
+    })
+
+    result = find_message(RubyLsp::Result, id: 1)
+    command = result.response[:command]
+
+    assert_equal("▶ Run", command.title)
+    assert_equal("rubyLsp.runTest", command.command)
+    assert_equal(arguments, command.arguments)
+  end
+
+  def test_code_lens_resolve_populates_run_test_in_terminal_command
+    arguments = ["/workspace/test/foo_test.rb", "FooTest#test_something"]
+    @server.process_message({
+      id: 1,
+      method: "codeLens/resolve",
+      params: {
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        data: {
+          kind: "run_test_in_terminal",
+          arguments: arguments,
+        },
+      },
+    })
+
+    result = find_message(RubyLsp::Result, id: 1)
+    command = result.response[:command]
+
+    assert_equal("▶ Run in terminal", command.title)
+    assert_equal("rubyLsp.runTestInTerminal", command.command)
+    assert_equal(arguments, command.arguments)
+  end
+
+  def test_code_lens_resolve_populates_debug_test_command
+    arguments = ["/workspace/test/foo_test.rb", "FooTest#test_something"]
+    @server.process_message({
+      id: 1,
+      method: "codeLens/resolve",
+      params: {
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        data: {
+          kind: "debug_test",
+          arguments: arguments,
+        },
+      },
+    })
+
+    result = find_message(RubyLsp::Result, id: 1)
+    command = result.response[:command]
+
+    assert_equal("⚙ Debug", command.title)
+    assert_equal("rubyLsp.debugTest", command.command)
+    assert_equal(arguments, command.arguments)
+  end
+
   private
 
   def wait_for_indexing


### PR DESCRIPTION
### Motivation

This PR makes test related code lenses be resolved lazily. When we first implemented code lens, we missed the point in the [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeLens) that mentions lazy resolution provides better performance.

My understanding is that the editor will use the range to reserve visual space for the lenses and then only shows the actual text when they are within the visible area of the file - allowing the editor to handle less data at a time.

### Implementation

Similar to all resolve requests, we pass the information we need between discovery and resolution in the `data` attribute and then use that to populate the lazy attributes.

Note that the client will only try to resolve lenses that don't have a `command` associated to them. If add-ons are pushing lenses that include the command directly, those are already considered resolve. In other words, this is not a breaking change.

### Automated Tests

Added tests.