### PR TITLE
Pick most specific parent class during linearization

### DIFF
--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -728,6 +728,30 @@ module RubyIndexer
       assert_equal(["A", "ALIAS"], @index.linearized_ancestors_of("A"))
     end
 
+    def test_linearizing_ancestors_for_classes_with_overridden_parents
+      index(<<~RUBY)
+        # Find the re-open of a class first, without specifying a parent
+        class Child
+        end
+
+        # Now, find the actual definition of the class, which includes a parent
+        class Parent; end
+        class Child < Parent
+        end
+      RUBY
+
+      assert_equal(
+        [
+          "Child",
+          "Parent",
+          "Object",
+          "Kernel",
+          "BasicObject",
+        ],
+        @index.linearized_ancestors_of("Child"),
+      )
+    end
+
     def test_resolving_an_inherited_method
       index(<<~RUBY)
         module Foo


### PR DESCRIPTION
### Motivation

Closes #3513

Since the order of file discovery during indexing does not necessarily match the require order, we may end up discovering a re-opening of an existing class before its initial definition.

In re-openings, it's quite common to omit the parent class. Currently, we're incorrectly just finding the parent class based on the first one we can find, but that means that if the re-opening was indexed first we ignore the real parent class.

### Implementation

I changed the loop that we use to find parent classes to prefer specific parent classes that aren't the implicit default (`::Object`). That way, if there's a more specific definition of the class, we find that one - which is the one that's actually setting the parent.

**Note**: if the developer makes a mistake and defines the same class with two different parents, we will linearize based on the first one found. I believe this is acceptable since Ruby will raise when you try to do this.

### Automated Tests

Added a test that reproduces the behaviour.