### PR TITLE
Update `collect_references` to use `Prism::LexResult`

### DIFF
--- a/lib/ruby_lsp/requests/references.rb
+++ b/lib/ruby_lsp/requests/references.rb
@@ -66,7 +66,7 @@ module RubyLsp
           # of reading from disk
           next if @store.key?(uri)
 
-          parse_result = Prism.parse_file(path)
+          parse_result = Prism.parse_lex_file(path)
           collect_references(reference_target, parse_result, uri)
         rescue Errno::EISDIR, Errno::ENOENT
           # If `path` is a directory, just ignore it and continue. If the file doesn't exist, then we also ignore it.
@@ -111,7 +111,7 @@ module RubyLsp
         end
       end
 
-      #: (RubyIndexer::ReferenceFinder::Target target, Prism::ParseResult parse_result, URI::Generic uri) -> void
+      #: (RubyIndexer::ReferenceFinder::Target target, Prism::LexResult parse_result, URI::Generic uri) -> void
       def collect_references(target, parse_result, uri)
         dispatcher = Prism::Dispatcher.new
         finder = RubyIndexer::ReferenceFinder.new(
@@ -121,7 +121,7 @@ module RubyLsp
           uri,
           include_declarations: @params.dig(:context, :includeDeclaration) || true,
         )
-        dispatcher.visit(parse_result.value)
+        dispatcher.visit(parse_result.value.first)
 
         finder.references.each do |reference|
           @locations << Interface::Location.new(

--- a/test/requests/references_test.rb
+++ b/test/requests/references_test.rb
@@ -28,6 +28,9 @@ class ReferencesTest < Minitest::Test
       global_state: global_state,
     )
 
+    # In addition to glob files from the workspace, we also want to test references collection from the store
+    store.set(uri: URI::Generic.from_path(path: path), source: source, version: 1, language_id: :ruby)
+
     RubyLsp::Requests::References.new(
       global_state,
       store,


### PR DESCRIPTION

### Motivation

In #3252, `RubyDocument#parse_result` becomes `Prism::ParseLexResult`, which's `value` is an array instead of a single node. And we forgot to update `collect_references` to account for this change because the codepath was not covered in the test.

So this commit adds a test for the codepath and updates `collect_references` to use `Prism::LexResult`.
### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
