### PR TITLE
Create Cop to catch YARD tag annotations for method signatures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ require:
   - rubocop-rake
   - ./lib/rubocop/cop/ruby_lsp/use_language_server_aliases
   - ./lib/rubocop/cop/ruby_lsp/use_register_with_handler_method
+  - ./lib/rubocop/cop/ruby_lsp/no_yard_annotations
 
 AllCops:
   NewCops: disable

--- a/lib/rubocop/cop/ruby_lsp/no_yard_annotations.rb
+++ b/lib/rubocop/cop/ruby_lsp/no_yard_annotations.rb
@@ -1,0 +1,119 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "rubocop"
+require "sorbet-runtime"
+require "strscan"
+
+module RuboCop
+  module Cop
+    module RubyLsp
+      # Detects and flags the use of YARD method annotations.
+      # YARD annotations should be converted to RBS comment syntax
+      # for better integration with Sorbet and static analysis.
+      #
+      # @example
+      #   # bad
+      #   # @param name [String] the name
+      #   # @return [String] the greeting
+      #   def greet(name)
+      #     "Hello #{name}"
+      #   end
+      #
+      #   # good
+      #   # name: String -> String
+      #   def greet(name)
+      #     "Hello #{name}"
+      #   end
+      class NoYardAnnotations < RuboCop::Cop::Base
+        extend T::Sig
+
+        MSG = "Avoid using YARD method annotations. Use RBS comment syntax instead."
+        private_constant :MSG
+
+        ANY_WHITESPACE = /\s*/ #: Regexp
+
+        FORBIDDEN_YARD_TAGS = [
+          "option",
+          "overload",
+          "param",
+          "return",
+          "yield",
+          "yieldparam",
+          "yieldreturn",
+        ].freeze #: Array[String]
+        private_constant :FORBIDDEN_YARD_TAGS
+
+        sig { void }
+        def on_new_investigation
+          return if processed_source.blank?
+
+          yard_tag_blocks.each do |block|
+            next unless (tag_block = block.first)
+            next unless contains_forbidden_yard_tag?(tag_block.text)
+
+            add_offense(tag_block.source_range, message: MSG)
+          end
+        end
+
+        private
+
+        sig { returns(T::Enumerator[T::Array[Parser::Source::Comment]]) }
+        def yard_tag_blocks
+          Enumerator.new do |yielder|
+            comments = processed_source.comments
+            next if comments.empty?
+
+            current_tag_chunk = []
+            previous_line = -1 #: untyped
+            tag_indent_level = 0 #: untyped
+
+            comments.each do |comment|
+              scanner = StringScanner.new(comment.text)
+              next unless scanner.skip("#")
+
+              indent_level = scanner.skip(ANY_WHITESPACE)
+
+              if !current_tag_chunk.empty? &&
+                  comment.location.line == previous_line + 1 &&
+                  indent_level >= tag_indent_level + 2
+                current_tag_chunk << comment
+              else
+                yielder << current_tag_chunk unless current_tag_chunk.empty?
+                current_tag_chunk = []
+
+                if scanner.skip("@")
+                  current_tag_chunk << comment
+                  tag_indent_level = indent_level
+                end
+              end
+
+              previous_line = comment.location.line
+            end
+
+            yielder << current_tag_chunk unless current_tag_chunk.empty?
+          end
+        end
+
+        sig { params(comment_text: String).returns(T::Boolean) }
+        def contains_forbidden_yard_tag?(comment_text)
+          scanner = StringScanner.new(comment_text)
+          return false unless scanner.skip("#")
+
+          scanner.skip(ANY_WHITESPACE)
+
+          return false unless scanner.skip("@")
+
+          FORBIDDEN_YARD_TAGS.any? do |tag_name|
+            if scanner.skip(tag_name)
+              scanner.unscan unless (match = scanner.eos? || scanner.peek(1).lstrip.empty?)
+              match
+            else
+              false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/rubocop/cop/ruby_lsp/no_yard_annotations_test.rb
+++ b/test/rubocop/cop/ruby_lsp/no_yard_annotations_test.rb
@@ -1,0 +1,182 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "rubocop-minitest"
+require "rubocop/minitest/assert_offense"
+
+class NoYardAnnotationsTest < Minitest::Test
+  include RuboCop::Minitest::AssertOffense
+
+  def setup
+    @cop = ::RuboCop::Cop::RubyLsp::NoYardAnnotations.new
+  end
+
+  def test_does_not_register_offense_for_regular_comments
+    assert_no_offenses(<<~RUBY)
+      class Example
+        # This is a regular comment
+        # TODO: This is a regular todo (not YARD)
+        # NOTE: This is a regular note (not YARD)
+        def greet(name)
+          "Hello \#{name}"
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_for_param_annotation
+    assert_offense(<<~RUBY)
+      class Example
+        # @param name [String] the name
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        def greet(name)
+          "Hello \#{name}"
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_for_return_annotation
+    assert_offense(<<~RUBY)
+      class Example
+        # @return [String] the greeting
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        def greet(name)
+          "Hello \#{name}"
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_for_multiple_param_annotations_with_wrapped_lines
+    assert_offense(<<~RUBY)
+      class Example
+        # @param first_name [String] the first name
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        #   of the person
+        # @param last_name [String] the last name
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        #    of the person
+        # @return [String] the full name for
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        #   the person
+        def full_name(first_name, last_name)
+          "\#{first_name} \#{last_name}"
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_for_yield_annotations
+    assert_offense(<<~RUBY)
+      class Example
+        # @yield [value] yields the processed value
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        # @yieldparam value [String] the value to process
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        # @yieldreturn [String] the processed result
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        def process_value(value)
+          yield(value)
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_for_overload_annotation
+    assert_offense(<<~RUBY)
+      class Example
+        # @overload greet(name)
+        ^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        #   @param name [String]
+        #   @return [String]
+        # @overload greet(first, last)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        #   @param first [String]
+        #   @param last [String]
+        #   @return [String]
+        def greet(*args)
+          # implementation
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_for_option_annotation
+    assert_offense(<<~RUBY)
+      class Example
+        # @option opts [String] :name The name
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        # @option opts [Integer] :age The age
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        def process_options(opts = {})
+          # implementation
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_for_mixed_yard_and_regular_comments
+    assert_offense(<<~RUBY)
+      class Example
+        # This is a regular comment
+        # @param name [String] the name
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        # Another regular comment
+        # @return [String] the greeting
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        # Final comment
+        def greet(name)
+          "Hello \#{name}"
+        end
+      end
+    RUBY
+  end
+
+  def test_does_not_register_offense_for_yard_like_tag_inside_comment_line
+    assert_no_offenses(<<~RUBY)
+      class Example
+        # This is a comment with a tag @param but not a YARD annotation
+        # This is a comment with a tag @return but not a YARD annotation
+        # This is a comment with a tag @option but not a YARD annotation
+        # This is a comment with a tag @overload but not a YARD annotation
+        # This is a comment with a tag @yield but not a YARD annotation
+        # This is a comment with a tag @yieldparam but not a YARD annotation
+        # This is a comment with a tag @yieldreturn but not a YARD annotation
+        def greet(name)
+          "Hello \#{name}"
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_for_yard_annotation_with_extra_spaces
+    assert_offense(<<~RUBY)
+      class Example
+        #   @param name [String] the name with extra spaces
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        #    @return [String] the greeting with extra spaces
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        def greet(name)
+          "Hello \#{name}"
+        end
+      end
+    RUBY
+  end
+
+  def test_registers_offense_for_yard_annotation_but_skips_wrapped_lines
+    assert_offense(<<~RUBY)
+      class Example
+        # @param name [String] the name with extra spaces
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RubyLsp/NoYardAnnotations: Avoid using YARD method annotations. Use RBS comment syntax instead.
+        #   @return [String] the greeting with extra spaces
+        #   No error on return because it's wrapped and part of the @param
+        def greet(name)
+          "Hello \#{name}"
+        end
+      end
+    RUBY
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,7 @@ require "ruby_lsp/internal"
 require "ruby_lsp/test_helper"
 require "rubocop/cop/ruby_lsp/use_language_server_aliases"
 require "rubocop/cop/ruby_lsp/use_register_with_handler_method"
+require "rubocop/cop/ruby_lsp/no_yard_annotations"
 
 require "ruby_lsp/test_reporters/minitest_reporter"
 require "minitest/autorun"


### PR DESCRIPTION
### Motivation

This creates a cop that flags YARD comments with method signature tags. The type annotations for YARD are not very robust. The only benefit to having them over using RBS-style comments is to document what the parameters are, but most methods should have good names that don't make this useful.

### Implementation

YARD tags can be wrapped over multiple comment lines. This solution creates an Enumerator that generates an array of comment lines for each YARD tag. It then checks if the tag is one of the method annotation tags and, if so, adds an error to the first comment line of the tag (the line with the tag).

### Automated Tests

Yes

### Manual Tests

