### PR TITLE
Escape example names for shell execution

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -92,7 +92,7 @@ module RubyLsp
         #: (String, Hash[String, Hash[Symbol, untyped]]) -> String
         def handle_minitest_groups(file_path, groups_and_examples)
           regexes = groups_and_examples.flat_map do |group, info|
-            examples = info[:examples].map { |e| e.gsub(/test_\d{4}/, "test_\\d{4}") }
+            examples = info[:examples].map { |e| Shellwords.escape(e).gsub(/test_\d{4}/, "test_\\d{4}") }
             group_regex = Shellwords.escape(group).gsub(
               Shellwords.escape(TestDiscovery::DYNAMIC_REFERENCE_MARKER),
               ".*",

--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -706,6 +706,51 @@ module RubyLsp
         )
       end
     end
+
+    def test_resolve_test_command_for_minitest_spec_with_backticks
+      with_server do |server|
+        server.process_message({
+          id: 1,
+          method: "rubyLsp/resolveTestCommands",
+          params: {
+            items: [
+              {
+                id: "ServerSpec",
+                uri: "file:///spec/server_spec.rb",
+                label: "ServerSpec",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 30, character: 3 },
+                },
+                tags: ["framework:minitest", "test_group"],
+                children: [
+                  {
+                    id: "ServerSpec#test_0001_uses `SomeClass` to do something",
+                    uri: "file:///spec/server_spec.rb",
+                    label: "test_server",
+                    range: {
+                      start: { line: 1, character: 2 },
+                      end: { line: 10, character: 3 },
+                    },
+                    tags: ["framework:minitest"],
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [
+            "bundle exec ruby -Ispec /spec/server_spec.rb --name " \
+              "\"/^ServerSpec#test_\\d{4}_uses\\ \\`SomeClass\\`\\ to\\ do\\ something\\$/\"",
+          ],
+          result[:commands],
+        )
+      end
+    end
   end
 
   class ResolveTestCommandsTestUnitTest < Minitest::Test


### PR DESCRIPTION
### Motivation

We need to escape example names for shell execution, especially because of Minitest spec. Examples can have shell reserved characters, like backticks, which makes execution fail.

### Implementation

Started invoking `Shellwords.escape` for the example names like we already do for groups.

### Automated Tests

Added a test to ensure we don't regress.