### PR TITLE
Allow to disable any addon in the addon settings.

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -78,6 +78,12 @@ module RubyLsp
         self.addons = addon_classes.map(&:new)
         self.file_watcher_addons = addons.select { |addon| addon.respond_to?(:workspace_did_change_watched_files) }
 
+        # Disable addons with { "rubyLsp.addonSettings": {"Addon Name": { enabled: false }}}
+        self.addons = addons.filter do |addon|
+          addon_settings = global_state.settings_for_addon(addon.name) || {}
+          addon_settings.fetch(:enabled, true)
+        end
+
         # Activate each one of the discovered add-ons. If any problems occur in the add-ons, we don't want to
         # fail to boot the server
         addons.each do |addon|

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -10,6 +10,7 @@ module RubyLsp
         attr_reader :activated, :field, :settings
 
         def initialize
+          @activated = false
           @field = 123
           super
         end
@@ -100,6 +101,10 @@ module RubyLsp
         def deactivate; end
 
         def workspace_did_change_watched_files(changes); end
+
+        def name
+          "Some Addon"
+        end
       end
 
       Addon.load_addons(@global_state, @outgoing_queue)
@@ -189,6 +194,43 @@ module RubyLsp
         assert_equal("Project Addon", addon.name)
         assert_predicate(addon, :hello)
       end
+    end
+
+    def test_disabled_addons_are_not_loaded
+      @global_state = GlobalState.new
+      @global_state.apply_options({
+        initializationOptions: {
+          addonSettings: {
+            "My Add-on": {
+              enabled: false,
+            },
+          },
+        },
+      })
+
+      Addon.load_addons(@global_state, @outgoing_queue)
+
+      assert_raises(Addon::AddonNotFoundError) do
+        Addon.get("My Add-on", "0.1.0")
+      end
+    end
+
+    def test_enabled_addons_are_loaded
+      @global_state = GlobalState.new
+      @global_state.apply_options({
+        initializationOptions: {
+          addonSettings: {
+            "My Add-on": {
+              enabled: true,
+            },
+          },
+        },
+      })
+
+      Addon.load_addons(@global_state, @outgoing_queue)
+
+      addon = Addon.get("My Add-on", "0.1.0")
+      assert_equal("My Add-on", addon.name)
     end
   end
 end


### PR DESCRIPTION
### Motivation

Closes #3418 

### Implementation

In addon loading check for the addon settings first. The addon can be disabled using

```json
"rubyLsp.addonSettings": {
    "RuboCop": {
      "enabled": false
    }
  }
```

We make the addons enabled by default.

### Automated Tests

Added tests when the addon is enabled and when the addon is disabled. The other tests are already testing if the setting is not set.

### Manual Tests

Tests in the same repo enabling/disabling a dummy addon.

[Screencast from 21-05-25 22:27:12.webm](https://github.com/user-attachments/assets/4e778adc-bd2b-41c1-8c7e-8094139bd5e5)

