### PR TITLE
Stop mutating the test terminal's environment

### DIFF
--- a/lib/ruby_lsp/test_reporters/lsp_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/lsp_reporter.rb
@@ -6,6 +6,7 @@ require "json"
 require "socket"
 require "singleton"
 require "tmpdir"
+require_relative "../../ruby_indexer/lib/ruby_indexer/uri"
 
 module RubyLsp
   class LspReporter

--- a/lib/ruby_lsp/test_reporters/minitest_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/minitest_reporter.rb
@@ -8,7 +8,6 @@ rescue LoadError
 end
 
 require_relative "lsp_reporter"
-require "ruby_indexer/lib/ruby_indexer/uri"
 
 module RubyLsp
   # An override of the default progress reporter in Minitest to add color to the output

--- a/lib/ruby_lsp/test_reporters/test_unit_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/test_unit_reporter.rb
@@ -10,7 +10,6 @@ rescue LoadError
 end
 
 require_relative "lsp_reporter"
-require "ruby_indexer/lib/ruby_indexer/uri"
 
 module RubyLsp
   class TestUnitReporter < Test::Unit::UI::Console::TestRunner

--- a/vscode/src/streamingRunner.ts
+++ b/vscode/src/streamingRunner.ts
@@ -174,7 +174,6 @@ export class StreamingRunner implements vscode.Disposable {
       terminal = vscode.window.createTerminal({
         name,
         cwd,
-        env,
       });
     }
 

--- a/vscode/src/test/suite/fakeTestServer.js
+++ b/vscode/src/test/suite/fakeTestServer.js
@@ -2,7 +2,7 @@ const path = require("path");
 const os = require("os");
 const net = require("net");
 
-const port = process.env.RUBY_LSP_REPORTER_PORT;
+const port = process.env.RUBY_LSP_REPORTER_PORT ? process.env.RUBY_LSP_REPORTER_PORT : process.argv[2].trim();
 
 const socket = new net.Socket();
 socket.connect(parseInt(port, 10), "localhost", () => {

--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -854,14 +854,13 @@ suite("TestController", () => {
       "fakeTestServer.js",
     );
 
-    workspace.ruby.mergeComposedEnvironment({
+    workspace.ruby.mergeComposedEnvironment(
       // eslint-disable-next-line no-process-env
-      ...process.env,
-      RUBY_LSP_REPORTER_PORT: controller.streamingPort!,
-    });
+      process.env as any,
+    );
     sandbox.stub(workspace, "lspClient").value({
       resolveTestCommands: sinon.stub().resolves({
-        commands: [`node ${fakeServerPath}`],
+        commands: [`node ${fakeServerPath} ${controller.streamingPort!}`],
         reporterPath: undefined,
       }),
       initializeResult: {


### PR DESCRIPTION
### Motivation

We're finding that mutating the environment of the terminal is not a great experience - especially regarding changing `BUNDLE_GEMFILE` to point to our composed gemfile. If users decide to continue running other tasks in the same terminal, a lot of things can go wrong.

### Implementation

This PR stops mutating the environment and changes our URI require to be relative, so that we don't need the `BUNDLE_GEMFILE` to be set in order to require it.