### PR TITLE
add mise install path for `apt` installations

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -21,6 +21,7 @@ async function detectMise() {
   const possiblePaths = [
     vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin", "mise"),
     vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin", "mise"),
+    vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "bin", "mise"),
   ];
 
   for (const possiblePath of possiblePaths) {

--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -48,6 +48,7 @@ export class Mise extends VersionManager {
     //
     // 1. Installation from curl | sh (per mise.jdx.dev Getting Started)
     // 2. Homebrew M series
+    // 3. Installation from `apt install mise`
     const possiblePaths = [
       vscode.Uri.joinPath(
         vscode.Uri.file(os.homedir()),
@@ -59,6 +60,12 @@ export class Mise extends VersionManager {
         vscode.Uri.file("/"),
         "opt",
         "homebrew",
+        "bin",
+        "mise",
+      ),
+      vscode.Uri.joinPath(
+        vscode.Uri.file("/"),
+        "usr",
         "bin",
         "mise",
       ),


### PR DESCRIPTION
### Motivation

Closes #3531 (LSP fails to detect `mise` that is installed via `apt` into `/usr/bin/mise`)

### Implementation

Followed pattern laid out in #2943 for multiple install locations.

### Automated Tests

No tests added since #2943 has none that I could use as a starting point to follow.

### Manual Tests

Follow the reproduction steps in #3531 to see if the problem has been resolved.
