### PR TITLE
Complete writer methods with self receiver when receiver is self

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -522,7 +522,7 @@ module RubyLsp
             method_name = entry_name.delete_suffix("=")
 
             # For writer methods, format as assignment and prefix "self." when no receiver is specified
-            new_text = node.receiver.nil? ? "self.#{method_name}=" : method_name
+            new_text = node.receiver.nil? ? "self.#{method_name} = " : "#{method_name} = "
           end
 
           label_details = Interface::CompletionItemLabelDetails.new(

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -706,7 +706,7 @@ class CompletionTest < Minitest::Test
         result = server.pop_response.response
         assert_equal(["qux", "qux="], result.map(&:label))
         assert_equal(["qux", "qux="], result.map(&:filter_text))
-        assert_equal(["qux", "self.qux="], result.map { |completion| completion.text_edit.new_text })
+        assert_equal(["qux", "self.qux = "], result.map { |completion| completion.text_edit.new_text })
 
         # Test explicit self receiver: "self.q"
         server.process_message(id: 1, method: "textDocument/completion", params: {
@@ -717,7 +717,7 @@ class CompletionTest < Minitest::Test
         result = server.pop_response.response
         assert_equal(["qux", "qux="], result.map(&:label))
         assert_equal(["qux", "qux="], result.map(&:filter_text))
-        assert_equal(["qux", "qux="], result.map { |completion| completion.text_edit.new_text })
+        assert_equal(["qux", "qux = "], result.map { |completion| completion.text_edit.new_text })
 
         # Test external receiver; "foo.q"
         server.process_message(id: 1, method: "textDocument/completion", params: {
@@ -728,7 +728,7 @@ class CompletionTest < Minitest::Test
         result = server.pop_response.response
         assert_equal(["qux", "qux="], result.map(&:label))
         assert_equal(["qux", "qux="], result.map(&:filter_text))
-        assert_equal(["qux", "qux="], result.map { |completion| completion.text_edit.new_text })
+        assert_equal(["qux", "qux = "], result.map { |completion| completion.text_edit.new_text })
       end
     end
   end


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/3528

Setter methods where the receiver is `self` were being completed without the explicit `self.` prefix. This would result in local variable assignment rather than calling the writer method.

For example, when typing `b` in a class method and expecting completion for `baz=`, the LSP would suggest:

```ruby
def bar
  baz= # This assigns to a local variable, not calling the writer method
end
```

Instead of the correct:
```ruby
def bar
  self.baz=
end
```

### Implementation

- Modified the `add_method_completions` method in `completion.rb` to detect when completing setter methods with a `self` receiver.
- The changes only affect files where Sorbet type checking is not enabled; those use Sorbet's completion, which has the same issue, but is outside the scope of Ruby LSP (as far as I know).

The implementation checks `node.receiver.nil?` to detect implicit self and avoid adding `self.` when the user has already typed the receiver.

> [!NOTE]
> This is my first ruby-lsp PR. Feedback on the approach would be appreciated, particularly:
> 
> - I read through [the documentation for CompletionItem](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem) and it _feels_ like setting the `newText` is the correct option (leaving the `label` and `filterText` as before) but I'd be curious if reviewers feel otherwise.
> - I put spaces around the "=" as suggested in the issue since that's how most people would write this..

### Automated Tests

Added test coverage in `completion_test.rb` with three scenarios:
- Implicit self receiver (`b` in class method) - verifies `self.` prefix is added to completion text
- Explicit self receiver (`self.b` in class method) - verifies no additional `self.` prefix is added 
- External receiver (`foo.b` outside class) - verifies no `self.` prefix is added