### PR TITLE
Stop reusing the Prism result for RuboCop for now

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -81,7 +81,7 @@ module RubyLsp
           @offenses = [] #: Array[::RuboCop::Cop::Offense]
           @errors = [] #: Array[String]
           @warnings = [] #: Array[String]
-          @prism_result = nil #: Prism::ParseLexResult?
+          # @prism_result = nil #: Prism::ParseLexResult?
 
           args += DEFAULT_ARGS
           rubocop_options = ::RuboCop::Options.new.parse(args).first
@@ -101,7 +101,11 @@ module RubyLsp
           @warnings = []
           @offenses = []
           @options[:stdin] = contents
-          @prism_result = prism_result
+
+          # Setting the Prism result before running the RuboCop runner makes it reuse the existing AST and avoids
+          # double-parsing. Unfortunately, this leads to a bunch of cops failing to execute properly under LSP mode.
+          # Uncomment this once reusing the Prism result is more stable
+          # @prism_result = prism_result
 
           super([path])
 


### PR DESCRIPTION
### Motivation

Related to #3657 and #3665. This PR "fixes" the issues by not reusing the Prism result anymore, but the real fix is on the RuboCop side.

Reusing the Prism parse result for RuboCop is a massive performance win as we avoid double-parsing the same document - both for computing diagnostics on every keypress and for formatting.

Unfortunately, we are receiving numerous reports of RuboCop crashing when the Prism result is reused, so I propose we turn this off while the RuboCop team investigates why the cops fail in this mode.

It might be easier to add some sort of experimental setting, so that people can find bugs. It seems like the problems are not related to running RuboCop in the CLI, where it sees all files in their final state, but in LSP mode when the user is in the middle of typing.