### PR TITLE
Fix upcoming RBS breaking changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ruby-lsp (0.23.22)
       language_server-protocol (~> 3.17.0)
       prism (>= 1.2, < 2.0)
-      rbs (>= 3, < 4)
+      rbs (>= 3, < 5)
       sorbet-runtime (>= 0.5.10782)
 
 GEM
@@ -50,8 +50,9 @@ GEM
       prism (~> 1.0)
       rbs (>= 3.4.4)
       sorbet-runtime (>= 0.5.9204)
-    rbs (3.9.1)
+    rbs (4.0.0.dev.4)
       logger
+      prism (>= 1.3.0)
     rdoc (6.13.0)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)

--- a/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/rbs_indexer.rb
@@ -103,7 +103,7 @@ module RubyIndexer
     #: (RBS::AST::Members::MethodDefinition member, Entry::Namespace owner) -> void
     def handle_method(member, owner)
       name = member.name.name
-      uri = URI::Generic.from_path(path: member.location.buffer.name)
+      uri = URI::Generic.from_path(path: member.location.buffer.name.to_s)
       location = to_ruby_indexer_location(member.location)
       comments = comments_to_string(member)
 
@@ -267,7 +267,7 @@ module RubyIndexer
 
     #: (RBS::AST::Members::Alias member, Entry::Namespace owner_entry) -> void
     def handle_signature_alias(member, owner_entry)
-      uri = URI::Generic.from_path(path: member.location.buffer.name)
+      uri = URI::Generic.from_path(path: member.location.buffer.name.to_s)
       comments = comments_to_string(member)
 
       entry = Entry::UnresolvedMethodAlias.new(

--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # Dependencies must be kept in sync with the checks in the extension side on workspace.ts
   s.add_dependency("language_server-protocol", "~> 3.17.0")
   s.add_dependency("prism", ">= 1.2", "< 2.0")
-  s.add_dependency("rbs", ">= 3", "< 4")
+  s.add_dependency("rbs", ">= 3", "< 5")
   s.add_dependency("sorbet-runtime", ">= 0.5.10782")
 
   s.required_ruby_version = ">= 3.0"

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -95,7 +95,7 @@ class IntegrationTest < Minitest::Test
         GEM
           remote: https://rubygems.org/
           specs:
-            stringio (3.1.0)
+            stringio (3.1.7)
 
         PLATFORMS
           arm64-darwin-23
@@ -134,7 +134,7 @@ class IntegrationTest < Minitest::Test
         GEM
           remote: https://rubygems.org/
           specs:
-            stringio (3.1.0)
+            stringio (3.1.7)
 
         PLATFORMS
           arm64-darwin-23
@@ -319,7 +319,7 @@ class IntegrationTest < Minitest::Test
   def launch(workspace_path, exec = "ruby-lsp-launcher", extra_env = {})
     specification = Gem::Specification.find_by_name("ruby-lsp")
     paths = [specification.full_gem_path]
-    paths.concat(specification.dependencies.map { |dep| dep.to_spec.full_gem_path })
+    paths.concat(specification.dependencies.filter_map { |dep| dep.to_spec&.full_gem_path })
 
     load_path = $LOAD_PATH.filter_map do |path|
       next unless paths.any? { |gem_path| path.start_with?(gem_path) } || !path.start_with?(Bundler.bundle_path.to_s)


### PR DESCRIPTION
### Motivation

Spoom started depending on the development version of RBS, which means Tapioca also will. We need to relax our RBS constraint or else we won't be able to install the LSP automatically since no version will satisfy the constraints.

### Implementation

1. Updated the constraint
2. Upgraded the gem to the latest dev version
3. Fixed a minor breaking change where the buffer name started returning a `Pathname` instead of a `String`