### PR TITLE
Prevent workspace dependencies from failing if there's no bundle

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1224,7 +1224,7 @@ module RubyLsp
             }
           end
         end
-      rescue Bundler::GemNotFound
+      rescue Bundler::GemNotFound, Bundler::GemfileNotFound
         []
       end
 


### PR DESCRIPTION
### Motivation

The `workspace_dependencies` custom request may fail if there's no Gemfile. We need to handle that possibility.

### Implementation

All we have to do is rescue the error raised by Bundler when there's no Gemfile.