### PR TITLE
Filter constant completion suggestions to only include constants

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -291,6 +291,15 @@ module RubyIndexer
 
       # Top level constants
       entries.concat(@entries_tree.search(name))
+
+      # Filter only constants since methods may have names that look like constants
+      entries.each do |definitions|
+        definitions.select! do |entry|
+          entry.is_a?(Entry::Constant) || entry.is_a?(Entry::ConstantAlias) ||
+            entry.is_a?(Entry::Namespace) || entry.is_a?(Entry::UnresolvedConstantAlias)
+        end
+      end
+
       entries.uniq!
       entries #: as Array[Array[Entry::Constant | Entry::ConstantAlias | Entry::Namespace | Entry::UnresolvedConstantAlias]]
     end

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1983,6 +1983,18 @@ module RubyIndexer
       assert_equal(["XQRK"], result.map { |entries| entries.first&.name })
     end
 
+    def test_constant_completion_does_not_confuse_uppercase_methods
+      index(<<~RUBY)
+        class Foo
+          def Qux
+          end
+        end
+      RUBY
+
+      candidates = @index.constant_completion_candidates("Q", [])
+      refute_includes(candidates.flat_map { |entries| entries.map(&:name) }, "Qux")
+    end
+
     def test_constant_completion_candidates_for_empty_name
       index(<<~RUBY)
         module Foo


### PR DESCRIPTION
### Motivation

Closes #3653

In the implement of constant completion candidates, we forgot to filter based on the definition type - since you can have methods that begin with an uppercase letter. That was leading to including methods incorrectly as part of constant completion suggestions.

### Implementation

Added the missing filtering.

### Automated Tests

Added a test that reproduces the issue.