### PR TITLE
Utf 8 encoding issue

### DIFF
--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -7,8 +7,6 @@ module RubyLsp
   class Document
     extend T::Generic
 
-    class LocationNotFoundError < StandardError; end
-
     # This maximum number of characters for providing expensive features, like semantic highlighting and diagnostics.
     # This is the same number used by the TypeScript extension in VS Code
     MAXIMUM_CHARACTERS_FOR_EXPENSIVE_FEATURES = 100_000
@@ -186,15 +184,7 @@ module RubyLsp
       def find_char_position(position)
         # Find the character index for the beginning of the requested line
         until @current_line == position[:line]
-          until LINE_BREAK == @source[@pos]
-            @pos += 1
-
-            if @pos >= @source.length
-              # Pack the code points back into the original string to provide context in the error message
-              raise LocationNotFoundError, "Requested position: #{position}\nSource:\n\n#{@source.pack("U*")}"
-            end
-          end
-
+          @pos += 1 until LINE_BREAK == @source[@pos]
           @pos += 1
           @current_line += 1
         end

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -121,23 +121,11 @@ module RubyLsp
         # If a document is deleted before we are able to process all of its enqueued requests, we will try to read it
         # from disk and it raise this error. This is expected, so we don't include the `data` attribute to avoid
         # reporting these to our telemetry
-        case e
-        when Store::NonExistingDocumentError
+        if e.is_a?(Store::NonExistingDocumentError)
           send_message(Error.new(
             id: message[:id],
             code: Constant::ErrorCodes::INVALID_PARAMS,
             message: e.full_message,
-          ))
-        when Document::LocationNotFoundError
-          send_message(Error.new(
-            id: message[:id],
-            code: Constant::ErrorCodes::REQUEST_FAILED,
-            message: <<~MESSAGE,
-              Request #{message[:method]} failed to find the target position.
-              The file might have been modified while the server was in the middle of searching for the target.
-              If you experience this regularly, please report any findings and extra information on
-              https://github.com/Shopify/ruby-lsp/issues/2446
-            MESSAGE
           ))
         else
           send_message(Error.new(

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -59,6 +59,20 @@ class RubyDocumentTest < Minitest::Test
     RUBY
   end
 
+  def test_multibyte_character_offsets_are_bytes_in_utf8
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
+      bá
+    RUBY
+
+    document.push_edits(
+      [{ range: { start: { line: 0, character: 3 }, end: { line: 0, character: 3 } }, text: "r" }], version: 2
+    )
+
+    assert_equal(<<~RUBY, document.source)
+      bár
+    RUBY
+  end
+
   def test_deletion_full_node
     document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       def foo

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -73,6 +73,34 @@ class RubyDocumentTest < Minitest::Test
     RUBY
   end
 
+  def test_multibyte_character_offsets_for_3_byte_character
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
+      bあ
+    RUBY
+
+    document.push_edits(
+      [{ range: { start: { line: 0, character: 4 }, end: { line: 0, character: 4 } }, text: "r" }], version: 2
+    )
+
+    assert_equal(<<~RUBY, document.source)
+      bあr
+    RUBY
+  end
+
+  def test_multibyte_character_offsets_for_4_byte_character
+    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
+      b🙂
+    RUBY
+
+    document.push_edits(
+      [{ range: { start: { line: 0, character: 5 }, end: { line: 0, character: 5 } }, text: "r" }], version: 2
+    )
+
+    assert_equal(<<~RUBY, document.source)
+      b🙂r
+    RUBY
+  end
+
   def test_deletion_full_node
     document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       def foo
@@ -286,55 +314,6 @@ class RubyDocumentTest < Minitest::Test
       puts 'hello'
 
       puts 'hello'
-    RUBY
-  end
-
-  def test_pushing_edits_to_document_with_unicode
-    document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
-      chars = ["億"]
-    RUBY
-
-    # Write puts 'a' in incremental edits
-    document.push_edits(
-      [{ range: { start: { line: 0, character: 13 }, end: { line: 0, character: 13 } }, text: "\n" }],
-      version: 2,
-    )
-    document.push_edits(
-      [{ range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } }, text: "p" }],
-      version: 3,
-    )
-    document.push_edits(
-      [{ range: { start: { line: 1, character: 1 }, end: { line: 1, character: 1 } }, text: "u" }],
-      version: 4,
-    )
-    document.push_edits(
-      [{ range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } }, text: "t" }],
-      version: 5,
-    )
-    document.push_edits(
-      [{ range: { start: { line: 1, character: 3 }, end: { line: 1, character: 3 } }, text: "s" }],
-      version: 6,
-    )
-    document.push_edits(
-      [{ range: { start: { line: 1, character: 4 }, end: { line: 1, character: 4 } }, text: " " }],
-      version: 7,
-    )
-    document.push_edits(
-      [{ range: { start: { line: 1, character: 5 }, end: { line: 1, character: 5 } }, text: "'" }],
-      version: 8,
-    )
-    document.push_edits(
-      [{ range: { start: { line: 1, character: 6 }, end: { line: 1, character: 6 } }, text: "a" }],
-      version: 9,
-    )
-    document.push_edits(
-      [{ range: { start: { line: 1, character: 7 }, end: { line: 1, character: 7 } }, text: "'" }],
-      version: 10,
-    )
-
-    assert_equal(<<~RUBY, document.source)
-      chars = ["億"]
-      puts 'a'
     RUBY
   end
 

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -774,29 +774,6 @@ class RubyDocumentTest < Minitest::Test
     assert_nil(document.cache_get("textDocument/codeLens"))
   end
 
-  def test_locating_a_non_existing_location_raises
-    document = RubyLsp::RubyDocument.new(source: <<~RUBY.chomp, version: 1, uri: @uri, global_state: @global_state)
-      class Foo
-      end
-    RUBY
-
-    # Exactly at the last character doesn't raise
-    document.locate_node({ line: 1, character: 2 })
-
-    # Anything beyond does
-    error = assert_raises(RubyLsp::Document::LocationNotFoundError) do
-      document.locate_node({ line: 3, character: 2 })
-    end
-
-    assert_match(/Requested position: {(:)?line[\s:=>]+3, (:)?character[\s:=>]+2}/, error.message)
-    assert_match(<<~MESSAGE.chomp, error.message)
-      Source:
-
-      class Foo
-      end
-    MESSAGE
-  end
-
   def test_document_tracks_latest_edit_context
     document = RubyLsp::RubyDocument.new(source: +<<~RUBY, version: 1, uri: @uri, global_state: @global_state)
       class Foo

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -893,36 +893,6 @@ class ServerTest < Minitest::Test
     end
   end
 
-  def test_requests_to_a_non_existing_position_return_error
-    uri = URI("file:///foo.rb")
-
-    @server.process_message({
-      method: "textDocument/didOpen",
-      params: {
-        textDocument: {
-          uri: uri,
-          text: "class Foo\nend",
-          version: 1,
-          languageId: "ruby",
-        },
-      },
-    })
-
-    @server.process_message({
-      id: 1,
-      method: "textDocument/completion",
-      params: {
-        textDocument: {
-          uri: uri,
-        },
-        position: { line: 10, character: 0 },
-      },
-    })
-
-    error = find_message(RubyLsp::Error)
-    assert_match("Request textDocument/completion failed to find the target position.", error.message)
-  end
-
   def test_cancelling_requests_returns_nil
     uri = URI("file:///foo.rb")
 


### PR DESCRIPTION
### Motivation

Closes: https://github.com/Shopify/ruby-lsp/issues/3494
Closes: https://github.com/Shopify/ruby-lsp/issues/2446

This PR addresses an issue where UTF-8 encoded text uses incorrect offsets within the language server. The language server was calculating offsets using the number of code points, but UTF-8 code units match the number of bytes (as explained in the [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#positionEncodingKind)).  

### Implementation

To fix this issue, the `Scanner` class was updated to calculate offset by taking a byte slice of the current text up until a given position, and return the number of chars within the given slice. This number was then added to the offset provided by the new character, which results in a correct char offset.

### Automated Tests

Added some unit tests.

### Manual Tests

Tested in neo-vim.
