### PR TITLE
Remove RUBYOPT from ruby-lsp-test-exec

### DIFF
--- a/exe/ruby-lsp-test-exec
+++ b/exe/ruby-lsp-test-exec
@@ -1,18 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Append to RUBYOPT the necessary requires to hook our custom test reporters so that results are automatically
-# reflected in the test explorer
-rubyopt = [
-  *ENV["RUBYOPT"],
-  "-rbundler/setup",
-  "-r#{File.expand_path("../lib/ruby_lsp/test_reporters/minitest_reporter", __dir__)}",
-  "-r#{File.expand_path("../lib/ruby_lsp/test_reporters/test_unit_reporter", __dir__)}",
-].join(" ")
-
-# Replace this process with whatever command was passed. We only want to set RUBYOPT.
-# The way you use this executable is by prefixing your test command with `ruby-lsp-test-exec`, like so:
-#  ruby-lsp-test-exec bundle exec ruby -Itest test/example_test.rb
-#  ruby-lsp-test-exec bundle exec ruby -Ispec spec/example_spec.rb
-#  ruby-lsp-test-exec bundle exec rspec spec/example_spec.rb
-exec({ "RUBYOPT" => rubyopt }, *ARGV)
+# This executable will be removed thanks to the changes in https://github.com/Shopify/ruby-lsp/pull/3661.
+# Remove this a few months after extension updates have rolled out
+exec(*ARGV)

--- a/jekyll/test_explorer.markdown
+++ b/jekyll/test_explorer.markdown
@@ -119,16 +119,13 @@ items accept metadata. This scenario will not be supported by the Ruby LSP.
 
 ## Connecting terminal tests to the explorer
 
-When running tests in the terminal through a code lens or test explorer, the Ruby LSP uses the `ruby-lsp-test-exec`
-executable, which hooks the test run to the extension so that we can show test results in the explorer.
-
-By running tests with this executable, even manually written test commands will also have their results reported
-to the test explorer. For example, all of the following will report test statuses to the extension:
+When running tests in the terminal through a code lens or test explorer, the Ruby LSP and add-ons will hook up the
+execution commands with the expected reporters using the `-r` argument for `ruby`. You can manually hook up execution
+by adding the same.
 
 ```shell
-ruby-lsp-test-exec bundle exec ruby -Itest test/example_test.rb
-ruby-lsp-test-exec bundle exec ruby -Ispec spec/example_spec.rb
-ruby-lsp-test-exec bundle exec rspec spec/example_spec.rb
+bundle exec ruby -r/path/to/ruby-lsp/reporter -Itest test/example_test.rb
+bundle exec ruby -r/path/to/ruby-lsp/reporter -Ispec spec/example_spec.rb
 ```
 
 ## Customization

--- a/vscode/src/streamingRunner.ts
+++ b/vscode/src/streamingRunner.ts
@@ -148,9 +148,7 @@ export class StreamingRunner implements vscode.Disposable {
     this.terminals.set(name, terminal);
 
     terminal.show();
-    const exec =
-      path.basename(cwd) === "ruby-lsp" && os.platform() !== "win32" ? "exe/ruby-lsp-test-exec" : "ruby-lsp-test-exec";
-    terminal.sendText(`${exec} ${command}`);
+    terminal.sendText(command);
   }
 
   // Spawns the test process and redirects any stdout or stderr output to the test run output


### PR DESCRIPTION
### Motivation

I was testing our breaking changes in #3661 ahead of the release and noticed that I forgot to remove the `RUBYOPT` modifications from the `ruby-lsp-test-exec` executable. Those are not only no longer needed since the commands are now always expected to hook the reporters, it actually leads to a double-require.

### Implementation

For now, I made the executable just a pass through, so that the extension update can roll out to users and eventually we can remove the executable completely.