### PR TITLE
Use a number regex for running spec examples

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -92,7 +92,7 @@ module RubyLsp
         #: (String, Hash[String, Hash[Symbol, untyped]]) -> String
         def handle_minitest_groups(file_path, groups_and_examples)
           regexes = groups_and_examples.flat_map do |group, info|
-            examples = info[:examples]
+            examples = info[:examples].map { |e| e.gsub(/test_\d{4}/, "test_\\d{4}") }
             group_regex = Shellwords.escape(group).gsub(
               Shellwords.escape(TestDiscovery::DYNAMIC_REFERENCE_MARKER),
               ".*",

--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -625,7 +625,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Ispec /spec/server_spec.rb --name \"/^ServerSpec#test_0003_something\\$/\"",
+            "bundle exec ruby -Ispec /spec/server_spec.rb --name \"/^ServerSpec#test_\\d{4}_something\\$/\"",
             "bundle exec ruby -Ispec -e \"ARGV.each { |f| require f }\" /spec/other_spec.rb",
           ],
           result[:commands],


### PR DESCRIPTION
### Motivation

Since we cannot guarantee that we will discover spec examples at the exact order Minitest will (because of the runtime vs static analysis difference), we use line numbers to ensure that the discovery and result reporting IDs will match.

However, for running the tests, we cannot use the line number information as that may not match the spec ID Minitest has assigned to that particular example. We can fix that by substituting that part of the command for a regex.

### Implementation

Minitest formats the spec count with 4 digits, so I started replacing the `test_XXXX` for the regex `test_\d{4}`. Note that this is still specific enough to run the right tests since we include the group's name and the rest of the example name.

### Automated Tests

Updated our tests.