### PR TITLE
Bump Node to v22.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           DISABLE_V8_COMPILE_CACHE: "1"
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20.9"
+          node-version: "22.15"
 
       - name: Run cspell
         run: |
@@ -72,7 +72,7 @@ jobs:
           DISABLE_V8_COMPILE_CACHE: "1"
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20.9"
+          node-version: "22.15"
           cache: "yarn"
           cache-dependency-path: "vscode"
 
@@ -96,7 +96,7 @@ jobs:
         env:
           DISABLE_V8_COMPILE_CACHE: 1
         with:
-          node-version: "20.9"
+          node-version: "22.15"
           cache: "yarn"
           cache-dependency-path: "vscode"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           DISABLE_V8_COMPILE_CACHE: "1"
         with:
-          node-version: "20.9"
+          node-version: "22.15"
           cache: "yarn"
           cache-dependency-path: "vscode"
 

--- a/dev.yml
+++ b/dev.yml
@@ -8,7 +8,7 @@ up:
   - bundler
   - node:
       yarn: true
-      version: 20.9.0
+      version: 22.15.1
       packages:
         - vscode
 


### PR DESCRIPTION
### Motivation

VS Code upgraded the Node version it runs on to v22.15.1. We should upgrade our development version to match.