### PR TITLE
Add TruffleRuby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ["3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", truffleruby]
+        exclude:
+        - { os: windows-latest, ruby: truffleruby }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}


### PR DESCRIPTION
I wanted to know if it passes the CI, but it seems not yet:
https://github.com/eregon/ruby-lsp/actions/runs/15741842934/job/44368858494
```
Run bundle exec rake
/home/runner/work/ruby-lsp/ruby-lsp/vendor/bundle/truffleruby/3.3.7.24.2.1.1/bin/rake: symbol lookup error: /home/runner/work/ruby-lsp/ruby-lsp/vendor/bundle/truffleruby/3.3.7.24.2.1.1/gems/rbs-4.0.0.dev.4/lib/rbs_extension.so: undefined symbol: ruby_vm_at_exit
```
So this means ruby-lsp or one of its dependencies depends on the ruby_vm_at_exit() C API function, but that's not implemented on truffleruby.
I found a usage of ruby_vm_at_exit here:
https://github.com/ruby/rbs/blob/b088f689f21c9a73d10ca3f854c25b13d061c3a7/ext/rbs_extension/main.c#L468