### PR TITLE
Move chruby activation script into a file

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -56,6 +56,25 @@ class IntegrationTest < Minitest::Test
     end
   end
 
+  def test_chruby_activation_script
+    _stdout, stderr, status = Open3.capture3(
+      "ruby",
+      "-EUTF-8:UTF-8",
+      File.join(__dir__, "..", "vscode", "chruby_activation.rb"),
+      RUBY_VERSION,
+    )
+
+    assert_equal(0, status.exitstatus, stderr)
+
+    default_gems, gem_home, yjit, version = stderr.split("RUBY_LSP_ACTIVATION_SEPARATOR")
+
+    assert_equal(RUBY_VERSION, version)
+    # These may be switched in CI due to Bundler settings, so we use simpler assertions
+    assert(yjit)
+    assert(gem_home)
+    assert(default_gems)
+  end
+
   def test_activation_script_succeeds_on_invalid_unicode
     ENV["LC_ALL"] = "C"
     ENV["LANG"] = "C"

--- a/vscode/chruby_activation.rb
+++ b/vscode/chruby_activation.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Typically, GEM_HOME points to $HOME/.gem/ruby/version_without_patch. For example, for Ruby 3.2.2, it would be
+# $HOME/.gem/ruby/3.2.0. However, chruby overrides GEM_HOME to use the patch part of the version, resulting in
+# $HOME/.gem/ruby/3.2.2. In our activation script, we check if a directory using the patch exists and then prefer
+# that over the default one.
+user_dir = Gem.user_dir
+paths = Gem.path
+default_dir = Gem.default_dir
+
+if paths.length > 2
+  paths.delete(default_dir)
+  paths.delete(user_dir)
+  first_path = paths[0]
+  user_dir = first_path if first_path && Dir.exist?(first_path)
+end
+
+newer_gem_home = File.join(File.dirname(user_dir), ARGV.first)
+gems = Dir.exist?(newer_gem_home) ? newer_gem_home : user_dir
+STDERR.print(
+  [
+    default_dir,
+    gems,
+    !!defined?(RubyVM::YJIT),
+    RUBY_VERSION
+  ].join("RUBY_LSP_ACTIVATION_SEPARATOR")
+)

--- a/vscode/src/ruby/rubyInstaller.ts
+++ b/vscode/src/ruby/rubyInstaller.ts
@@ -3,8 +3,6 @@ import os from "os";
 
 import * as vscode from "vscode";
 
-import { asyncExec } from "../common";
-
 import { Chruby } from "./chruby";
 
 interface RubyVersion {
@@ -76,22 +74,5 @@ export class RubyInstaller extends Chruby {
     );
 
     return activationResult;
-  }
-
-  // Override the `runScript` method to ensure that we do not pass any `shell` to `asyncExec`. The activation script is
-  // only compatible with `cmd.exe`, and not Powershell, due to escaping of quotes. We need to ensure to always run the
-  // script on `cmd.exe`.
-  protected runScript(command: string) {
-    this.outputChannel.info(
-      `Running command: \`${command}\` in ${this.bundleUri.fsPath}`,
-    );
-    this.outputChannel.debug(
-      `Environment used for command: ${JSON.stringify(process.env)}`,
-    );
-
-    return asyncExec(command, {
-      cwd: this.bundleUri.fsPath,
-      env: process.env,
-    });
   }
 }

--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -24,8 +24,7 @@ export abstract class VersionManager {
   protected readonly workspaceFolder: vscode.WorkspaceFolder;
   protected readonly bundleUri: vscode.Uri;
   protected readonly manuallySelectRuby: () => Promise<void>;
-
-  private readonly context: vscode.ExtensionContext;
+  protected readonly context: vscode.ExtensionContext;
   private readonly customBundleGemfile?: string;
 
   constructor(

--- a/vscode/src/test/suite/ruby/chruby.test.ts
+++ b/vscode/src/test/suite/ruby/chruby.test.ts
@@ -13,6 +13,7 @@ import { WorkspaceChannel } from "../../../workspaceChannel";
 import { LOG_CHANNEL } from "../../../common";
 import { RUBY_VERSION, MAJOR, MINOR, VERSION_REGEX } from "../../rubyVersion";
 import { ActivationResult } from "../../../ruby/versionManager";
+import { CONTEXT } from "../helpers";
 
 // Create links to the real Ruby installations on CI and on our local machines
 function createRubySymlinks(destination: string) {
@@ -49,16 +50,6 @@ suite("Chruby", () => {
     console.log("Skipping Chruby tests on Windows");
     return;
   }
-
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-    extensionUri: vscode.Uri.parse("file:///fake"),
-  } as unknown as vscode.ExtensionContext;
 
   let rootPath: string;
   let workspacePath: string;
@@ -97,7 +88,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -114,7 +105,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -151,7 +142,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -201,7 +192,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -236,7 +227,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [vscode.Uri.file(rubyHome)];
@@ -263,7 +254,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     configStub.restore();
@@ -288,7 +279,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -320,7 +311,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -336,7 +327,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -353,7 +344,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -371,7 +362,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -388,7 +379,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -408,7 +399,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     chruby.rubyInstallationUris = [

--- a/vscode/src/test/suite/ruby/rubyInstaller.test.ts
+++ b/vscode/src/test/suite/ruby/rubyInstaller.test.ts
@@ -13,7 +13,7 @@ import { WorkspaceChannel } from "../../../workspaceChannel";
 import { LOG_CHANNEL } from "../../../common";
 import { RUBY_VERSION, VERSION_REGEX } from "../../rubyVersion";
 import { ACTIVATION_SEPARATOR } from "../../../ruby/versionManager";
-import { createRubySymlinks } from "../helpers";
+import { createRubySymlinks, CONTEXT } from "../helpers";
 
 suite("RubyInstaller", () => {
   if (os.platform() !== "win32") {
@@ -21,16 +21,6 @@ suite("RubyInstaller", () => {
     console.log("This test can only run on Windows");
     return;
   }
-
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-    extensionUri: vscode.Uri.parse("file:///fake"),
-  } as unknown as vscode.ExtensionContext;
 
   let rootPath: string;
   let workspacePath: string;
@@ -68,7 +58,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     const { env, version, yjit } = await windows.activate();
@@ -88,7 +78,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     const { env, version, yjit } = await windows.activate();
@@ -108,7 +98,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     const result = ["/fake/dir", "/other/fake/dir", true, RUBY_VERSION].join(
@@ -133,7 +123,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
-      context,
+      CONTEXT,
       async () => {},
     );
     const result = [


### PR DESCRIPTION
### Motivation

Closes #2769

This PR moves our chruby/Ruby Installer activation script into a proper file, so that we can avoid using `-e` - which eliminates escaping issues that are shell dependent.

### Implementation

1. Put the script in a file
2. Started invoking the script
3. Got rid of a useless override in RubyInstaller

### Automated Tests

Added a new integration test and updated chruby/Ruby installer tests.