### PR TITLE
Index `attr`

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -254,7 +254,7 @@ module RubyIndexer
       case message
       when :private_constant
         handle_private_constant(node)
-      when :attr_reader
+      when :attr_reader, :attr
         handle_attribute(node, reader: true, writer: false)
       when :attr_writer
         handle_attribute(node, reader: false, writer: true)

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -950,6 +950,16 @@ module RubyIndexer
       assert_predicate(entry, :public?)
     end
 
+    def test_handling_attr
+      index(<<~RUBY)
+        class Foo
+          attr :bar
+        end
+      RUBY
+
+      assert_entry("bar", Entry::Accessor, "/fake/path/foo.rb:1-8:1-11")
+    end
+
     private
 
     #: (Entry::Method entry, String call_string) -> void


### PR DESCRIPTION
### Motivation

When we added attribute indexing, we forgot to consider `attr`, which is an alias to `attr_reader`.

### Implementation

Added `attr` in the same branch as `attr_reader`.

### Automated Tests

Added a test.