### PR TITLE
Show progress while discovering tests

### DIFF
--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -1102,4 +1102,12 @@ suite("TestController", () => {
       testItem.tags.find((tag) => tag.id.startsWith("framework:minitest")),
     );
   }).timeout(10000);
+
+  test("trying to populate test files twice doesn't do duplicate work", async () => {
+    const spy = sandbox.spy(vscode.workspace, "findFiles");
+    await controller.testController.resolveHandler!(undefined);
+    await controller.testController.resolveHandler!(undefined);
+
+    assert.ok(spy.calledOnce);
+  });
 });


### PR DESCRIPTION
### Motivation

If someone uses a code lens without having expanded the test explorer panel, we need to discover test items in the background before starting execution.

For large projects, the user has no visual indication that anything is happening, so it can be a bit confusing. Let's show a progress notification, so that the user is aware something is happening.

### Implementation

Added a progress notification that will print how far we are into discovering test files. Also, prevented the test controller from doing duplicate work in case we discover tests in the background and then VS Code still fires another initial resolve request.

### Automated Tests

Added a test.