### PR TITLE
Remove git scheme from document selector

### DIFF
--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -619,7 +619,7 @@ suite("Client", () => {
   test("document selectors match default gems and bundled gems appropriately", () => {
     const selector = client.clientOptions
       .documentSelector! as TextDocumentFilter[];
-    assert.strictEqual(selector.length, 10);
+    assert.strictEqual(selector.length, 5);
 
     // We don't care about the order of the document filters, just that they are present. This assertion helper is just
     // a convenience to search the registered filters
@@ -641,26 +641,14 @@ suite("Client", () => {
     };
 
     assertSelector("ruby", `${workspaceUri.fsPath}/**/*`, "file");
-    assertSelector("ruby", `${workspaceUri.fsPath}/**/*`, "git");
     assertSelector("erb", `${workspaceUri.fsPath}/**/*`, "file");
-    assertSelector("erb", `${workspaceUri.fsPath}/**/*`, "git");
-
     assertSelector(
       "ruby",
       new RegExp(`ruby\\/\\d\\.\\d\\.\\d\\/\\*\\*\\/\\*`),
       "file",
     );
-    assertSelector(
-      "ruby",
-      new RegExp(`ruby\\/\\d\\.\\d\\.\\d\\/\\*\\*\\/\\*`),
-      "git",
-    );
-
     assertSelector("ruby", /lib\/ruby\/gems\/\d\.\d\.\d\/\*\*\/\*/, "file");
-    assertSelector("ruby", /lib\/ruby\/gems\/\d\.\d\.\d\/\*\*\/\*/, "git");
-
     assertSelector("ruby", /lib\/ruby\/\d\.\d\.\d\/\*\*\/\*/, "file");
-    assertSelector("ruby", /lib\/ruby\/\d\.\d\.\d\/\*\*\/\*/, "git");
   });
 
   test("requests for non existing documents do not crash the server", async () => {


### PR DESCRIPTION
### Motivation

I noticed that we were sometimes getting duplicate indexing entries and finally managed to understand what's going on. We have `git` as a supported scheme in our document selector. If a user opens the git panel, VS Code will fire did open events for those documents using the `git` scheme, but git URIs don't match file URIs, resulting in the same declarations to be inserted into the index under different identifiers.

Originally, the only reason we added the `git` scheme to the selector was to get better highlighting when reviewing changes, but it will lead to a lot of complexity in the server trying to ensure that we only perform certain operations on certain schemes, so I propose we stop handling git schemes.