### PR TITLE
Handle attr with `true` argument for writer

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -254,12 +254,15 @@ module RubyIndexer
       case message
       when :private_constant
         handle_private_constant(node)
-      when :attr_reader, :attr
+      when :attr_reader
         handle_attribute(node, reader: true, writer: false)
       when :attr_writer
         handle_attribute(node, reader: false, writer: true)
       when :attr_accessor
         handle_attribute(node, reader: true, writer: true)
+      when :attr
+        has_writer = node.arguments&.arguments&.last&.is_a?(Prism::TrueNode) || false
+        handle_attribute(node, reader: true, writer: has_writer)
       when :alias_method
         handle_alias_method(node)
       when :include, :prepend, :extend

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -954,10 +954,17 @@ module RubyIndexer
       index(<<~RUBY)
         class Foo
           attr :bar
+          attr :baz, true
+          attr :qux, false
         end
       RUBY
 
       assert_entry("bar", Entry::Accessor, "/fake/path/foo.rb:1-8:1-11")
+      assert_no_entry("bar=")
+      assert_entry("baz", Entry::Accessor, "/fake/path/foo.rb:2-8:2-11")
+      assert_entry("baz=", Entry::Accessor, "/fake/path/foo.rb:2-8:2-11")
+      assert_entry("qux", Entry::Accessor, "/fake/path/foo.rb:3-8:3-11")
+      assert_no_entry("qux=")
     end
 
     private


### PR DESCRIPTION
### Motivation

As pointed out in https://github.com/Shopify/ruby-lsp/pull/3544#discussion_r2124125576, `attr` actually accepts a boolean argument to determine if a writer is defined or not.

### Implementation

Started handling the argument in a separate branch for `attr`.

### Automated Tests

Improved our existing tests.