### PR TITLE
fix: prevent NoMethodError when popping empty spec_group_id_stack

### DIFF
--- a/lib/ruby_lsp/listeners/spec_style.rb
+++ b/lib/ruby_lsp/listeners/spec_style.rb
@@ -41,7 +41,7 @@ module RubyLsp
 
       #: (Prism::ClassNode) -> void
       def on_class_node_leave(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
-        @spec_group_id_stack.pop
+        @spec_group_id_stack&.pop
         super
       end
 


### PR DESCRIPTION
### Motivation

The error forbids me to search through class methods and variables

> 2025-05-28 12:37:11.735 [info] (rails-7)   Message: /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/ruby-lsp-0.23.23/lib/ruby_lsp/listeners/spec_style.rb:44:in 'RubyLsp::Listeners::SpecStyle#on_class_node_leave': undefined method 'pop' for nil (NoMethodError)
> 
>         @spec_group_id_stack.pop
>                             ^^^^
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/dispatcher.rb:275:in 'block in Prism::Dispatcher#visit_class_node'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/dispatcher.rb:275:in 'Array#each'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/dispatcher.rb:275:in 'Prism::Dispatcher#visit_class_node'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/node.rb:3831:in 'Prism::ClassNode#accept'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/visitor.rb:31:in 'block in Prism::Visitor#visit_child_nodes'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/visitor.rb:31:in 'Array#each'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/visitor.rb:31:in 'Prism::Visitor#visit_child_nodes'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/dispatcher.rb:1186:in 'Prism::Dispatcher#visit_statements_node'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/node.rb:16808:in 'Prism::StatementsNode#accept'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/visitor.rb:31:in 'block in Prism::Visitor#visit_child_nodes'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/visitor.rb:31:in 'Array#each'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/visitor.rb:31:in 'Prism::Visitor#visit_child_nodes'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/dispatcher.rb:1034:in 'Prism::Dispatcher#visit_program_node'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/node.rb:14889:in 'Prism::ProgramNode#accept'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/prism-1.4.0/lib/prism/visitor.rb:19:in 'Prism::Dispatcher#visit'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/ruby-lsp-0.23.23/lib/ruby_lsp/server.rb:516:in 'block (2 levels) in RubyLsp::Server#run_combined_requests'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/ruby-lsp-0.23.23/lib/ruby_indexer/lib/ruby_indexer/index.rb:637:in 'RubyIndexer::Index#handle_change'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/ruby-lsp-0.23.23/lib/ruby_lsp/server.rb:512:in 'block in RubyLsp::Server#run_combined_requests'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/ruby-lsp-0.23.23/lib/ruby_lsp/global_state.rb:63:in 'Thread::Mutex#synchronize'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/ruby-lsp-0.23.23/lib/ruby_lsp/global_state.rb:63:in 'RubyLsp::GlobalState#synchronize'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/ruby-lsp-0.23.23/lib/ruby_lsp/server.rb:509:in 'RubyLsp::Server#run_combined_requests'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/ruby-lsp-0.23.23/lib/ruby_lsp/server.rb:30:in 'RubyLsp::Server#process_message'
> 	from /home/martinbarilik/.rvm/gems/ruby-3.4.4@project/gems/ruby-lsp-0.23.23/lib/ruby_lsp/base_server.rb:160:in 'block in RubyLsp::BaseServer#new_worker'
> 
>   Code: -32603 
> [object Object]

i do not know much because the implementation is above my paygrade, Using safe navigation prevents error and server runs after accessing any ruby class.

Hope this helps at least fix the root of the problem.

Bug was introduced since 0.9.24, version 0.9.23 does not have it.

edit:
using ruby 3.4.4 with rails 8.0.2 on Windsurf 1.9.2
