### PR TITLE
Add minitest/spec code lens test command resolution for minitest/spec

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -44,7 +44,7 @@ module RubyLsp
               # If all of the children of the current test group are other groups, then there's no need to add it to the
               # aggregated examples
               unless children.any? && children.all? { |child| child[:tags].include?("test_group") }
-                aggregated_tests[path][item[:label]] = { tags: tags, examples: [] }
+                aggregated_tests[path][item[:id]] = { tags: tags, examples: [] }
               end
             else
               class_name, method_name = item[:id].split("#")

--- a/test/fixtures/minitest_spec_nested.rb
+++ b/test/fixtures/minitest_spec_nested.rb
@@ -13,5 +13,11 @@ class BogusSpec < Minitest::Spec
     specify "test three" do
       assert true
     end
+
+    describe "lorem ipsum" do
+      it "dolor sit" do
+        assert false
+      end
+    end
   end
 end

--- a/test/requests/discover_tests_test.rb
+++ b/test/requests/discover_tests_test.rb
@@ -239,16 +239,43 @@ module RubyLsp
 
       with_minitest_spec_configured(source) do |items|
         top_level_specs = items[0][:children]
+
         assert_equal(
           ["First Spec"],
           top_level_specs.map { |i| i[:label] },
         )
+        assert_equal(
+          ["BogusSpec::First Spec"],
+          top_level_specs.map { |i| i[:id] },
+        )
 
         nested_specs = top_level_specs[0][:children]
         assert_equal(
-          ["test one", "test two", "test three"],
+          ["test one", "test two", "test three", "lorem ipsum"],
           nested_specs.map { |i| i[:label] },
         )
+        assert_equal(
+          [
+            "BogusSpec::First Spec#test_0001_test one",
+            "BogusSpec::First Spec#test_0002_test two",
+            "BogusSpec::First Spec#test_0003_test three",
+            "BogusSpec::First Spec::lorem ipsum",
+          ],
+          nested_specs.map { |i| i[:id] },
+        )
+
+        second_level_nest_specs = nested_specs.last[:children]
+        assert_equal(
+          ["dolor sit"],
+          second_level_nest_specs.map { |i| i[:label] },
+        )
+        assert_equal(
+          [
+            "BogusSpec::First Spec::lorem ipsum#test_0001_dolor sit",
+          ],
+          second_level_nest_specs.map { |i| i[:id] },
+        )
+
         assert_all_items_tagged_with(items, :minitest)
       end
     end


### PR DESCRIPTION


<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->

Currently the Minitest Spec style is not beign resolved correctly in the code lens for the new Test Explorer implementation. That happens because the ids of the TestItem generated by `SpecStyle` was not using the `GroupX::GroupY#ExampleZ` syntax required for the vscode extension `runTestCommand` function.

Because of that, even when the code lens for the inner groups of minitest spec style test was beign shown in the editor, they were not working correctly.

### Implementation

1. Change the ids of the TestItem generated by minitest spec to what actually minitest parse underground, generating ids like `describe 1:: describe 2#test_0001_example` this reflects the _real methods_ created by this DSL in the minitest runtime.
2. Change the command test resolution to use the `id` instead of the label. With that we can have the spec syntax nicely formatted in the Vscode pannel, but the id contains all the necesary information for the Minitest Test Style to work. Because of that the command test resolution of minitest spec is the same as the current minitest test resolution.

### Automated Tests

1. Added tests to the correct id parsing of the test items in the minitest spec style.
2. Extended the current test to reflect deeply nested (2 level) describe/example blocks in the minitest style.

### Manual Tests

1. Enable the `"fullTestDiscovery": true`
2. Create a file `some_test.rb` in the `spec/` folder 
3. Test that the CodeLens and Test Pannel works correctly for the spec style

Example File:
```ruby
# ./spec/some_test.rb
# frozen_string_literal: true
require "minitest/autorun"

describe "First Spec" do
  it "test one" do
    assert true
  end

  it "test two" do
    assert true
  end

  specify "test three" do
    assert true
  end

  describe "other block" do

    it "pass" do
      assert true
    end

    it "fails" do
      assert false
    end
  end
end
```

Result:

[Screencast from 18-05-25 20:58:20.webm](https://github.com/user-attachments/assets/390404d9-56db-4505-94fa-7ec6ab6266e7)
