### PR TITLE
Use remaining path as test file label

### DIFF
--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -1123,18 +1123,16 @@ export class TestController {
       initialCollection,
     );
 
-    const finalCollection = secondLevel
-      ? secondLevel.children
-      : firstLevel.children;
-
+    const finalItem = secondLevel ?? firstLevel;
     const testItem = this.testController.createTestItem(
       uri.toString(),
-      fileName,
+      path.relative(finalItem.uri!.fsPath, uri.fsPath),
       uri,
     );
+
     testItem.canResolveChildren = true;
     testItem.tags = [TEST_FILE_TAG, DEBUG_TAG];
-    finalCollection.add(testItem);
+    finalItem.children.add(testItem);
 
     return { firstLevel, secondLevel, testItem };
   }


### PR DESCRIPTION
### Motivation

We were using just the file name as the label of the test item. That's not ideal because sometimes there are test files with the same name, but under different directories.

This PR starts using the relative path from the previous level in the test tree as the label, which removes the ambiguity.

For example, for a test file in `domains/indexer/test/models/namespaces/class_test.rb`

```ruby
# Before

domains/indexer/test # first level
  models # second level
    class_test.rb

# After

domains/indexer/test # first level
  models # second level
    namespaces/class_test.rb
```