### PR TITLE
chore: remove deprecated activationEvents from extension package.json

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -21,10 +21,8 @@
     "Chat"
   ],
   "activationEvents": [
-    "onLanguage:ruby",
     "workspaceContains:Gemfile.lock",
-    "workspaceContains:gems.locked",
-    "onView:dependencies"
+    "workspaceContains:gems.locked"
   ],
   "extensionDependencies": [
     "vscode.git"


### PR DESCRIPTION
### Motivation

I noticed two deprecation warnings when registering a new command; went ahead and removed them.