### PR TITLE
Fix commands for groups inside class in minitest spec style

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -44,7 +44,7 @@ module RubyLsp
               # If all of the children of the current test group are other groups, then there's no need to add it to the
               # aggregated examples
               unless children.any? && children.all? { |child| child[:tags].include?("test_group") }
-                aggregated_tests[path][item[:label]] = { tags: tags, examples: [] }
+                aggregated_tests[path][item[:id]] = { tags: tags, examples: [] }
               end
             else
               class_name, method_name = item[:id].split("#")

--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -662,6 +662,50 @@ module RubyLsp
         )
       end
     end
+
+    def test_resolve_test_command_for_nested_spec_in_class
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerSpec",
+                uri: "file:///spec/server_spec.rb",
+                label: "ServerSpec",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["framework:minitest", "test_group"],
+                children: [
+                  {
+                    id: "ServerSpec::foo",
+                    uri: "file:///spec/server_spec.rb",
+                    label: "foo",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 5, character: 19 },
+                    },
+                    tags: ["framework:minitest", "test_group"],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Ispec /spec/server_spec.rb --name \"/^ServerSpec::foo(#|::)/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
   end
 
   class ResolveTestCommandsTestUnitTest < Minitest::Test


### PR DESCRIPTION
### Motivation

Closes #3516

The minitest spec style commands where not resolved correctly inside classes.

### Implementation

Instead of using the `label` of the test groups use the `id` because the id contains all the information.

### Automated Tests

Added 1 tests with the case to run the tests of just a group.

### Manual Tests

Tested against this example

```ruby
# ./spec/some_test.rb
require "minitest/autorun"

class SomeTest < Minitest::Spec
  describe "foo" do
    it "bar" do
      assert true
    end
  end
end
```

And works fine.
