### PR TITLE
Support Windsurf for setting cursor position in snippets

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -162,7 +162,7 @@ module RubyLsp
 
       #: (Integer line, Integer character) -> void
       def move_cursor_to(line, character)
-        return unless /Visual Studio Code|Cursor|VSCodium/.match?(@client_name)
+        return unless /Visual Studio Code|Cursor|VSCodium|Windsurf/.match?(@client_name)
 
         position = Interface::Position.new(
           line: line,

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -1015,6 +1015,46 @@ class OnTypeFormattingTest < Minitest::Test
     assert_equal(expected_edits.to_json, edits.to_json)
   end
 
+  def test_includes_snippets_on_windsurf
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
+
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "class Foo",
+      }],
+      version: 2,
+    )
+    document.parse!
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(
+      document,
+      { line: 1, character: 2 },
+      "\n",
+      "Windsurf",
+    ).perform
+    expected_edits = [
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "\n",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "end",
+      },
+      {
+        range: { start: { line: 1, character: 2 }, end: { line: 1, character: 2 } },
+        newText: "$0",
+      },
+    ]
+    assert_equal(expected_edits.to_json, edits.to_json)
+  end
+
   def test_does_not_confuse_class_parameter_with_keyword
     document = RubyLsp::RubyDocument.new(
       source: +"",


### PR DESCRIPTION
### Motivation

Closes #3633 by repeating the work done for supporting VSCodium.

### Implementation

Copies the same pattern fixing a similar issue in VSCodium from https://github.com/Shopify/ruby-lsp/pull/3302

The discussion in that PR noted that there might be a better way, but if it's acceptable to repeat that style of support for now, I've presented a working PR that I've tested locally.

### Automated Tests

Yes, the tests were copied from the previous referenced implementation.

### Manual Tests

I made this change in my local `bundle open ruby-lsp` to check the correct key being `Windsurf`, and Windsurf then operated as expected.

Typing `class Hotdog<enter>` successfully added `end` with the cursor in the body instead of end.

```rb
class Hotdog
  _ #<-- cursor
end