### PR TITLE
Update Stray VS Code Workspace Name in Docs

### DIFF
--- a/jekyll/contributing.markdown
+++ b/jekyll/contributing.markdown
@@ -39,8 +39,8 @@ When adding or changing an existing feature, first identify which request is res
 server implements that request and start thinking about the implementation.
 
 {: .note }
-When using VS Code, open the `lsp.code-workspace` file instead of just opening the regular folder. It contains
-configurations for working with the sub projects side by side effectively
+When using VS Code, open the `ruby-lsp.code-workspace` file instead of just opening the regular folder. It contains
+configurations for working with the sub projects side by side effectively.
 
 ### Debugging
 


### PR DESCRIPTION
When [updating the VS Code workspace file name][Commit], it didn't get fully updated in the docs. This updates one of the places that had the old name.

[Commit]: https://github.com/Shopify/ruby-lsp/commit/2be659e375cf0cee8a8c161651e96ac75a192d56
