### PR TITLE
Use a progress middleware for indexing promise

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -28,7 +28,6 @@ import {
   FeatureState,
   ServerCapabilities,
   ErrorCodes,
-  WorkDoneProgress,
 } from "vscode-languageclient/node";
 
 import {
@@ -436,16 +435,17 @@ export default class Client extends LanguageClient implements ClientInterface {
     );
 
     this.indexingPromise = new Promise<void>((resolve) => {
-      const disposable = this.onProgress(
-        WorkDoneProgress.type,
-        "indexing-progress",
-        (value: any) => {
-          if (value.kind === "end") {
-            disposable.dispose();
-            resolve();
-          }
-        },
-      );
+      this.clientOptions.middleware!.handleWorkDoneProgress = (
+        token,
+        params,
+        next,
+      ) => {
+        if (token.toString() === "indexing-progress" && params.kind === "end") {
+          resolve();
+        }
+
+        next(token, params);
+      };
     });
   }
 


### PR DESCRIPTION
### Motivation

I noticed that I stopped seeing the indexing progress on the VS Code window. It turns out that calling `onProgress` will actually override the default behaviour of the client and make it not show in the status bar.

### Implementation

We can implement the indexing promise with a middleware instead, which achieves the same result without overriding the default behavior.

### Automated Tests

Current tests should cover it.