### PR TITLE
Enhance test isolation with disposal and sandbox patterns

### DIFF
--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -33,7 +33,7 @@ import { WorkspaceChannel } from "../../workspaceChannel";
 import { MAJOR, MINOR } from "../rubyVersion";
 
 import { FAKE_TELEMETRY, FakeLogger } from "./fakeTelemetry";
-import { createRubySymlinks } from "./helpers";
+import { createContext, createRubySymlinks } from "./helpers";
 
 async function launchClient(workspaceUri: vscode.Uri) {
   const workspaceFolder: vscode.WorkspaceFolder = {
@@ -42,15 +42,7 @@ async function launchClient(workspaceUri: vscode.Uri) {
     index: 0,
   };
 
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-    extensionUri: vscode.Uri.file(path.join(workspaceUri.fsPath, "vscode")),
-  } as unknown as vscode.ExtensionContext;
+  const context = createContext();
   const fakeLogger = new FakeLogger();
   const outputChannel = new WorkspaceChannel("fake", fakeLogger as any);
 

--- a/vscode/src/test/suite/client.test.ts
+++ b/vscode/src/test/suite/client.test.ts
@@ -25,7 +25,7 @@ import {
   ShowMessageParams,
   MessageType,
 } from "vscode-languageclient/node";
-import { after, afterEach, before, setup } from "mocha";
+import { after, afterEach, before, beforeEach, setup } from "mocha";
 
 import { Ruby, ManagerIdentifier } from "../../ruby";
 import Client from "../../client";
@@ -141,6 +141,7 @@ suite("Client", () => {
     "fake.rb",
   );
   let client: Client;
+  let sandbox: sinon.SinonSandbox;
 
   before(async function () {
     // 60000 should be plenty but we're seeing timeouts on Windows in CI
@@ -148,6 +149,10 @@ suite("Client", () => {
     // eslint-disable-next-line no-invalid-this
     this.timeout(90000);
     client = await launchClient(workspaceUri);
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
   });
 
   after(async function () {
@@ -177,6 +182,7 @@ suite("Client", () => {
   });
 
   afterEach(async () => {
+    sandbox.restore();
     await client.sendNotification("textDocument/didClose", {
       textDocument: {
         uri: documentUri.toString(),
@@ -807,7 +813,7 @@ suite("Client", () => {
       },
     });
 
-    const stub = sinon.stub(vscode.commands, "executeCommand").resolves(null);
+    const stub = sandbox.stub(vscode.commands, "executeCommand").resolves(null);
 
     await client.sendRequest("textDocument/definition", {
       textDocument: {
@@ -815,7 +821,6 @@ suite("Client", () => {
       },
       position: { line: 1, character: 5 },
     });
-    stub.restore();
 
     await client.sendNotification("textDocument/didClose", {
       textDocument: { uri },
@@ -862,7 +867,7 @@ suite("Client", () => {
       },
     });
 
-    const stub = sinon.stub(vscode.commands, "executeCommand").resolves(null);
+    const stub = sandbox.stub(vscode.commands, "executeCommand").resolves(null);
 
     await client.sendRequest("textDocument/signatureHelp", {
       textDocument: {
@@ -871,7 +876,6 @@ suite("Client", () => {
       position: { line: 1, character: 23 },
       context: {},
     });
-    stub.restore();
 
     await client.sendNotification("textDocument/didClose", {
       textDocument: { uri },
@@ -919,7 +923,7 @@ suite("Client", () => {
       },
     });
 
-    const stub = sinon.stub(vscode.commands, "executeCommand").resolves(null);
+    const stub = sandbox.stub(vscode.commands, "executeCommand").resolves(null);
 
     await client.sendRequest("textDocument/documentHighlight", {
       textDocument: {
@@ -928,7 +932,6 @@ suite("Client", () => {
       position: { line: 1, character: 4 },
       context: {},
     });
-    stub.restore();
 
     await client.sendNotification("textDocument/didClose", {
       textDocument: { uri },

--- a/vscode/src/test/suite/helpers.ts
+++ b/vscode/src/test/suite/helpers.ts
@@ -70,9 +70,19 @@ export const LSP_WORKSPACE_FOLDER: vscode.WorkspaceFolder = {
   name: path.basename(LSP_WORKSPACE_PATH),
   index: 0,
 };
-export const CONTEXT = {
-  extensionMode: vscode.ExtensionMode.Test,
-  subscriptions: [],
-  workspaceState: new FakeWorkspaceState(),
-  extensionUri: vscode.Uri.joinPath(LSP_WORKSPACE_URI, "vscode"),
-} as unknown as vscode.ExtensionContext;
+
+export type FakeContext = vscode.ExtensionContext & { dispose: () => void };
+
+export function createContext() {
+  const subscriptions: vscode.Disposable[] = [];
+
+  return {
+    extensionMode: vscode.ExtensionMode.Test,
+    subscriptions,
+    workspaceState: new FakeWorkspaceState(),
+    extensionUri: vscode.Uri.joinPath(LSP_WORKSPACE_URI, "vscode"),
+    dispose: () => {
+      subscriptions.forEach((subscription) => subscription.dispose());
+    },
+  } as unknown as FakeContext;
+}

--- a/vscode/src/test/suite/launch.test.ts
+++ b/vscode/src/test/suite/launch.test.ts
@@ -6,7 +6,7 @@ import os from "os";
 import * as vscode from "vscode";
 import { State } from "vscode-languageclient/node";
 import sinon from "sinon";
-import { beforeEach } from "mocha";
+import { afterEach, beforeEach } from "mocha";
 
 import { ManagerIdentifier, Ruby } from "../../ruby";
 import Client from "../../client";
@@ -14,7 +14,7 @@ import { WorkspaceChannel } from "../../workspaceChannel";
 import * as common from "../../common";
 
 import { FAKE_TELEMETRY, FakeLogger } from "./fakeTelemetry";
-import { createRubySymlinks } from "./helpers";
+import { createContext, createRubySymlinks, FakeContext } from "./helpers";
 
 suite("Launch integrations", () => {
   const workspacePath = path.dirname(
@@ -27,15 +27,16 @@ suite("Launch integrations", () => {
     index: 0,
   };
 
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-    extensionUri: vscode.Uri.joinPath(workspaceUri, "vscode"),
-  } as unknown as vscode.ExtensionContext;
+  let context: FakeContext;
+
+  beforeEach(() => {
+    context = createContext();
+  });
+
+  afterEach(() => {
+    context.dispose();
+  });
+
   const fakeLogger = new FakeLogger();
   const outputChannel = new WorkspaceChannel("fake", fakeLogger as any);
 

--- a/vscode/src/test/suite/launch.test.ts
+++ b/vscode/src/test/suite/launch.test.ts
@@ -28,12 +28,15 @@ suite("Launch integrations", () => {
   };
 
   let context: FakeContext;
+  let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     context = createContext();
   });
 
   afterEach(() => {
+    sandbox.restore();
     context.dispose();
   });
 
@@ -98,9 +101,8 @@ suite("Launch integrations", () => {
   });
 
   test("with launcher mode enabled", async () => {
-    const featureStub = sinon.stub(common, "featureEnabled").returns(true);
+    sandbox.stub(common, "featureEnabled").returns(true);
     const client = await createClient();
-    featureStub.restore();
 
     await startClient(client);
 

--- a/vscode/src/test/suite/rails.test.ts
+++ b/vscode/src/test/suite/rails.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 
 import * as vscode from "vscode";
 import sinon from "sinon";
+import { beforeEach, afterEach } from "mocha";
 
 import { Rails } from "../../rails";
 import { Workspace } from "../../workspace";
@@ -21,8 +22,18 @@ suite("Rails", () => {
     index: 0,
   };
 
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   test("generate", async () => {
-    const executeStub = sinon.stub();
+    const executeStub = sandbox.stub();
     const workspace = {
       workspaceFolder,
       execute: executeStub.resolves({
@@ -31,8 +42,8 @@ suite("Rails", () => {
       }),
     } as unknown as Workspace;
 
-    const showDocumentStub = sinon.stub(vscode.window, "showTextDocument");
-    const executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+    const showDocumentStub = sandbox.stub(vscode.window, "showTextDocument");
+    sandbox.stub(vscode.commands, "executeCommand");
 
     const selectedWorkspace = undefined;
     const rails = new Rails(() => Promise.resolve(workspace));
@@ -64,12 +75,10 @@ suite("Rails", () => {
           { preview: false },
         ),
     );
-    showDocumentStub.restore();
-    executeCommandStub.restore();
   });
 
   test("destroy", async () => {
-    const executeStub = sinon.stub();
+    const executeStub = sandbox.stub();
     const workspace = {
       workspaceFolder,
       execute: executeStub.resolves({
@@ -78,7 +87,7 @@ suite("Rails", () => {
       }),
     } as unknown as Workspace;
 
-    const executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+    const executeCommandStub = sandbox.stub(vscode.commands, "executeCommand");
 
     const selectedWorkspace = undefined;
     const rails = new Rails(() => Promise.resolve(workspace));
@@ -110,6 +119,5 @@ suite("Rails", () => {
           vscode.Uri.joinPath(workspaceUri, "app/models/user.rb"),
         ),
     );
-    executeCommandStub.restore();
   });
 });

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -17,7 +17,7 @@ import {
   VALUE_SEPARATOR,
 } from "../../ruby/versionManager";
 
-import { CONTEXT } from "./helpers";
+import { createContext, FakeContext } from "./helpers";
 import { FAKE_TELEMETRY } from "./fakeTelemetry";
 
 suite("Ruby environment activation", () => {
@@ -31,13 +31,16 @@ suite("Ruby environment activation", () => {
   };
   const outputChannel = new WorkspaceChannel("fake", LOG_CHANNEL);
   let sandbox: sinon.SinonSandbox;
+  let context: FakeContext;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    context = createContext();
   });
 
   afterEach(() => {
     sandbox.restore();
+    context.dispose();
   });
 
   test("Activate fetches Ruby information when outside of Ruby LSP", async () => {
@@ -58,7 +61,7 @@ suite("Ruby environment activation", () => {
     } as unknown as vscode.WorkspaceConfiguration);
 
     const ruby = new Ruby(
-      CONTEXT,
+      context,
       workspaceFolder,
       outputChannel,
       FAKE_TELEMETRY,
@@ -91,7 +94,7 @@ suite("Ruby environment activation", () => {
     } as unknown as vscode.WorkspaceConfiguration);
 
     const ruby = new Ruby(
-      CONTEXT,
+      context,
       workspaceFolder,
       outputChannel,
       FAKE_TELEMETRY,
@@ -136,7 +139,7 @@ suite("Ruby environment activation", () => {
     });
 
     const ruby = new Ruby(
-      CONTEXT,
+      context,
       workspaceFolder,
       outputChannel,
       FAKE_TELEMETRY,
@@ -151,7 +154,7 @@ suite("Ruby environment activation", () => {
 
   test("mergeComposedEnv merges environment variables", () => {
     const ruby = new Ruby(
-      CONTEXT,
+      context,
       workspaceFolder,
       outputChannel,
       FAKE_TELEMETRY,
@@ -168,7 +171,7 @@ suite("Ruby environment activation", () => {
 
   test("Ignores untrusted workspace for telemetry", async () => {
     const telemetry = { ...FAKE_TELEMETRY, logError: sinon.stub() };
-    const ruby = new Ruby(CONTEXT, workspaceFolder, outputChannel, telemetry);
+    const ruby = new Ruby(context, workspaceFolder, outputChannel, telemetry);
 
     sandbox
       .stub(Shadowenv.prototype, "activate")
@@ -198,12 +201,12 @@ suite("Ruby environment activation", () => {
       },
     } as unknown as vscode.WorkspaceConfiguration);
 
-    await CONTEXT.workspaceState.update(
+    await context.workspaceState.update(
       `rubyLsp.workspaceRubyPath.${workspaceFolder.name}`,
       "/totally/non/existent/path/ruby",
     );
     const ruby = new Ruby(
-      CONTEXT,
+      context,
       workspaceFolder,
       outputChannel,
       FAKE_TELEMETRY,
@@ -212,7 +215,7 @@ suite("Ruby environment activation", () => {
     await ruby.activateRuby();
 
     assert.strictEqual(
-      CONTEXT.workspaceState.get(
+      context.workspaceState.get(
         `rubyLsp.workspaceRubyPath.${workspaceFolder.name}`,
       ),
       undefined,

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -170,7 +170,7 @@ suite("Ruby environment activation", () => {
   });
 
   test("Ignores untrusted workspace for telemetry", async () => {
-    const telemetry = { ...FAKE_TELEMETRY, logError: sinon.stub() };
+    const telemetry = { ...FAKE_TELEMETRY, logError: sandbox.stub() };
     const ruby = new Ruby(context, workspaceFolder, outputChannel, telemetry);
 
     sandbox

--- a/vscode/src/test/suite/ruby/asdf.test.ts
+++ b/vscode/src/test/suite/ruby/asdf.test.ts
@@ -4,6 +4,7 @@ import os from "os";
 
 import * as vscode from "vscode";
 import sinon from "sinon";
+import { afterEach, beforeEach } from "mocha";
 
 import { Asdf } from "../../../ruby/asdf";
 import { WorkspaceChannel } from "../../../workspaceChannel";
@@ -13,6 +14,7 @@ import {
   FIELD_SEPARATOR,
   VALUE_SEPARATOR,
 } from "../../../ruby/versionManager";
+import { createContext, FakeContext } from "../helpers";
 
 suite("Asdf", () => {
   if (os.platform() === "win32") {
@@ -20,15 +22,18 @@ suite("Asdf", () => {
     console.log("Skipping Asdf tests on Windows");
     return;
   }
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-    extensionUri: vscode.Uri.parse("file:///fake"),
-  } as unknown as vscode.ExtensionContext;
+  let context: FakeContext;
+  let activationPath: vscode.Uri;
+
+  beforeEach(() => {
+    context = createContext();
+    activationPath = vscode.Uri.joinPath(context.extensionUri, "activation.rb");
+  });
+
+  afterEach(() => {
+    context.dispose();
+  });
+
   // eslint-disable-next-line no-process-env
   const workspacePath = process.env.PWD!;
   const workspaceFolder = {
@@ -66,7 +71,7 @@ suite("Asdf", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `. ${os.homedir()}/.asdf/asdf.sh && asdf exec ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
+        `. ${os.homedir()}/.asdf/asdf.sh && asdf exec ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`,
         {
           cwd: workspacePath,
           shell: "/bin/bash",
@@ -116,7 +121,7 @@ suite("Asdf", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `. ${os.homedir()}/.asdf/asdf.fish && asdf exec ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
+        `. ${os.homedir()}/.asdf/asdf.fish && asdf exec ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`,
         {
           cwd: workspacePath,
           shell: "/opt/homebrew/bin/fish",
@@ -167,7 +172,7 @@ suite("Asdf", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `/opt/homebrew/bin/asdf exec ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
+        `/opt/homebrew/bin/asdf exec ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`,
         {
           cwd: workspacePath,
           shell: vscode.env.shell,
@@ -214,7 +219,7 @@ suite("Asdf", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `asdf exec ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
+        `asdf exec ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`,
         {
           cwd: workspacePath,
           shell: vscode.env.shell,

--- a/vscode/src/test/suite/ruby/asdf.test.ts
+++ b/vscode/src/test/suite/ruby/asdf.test.ts
@@ -24,13 +24,16 @@ suite("Asdf", () => {
   }
   let context: FakeContext;
   let activationPath: vscode.Uri;
+  let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     context = createContext();
     activationPath = vscode.Uri.joinPath(context.extensionUri, "activation.rb");
   });
 
   afterEach(() => {
+    sandbox.restore();
     context.dispose();
   });
 
@@ -57,15 +60,15 @@ suite("Asdf", () => {
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
 
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
-    const findInstallationStub = sinon
+    sandbox
       .stub(asdf, "findAsdfInstallation")
       .resolves(`${os.homedir()}/.asdf/asdf.sh`);
-    const shellStub = sinon.stub(vscode.env, "shell").get(() => "/bin/bash");
+    sandbox.stub(vscode.env, "shell").get(() => "/bin/bash");
 
     const { env, version, yjit } = await asdf.activate();
 
@@ -85,10 +88,6 @@ suite("Asdf", () => {
     assert.strictEqual(version, "3.0.0");
     assert.strictEqual(yjit, true);
     assert.strictEqual(env.ANY, "true");
-
-    execStub.restore();
-    findInstallationStub.restore();
-    shellStub.restore();
   });
 
   test("Searches for asdf.fish when using the fish shell", async () => {
@@ -105,17 +104,15 @@ suite("Asdf", () => {
       "true",
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
-    const findInstallationStub = sinon
+    sandbox
       .stub(asdf, "findAsdfInstallation")
       .resolves(`${os.homedir()}/.asdf/asdf.fish`);
-    const shellStub = sinon
-      .stub(vscode.env, "shell")
-      .get(() => "/opt/homebrew/bin/fish");
+    sandbox.stub(vscode.env, "shell").get(() => "/opt/homebrew/bin/fish");
 
     const { env, version, yjit } = await asdf.activate();
 
@@ -135,10 +132,6 @@ suite("Asdf", () => {
     assert.strictEqual(version, "3.0.0");
     assert.strictEqual(yjit, true);
     assert.strictEqual(env.ANY, "true");
-
-    execStub.restore();
-    findInstallationStub.restore();
-    shellStub.restore();
   });
 
   test("Finds ASDF executable for Homebrew if script is not available", async () => {
@@ -155,16 +148,14 @@ suite("Asdf", () => {
       "true",
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
-    const findInstallationStub = sinon
-      .stub(asdf, "findAsdfInstallation")
-      .resolves(undefined);
+    sandbox.stub(asdf, "findAsdfInstallation").resolves(undefined);
 
-    const fsStub = sinon.stub(vscode.workspace, "fs").value({
+    sandbox.stub(vscode.workspace, "fs").value({
       stat: () => Promise.resolve(undefined),
     });
 
@@ -186,10 +177,6 @@ suite("Asdf", () => {
     assert.strictEqual(version, "3.0.0");
     assert.strictEqual(yjit, true);
     assert.strictEqual(env.ANY, "true");
-
-    fsStub.restore();
-    execStub.restore();
-    findInstallationStub.restore();
   });
 
   test("Uses ASDF executable in PATH if script and Homebrew executable are not available", async () => {
@@ -206,14 +193,12 @@ suite("Asdf", () => {
       "true",
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
-    const findInstallationStub = sinon
-      .stub(asdf, "findAsdfInstallation")
-      .resolves(undefined);
+    sandbox.stub(asdf, "findAsdfInstallation").resolves(undefined);
 
     const { env, version, yjit } = await asdf.activate();
 
@@ -233,8 +218,5 @@ suite("Asdf", () => {
     assert.strictEqual(version, "3.0.0");
     assert.strictEqual(yjit, true);
     assert.strictEqual(env.ANY, "true");
-
-    execStub.restore();
-    findInstallationStub.restore();
   });
 });

--- a/vscode/src/test/suite/ruby/chruby.test.ts
+++ b/vscode/src/test/suite/ruby/chruby.test.ts
@@ -13,7 +13,7 @@ import { WorkspaceChannel } from "../../../workspaceChannel";
 import { LOG_CHANNEL } from "../../../common";
 import { RUBY_VERSION, MAJOR, MINOR, VERSION_REGEX } from "../../rubyVersion";
 import { ActivationResult } from "../../../ruby/versionManager";
-import { CONTEXT } from "../helpers";
+import { createContext, FakeContext } from "../helpers";
 
 // Create links to the real Ruby installations on CI and on our local machines
 function createRubySymlinks(destination: string) {
@@ -55,6 +55,7 @@ suite("Chruby", () => {
   let workspacePath: string;
   let workspaceFolder: vscode.WorkspaceFolder;
   let outputChannel: WorkspaceChannel;
+  let context: FakeContext;
 
   beforeEach(() => {
     rootPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-chruby-"));
@@ -76,10 +77,12 @@ suite("Chruby", () => {
       index: 0,
     };
     outputChannel = new WorkspaceChannel("fake", LOG_CHANNEL);
+    context = createContext();
   });
 
   afterEach(() => {
     fs.rmSync(rootPath, { recursive: true, force: true });
+    context.dispose();
   });
 
   test("Finds Ruby when .ruby-version is inside workspace", async () => {
@@ -88,7 +91,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -105,7 +108,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -142,7 +145,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -192,7 +195,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -227,7 +230,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [vscode.Uri.file(rubyHome)];
@@ -254,7 +257,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     configStub.restore();
@@ -279,7 +282,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -311,7 +314,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -327,7 +330,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -344,7 +347,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -362,7 +365,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -379,7 +382,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [
@@ -399,7 +402,7 @@ suite("Chruby", () => {
     const chruby = new Chruby(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     chruby.rubyInstallationUris = [

--- a/vscode/src/test/suite/ruby/custom.test.ts
+++ b/vscode/src/test/suite/ruby/custom.test.ts
@@ -5,6 +5,7 @@ import os from "os";
 
 import * as vscode from "vscode";
 import sinon from "sinon";
+import { afterEach, beforeEach } from "mocha";
 
 import { Custom } from "../../../ruby/custom";
 import { WorkspaceChannel } from "../../../workspaceChannel";
@@ -14,17 +15,18 @@ import {
   FIELD_SEPARATOR,
   VALUE_SEPARATOR,
 } from "../../../ruby/versionManager";
+import { createContext, FakeContext } from "../helpers";
 
 suite("Custom", () => {
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-    extensionUri: vscode.Uri.parse("file:///fake"),
-  } as unknown as vscode.ExtensionContext;
+  let context: FakeContext;
+
+  beforeEach(() => {
+    context = createContext();
+  });
+
+  afterEach(() => {
+    context.dispose();
+  });
 
   test("Invokes custom script and then Ruby", async () => {
     const workspacePath = fs.mkdtempSync(

--- a/vscode/src/test/suite/ruby/custom.test.ts
+++ b/vscode/src/test/suite/ruby/custom.test.ts
@@ -19,12 +19,15 @@ import { createContext, FakeContext } from "../helpers";
 
 suite("Custom", () => {
   let context: FakeContext;
+  let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     context = createContext();
   });
 
   afterEach(() => {
+    sandbox.restore();
     context.dispose();
   });
 
@@ -53,12 +56,12 @@ suite("Custom", () => {
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
 
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
-    const commandStub = sinon
+    sandbox
       .stub(custom, "customCommand")
       .returns("my_version_manager activate_env");
     const { env, version, yjit } = await custom.activate();
@@ -87,8 +90,6 @@ suite("Custom", () => {
     assert.strictEqual(yjit, true);
     assert.deepStrictEqual(env.ANY, "true");
 
-    execStub.restore();
-    commandStub.restore();
     fs.rmSync(workspacePath, { recursive: true, force: true });
   });
 });

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 
 import * as vscode from "vscode";
 import sinon from "sinon";
+import { afterEach, beforeEach } from "mocha";
 
 import { Mise } from "../../../ruby/mise";
 import { WorkspaceChannel } from "../../../workspaceChannel";
@@ -14,6 +15,7 @@ import {
   FIELD_SEPARATOR,
   VALUE_SEPARATOR,
 } from "../../../ruby/versionManager";
+import { createContext, FakeContext } from "../helpers";
 
 suite("Mise", () => {
   if (os.platform() === "win32") {
@@ -22,15 +24,17 @@ suite("Mise", () => {
     return;
   }
 
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-    extensionUri: vscode.Uri.parse("file:///fake"),
-  } as unknown as vscode.ExtensionContext;
+  let context: FakeContext;
+  let activationPath: vscode.Uri;
+
+  beforeEach(() => {
+    context = createContext();
+    activationPath = vscode.Uri.joinPath(context.extensionUri, "activation.rb");
+  });
+
+  afterEach(() => {
+    context.dispose();
+  });
 
   test("Finds Ruby only binary path is appended to PATH", async () => {
     // eslint-disable-next-line no-process-env
@@ -74,7 +78,7 @@ suite("Mise", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `${os.homedir()}/.local/bin/mise x -- ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
+        `${os.homedir()}/.local/bin/mise x -- ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`,
         {
           cwd: workspacePath,
           shell: vscode.env.shell,
@@ -140,7 +144,7 @@ suite("Mise", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `${misePath} x -- ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
+        `${misePath} x -- ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`,
         {
           cwd: workspacePath,
           shell: vscode.env.shell,

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -26,13 +26,16 @@ suite("Mise", () => {
 
   let context: FakeContext;
   let activationPath: vscode.Uri;
+  let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     context = createContext();
     activationPath = vscode.Uri.joinPath(context.extensionUri, "activation.rb");
   });
 
   afterEach(() => {
+    sandbox.restore();
     context.dispose();
   });
 
@@ -59,11 +62,11 @@ suite("Mise", () => {
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
 
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
-    const findStub = sinon
+    const findStub = sandbox
       .stub(mise, "findMiseUri")
       .resolves(
         vscode.Uri.joinPath(
@@ -121,7 +124,7 @@ suite("Mise", () => {
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
 
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
@@ -129,7 +132,7 @@ suite("Mise", () => {
     const misePath = path.join(workspacePath, "mise");
     fs.writeFileSync(misePath, "fakeMiseBinary");
 
-    const configStub = sinon
+    const configStub = sandbox
       .stub(vscode.workspace, "getConfiguration")
       .returns({
         get: (name: string) => {

--- a/vscode/src/test/suite/ruby/none.test.ts
+++ b/vscode/src/test/suite/ruby/none.test.ts
@@ -19,12 +19,15 @@ import { createContext, FakeContext } from "../helpers";
 
 suite("None", () => {
   let context: FakeContext;
+  let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     context = createContext();
   });
 
   afterEach(() => {
+    sandbox.restore();
     context.dispose();
   });
 
@@ -53,7 +56,7 @@ suite("None", () => {
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
 
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
@@ -84,7 +87,6 @@ suite("None", () => {
     assert.strictEqual(yjit, true);
     assert.deepStrictEqual(env.ANY, "true");
 
-    execStub.restore();
     fs.rmSync(workspacePath, { recursive: true, force: true });
   });
 });

--- a/vscode/src/test/suite/ruby/none.test.ts
+++ b/vscode/src/test/suite/ruby/none.test.ts
@@ -5,6 +5,7 @@ import os from "os";
 
 import * as vscode from "vscode";
 import sinon from "sinon";
+import { afterEach, beforeEach } from "mocha";
 
 import { None } from "../../../ruby/none";
 import { WorkspaceChannel } from "../../../workspaceChannel";
@@ -14,18 +15,20 @@ import {
   FIELD_SEPARATOR,
   VALUE_SEPARATOR,
 } from "../../../ruby/versionManager";
+import { createContext, FakeContext } from "../helpers";
 
 suite("None", () => {
+  let context: FakeContext;
+
+  beforeEach(() => {
+    context = createContext();
+  });
+
+  afterEach(() => {
+    context.dispose();
+  });
+
   test("Invokes Ruby directly", async () => {
-    const context = {
-      extensionMode: vscode.ExtensionMode.Test,
-      subscriptions: [],
-      workspaceState: {
-        get: (_name: string) => undefined,
-        update: (_name: string, _value: any) => Promise.resolve(),
-      },
-      extensionUri: vscode.Uri.parse("file:///fake"),
-    } as unknown as vscode.ExtensionContext;
     const workspacePath = fs.mkdtempSync(
       path.join(os.tmpdir(), "ruby-lsp-test-"),
     );

--- a/vscode/src/test/suite/ruby/rbenv.test.ts
+++ b/vscode/src/test/suite/ruby/rbenv.test.ts
@@ -25,14 +25,17 @@ suite("Rbenv", () => {
   }
 
   let activationPath: vscode.Uri;
+  let sandbox: sinon.SinonSandbox;
   let context: FakeContext;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     context = createContext();
     activationPath = vscode.Uri.joinPath(context.extensionUri, "activation.rb");
   });
 
   afterEach(() => {
+    sandbox.restore();
     context.dispose();
   });
 
@@ -59,7 +62,7 @@ suite("Rbenv", () => {
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
 
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
@@ -82,7 +85,6 @@ suite("Rbenv", () => {
     assert.strictEqual(version, "3.0.0");
     assert.strictEqual(yjit, true);
     assert.strictEqual(env.ANY, "true");
-    execStub.restore();
   });
 
   test("Allows configuring where rbenv is installed", async () => {
@@ -109,7 +111,7 @@ suite("Rbenv", () => {
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
 
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });

--- a/vscode/src/test/suite/ruby/rbenv.test.ts
+++ b/vscode/src/test/suite/ruby/rbenv.test.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 
 import * as vscode from "vscode";
 import sinon from "sinon";
+import { afterEach, beforeEach } from "mocha";
 
 import { Rbenv } from "../../../ruby/rbenv";
 import { WorkspaceChannel } from "../../../workspaceChannel";
@@ -14,6 +15,7 @@ import {
   FIELD_SEPARATOR,
   VALUE_SEPARATOR,
 } from "../../../ruby/versionManager";
+import { createContext, FakeContext } from "../helpers";
 
 suite("Rbenv", () => {
   if (os.platform() === "win32") {
@@ -22,15 +24,17 @@ suite("Rbenv", () => {
     return;
   }
 
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-    extensionUri: vscode.Uri.parse("file:///fake"),
-  } as unknown as vscode.ExtensionContext;
+  let activationPath: vscode.Uri;
+  let context: FakeContext;
+
+  beforeEach(() => {
+    context = createContext();
+    activationPath = vscode.Uri.joinPath(context.extensionUri, "activation.rb");
+  });
+
+  afterEach(() => {
+    context.dispose();
+  });
 
   test("Finds Ruby based on .ruby-version", async () => {
     // eslint-disable-next-line no-process-env
@@ -64,7 +68,7 @@ suite("Rbenv", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `rbenv exec ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
+        `rbenv exec ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`,
         {
           cwd: workspacePath,
           shell: vscode.env.shell,
@@ -128,7 +132,7 @@ suite("Rbenv", () => {
 
     assert.ok(
       execStub.calledOnceWithExactly(
-        `${rbenvPath} exec ruby -EUTF-8:UTF-8 '/fake/activation.rb'`,
+        `${rbenvPath} exec ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`,
         {
           cwd: workspacePath,
           shell: vscode.env.shell,

--- a/vscode/src/test/suite/ruby/rubyInstaller.test.ts
+++ b/vscode/src/test/suite/ruby/rubyInstaller.test.ts
@@ -4,7 +4,7 @@ import path from "path";
 import os from "os";
 
 import sinon from "sinon";
-import { before, after, beforeEach } from "mocha";
+import { before, after, beforeEach, afterEach } from "mocha";
 import * as vscode from "vscode";
 
 import * as common from "../../../common";
@@ -13,7 +13,7 @@ import { WorkspaceChannel } from "../../../workspaceChannel";
 import { LOG_CHANNEL } from "../../../common";
 import { RUBY_VERSION, VERSION_REGEX } from "../../rubyVersion";
 import { ACTIVATION_SEPARATOR } from "../../../ruby/versionManager";
-import { createRubySymlinks, CONTEXT } from "../helpers";
+import { createRubySymlinks, createContext, FakeContext } from "../helpers";
 
 suite("RubyInstaller", () => {
   if (os.platform() !== "win32") {
@@ -26,12 +26,18 @@ suite("RubyInstaller", () => {
   let workspacePath: string;
   let workspaceFolder: vscode.WorkspaceFolder;
   let outputChannel: WorkspaceChannel;
+  let context: FakeContext;
 
   beforeEach(() => {
     // eslint-disable-next-line no-process-env
     if (process.env.CI) {
       createRubySymlinks();
     }
+    context = createContext();
+  });
+
+  afterEach(() => {
+    context.dispose();
   });
 
   before(() => {
@@ -58,7 +64,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     const { env, version, yjit } = await windows.activate();
@@ -78,7 +84,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     const { env, version, yjit } = await windows.activate();
@@ -98,7 +104,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     const result = ["/fake/dir", "/other/fake/dir", true, RUBY_VERSION].join(
@@ -123,7 +129,7 @@ suite("RubyInstaller", () => {
     const windows = new RubyInstaller(
       workspaceFolder,
       outputChannel,
-      CONTEXT,
+      context,
       async () => {},
     );
     const result = [

--- a/vscode/src/test/suite/ruby/rubyInstaller.test.ts
+++ b/vscode/src/test/suite/ruby/rubyInstaller.test.ts
@@ -27,8 +27,10 @@ suite("RubyInstaller", () => {
   let workspaceFolder: vscode.WorkspaceFolder;
   let outputChannel: WorkspaceChannel;
   let context: FakeContext;
+  let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     // eslint-disable-next-line no-process-env
     if (process.env.CI) {
       createRubySymlinks();
@@ -37,6 +39,7 @@ suite("RubyInstaller", () => {
   });
 
   afterEach(() => {
+    sandbox.restore();
     context.dispose();
   });
 
@@ -110,13 +113,12 @@ suite("RubyInstaller", () => {
     const result = ["/fake/dir", "/other/fake/dir", true, RUBY_VERSION].join(
       ACTIVATION_SEPARATOR,
     );
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: result,
     });
 
     await windows.activate();
-    execStub.restore();
 
     assert.strictEqual(execStub.callCount, 1);
     const callArgs = execStub.getCall(0).args;
@@ -138,13 +140,12 @@ suite("RubyInstaller", () => {
       true,
       RUBY_VERSION,
     ].join(ACTIVATION_SEPARATOR);
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: result,
     });
 
     const { gemPath } = await windows.activate();
-    execStub.restore();
 
     assert.deepStrictEqual(gemPath, [
       "\\\\?\\C:\\Ruby32\\default_gems",

--- a/vscode/src/test/suite/ruby/rvm.test.ts
+++ b/vscode/src/test/suite/ruby/rvm.test.ts
@@ -25,10 +25,17 @@ suite("RVM", () => {
   }
 
   let context: FakeContext;
+  let activationPath: vscode.Uri;
+  let sandbox: sinon.SinonSandbox;
+
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     context = createContext();
+    activationPath = vscode.Uri.joinPath(context.extensionUri, "activation.rb");
   });
+
   afterEach(() => {
+    sandbox.restore();
     context.dispose();
   });
 
@@ -47,7 +54,7 @@ suite("RVM", () => {
       async () => {},
     );
 
-    const installationPathStub = sinon
+    const installationPathStub = sandbox
       .stub(rvm, "findRvmInstallation")
       .resolves(
         vscode.Uri.joinPath(
@@ -65,16 +72,12 @@ suite("RVM", () => {
       `ANY${VALUE_SEPARATOR}true`,
     ].join(FIELD_SEPARATOR);
 
-    const execStub = sinon.stub(common, "asyncExec").resolves({
+    const execStub = sandbox.stub(common, "asyncExec").resolves({
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
 
     const { env, version, yjit } = await rvm.activate();
-    const activationPath = vscode.Uri.joinPath(
-      context.extensionUri,
-      "activation.rb",
-    );
 
     assert.ok(
       execStub.calledOnceWithExactly(

--- a/vscode/src/test/suite/ruby/shadowenv.test.ts
+++ b/vscode/src/test/suite/ruby/shadowenv.test.ts
@@ -14,6 +14,7 @@ import { WorkspaceChannel } from "../../../workspaceChannel";
 import { LOG_CHANNEL, asyncExec } from "../../../common";
 import { RUBY_VERSION } from "../../rubyVersion";
 import * as common from "../../../common";
+import { createContext, FakeContext } from "../helpers";
 
 suite("Shadowenv", () => {
   if (os.platform() === "win32") {
@@ -30,18 +31,13 @@ suite("Shadowenv", () => {
     return;
   }
 
-  const extensionPath = path.dirname(
-    path.dirname(path.dirname(path.dirname(path.dirname(__dirname)))),
-  );
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-    extensionUri: vscode.Uri.file(path.join(extensionPath, "vscode")),
-  } as unknown as vscode.ExtensionContext;
+  let context: FakeContext;
+  beforeEach(() => {
+    context = createContext();
+  });
+  afterEach(() => {
+    context.dispose();
+  });
 
   let rootPath: string;
   let workspacePath: string;

--- a/vscode/src/test/suite/status.test.ts
+++ b/vscode/src/test/suite/status.test.ts
@@ -20,8 +20,14 @@ suite("StatusItems", () => {
   let ruby: Ruby;
   let status: StatusItem;
   let workspace: WorkspaceInterface;
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
 
   afterEach(() => {
+    sandbox.restore();
     status.dispose();
   });
 
@@ -184,7 +190,7 @@ suite("StatusItems", () => {
         typeHierarchy: true,
       };
       const numberOfFeatures = Object.keys(features).length;
-      const stub = sinon.stub(vscode.workspace, "getConfiguration").returns({
+      sandbox.stub(vscode.workspace, "getConfiguration").returns({
         get: () => features,
       } as unknown as vscode.WorkspaceConfiguration);
 
@@ -195,7 +201,6 @@ suite("StatusItems", () => {
       assert.strictEqual(status.item.name, "Ruby LSP Features");
       assert.strictEqual(status.item.command?.title, "Manage");
       assert.strictEqual(status.item.command.command, Command.ToggleFeatures);
-      stub.restore();
     });
 
     test("Refresh updates number of features", () => {
@@ -219,7 +224,7 @@ suite("StatusItems", () => {
         signatureHelp: true,
       };
       const numberOfFeatures = Object.keys(features).length;
-      const stub = sinon.stub(vscode.workspace, "getConfiguration").returns({
+      sandbox.stub(vscode.workspace, "getConfiguration").returns({
         get: () => features,
       } as unknown as vscode.WorkspaceConfiguration);
 
@@ -228,8 +233,6 @@ suite("StatusItems", () => {
         status.item.text,
         `${numberOfFeatures - 1}/${numberOfFeatures} features enabled`,
       );
-
-      stub.restore();
     });
   });
 

--- a/vscode/src/test/suite/streamingRunner.test.ts
+++ b/vscode/src/test/suite/streamingRunner.test.ts
@@ -8,13 +8,14 @@ import { after, afterEach, before, beforeEach } from "mocha";
 
 import { StreamingRunner } from "../../streamingRunner";
 
-import { CONTEXT } from "./helpers";
+import { createContext, FakeContext } from "./helpers";
 
 suite("StreamingRunner", () => {
   let sandbox: sinon.SinonSandbox;
   const tempDirUri = vscode.Uri.file(path.join(os.tmpdir(), "ruby-lsp"));
   const dbUri = vscode.Uri.joinPath(tempDirUri, "test_reporter_port_db.json");
   let currentDbContents: string | undefined;
+  let context: FakeContext;
 
   before(async () => {
     try {
@@ -37,11 +38,12 @@ suite("StreamingRunner", () => {
   beforeEach(async () => {
     await vscode.workspace.fs.createDirectory(tempDirUri);
     sandbox = sinon.createSandbox();
+    context = createContext();
   });
 
   afterEach(() => {
     sandbox.restore();
-    CONTEXT.subscriptions.forEach((disposable) => disposable.dispose());
+    context.dispose();
   });
 
   test("updates port DB with new values", async () => {
@@ -57,7 +59,7 @@ suite("StreamingRunner", () => {
     );
 
     const streamingRunner = new StreamingRunner(
-      CONTEXT,
+      context,
       () => Promise.resolve(undefined),
       () => ({}) as any as vscode.TestRun,
     );

--- a/vscode/src/test/suite/testController.test.ts
+++ b/vscode/src/test/suite/testController.test.ts
@@ -17,10 +17,11 @@ import { Debugger } from "../../debugger";
 import { FAKE_TELEMETRY } from "./fakeTelemetry";
 import {
   createRubySymlinks,
-  CONTEXT,
   LSP_WORKSPACE_FOLDER,
   LSP_WORKSPACE_PATH,
   LSP_WORKSPACE_URI,
+  createContext,
+  FakeContext,
 } from "./helpers";
 
 suite("TestController", () => {
@@ -32,12 +33,15 @@ suite("TestController", () => {
   const serverTestUri = vscode.Uri.joinPath(testDirUri, "server_test.rb");
   const storeTestUri = vscode.Uri.joinPath(testDirUri, "store_test.rb");
 
+  let context: FakeContext;
+
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
+    context = createContext();
     workspaceStubs = [];
 
     workspace = new Workspace(
-      CONTEXT,
+      context,
       LSP_WORKSPACE_FOLDER,
       FAKE_TELEMETRY,
       () => undefined,
@@ -47,7 +51,7 @@ suite("TestController", () => {
 
     const commonStub = sandbox.stub(common, "featureEnabled").returns(true);
     controller = new TestController(
-      CONTEXT,
+      context,
       FAKE_TELEMETRY,
       () => undefined,
       () => Promise.resolve(workspace),
@@ -62,7 +66,7 @@ suite("TestController", () => {
 
   afterEach(() => {
     sandbox.restore();
-    CONTEXT.subscriptions.forEach((subscription) => subscription.dispose());
+    context.dispose();
   });
 
   function setupLspClientStub(workspace: Workspace) {
@@ -714,7 +718,7 @@ suite("TestController", () => {
     } as any;
     sandbox.stub(controller.testController, "createTestRun").returns(runStub);
 
-    const debug = new Debugger(CONTEXT, () => workspace);
+    const debug = new Debugger(context, () => workspace);
     const startDebuggingSpy = sandbox.spy(vscode.debug, "startDebugging");
 
     const runRequest = new vscode.TestRunRequest(

--- a/vscode/src/test/suite/workspace.test.ts
+++ b/vscode/src/test/suite/workspace.test.ts
@@ -11,24 +11,19 @@ import { beforeEach, afterEach } from "mocha";
 import { Workspace } from "../../workspace";
 
 import { FAKE_TELEMETRY } from "./fakeTelemetry";
+import { createContext, FakeContext } from "./helpers";
 
 suite("Workspace", () => {
-  const context = {
-    extensionMode: vscode.ExtensionMode.Test,
-    subscriptions: [],
-    workspaceState: {
-      get: (_name: string) => undefined,
-      update: (_name: string, _value: any) => Promise.resolve(),
-    },
-  } as unknown as vscode.ExtensionContext;
   let workspacePath: string;
   let workspaceUri: vscode.Uri;
   let workspaceFolder: vscode.WorkspaceFolder;
   let sandbox: sinon.SinonSandbox;
   let workspace: Workspace;
+  let context: FakeContext;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    context = createContext();
     workspacePath = fs.mkdtempSync(
       path.join(os.tmpdir(), "ruby-lsp-test-workspace-"),
     );
@@ -52,6 +47,7 @@ suite("Workspace", () => {
   afterEach(() => {
     sandbox.restore();
     fs.rmSync(workspacePath, { recursive: true, force: true });
+    context.dispose();
   });
 
   test("repeated rebase steps don't trigger multiple restarts", async () => {


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

Tests were leaking context between runs due to:

- Stubs not being properly restored after each test
- Missing proper context disposal mechanism  
- Direct `sinon.stub()` calls without cleanup

This could cause flaky tests and unexpected behaviour, with some test failures affecting subsequent tests.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

- **Added sinon sandbox pattern** to all test files that use stubs
  - `sandbox.createSandbox()` in `beforeEach()`
  - `sandbox.restore()` in `afterEach()` 
  - Replace `sinon.stub()` with `sandbox.stub()` for automatic cleanup
- **Created `createContext()` helper function** with `dispose()` method for proper cleanup of subscriptions
- **Maintained correct usage** of direct `sinon.stub()` for creating fake objects (vs stubbing real methods)

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

Tests now run in isolation and with no leftover stubs.
