### PR TITLE
Bring back `extend T::Generic` for add-on API classes

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -6,6 +6,7 @@ module RubyLsp
   class Document
     extend T::Sig
     extend T::Helpers
+    extend T::Generic
 
     class LocationNotFoundError < StandardError; end
 

--- a/lib/ruby_lsp/response_builders/response_builder.rb
+++ b/lib/ruby_lsp/response_builders/response_builder.rb
@@ -6,6 +6,7 @@ module RubyLsp
     class ResponseBuilder
       extend T::Sig
       extend T::Helpers
+      extend T::Generic
 
       abstract!
 


### PR DESCRIPTION
### Motivation

We can't remove the `extend T::Generic` statements from classes that are involved in the public add-on API without marking it as a breaking change. If the add-on is using Sorbet and puts an inline signature in the code referencing a generic class, it will crash because the `self.[]` method no longer exists.

This is unfortunately happening in v0.23.18 for the Rails (for users who haven't upgraded) and RSpec add-ons. I think we should bring back the `extend T::Generic` and ship a new version to avoid the crashes.

Then we mark the removal of these as a breaking changes, so that upgrades happen smoothly.