### PR TITLE
feat: register profile command

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -59,6 +59,12 @@
           "command": "rubyLsp.goToRelevantFile",
           "when": "rubyLsp.activated",
           "group": "navigation"
+        },
+        {
+          "command": "rubyLsp.profileCurrentFile",
+          "when": "editorTextFocus && resourceLangId == ruby",
+          "group": "navigation",
+          "icon": "$(record)"
         }
       ],
       "view/title": [
@@ -191,6 +197,12 @@
         "command": "rubyLsp.showOutput",
         "title": "Show output channel",
         "category": "Ruby LSP"
+      },
+      {
+        "command": "rubyLsp.profileCurrentFile",
+        "title": "Profile current file",
+        "category": "Ruby LSP",
+        "icon": "$(record)"
       }
     ],
     "configuration": {

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -34,6 +34,7 @@ export enum Command {
   ShowOutput = "rubyLsp.showOutput",
   MigrateLaunchConfiguration = "rubyLsp.migrateLaunchConfiguration",
   GoToRelevantFile = "rubyLsp.goToRelevantFile",
+  ProfileCurrentFile = "rubyLsp.profileCurrentFile",
 }
 
 export interface RubyInterface {

--- a/vscode/src/rubyLsp.ts
+++ b/vscode/src/rubyLsp.ts
@@ -756,27 +756,26 @@ export class RubyLsp {
           return;
         }
 
-        vscode.window.showInformationMessage("Profiling in progress...");
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: "Profiling in progress...",
+            cancellable: false,
+          },
+          async () => {
+            const profileUri = vscode.Uri.file(
+              path.join(os.tmpdir(), `profile-${Date.now()}.cpuprofile`)
+            );
 
-        // const { stderr } = await workspace.execute('vernier --version', true)
+            await workspace.execute(
+              `vernier run --output ${profileUri.fsPath} --format cpuprofile -- ruby ${currentFile}`,
+            );
 
-        // if (stderr.includes("command not found")) {
-        //   await vscode.window.showInformationMessage(
-        //     "Ensure Vernier 1.8+ is installed",
-        //   );
-        //   return
-        // }
-
-        const profileUri = vscode.Uri.file(
-          path.join(os.tmpdir(), `profile-${Date.now()}.cpuprofile`)
+            await vscode.commands.executeCommand("vscode.open", profileUri, {
+              viewColumn: vscode.ViewColumn.Beside,
+            });
+          }
         );
-        await workspace.execute(
-          `vernier run --output ${profileUri.fsPath} --format cpuprofile -- ruby ${currentFile}`,
-        );
-
-        await vscode.commands.executeCommand("vscode.open", profileUri, {
-          viewColumn: vscode.ViewColumn.Beside,
-        });
       }),
     ];
   }


### PR DESCRIPTION
### Motivation

Closes #2273 
Requires this [Vernier PR](https://github.com/jhawthorn/vernier/pull/154) to ship and a new version to be released. ✅

This adds a way to profile the currently open file using Vernier, and display the output in editor (VSCode will also display numbers inline with the file).

### Implementation

Registers a command that uses Vernier under the hood with the active file and open the `.cpuprofile` file.

### Automated Tests

Since this was a straightforward command and I didn't see tests for similar commands, I opted to not add a test here. Happy to extract this to a function and test it if we'd prefer to do so.

### Manual Tests

1. Run the extension, using a project with a Ruby workspace that as a Ruby script that can be profiled.
2. Run the `Profile current file` command (either from the palette or editor menu of active file)
3. See a `.cpuprofile` open. When you click back to the profiled file, VSCode should automatically annotate lines with perf information.

https://github.com/user-attachments/assets/f513d7a5-7a93-4047-9764-a59115db45e2