### PR TITLE
Avoid shitfting editor focus when using test code lens

### DIFF
--- a/vscode/src/streamingRunner.ts
+++ b/vscode/src/streamingRunner.ts
@@ -250,7 +250,13 @@ export class StreamingRunner implements vscode.Disposable {
 
           if (!this.run) {
             this.run = this.createTestRun(
-              new vscode.TestRunRequest(),
+              new vscode.TestRunRequest(
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                true,
+              ),
               "on_demand_run_in_terminal",
             );
           }

--- a/vscode/src/testController.ts
+++ b/vscode/src/testController.ts
@@ -386,12 +386,14 @@ export class TestController {
     const testItem = await this.findTestItem(name, uri);
     if (!testItem) return;
 
-    await vscode.commands.executeCommand(
-      "vscode.revealTestInExplorer",
-      testItem,
-    );
-    const tokenSource = new vscode.CancellationTokenSource();
+    if (mode === Mode.Run) {
+      await vscode.commands.executeCommand(
+        "vscode.revealTestInExplorer",
+        testItem,
+      );
+    }
 
+    const tokenSource = new vscode.CancellationTokenSource();
     tokenSource.token.onCancellationRequested(async () => {
       tokenSource.dispose();
       await vscode.window.showInformationMessage("Cancelled the progress");


### PR DESCRIPTION
### Motivation

We received feedback from users that the shifting of editor focus when running a test in the terminal via code lens is surprising and not the desired behaviour. Let's prevent the focus from changing and let people manually expand the explorer if desired.

I still kept the focus change for when someone uses the `Run` code lens. I think that's sensible since the user will probably want to see the test results and those will only show up there.