### PR TITLE
Move all abstract methods to RBS syntax

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/enhancement.rb
@@ -2,11 +2,8 @@
 # frozen_string_literal: true
 
 module RubyIndexer
+  # @abstract
   class Enhancement
-    extend T::Helpers
-
-    abstract!
-
     @enhancements = [] #: Array[Class[Enhancement]]
 
     class << self

--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -98,11 +98,8 @@ module RubyIndexer
       end
     end
 
+    # @abstract
     class ModuleOperation
-      extend T::Helpers
-
-      abstract!
-
       #: String
       attr_reader :module_name
 
@@ -115,11 +112,8 @@ module RubyIndexer
     class Include < ModuleOperation; end
     class Prepend < ModuleOperation; end
 
+    # @abstract
     class Namespace < Entry
-      extend T::Helpers
-
-      abstract!
-
       #: Array[String]
       attr_reader :nesting
 
@@ -191,11 +185,8 @@ module RubyIndexer
     class Constant < Entry
     end
 
+    # @abstract
     class Parameter
-      extend T::Helpers
-
-      abstract!
-
       # Name includes just the name of the parameter, excluding symbols like splats
       #: Symbol
       attr_reader :name
@@ -289,12 +280,8 @@ module RubyIndexer
       end
     end
 
+    # @abstract
     class Member < Entry
-      extend T::Sig
-      extend T::Helpers
-
-      abstract!
-
       #: Entry::Namespace?
       attr_reader :owner
 
@@ -305,7 +292,8 @@ module RubyIndexer
         @owner = owner
       end
 
-      sig { abstract.returns(T::Array[Entry::Signature]) }
+      # @abstract
+      #: -> Array[Signature]
       def signatures; end
 
       #: -> String

--- a/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
@@ -3,11 +3,8 @@
 
 module RubyIndexer
   class ReferenceFinder
-    class Target
-      extend T::Helpers
-
-      abstract!
-    end
+    # @abstract
+    class Target; end
 
     class ConstTarget < Target
       #: String

--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -19,12 +19,8 @@ module RubyLsp
   #   end
   # end
   # ```
+  # @abstract
   class Addon
-    extend T::Sig
-    extend T::Helpers
-
-    abstract!
-
     @addons = [] #: Array[Addon]
     @addon_classes = [] #: Array[singleton(Addon)]
     # Add-on instances that have declared a handler to accept file watcher events
@@ -178,21 +174,25 @@ module RubyLsp
 
     # Each add-on should implement `MyAddon#activate` and use to perform any sort of initialization, such as
     # reading information into memory or even spawning a separate process
-    sig { abstract.params(global_state: GlobalState, outgoing_queue: Thread::Queue).void }
+    # @abstract
+    #: (GlobalState, Thread::Queue) -> void
     def activate(global_state, outgoing_queue); end
 
     # Each add-on should implement `MyAddon#deactivate` and use to perform any clean up, like shutting down a
     # child process
-    sig { abstract.void }
+    # @abstract
+    #: -> void
     def deactivate; end
 
     # Add-ons should override the `name` method to return the add-on name
-    sig { abstract.returns(String) }
+    # @abstract
+    #: -> String
     def name; end
 
     # Add-ons should override the `version` method to return a semantic version string representing the add-on's
     # version. This is used for compatibility checks
-    sig { abstract.returns(String) }
+    # @abstract
+    #: -> String
     def version; end
 
     # Handle a response from a window/showMessageRequest request. Add-ons must include the addon_name as part of the

--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -2,12 +2,8 @@
 # frozen_string_literal: true
 
 module RubyLsp
+  # @abstract
   class BaseServer
-    extend T::Sig
-    extend T::Helpers
-
-    abstract!
-
     #: (**untyped options) -> void
     def initialize(**options)
       @test_mode = options[:test_mode] #: bool?
@@ -130,10 +126,12 @@ module RubyLsp
       @incoming_queue << message
     end
 
-    sig { abstract.params(message: T::Hash[Symbol, T.untyped]).void }
+    # @abstract
+    #: (Hash[Symbol, untyped] message) -> void
     def process_message(message); end
 
-    sig { abstract.void }
+    # @abstract
+    #: -> void
     def shutdown; end
 
     #: (Integer id, String message, ?type: Integer) -> void

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -2,10 +2,9 @@
 # frozen_string_literal: true
 
 module RubyLsp
+  # @abstract
   #: [ParseResultType]
   class Document
-    extend T::Sig
-    extend T::Helpers
     extend T::Generic
 
     class LocationNotFoundError < StandardError; end
@@ -14,8 +13,6 @@ module RubyLsp
     # This is the same number used by the TypeScript extension in VS Code
     MAXIMUM_CHARACTERS_FOR_EXPENSIVE_FEATURES = 100_000
     EMPTY_CACHE = Object.new.freeze #: Object
-
-    abstract!
 
     #: ParseResultType
     attr_reader :parse_result
@@ -63,7 +60,8 @@ module RubyLsp
       self.class == other.class && uri == other.uri && @source == other.source
     end
 
-    sig { abstract.returns(Symbol) }
+    # @abstract
+    #: -> Symbol
     def language_id; end
 
     #: [T] (String request_name) { (Document[ParseResultType] document) -> T } -> T
@@ -122,10 +120,12 @@ module RubyLsp
     end
 
     # Returns `true` if the document was parsed and `false` if nothing needed parsing
-    sig { abstract.returns(T::Boolean) }
+    # @abstract
+    #: -> bool
     def parse!; end
 
-    sig { abstract.returns(T::Boolean) }
+    # @abstract
+    #: -> bool
     def syntax_error?; end
 
     #: -> bool
@@ -150,12 +150,8 @@ module RubyLsp
       Scanner.new(@source, @encoding)
     end
 
+    # @abstract
     class Edit
-      extend T::Sig
-      extend T::Helpers
-
-      abstract!
-
       #: Hash[Symbol, untyped]
       attr_reader :range
 

--- a/lib/ruby_lsp/listeners/test_discovery.rb
+++ b/lib/ruby_lsp/listeners/test_discovery.rb
@@ -3,10 +3,8 @@
 
 module RubyLsp
   module Listeners
+    # @abstract
     class TestDiscovery
-      extend T::Helpers
-      abstract!
-
       include Requests::Support::Common
 
       DYNAMIC_REFERENCE_MARKER = "<dynamic_reference>"

--- a/lib/ruby_lsp/requests/request.rb
+++ b/lib/ruby_lsp/requests/request.rb
@@ -3,15 +3,12 @@
 
 module RubyLsp
   module Requests
+    # @abstract
     class Request
-      extend T::Helpers
-      extend T::Sig
-
       class InvalidFormatter < StandardError; end
 
-      abstract!
-
-      sig { abstract.returns(T.anything) }
+      # @abstract
+      #: -> untyped
       def perform; end
 
       private

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -4,13 +4,11 @@
 module RubyLsp
   module Requests
     module Support
+      # @requires_ancestor: Kernel
       module Common
         # WARNING: Methods in this class may be used by Ruby LSP add-ons such as
         # https://github.com/Shopify/ruby-lsp-rails, or add-ons by created by developers outside of Shopify, so be
         # cautious of changing anything.
-        extend T::Helpers
-
-        requires_ancestor { Kernel }
 
         #: (Prism::Node node) -> Interface::Range
         def range_from_node(node)

--- a/lib/ruby_lsp/requests/support/formatter.rb
+++ b/lib/ruby_lsp/requests/support/formatter.rb
@@ -4,24 +4,19 @@
 module RubyLsp
   module Requests
     module Support
+      # Empty module to avoid the runtime component. This is an interface defined in sorbet/rbi/shims/ruby_lsp.rbi
+      # @interface
       module Formatter
-        extend T::Sig
-        extend T::Helpers
-
-        interface!
-
-        sig { abstract.params(uri: URI::Generic, document: RubyDocument).returns(T.nilable(String)) }
+        # @abstract
+        #: (URI::Generic, RubyLsp::RubyDocument) -> String?
         def run_formatting(uri, document); end
 
-        sig { abstract.params(uri: URI::Generic, source: String, base_indentation: Integer).returns(T.nilable(String)) }
+        # @abstract
+        #: (URI::Generic, String, Integer) -> String?
         def run_range_formatting(uri, source, base_indentation); end
 
-        sig do
-          abstract.params(
-            uri: URI::Generic,
-            document: RubyDocument,
-          ).returns(T.nilable(T::Array[Interface::Diagnostic]))
-        end
+        # @abstract
+        #: (URI::Generic, RubyLsp::RubyDocument) -> Array[Interface::Diagnostic]?
         def run_diagnostic(uri, document); end
       end
     end

--- a/lib/ruby_lsp/response_builders/response_builder.rb
+++ b/lib/ruby_lsp/response_builders/response_builder.rb
@@ -3,14 +3,12 @@
 
 module RubyLsp
   module ResponseBuilders
+    # @abstract
     class ResponseBuilder
-      extend T::Sig
-      extend T::Helpers
       extend T::Generic
 
-      abstract!
-
-      sig { abstract.returns(T.anything) }
+      # @abstract
+      #: -> top
       def response; end
     end
   end

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -94,16 +94,7 @@ module RubyLsp
             id: message[:id],
             response:
               Addon.addons.map do |addon|
-                version_method = addon.method(:version)
-
-                # If the add-on doesn't define a `version` method, we'd be calling the abstract method defined by
-                # Sorbet, which would raise an error.
-                # Therefore, we only call the method if it's defined by the add-on itself
-                if version_method.owner != Addon
-                  version = addon.version
-                end
-
-                { name: addon.name, version: version, errored: addon.error? }
+                { name: addon.name, version: addon.version, errored: addon.error? }
               end,
           ),
         )

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -4,12 +4,9 @@
 # NOTE: This module is intended to be used by addons for writing their own tests, so keep that in mind if changing.
 
 module RubyLsp
+  # @requires_ancestor: Kernel
   module TestHelper
     class TestError < StandardError; end
-
-    extend T::Helpers
-
-    requires_ancestor { Kernel }
 
     #: [T] (?String? source, ?URI::Generic uri, ?stub_no_typechecker: bool, ?load_addons: bool) { (RubyLsp::Server server, URI::Generic uri) -> T } -> T
     def with_server(source = nil, uri = Kernel.URI("file:///fake.rb"), stub_no_typechecker: false, load_addons: true,

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -34,17 +34,13 @@ module RubyLsp
   BUNDLE_COMPOSE_FAILED_CODE = -33000
 
   # A notification to be sent to the client
+  # @abstract
   class Message
-    extend T::Sig
-    extend T::Helpers
-
     #: String
     attr_reader :method
 
     #: Object
     attr_reader :params
-
-    abstract!
 
     #: (method: String, params: Object) -> void
     def initialize(method:, params:)
@@ -52,7 +48,8 @@ module RubyLsp
       @params = params
     end
 
-    sig { abstract.returns(T::Hash[Symbol, T.untyped]) }
+    # @abstract
+    #: -> Hash[Symbol, untyped]
     def to_hash; end
   end
 


### PR DESCRIPTION
### Motivation

This PR moves all abstract methods to RBIs, which is the second to last step needed to remove the dependency on `sorbet-runtime`.

### Implementation

Moved all abstract things to RBIs.