### PR TITLE
Prevent outdated Bundler errors from crashing launcher

### DIFF
--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -83,8 +83,13 @@ begin
     # This Marshal load can only happen after requiring Bundler because it will load a custom error class from Bundler
     # itself. If we try to load before requiring, the class will not be defined and loading will fail
     error_path = File.join(".ruby-lsp", "install_error")
-    install_error = if File.exist?(error_path)
-      Marshal.load(File.read(error_path))
+    install_error = begin
+      Marshal.load(File.read(error_path)) if File.exist?(error_path)
+    rescue ArgumentError
+      # The class we tried to load is not defined. This might happen when the user upgrades Bundler and new error
+      # classes are introduced or removed
+      File.delete(error_path)
+      nil
     end
 
     Bundler.setup


### PR DESCRIPTION
### Motivation

The following scenario is currently possible:

1. Launch the LSP and get a bundle install failure. We Marshal the error object into the `install_error` file
2. The user upgrades/downgrades Bundler. The class no longer exists or was moved
3. Now trying to Marshal load `install_error` is guaranteed to fail with an `ArgumentError`

We should protect the launching mechanism against this.

### Implementation

If an `ArgumentError` happens while trying to Marshal load, I just started deleting the `install_error` file so that we recover on the next launch.