### PR TITLE
Bump setup-ruby for windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: "recursive"
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
         with:
           bundler-cache: true
 
@@ -54,7 +54,7 @@ jobs:
           submodules: "recursive"
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -102,7 +102,7 @@ jobs:
 
       # We need some Ruby installed for the environment activation tests
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
         with:
           bundler-cache: true
 
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
         with:
           bundler-cache: true
           working-directory: ./jekyll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          cache-version: 1
+          cache-version: 2
 
       - name: Run tests
         run: bundle exec rake
@@ -105,6 +105,7 @@ jobs:
         uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
         with:
           bundler-cache: true
+          cache-version: 2
 
       - name: Download shadowenv
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'

--- a/.github/workflows/dependabot_update_rbis.yml
+++ b/.github/workflows/dependabot_update_rbis.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
-      - uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+      - uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
         id: setup
         with:
           bundler-cache: true

--- a/.github/workflows/indexing.yml
+++ b/.github/workflows/indexing.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
         with:
           bundler-cache: true
 

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
         with:
           bundler-cache: true
           working-directory: ./jekyll

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -20,7 +20,7 @@ jobs:
         name: Checkout
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
         with:
           bundler-cache: true
           cache-version: 1


### PR DESCRIPTION
### Motivation

The `ruby/date`'s building failure issue on `windows-latest` has been resolved in the latest `setup-ruby` version. Once we bumped the action to that version all windows builds should pass.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
