### PR TITLE
Bump build timeout to 40 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ruby: ["3.2", "3.3", "3.4"]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### Motivation

Windows builds are getting closer and closer to taking 30 minutes and we started seeing timeouts quite regularly. Let's bump it 40 minutes so that the build can finish.