### PR TITLE
Always specify a valid constant for Symbol kind

### DIFF
--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -155,6 +155,10 @@ module RubyLsp
             Constant::SymbolKind::PROPERTY
           when RubyIndexer::Entry::InstanceVariable
             Constant::SymbolKind::FIELD
+          when RubyIndexer::Entry::GlobalVariable
+            Constant::SymbolKind::VARIABLE
+          else
+            Constant::SymbolKind::NULL
           end
         end
       end


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation
Ruby-lsp defines the method `kind_for_entry` which maps entry types from RubyIndexer to SymbolKind constants as defined in the LSP specification. Zed expects the JSONRPC results to strictly match the protocol specificaion and when they don't it will reject the whole response. Because `kind_for_entry` did not map _every_ RubyIndexer entry type to a SymbolKind constant, often results would be sent back to the client where the value of `kind` was `null`. Since the LSP protocol specification defines SchemaKind as an integer enum, this means the results don't strictly match the specification and the end result was that in almost all cases I was getting no results for project symbols even though I could see the results in the Zed LSP message traces.

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation
This PR adds a default SymbolKind value of `NULL` for unknown RubyIndexer entry classes, which will allow results to always match the protocol specification. Ideally every RubyIndexer entry class is mapped to a SymbolKind enum value, but I don't have enough experience with the LSP specification or the Ruby-lsp project to ensure all of these cases are handled. I did find that there was one entry class, `RubyIndexer::Entry::GlobalVariable`, that seemed like it would correctly map to the `VARIABLE` SymbolKind value and I added that here.

I also encountered `RubyIndexer::Entry::UnresolvedMethodAlias`, but was unsure of which SymbolKind value that would map to. Because this class is not defined in `kind_of_entry`, it will get the default SymbolKind of `NULL`. In Zed this is handled as a valid value, but the result is discarded and not displayed in the Project Symbols dialog. I have not tested how other IDEs handle the `NULL` enum value, but it does conform to the specification, so it should be valid.

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests
I didn't spend enough time with the codebase to understand how to add tests. If there is a basic example that I can modify to get coverage and ensure no regressions for this and someone can point me to it, I will gladly add a test.

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests
I verified these changes worked using the Zed LSP debug logs and was able to see the expected symbols in the Project Symbols dialog.

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
