### PR TITLE
Replace LanguageServer::Protocol::Transport with our own implementation

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -88,6 +88,13 @@ if ENV["BUNDLE_GEMFILE"].nil?
   exit exec(env, "#{base_command} exec ruby-lsp #{original_args.join(" ")}".strip)
 end
 
+$stdin.sync = true
+$stdout.sync = true
+$stderr.sync = true
+$stdin.binmode
+$stdout.binmode
+$stderr.binmode
+
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
 require "ruby_lsp/internal"
@@ -144,8 +151,10 @@ if options[:doctor]
   return
 end
 
+server = RubyLsp::Server.new
+
 # Ensure all output goes out stderr by default to allow puts/p/pp to work
 # without specifying output device.
 $> = $stderr
 
-RubyLsp::Server.new.start
+server.start

--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -6,6 +6,13 @@
 # composed bundle
 # !!!!!!!
 
+$stdin.sync = true
+$stdout.sync = true
+$stderr.sync = true
+$stdin.binmode
+$stdout.binmode
+$stderr.binmode
+
 setup_error = nil
 install_error = nil
 reboot = false
@@ -28,7 +35,6 @@ else
   # Read the initialize request before even starting the server. We need to do this to figure out the workspace URI.
   # Editors are not required to spawn the language server process on the same directory as the workspace URI, so we need
   # to ensure that we're setting up the bundle in the right place
-  $stdin.binmode
   headers = $stdin.gets("\r\n\r\n")
   content_length = headers[/Content-Length: (\d+)/i, 1].to_i
   $stdin.read(content_length)
@@ -140,22 +146,28 @@ if ARGV.include?("--debug")
   end
 end
 
-# Ensure all output goes out stderr by default to allow puts/p/pp to work without specifying output device.
-$> = $stderr
-
 initialize_request = JSON.parse(raw_initialize, symbolize_names: true) if raw_initialize
 
 begin
-  RubyLsp::Server.new(
+  server = RubyLsp::Server.new(
     install_error: install_error,
     setup_error: setup_error,
     initialize_request: initialize_request,
-  ).start
+  )
+
+  # Ensure all output goes out stderr by default to allow puts/p/pp to work without specifying output device.
+  $> = $stderr
+
+  server.start
 rescue ArgumentError
   # If the launcher is booting an outdated version of the server, then the initializer doesn't accept a keyword splat
   # and we already read the initialize request from the stdin pipe. In this case, we need to process the initialize
   # request manually and then start the main loop
   server = RubyLsp::Server.new
+
+  # Ensure all output goes out stderr by default to allow puts/p/pp to work without specifying output device.
+  $> = $stderr
+
   server.process_message(initialize_request)
   server.start
 end

--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -6,11 +6,11 @@ module RubyLsp
   class BaseServer
     #: (**untyped options) -> void
     def initialize(**options)
+      @reader = MessageReader.new(options[:reader] || $stdin) #: MessageReader
+      @writer = MessageWriter.new(options[:writer] || $stdout) #: MessageWriter
       @test_mode = options[:test_mode] #: bool?
       @setup_error = options[:setup_error] #: StandardError?
       @install_error = options[:install_error] #: StandardError?
-      @writer = Transport::Stdio::Writer.new #: Transport::Stdio::Writer
-      @reader = Transport::Stdio::Reader.new #: Transport::Stdio::Reader
       @incoming_queue = Thread::Queue.new #: Thread::Queue
       @outgoing_queue = Thread::Queue.new #: Thread::Queue
       @cancelled_requests = [] #: Array[Integer]
@@ -36,7 +36,7 @@ module RubyLsp
 
     #: -> void
     def start
-      @reader.read do |message|
+      @reader.each_message do |message|
         method = message[:method]
 
         # We must parse the document under a mutex lock or else we might switch threads and accept text edits in the

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -333,6 +333,23 @@ class IntegrationTest < Minitest::Test
     end
   end
 
+  def test_launching_an_older_server_version
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~RUBY)
+        source "https://rubygems.org"
+        gem "ruby-lsp", "0.23.0"
+      RUBY
+
+      Bundler.with_unbundled_env do
+        capture_subprocess_io do
+          system("bundle", "install")
+        end
+
+        launch(dir)
+      end
+    end
+  end
+
   private
 
   def launch(workspace_path, exec = "ruby-lsp-launcher", extra_env = {})


### PR DESCRIPTION
### Motivation

This is the first step in removing the `language-server_protocol` dependency, in our efforts to minimize runtime dependencies that risk blocking the LSP's auto upgrades.

This PR replaces the `Transport` module with our own implementation. This is not a breaking change as add-ons were already not supposed to try to read or write messages to the client directly without going through the Ruby LSP.

### Implementation

Implemented super simple reader and writer classes that embed the JSON RPC format for any IO. This will also make it easier to support booting the language server via sockets.

### Automated Tests

There's a subtle important aspect of this. We need to capture the handles for the stdio pipes _before_ changing the default output device (`$>`) or else communication is broken.

I added an integration test that will use the current launcher with an older server version to ensure that this works even when trying to boot previous versions.