### PR TITLE
Add filename based completion for class names

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -701,7 +701,7 @@ module RubyLsp
         false
       end
 
-      # Add filename-based class completion for sparse files
+      # Add filename-based class completion
       #: (Prism::ConstantReadNode node, String name, Interface::Range range) -> void
       def add_filename_based_class_completion(node, name, range)
         filename_class = filename_to_class_name

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1761,44 +1761,13 @@ class CompletionTest < Minitest::Test
         })
 
         result = server.pop_response.response
-        assert_includes(result.map(&:label), "StudentProfile")
 
-        # Find the StudentProfile completion item
         student_profile_item = result.find { |item| item.label == "StudentProfile" }
+
         refute_nil(student_profile_item)
         assert_equal("StudentProfile", student_profile_item.text_edit.new_text)
         assert_equal(LanguageServer::Protocol::Constant::CompletionItemKind::CLASS, student_profile_item.kind)
-      end
-    end
-  end
-
-  def test_completion_for_filename_based_class_suggestion_with_underscores
-    source = <<~RUBY
-      User
-    RUBY
-
-    with_server(source, stub_no_typechecker: true) do |server|
-      with_file_structure(server) do |tmpdir|
-        uri = URI("file://#{tmpdir}/user_authentication_service.rb")
-        server.process_message({
-          method: "textDocument/didOpen",
-          params: {
-            textDocument: {
-              uri: uri,
-              text: source,
-              version: 1,
-              languageId: "ruby",
-            },
-          },
-        })
-
-        server.process_message(id: 1, method: "textDocument/completion", params: {
-          textDocument: { uri: uri },
-          position: { line: 0, character: 4 },
-        })
-
-        result = server.pop_response.response
-        assert_includes(result.map(&:label), "UserAuthenticationService")
+        assert_equal("class suggested from filename", student_profile_item.label_details.description)
       end
     end
   end


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation


Sublime has a feature where it autocompletes a class name based on the file name. This implements support for this such that if you open `student_profile.rb`, it will autocomplete `StudentProfile`.


### Implementation

The implementation takes the file's basename and performs `basename.split("_").map(&:capitalize).join` to get the class name.

### Automated Tests

Added tests.

### Manual Tests

https://github.com/user-attachments/assets/1fb22c5a-6cae-4777-9f60-0e8c12963b8a

