### PR TITLE
Allow users to disable test related code lenses

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -62,6 +62,10 @@ module RubyLsp
           implicitRescue: false,
           implicitHashValue: false,
         }),
+        codeLens: RequestConfig.new({
+          enableAll: false,
+          enableTestCodeLens: true,
+        }),
       } #: Hash[Symbol, RequestConfig]
     end
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -342,6 +342,20 @@
                   "type": "boolean"
                 }
               }
+            },
+            "codeLens": {
+              "description": "Customize code lens features",
+              "type": "object",
+              "properties": {
+                "enableAll": {
+                  "type": "boolean"
+                },
+                "enableTestCodeLens": {
+                  "description": "Enable the run, run in terminal, debug code and other test related code lenses",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
### Motivation

Closes #2167

This PR allows users to configure their code lens request, giving them the ability to disable test related buttons.

**Question**: I thought providing 3 settings for controlling each one of the lenses (run, run in terminal and debug) could be a bit too much granularity. Do people agree? Or would people prefer being able to customize at that level?

### Implementation

Added another entry to our feature configuration object and started checking that before registering the test code lens listeners.

### Automated Tests

Added a test.