### PR TITLE
Avoid sending add-on load error messages in test mode

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -118,6 +118,11 @@ module RubyLsp
       raise AbstractMethodInvokedError
     end
 
+    #: -> bool?
+    def test_mode?
+      @test_mode
+    end
+
     #: -> void
     def run_shutdown
       @incoming_queue.clear

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -167,6 +167,7 @@ module RubyLsp
       return if @setup_error
 
       errors = Addon.load_addons(@global_state, @outgoing_queue, include_project_addons: include_project_addons)
+      return if test_mode?
 
       if errors.any?
         send_log_message(
@@ -179,21 +180,13 @@ module RubyLsp
 
       if errored_addons.any?
         send_message(
-          Notification.new(
-            method: "window/showMessage",
-            params: Interface::ShowMessageParams.new(
-              type: Constant::MessageType::WARNING,
-              message: "Error loading add-ons:\n\n#{errored_addons.map(&:formatted_errors).join("\n\n")}",
-            ),
+          Notification.window_show_message(
+            "Error loading add-ons:\n\n#{errored_addons.map(&:formatted_errors).join("\n\n")}",
+            type: Constant::MessageType::WARNING,
           ),
         )
 
-        unless @test_mode
-          send_log_message(
-            errored_addons.map(&:errors_details).join("\n\n"),
-            type: Constant::MessageType::WARNING,
-          )
-        end
+        send_log_message(errored_addons.map(&:errors_details).join("\n\n"), type: Constant::MessageType::WARNING)
       end
     end
 

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -573,14 +573,16 @@ class ServerTest < Minitest::Test
 
   def test_workspace_addons
     create_test_addons
+
+    @server.stubs(:test_mode?).returns(false)
     @server.load_addons
 
     @server.process_message({ id: 1, method: "rubyLsp/workspace/addons" })
 
-    addon_error_notification = @server.pop_response
+    addon_error_notification = find_message(RubyLsp::Notification, "window/showMessage")
     assert_equal("window/showMessage", addon_error_notification.method)
     assert_equal("Error loading add-ons:\n\nBar:\n  boom\n", addon_error_notification.params.message)
-    addons_info = @server.pop_response.response
+    addons_info = find_message(RubyLsp::Result, id: 1).response
     addons_info.delete_if { |addon_info| addon_info[:name] == "RuboCop" }
 
     assert_equal("Foo", addons_info[0][:name])


### PR DESCRIPTION
### Motivation

Whenever we eagerly bump our version due to a breaking change, all add-ons that exist in our bundle (like Tapioca) may start failing to load because they haven't handled the breaking changes yet. That causes our tests to fail because some log notifications are added to the outgoing queue.

We shouldn't fail our build because add-ons haven't handled the breaking changes yet.

### Implementation

I started not sending any logs at all in test mode.

### Automated Tests

For our test that actually checks for these, I used a stub to get the errors produced.