### PR TITLE
Exclude non-workspace coverage data

### DIFF
--- a/lib/ruby_lsp/test_reporters/lsp_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/lsp_reporter.rb
@@ -126,10 +126,9 @@ module RubyLsp
     def gather_coverage_results
       # Ignore coverage results inside dependencies
       bundle_path = Bundler.bundle_path.to_s
-      default_gems_path = File.dirname(RbConfig::CONFIG["rubylibdir"])
 
       result = Coverage.result.reject do |file_path, _coverage_info|
-        file_path.start_with?(bundle_path, default_gems_path, "eval")
+        file_path.start_with?(bundle_path) || !file_path.start_with?(Dir.pwd)
       end
 
       result.to_h do |file_path, coverage_info|

--- a/test/test_reporters/lsp_reporter_test.rb
+++ b/test/test_reporters/lsp_reporter_test.rb
@@ -9,8 +9,15 @@ module RubyLsp
   class LspReporterTest < Minitest::Test
     def test_coverage_results_are_formatted_as_vscode_expects
       path = "/path/to/file.rb"
+      Dir.expects(:pwd).returns("/path/to").at_least_once
       Coverage.expects(:result).returns({
         path => {
+          lines: [1, 2, 3, nil],
+          branches: {
+            ["&.", 0, 2, 2, 3, 6] => { [:then, 1, 2, 2, 2, 6] => 0, [:else, 3, 3, 2, 3, 6] => 1 },
+          },
+        },
+        "/unrelated/file.rb" => {
           lines: [1, 2, 3, nil],
           branches: {
             ["&.", 0, 2, 2, 3, 6] => { [:then, 1, 2, 2, 2, 6] => 0, [:else, 3, 3, 2, 3, 6] => 1 },


### PR DESCRIPTION
### Motivation

While doing more manual testing, I noticed that we always get coverage data from sources that are not interesting to the user.

For example, because our LSP reporters are hooked into the test run, they show up in coverage data. Similarly, we get some random evals that end up happening somewhere.

These are not useful at all to the user trying to measure coverage in their project, so I think they should be excluded.

### Implementation

Started excluding anything that isn't inside of the `Dir.pwd` where the tests are running. Note that we still need to do the `Bundler.bundle_path` check, because the user may have configured that to be inside of the workspace (e.g.: vendor/bundle).

### Automated Tests

Adapted our existing test.