### PR TITLE
Pass workspace to telemetry on every error log

### DIFF
--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -424,6 +424,9 @@ export default class Client extends LanguageClient implements ClientInterface {
             {
               appType: "server",
               appVersion: this.serverVersion,
+              workspace: new vscode.TelemetryTrustedValue(
+                path.basename(this.workingDirectory),
+              ),
             },
           );
         } else if (event.type === "data" && this.validServerTelemetry(event)) {


### PR DESCRIPTION
### Motivation

We [sometimes pass workspace information when error logging](https://github.com/Shopify/ruby-lsp/blob/main/vscode/src/client.ts#L601C17-L601C27), but we should be doing it everywhere we log errors. This can help us keep track of which projects are producing errors and fix them more easily.

### Implementation

I added workspace information to our error logging on a server telemetry event.

### Automated Tests

Automated tests should continue to pass.