### PR TITLE
Use a custom executable to hook to test explorer

### DIFF
--- a/exe/ruby-lsp-test-exec
+++ b/exe/ruby-lsp-test-exec
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Append to RUBYOPT the necessary requires to hook our custom test reporters so that results are automatically
+# reflected in the test explorer
+rubyopt = [
+  *ENV["RUBYOPT"],
+  "-rbundler/setup",
+  "-r#{File.expand_path("../lib/ruby_lsp/test_reporters/minitest_reporter", __dir__)}",
+  "-r#{File.expand_path("../lib/ruby_lsp/test_reporters/test_unit_reporter", __dir__)}",
+].join(" ")
+
+# Replace this process with whatever command was passed. We only want to set RUBYOPT.
+# The way you use this executable is by prefixing your test command with `ruby-lsp-test-exec`, like so:
+#  ruby-lsp-test-exec bundle exec ruby -Itest test/example_test.rb
+#  ruby-lsp-test-exec bundle exec ruby -Ispec spec/example_spec.rb
+#  ruby-lsp-test-exec bundle exec rspec spec/example_spec.rb
+exec({ "RUBYOPT" => rubyopt }, *ARGV)

--- a/jekyll/test_explorer.markdown
+++ b/jekyll/test_explorer.markdown
@@ -107,6 +107,20 @@ Automatically detecting what type of external argument is required for each test
 Code's test explorer doesn't have support for arguments when running tests out of the box and neither do its test
 items accept metadata. This scenario will not be supported by the Ruby LSP.
 
+## Connecting terminal tests to the explorer
+
+When running tests in the terminal through a code lens or test explorer, the Ruby LSP uses the `ruby-lsp-test-exec`
+executable, which hooks the test run to the extension so that we can show test results in the explorer.
+
+By running tests with this executable, even manually written test commands will also have their results reported
+to the test explorer. For example, all of the following will report test statuses to the extension:
+
+```shell
+ruby-lsp-test-exec bundle exec ruby -Itest test/example_test.rb
+ruby-lsp-test-exec bundle exec ruby -Ispec spec/example_spec.rb
+ruby-lsp-test-exec bundle exec rspec spec/example_spec.rb
+```
+
 ## Customization
 
 When tests are running through any execution mode, we set the `RUBY_LSP_TEST_RUNNER` environment variable to allow

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("lib/**/*.rb") + ["README.md", "VERSION", "LICENSE.txt"] + Dir.glob("static_docs/**/*.md")
   s.bindir = "exe"
-  s.executables = ["ruby-lsp", "ruby-lsp-check", "ruby-lsp-launcher"]
+  s.executables = ["ruby-lsp", "ruby-lsp-check", "ruby-lsp-launcher", "ruby-lsp-test-exec"]
   s.require_paths = ["lib"]
 
   # Dependencies must be kept in sync with the checks in the extension side on workspace.ts


### PR DESCRIPTION
### Motivation

Setting the `RUBYOPT` in the user's terminal turned out to not be a great idea. The value persists and if the terminal is reused for other tasks, it may cause those to crash or result in unexpected behaviour.

Instead of mutating the terminal environment, we can provide a simple proxy executable that will run the given command with our reporters hooked into it.

### Implementation

Created a new executable that simple runs any given command with the modified `RUBYOPT` to hook our reporters. That way, we can run terminal tests connecting to the explorer without polluting the user's terminal.

Stopped modifying `RUBYOPT`.