### PR TITLE
Handle spec example name normalization

### DIFF
--- a/jekyll/test_explorer.markdown
+++ b/jekyll/test_explorer.markdown
@@ -67,6 +67,19 @@ class MyTest < Minitest::Spec
 end
 ```
 
+Dynamically defined anonymous tests are not supported properly because there's no way to accurately reconcile their
+discovery with execution.
+
+```ruby
+class MyTest < Minitest::Spec
+  # Anonymous examples (no description) defined dynamically are not supported
+  5.times do
+    it do
+    end
+  end
+end
+```
+
 ### Tests that accept external parameters
 
 In Ruby, you can write tests that accept external parameters, like environment variables.

--- a/test/fixtures/minitest_spec_example.rb
+++ b/test/fixtures/minitest_spec_example.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "minitest/spec"
+require "minitest/autorun"
+
+Minitest::Test.i_suck_and_my_tests_are_order_dependent!
+
+class MySpec < Minitest::Spec
+  describe "some scenario" do
+    it "works as expected!" do
+      assert_equal(1, 1)
+    end
+
+    # Anonymous example
+    it do
+      assert_equal(2, 2)
+    end
+  end
+end

--- a/test/requests/discover_tests_test.rb
+++ b/test/requests/discover_tests_test.rb
@@ -318,6 +318,24 @@ module RubyLsp
       end
     end
 
+    def test_anonymous_examples
+      source = <<~RUBY
+        class BogusSpec < Minitest::Spec
+          it do
+            assert true
+          end
+        end
+      RUBY
+
+      with_minitest_spec_configured(source) do |items|
+        examples = items[0][:children]
+        assert_equal(
+          ["test_0002_anonymous"],
+          examples.map { |i| i[:label] },
+        )
+      end
+    end
+
     def test_discovers_nested_specs
       source = File.read("test/fixtures/minitest_spec_nested.rb")
 
@@ -330,7 +348,7 @@ module RubyLsp
 
         nested_specs = top_level_specs[0][:children]
         assert_equal(
-          ["test one", "test two", "test three"],
+          ["test_0005_test one", "test_0009_test two", "test_0013_test three"],
           nested_specs.map { |i| i[:label] },
         )
         assert_all_items_tagged_with(items, :minitest)
@@ -349,7 +367,7 @@ module RubyLsp
 
         nested_specs = top_level_specs[0][:children]
         assert_equal(
-          ["it_level_one", "nested", "it_level_one_again"],
+          ["test_0002_it_level_one", "nested", "test_0014_it_level_one_again"],
           nested_specs.map { |i| i[:label] },
         )
         assert_all_items_tagged_with(items, :minitest)
@@ -362,7 +380,7 @@ module RubyLsp
       with_minitest_spec_configured(source) do |items|
         nested_specs = items[0][:children][0][:children]
         assert_equal(
-          ["dynamic_name"],
+          ["test_0005_dynamic_name"],
           nested_specs.map { |i| i[:label] },
         )
         assert_all_items_tagged_with(items, :minitest)
@@ -393,7 +411,7 @@ module RubyLsp
         assert_equal(["FooSpec"], items.map { |i| i[:label] })
         assert_equal(
           [
-            "does something",
+            "test_0002_does something",
             "test_also_valid",
           ],
           items[0][:children].map { |i| i[:label] },

--- a/test/test_reporters/minitest_reporter_test.rb
+++ b/test/test_reporters/minitest_reporter_test.rb
@@ -105,6 +105,48 @@ module RubyLsp
       assert_equal(expected, events)
     end
 
+    def test_minitest_spec_output
+      uri = URI::Generic.from_path(path: "#{Dir.pwd}/test/fixtures/minitest_spec_example.rb")
+      string_uri = uri.to_s
+      events = gather_events(uri)
+
+      expected = [
+        {
+          "method" => "start",
+          "params" => {
+            "id" => "MySpec::some scenario#test_0009_works as expected!",
+            "uri" => string_uri,
+            "line" => 9,
+          },
+        },
+        {
+          "method" => "pass",
+          "params" => {
+            "id" => "MySpec::some scenario#test_0009_works as expected!",
+            "uri" => string_uri,
+          },
+        },
+        {
+          "method" => "start",
+          "params" => {
+            "id" => "MySpec::some scenario#test_0014_anonymous",
+            "uri" => string_uri,
+            "line" => 14,
+          },
+        },
+        {
+          "method" => "pass",
+          "params" => {
+            "id" => "MySpec::some scenario#test_0014_anonymous",
+            "uri" => string_uri,
+          },
+        },
+        { "method" => "finish", "params" => {} },
+      ]
+
+      assert_equal(expected, events)
+    end
+
     private
 
     #: (URI::Generic, ?output: Symbol) -> Array[Hash[untyped, untyped]]


### PR DESCRIPTION
### Motivation

We were not using the correct IDs for `it` examples in `Minitest::Spec`. Minitest will take the description and format it using the example count ([see here](https://github.com/minitest/minitest/blob/4c7eb3567a3168b3e100ff1ccd345b0f88d0fb4b/lib/minitest/spec.rb#L230C20-L230C23)).

This means that the Minitest reporter will use a different ID than discovery and we'll not be able to show results properly.

### Implementation

Since we discover tests through static analysis, it is not possible to match the exact same numbers Minitest uses from the runtime for its examples.

Instead of trying to match that exactly, we can be more accurate if we use the line number of where we found that test as part of its ID - which is guaranteed to match. For this to work, we must ensure that both discovery and test result reporting are using the same ID formatting, which is what this PR does.

**Note**: there's a decision being made here, which is that dynamically defined anonymous tests cannot be supported (see the doc changes). They are not that common anyway and we have limited support for meta-programming.

### Automated Tests

Added/improved current tests.