### PR TITLE
Ensure that Test Unit's finish summary is printed

### DIFF
--- a/lib/ruby_lsp/test_reporters/test_unit_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/test_unit_reporter.rb
@@ -59,6 +59,7 @@ module RubyLsp
 
     #: (Float) -> void
     def finished(elapsed_time)
+      super
       LspReporter.instance.shutdown
     end
 

--- a/test/test_reporters/test_unit_reporter_test.rb
+++ b/test/test_reporters/test_unit_reporter_test.rb
@@ -141,6 +141,7 @@ module RubyLsp
 
       io = output == :stdout ? stdout : stderr
       refute_empty(io.read)
+
       events
     end
   end


### PR DESCRIPTION
### Motivation

We were not invoking `super` inside the `finished` event, which means the summary at the end of the run never printed.

### Implementation

We just need to invoker `super` to get the parent class' behaviour.

### Automated Tests

Added a test that checks if the pass percentage was printed, which is part of the summary.