### PR TITLE
Remove excessive mutex synchronization

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -83,8 +83,7 @@ module RubyLsp
         # The following requests need to be executed in the main thread directly to avoid concurrency issues. Everything
         # else is pushed into the incoming queue
         case method
-        when "initialize", "initialized", "textDocument/didOpen", "textDocument/didClose", "textDocument/didChange",
-          "rubyLsp/diagnoseState"
+        when "initialize", "initialized", "rubyLsp/diagnoseState"
           process_message(message)
         when "shutdown"
           @global_state.synchronize do
@@ -94,7 +93,7 @@ module RubyLsp
             @writer.write(Result.new(id: message[:id], response: nil).to_hash)
           end
         when "exit"
-          @global_state.synchronize { exit(@incoming_queue.closed? ? 0 : 1) }
+          exit(@incoming_queue.closed? ? 0 : 1)
         else
           @incoming_queue << message
         end

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -139,12 +139,10 @@ module RubyLsp
 
     #: (Hash[Symbol, untyped] start_pos, ?Hash[Symbol, untyped]? end_pos) -> [Integer, Integer?]
     def find_index_by_position(start_pos, end_pos = nil)
-      @global_state.synchronize do
-        scanner = create_scanner
-        start_index = scanner.find_char_position(start_pos)
-        end_index = scanner.find_char_position(end_pos) if end_pos
-        [start_index, end_index]
-      end
+      scanner = create_scanner
+      start_index = scanner.find_char_position(start_pos)
+      end_index = scanner.find_char_position(end_pos) if end_pos
+      [start_index, end_index]
     end
 
     private


### PR DESCRIPTION
### Motivation

With the improvements to the position scanners (#3612 and #3583), we're now seeing some cases of invalid location being raised, despite no reports of any issues regarding the state of the documents.

I think we're making a mistake by trying to apply document operations with higher priority than feature requests. For example, if we receive a request for completion and the user immediately edits the file, the server might process the edit before finishing the completion request and there are no guarantees that the new state of the document can satisfy that original request.

I want to propose pushing text synchronization operations to the queue, so that they are processed in order and without locking, which I believe will improve the situation.

### Implementation

I start pushing text synchronization operations to the work queue and removed many of the mutex locks that we originally had.

Since requests are processed in order, there should not be a chance of a feature request being processed with an incorrect document state.