### PR TITLE
Always reset run object on finalize

### DIFF
--- a/vscode/src/streamingRunner.ts
+++ b/vscode/src/streamingRunner.ts
@@ -299,9 +299,9 @@ export class StreamingRunner implements vscode.Disposable {
 
     if (this.run && this.run.name === "on_demand_run_in_terminal") {
       this.run.end();
-      this.run = undefined;
     }
 
+    this.run = undefined;
     this.executionPromise!.resolve();
   }
 


### PR DESCRIPTION
### Motivation

We always need to reset `this.run`, even if it's not a `run_in_terminal` execution, otherwise we never clean up the state from previous runs and we fail to report terminal run statuses.