### PR TITLE
Add `spec` to load path when running Minitest specs

### DIFF
--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -576,6 +576,92 @@ module RubyLsp
         )
       end
     end
+
+    def test_resolve_test_command_for_minitest_spec
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerSpec",
+                uri: "file:///spec/server_spec.rb",
+                label: "ServerSpec",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["framework:minitest", "test_group"],
+                children: [
+                  {
+                    id: "ServerSpec#test_0003_something",
+                    uri: "file:///spec/server_spec.rb",
+                    label: "test_server",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["framework:minitest"],
+                    children: [],
+                  },
+                ],
+              },
+              {
+                id: "file:///spec/other_spec.rb",
+                uri: "file:///spec/other_spec.rb",
+                label: "/spec/other_spec.rb",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["framework:minitest", "test_file"],
+                children: [],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Ispec /spec/server_spec.rb --name \"/^ServerSpec#test_0003_something\\$/\"",
+            "bundle exec ruby -Ispec -e \"ARGV.each { |f| require f }\" /spec/other_spec.rb",
+          ],
+          result[:commands],
+        )
+      end
+    end
+
+    def test_resolve_test_command_for_minitest_spec_directory
+      with_server do |server|
+        Dir.stubs(:glob).returns(["/other/spec/fake_spec.rb", "/other/spec/fake2_spec.rb"])
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "file:///other/spec",
+                uri: "file:///other/spec",
+                label: "/other/spec",
+                tags: ["test_dir", "framework:minitest"],
+                children: [],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Ispec -e \"ARGV.each { |f| require f }\" /other/spec/fake_spec.rb " \
+              "/other/spec/fake2_spec.rb",
+          ],
+          result[:commands],
+        )
+      end
+    end
   end
 
   class ResolveTestCommandsTestUnitTest < Minitest::Test


### PR DESCRIPTION
### Motivation

When running Minitest spec files that are under the `spec` directory, we have to add `spec` instead of `test` to the load path.

### Implementation

Started checking the paths to add the right directory to the load path.

### Automated Tests

Added tests.