### PR TITLE
Ignore methods that look like tests inside other namespaces

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -197,6 +197,18 @@ module RubyLsp
         super
       end
 
+      #: (Prism::ModuleNode node) -> void
+      def on_module_node_enter(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
+        @parent_stack << nil
+        super
+      end
+
+      #: (Prism::ModuleNode node) -> void
+      def on_module_node_leave(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
+        @parent_stack.pop
+        super
+      end
+
       #: (Prism::DefNode node) -> void
       def on_def_node_enter(node)
         return if @visibility_stack.last != :public

--- a/test/requests/discover_tests_test.rb
+++ b/test/requests/discover_tests_test.rb
@@ -583,6 +583,30 @@ module RubyLsp
       end
     end
 
+    def test_ignores_methods_that_look_like_tests_in_other_namespaces
+      source = <<~RUBY
+        class MyTest < Minitest::Test
+          def test_something; end
+
+          module Foo
+            def test_something_else; end
+          end
+
+          class Bar
+            def test_other_thing; end
+          end
+        end
+      RUBY
+
+      with_minitest_test(source) do |items|
+        assert_equal(["MyTest"], items.map { |i| i[:id] })
+        assert_equal(
+          ["MyTest#test_something"],
+          items.dig(0, :children).map { |i| i[:id] },
+        )
+      end
+    end
+
     private
 
     def create_test_discovery_addon


### PR DESCRIPTION
### Motivation

The implementation in #3497 missed the fact that defining `test_` methods in other namespaces will accidentally associate them with the closest parent if we don't add special handling for modules.

This PR starts ensuring that a module is not considered as a valid test group.

### Implementation

We just need to push `nil` to the parent stack on modules, so that no examples can be associated to anything, and then pop when leaving.

### Automated Tests

Added a test that fails before this change.