### PR TITLE
Use -r instead of RUBYOPT to require LSP reporters

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -75,8 +75,9 @@ module RubyLsp
 
           unless full_files.empty?
             specs, tests = full_files.partition { |path| spec?(path) }
-            commands << "#{BASE_COMMAND} -Itest -e \"ARGV.each { |f| require f }\" #{tests.join(" ")}" if tests.any?
-            commands << "#{BASE_COMMAND} -Ispec -e \"ARGV.each { |f| require f }\" #{specs.join(" ")}" if specs.any?
+
+            commands << "#{COMMAND} -Itest -e \"ARGV.each { |f| require f }\" #{tests.join(" ")}" if tests.any?
+            commands << "#{COMMAND} -Ispec -e \"ARGV.each { |f| require f }\" #{specs.join(" ")}" if specs.any?
           end
 
           commands
@@ -113,7 +114,7 @@ module RubyLsp
           end
 
           load_path = spec?(file_path) ? "-Ispec" : "-Itest"
-          "#{BASE_COMMAND} #{load_path} #{file_path} --name \"/#{regex}/\""
+          "#{COMMAND} #{load_path} #{file_path} --name \"/#{regex}/\""
         end
 
         #: (String, Hash[String, Hash[Symbol, untyped]]) -> Array[String]
@@ -124,7 +125,7 @@ module RubyLsp
               Shellwords.escape(TestDiscovery::DYNAMIC_REFERENCE_MARKER),
               ".*",
             )
-            command = +"#{BASE_COMMAND} -Itest #{file_path} --testcase \"/^#{group_regex}\\$/\""
+            command = +"#{COMMAND} -Itest #{file_path} --testcase \"/^#{group_regex}\\$/\""
 
             unless examples.empty?
               command << if examples.length == 1
@@ -143,13 +144,14 @@ module RubyLsp
 
       MINITEST_REPORTER_PATH = File.expand_path("../test_reporters/minitest_reporter.rb", __dir__) #: String
       TEST_UNIT_REPORTER_PATH = File.expand_path("../test_reporters/test_unit_reporter.rb", __dir__) #: String
-      ACCESS_MODIFIERS = [:public, :private, :protected].freeze
       BASE_COMMAND = begin
         Bundler.with_original_env { Bundler.default_lockfile }
         "bundle exec ruby"
       rescue Bundler::GemfileNotFound
         "ruby"
       end #: String
+      COMMAND = "#{BASE_COMMAND} -r#{MINITEST_REPORTER_PATH} -r#{TEST_UNIT_REPORTER_PATH}" #: String
+      ACCESS_MODIFIERS = [:public, :private, :protected].freeze
 
       #: (ResponseBuilders::TestCollection, GlobalState, Prism::Dispatcher, URI::Generic) -> void
       def initialize(response_builder, global_state, dispatcher, uri)

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1510,10 +1510,7 @@ module RubyLsp
 
       send_message(Result.new(
         id: message[:id],
-        response: {
-          commands: commands,
-          reporterPaths: [Listeners::TestStyle::MINITEST_REPORTER_PATH, Listeners::TestStyle::TEST_UNIT_REPORTER_PATH],
-        },
+        response: { commands: commands },
       ))
     end
 

--- a/lib/ruby_lsp/test_reporters/lsp_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/lsp_reporter.rb
@@ -24,9 +24,6 @@ module RubyLsp
     # https://code.visualstudio.com/api/references/vscode-api#StatementCoverage
     #: type statement_coverage = { executed: Integer, location: position, branches: Array[branch_coverage] }
 
-    #: bool
-    attr_reader :invoked_shutdown
-
     #: -> void
     def initialize
       dir_path = File.join(Dir.tmpdir, "ruby-lsp")
@@ -195,7 +192,7 @@ module RubyLsp
 
     #: -> void
     def at_exit
-      internal_shutdown unless invoked_shutdown
+      internal_shutdown unless @invoked_shutdown
     end
 
     class << self

--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -5,6 +5,8 @@ require "test_helper"
 
 module RubyLsp
   class ResolveTestCommandsMinitestTest < Minitest::Test
+    COMMAND = Listeners::TestStyle::COMMAND
+
     def test_resolve_test_command_specific_examples
       with_server do |server|
         server.process_message({
@@ -65,8 +67,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --name \"/^ServerTest#test_server\\$/\"",
-            "bundle exec ruby -Itest /test/store_test.rb --name \"/^StoreTest#test_store\\$/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --name \"/^ServerTest#test_server\\$/\"",
+            "#{COMMAND} -Itest /test/store_test.rb --name \"/^StoreTest#test_store\\$/\"",
           ],
           result[:commands],
         )
@@ -121,8 +123,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --name \"/^ServerTest(#|::)/\"",
-            "bundle exec ruby -Itest /test/store_test.rb --name \"/^StoreTest#test_store\\$/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --name \"/^ServerTest(#|::)/\"",
+            "#{COMMAND} -Itest /test/store_test.rb --name \"/^StoreTest#test_store\\$/\"",
           ],
           result[:commands],
         )
@@ -177,7 +179,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --name \"/^ServerTest#(test_server|test_server_again)\\$/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --name \"/^ServerTest#(test_server|test_server_again)\\$/\"",
           ],
           result[:commands],
         )
@@ -212,7 +214,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest -e \"ARGV.each { |f| require f }\" /test/server_test.rb /test/store_test.rb",
+            "#{COMMAND} -Itest -e \"ARGV.each { |f| require f }\" /test/server_test.rb /test/store_test.rb",
           ],
           result[:commands],
         )
@@ -255,7 +257,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest -e \"ARGV.each { |f| require f }\" /other/test/fake_test.rb " \
+            "#{COMMAND} -Itest -e \"ARGV.each { |f| require f }\" /other/test/fake_test.rb " \
               "/other/test/fake_test2.rb /test/server_test.rb /test/store_test.rb",
           ],
           result[:commands],
@@ -299,7 +301,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --name \"/(^ServerTest(#|::)|^OtherServerTest(#|::))/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --name \"/(^ServerTest(#|::)|^OtherServerTest(#|::))/\"",
           ],
           result[:commands],
         )
@@ -388,9 +390,9 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --name " \
+            "#{COMMAND} -Itest /test/server_test.rb --name " \
               "\"/(^ServerTest#(test_server|test_server_again)\\$|^OtherServerTest(#|::))/\"",
-            "bundle exec ruby -Itest /test/store_test.rb --name \"/^StoreTest#test_store\\$/\"",
+            "#{COMMAND} -Itest /test/store_test.rb --name \"/^StoreTest#test_store\\$/\"",
           ],
           result[:commands],
         )
@@ -445,8 +447,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --name \"/^.*::ServerTest#test_server\\$/\"",
-            "bundle exec ruby -Itest /test/store_test.rb --name \"/^.*::StoreTest(#|::)/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --name \"/^.*::ServerTest#test_server\\$/\"",
+            "#{COMMAND} -Itest /test/store_test.rb --name \"/^.*::StoreTest(#|::)/\"",
           ],
           result[:commands],
         )
@@ -483,7 +485,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/requests/completion_test.rb " \
+            "#{COMMAND} -Itest /test/requests/completion_test.rb " \
               "--name \"/^CompletionTest#(test_with_typed_false|test_with_typed_true)\\$/\"",
           ],
           result[:commands],
@@ -528,7 +530,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --name \"/^ServerTest::MainTest::NestedTest(#|::)/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --name \"/^ServerTest::MainTest::NestedTest(#|::)/\"",
           ],
           result[:commands],
         )
@@ -568,8 +570,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --name \"/^ServerTest#test_server\\$/\"",
-            "bundle exec ruby -Itest -e \"ARGV.each { |f| require f }\" /test/unit/fake_test.rb " \
+            "#{COMMAND} -Itest /test/server_test.rb --name \"/^ServerTest#test_server\\$/\"",
+            "#{COMMAND} -Itest -e \"ARGV.each { |f| require f }\" /test/unit/fake_test.rb " \
               "/test/unit/fake_test2.rb",
           ],
           result[:commands],
@@ -625,8 +627,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Ispec /spec/server_spec.rb --name \"/^ServerSpec#test_\\d{4}_something\\$/\"",
-            "bundle exec ruby -Ispec -e \"ARGV.each { |f| require f }\" /spec/other_spec.rb",
+            "#{COMMAND} -Ispec /spec/server_spec.rb --name \"/^ServerSpec#test_\\d{4}_something\\$/\"",
+            "#{COMMAND} -Ispec -e \"ARGV.each { |f| require f }\" /spec/other_spec.rb",
           ],
           result[:commands],
         )
@@ -655,7 +657,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Ispec -e \"ARGV.each { |f| require f }\" /other/spec/fake_spec.rb " \
+            "#{COMMAND} -Ispec -e \"ARGV.each { |f| require f }\" /other/spec/fake_spec.rb " \
               "/other/spec/fake2_spec.rb",
           ],
           result[:commands],
@@ -700,7 +702,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Ispec /spec/server_spec.rb --name \"/^ServerSpec::foo(#|::)/\"",
+            "#{COMMAND} -Ispec /spec/server_spec.rb --name \"/^ServerSpec::foo(#|::)/\"",
           ],
           result[:commands],
         )
@@ -744,7 +746,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Ispec /spec/server_spec.rb --name " \
+            "#{COMMAND} -Ispec /spec/server_spec.rb --name " \
               "\"/^ServerSpec#test_\\d{4}_uses\\ \\`SomeClass\\`\\ to\\ do\\ something\\$/\"",
           ],
           result[:commands],
@@ -754,6 +756,8 @@ module RubyLsp
   end
 
   class ResolveTestCommandsTestUnitTest < Minitest::Test
+    COMMAND = Listeners::TestStyle::COMMAND
+
     def test_resolve_test_command_specific_examples
       with_server do |server|
         server.process_message({
@@ -814,8 +818,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\" --name \"/test_server\\$/\"",
-            "bundle exec ruby -Itest /test/store_test.rb --testcase \"/^StoreTest\\$/\" --name \"/test_store\\$/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\" --name \"/test_server\\$/\"",
+            "#{COMMAND} -Itest /test/store_test.rb --testcase \"/^StoreTest\\$/\" --name \"/test_store\\$/\"",
           ],
           result[:commands],
         )
@@ -870,8 +874,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\"",
-            "bundle exec ruby -Itest /test/store_test.rb --testcase \"/^StoreTest\\$/\" --name \"/test_store\\$/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\"",
+            "#{COMMAND} -Itest /test/store_test.rb --testcase \"/^StoreTest\\$/\" --name \"/test_store\\$/\"",
           ],
           result[:commands],
         )
@@ -926,7 +930,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\" " \
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\" " \
               "--name \"/(test_server|test_server_again)\\$/\"",
           ],
           result[:commands],
@@ -970,8 +974,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\"",
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^OtherServerTest\\$/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^OtherServerTest\\$/\"",
           ],
           result[:commands],
         )
@@ -1060,10 +1064,10 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\" " \
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\" " \
               "--name \"/(test_server|test_server_again)\\$/\"",
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^OtherServerTest\\$/\"",
-            "bundle exec ruby -Itest /test/store_test.rb --testcase \"/^StoreTest\\$/\" --name \"/test_store\\$/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^OtherServerTest\\$/\"",
+            "#{COMMAND} -Itest /test/store_test.rb --testcase \"/^StoreTest\\$/\" --name \"/test_store\\$/\"",
           ],
           result[:commands],
         )
@@ -1118,9 +1122,9 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^.*::ServerTest\\$/\" " \
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^.*::ServerTest\\$/\" " \
               "--name \"/test_server\\$/\"",
-            "bundle exec ruby -Itest /test/store_test.rb --testcase \"/^.*::StoreTest\\$/\"",
+            "#{COMMAND} -Itest /test/store_test.rb --testcase \"/^.*::StoreTest\\$/\"",
           ],
           result[:commands],
         )
@@ -1157,7 +1161,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/requests/completion_test.rb --testcase \"/^CompletionTest\\$/\" " \
+            "#{COMMAND} -Itest /test/requests/completion_test.rb --testcase \"/^CompletionTest\\$/\" " \
               "--name \"/(test_with_typed_false|test_with_typed_true)\\$/\"",
           ],
           result[:commands],
@@ -1202,7 +1206,7 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest::MainTest::NestedTest\\$/\"",
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^ServerTest::MainTest::NestedTest\\$/\"",
           ],
           result[:commands],
         )
@@ -1242,8 +1246,8 @@ module RubyLsp
         result = server.pop_response.response
         assert_equal(
           [
-            "bundle exec ruby -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\" --name \"/test_server\\$/\"",
-            "bundle exec ruby -Itest -e \"ARGV.each { |f| require f }\" /test/unit/fake_test.rb " \
+            "#{COMMAND} -Itest /test/server_test.rb --testcase \"/^ServerTest\\$/\" --name \"/test_server\\$/\"",
+            "#{COMMAND} -Itest -e \"ARGV.each { |f| require f }\" /test/unit/fake_test.rb " \
               "/test/unit/fake_test2.rb",
           ],
           result[:commands],

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1376,21 +1376,6 @@ class ServerTest < Minitest::Test
     end
   end
 
-  def test_resolve_test_commands_returns_custom_reporters
-    @server.process_message({
-      id: 1,
-      method: "rubyLsp/resolveTestCommands",
-      params: {
-        items: [],
-      },
-    })
-    result = find_message(RubyLsp::Result, id: 1)
-    reporters = result.response[:reporterPaths]
-
-    assert_includes(reporters, File.expand_path("../lib/ruby_lsp/test_reporters/minitest_reporter.rb", __dir__))
-    assert_includes(reporters, File.expand_path("../lib/ruby_lsp/test_reporters/test_unit_reporter.rb", __dir__))
-  end
-
   def test_requests_code_lens_refresh_after_indexing
     @server.process_message({
       id: 1,


### PR DESCRIPTION
### Motivation

I identified an issue we did not foresee. By requiring our custom reporters through `RUBYOPT`, we end up causing any subprocesses spawned by the user's code to also require them. This can lead to weird issues.

For example, if the user code raises, then our `at_exit` hook that checks for crashes will run and send a duplicate `finish` event to the explorer _after_ we already closed the current run request. Since there's no current run, the explorer then thinks that this is a test being executed from the terminal manually and creates a fresh run with zero results inside.

Note: it is possible that this is the infamous issue where spring prevents us from reporting test execution events, but I'm not 100% confident yet.

### Implementation

Instead of trying to sanitize `RUBYOPT`, which can become tricky very quickly, we should just move to using the `-r` command line argument for Ruby. That simply requires the reporter without cascading down to subprocesses and does what we want.

Note: this is a breaking change because the Rails add-on will now need to add the same require to its command.