### PR TITLE
Avoid writing error file if client is closed during bundle compose

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -234,6 +234,14 @@ module RubyLsp
         # If no error occurred, then clear previous errors
         @error_path.delete if @error_path.exist?
         $stderr.puts("Ruby LSP> Composed bundle installation complete")
+      rescue Errno::EPIPE
+        # If the $stderr pipe was closed by the client, for example when closing the editor during running bundle
+        # install, we don't want to write the error to a file or else we will report to telemetry on the next launch and
+        # it does not represent an actual error.
+        #
+        # This situation may happen because while running bundle install, the server is not yet ready to receive
+        # shutdown requests and we may continue doing work until the process is killed.
+        @error_path.delete if @error_path.exist?
       rescue => e
         # Write the error object to a file so that we can read it from the parent process
         @error_path.write(Marshal.dump(e))


### PR DESCRIPTION
### Motivation

This PR addresses one of the telemetry errors we see when using the new launcher mode. If the editor is closed while we're in the middle of composing the bundle, the server is not yet fully booted and cannot respond to shutdown requests.

If the client disconnects, closing their ends of the stdio pipes, the bundle install process may continue to try writing output to stderr, which results in raising `Errno::EPIPE`. When the error is raised, we write that error to the `install_error` file and then the process exists soon after.

The next time the language server is booted, it sees that the `install_error` file is there and reports that as an error, but this situation doesn't actually indicate a bug. It just means the user closed the editor before we were done composing the bundle. The next time they open it, we'll compose from scratch.

### Implementation

Started rescuing `Errno::EPIPE` when running bundle install and clearing the `install_error` file, so that we don't report this scenario to telemetry and simply shutdown gracefully.

### Automated Tests

Added a test to verify that the `install_error` file is not created when one of these happen.