### PR TITLE
Register all test discovery listener events in one go

### DIFF
--- a/lib/ruby_lsp/listeners/spec_style.rb
+++ b/lib/ruby_lsp/listeners/spec_style.rb
@@ -19,21 +19,20 @@ module RubyLsp
 
       #: (ResponseBuilders::TestCollection, GlobalState, Prism::Dispatcher, URI::Generic) -> void
       def initialize(response_builder, global_state, dispatcher, uri)
-        super
+        super(response_builder, global_state, uri)
 
         @spec_group_id_stack = [] #: Array[Group?]
 
-        dispatcher.register(
-          self,
-          # Common handlers registered in parent class
+        register_events(
+          dispatcher,
           :on_class_node_enter,
-          :on_call_node_enter, # e.g. `describe` or `it`
+          :on_call_node_enter,
           :on_call_node_leave,
         )
       end
 
       #: (Prism::ClassNode) -> void
-      def on_class_node_enter(node)
+      def on_class_node_enter(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
         with_test_ancestor_tracking(node) do |name, ancestors|
           @spec_group_id_stack << (ancestors.include?("Minitest::Spec") ? ClassGroup.new(name) : nil)
         end
@@ -58,7 +57,7 @@ module RubyLsp
       end
 
       #: (Prism::CallNode) -> void
-      def on_call_node_enter(node)
+      def on_call_node_enter(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
         return unless in_spec_context?
 
         case node.name
@@ -70,7 +69,7 @@ module RubyLsp
       end
 
       #: (Prism::CallNode) -> void
-      def on_call_node_leave(node)
+      def on_call_node_leave(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
         return unless node.name == :describe && !node.receiver
 
         current_group = @spec_group_id_stack.last

--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -153,14 +153,13 @@ module RubyLsp
 
       #: (ResponseBuilders::TestCollection, GlobalState, Prism::Dispatcher, URI::Generic) -> void
       def initialize(response_builder, global_state, dispatcher, uri)
-        super
+        super(response_builder, global_state, uri)
 
         @framework = :minitest #: Symbol
         @parent_stack = [@response_builder] #: Array[(Requests::Support::TestItem | ResponseBuilders::TestCollection)?]
 
-        dispatcher.register(
-          self,
-          # Common handlers registered in parent class
+        register_events(
+          dispatcher,
           :on_class_node_enter,
           :on_def_node_enter,
           :on_call_node_enter,
@@ -169,7 +168,7 @@ module RubyLsp
       end
 
       #: (Prism::ClassNode node) -> void
-      def on_class_node_enter(node)
+      def on_class_node_enter(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
         with_test_ancestor_tracking(node) do |name, ancestors|
           @framework = :test_unit if ancestors.include?("Test::Unit::TestCase")
 
@@ -210,7 +209,7 @@ module RubyLsp
       end
 
       #: (Prism::DefNode node) -> void
-      def on_def_node_enter(node)
+      def on_def_node_enter(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
         return if @visibility_stack.last != :public
 
         name = node.name.to_s
@@ -232,7 +231,7 @@ module RubyLsp
       end
 
       #: (Prism::CallNode node) -> void
-      def on_call_node_enter(node)
+      def on_call_node_enter(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
         name = node.name
         return unless ACCESS_MODIFIERS.include?(name)
 
@@ -240,7 +239,7 @@ module RubyLsp
       end
 
       #: (Prism::CallNode node) -> void
-      def on_call_node_leave(node)
+      def on_call_node_leave(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
         name = node.name
         return unless ACCESS_MODIFIERS.include?(name)
         return unless node.arguments&.arguments


### PR DESCRIPTION
### Motivation

This PR makes sure that we register all events for the test discovery listeners in one go, so that we're not making registrations at different points in time.

### Implementation

Added a method to the parent class to register the base events + the ones the listener is interested in. This is a breaking change because without updating add-ons, the original events will be missing and it won't work properly.

### Automated Tests

Current tests cover this refactor.