### PR TITLE
Prevent relative require completion for unsaved files

### DIFF
--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -445,11 +445,14 @@ module RubyLsp
         return unless arguments_node
 
         path_node_to_complete = arguments_node.arguments.first
-
         return unless path_node_to_complete.is_a?(Prism::StringNode)
 
-        origin_dir = Pathname.new(@uri.to_standardized_path).dirname
+        # If the file is unsaved (e.g.: untitled:Untitled-1), we can't provide relative completion as we don't know
+        # where the user intends to save it
+        full_path = @uri.to_standardized_path
+        return unless full_path
 
+        origin_dir = Pathname.new(full_path).dirname
         content = path_node_to_complete.content
         # if the path is not a directory, glob all possible next characters
         # for example ../somethi| (where | is the cursor position)

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1761,6 +1761,25 @@ class CompletionTest < Minitest::Test
     end
   end
 
+  def test_require_relative_returns_empty_result_for_unsaved_files
+    prefix = "support/"
+    source = <<~RUBY
+      require_relative "#{prefix}"
+    RUBY
+    end_char = source.rindex('"') #: as !nil
+
+    with_server(source, URI("untitled:Untitled-1")) do |server, uri|
+      with_file_structure(server) do
+        server.process_message(id: 1, method: "textDocument/completion", params: {
+          textDocument: { uri: uri },
+          position: { line: 0, character: end_char },
+        })
+
+        assert_empty(server.pop_response.response)
+      end
+    end
+  end
+
   private
 
   def with_file_structure(server, &block)


### PR DESCRIPTION
### Motivation

If a user is typing a `require_relative` in an unsaved file, we have no way of providing completion since we don't know where the user intends to save the file and the path needs to be relative to that.

This currently crashes the request, but we can simply protect the code from this and return empty completions.

### Implementation

Started returning early if the `full_path` of the URI is `nil` (which means the file is unsaved and we don't know what the file system path is).

### Automated Tests

Added a test that reproduces the same crash.