### PR TITLE
Avoid keeping empty arrays inside constant completion candidates

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -293,11 +293,13 @@ module RubyIndexer
       entries.concat(@entries_tree.search(name))
 
       # Filter only constants since methods may have names that look like constants
-      entries.each do |definitions|
+      entries.select! do |definitions|
         definitions.select! do |entry|
           entry.is_a?(Entry::Constant) || entry.is_a?(Entry::ConstantAlias) ||
             entry.is_a?(Entry::Namespace) || entry.is_a?(Entry::UnresolvedConstantAlias)
         end
+
+        definitions.any?
       end
 
       entries.uniq!

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1993,6 +1993,9 @@ module RubyIndexer
 
       candidates = @index.constant_completion_candidates("Q", [])
       refute_includes(candidates.flat_map { |entries| entries.map(&:name) }, "Qux")
+
+      candidates = @index.constant_completion_candidates("Qux", [])
+      assert_equal(0, candidates.length)
     end
 
     def test_constant_completion_candidates_for_empty_name


### PR DESCRIPTION
### Motivation

#3654 introduced a bug where we may return an array of empty arrays if all candidates get excluded in the class select. We can't return empty arrays inside as that's not what consumers of the API expect, we need to filter those out completely.

### Implementation

Started ensuring that empty arrays are discarded during the filtering.

### Automated Tests

Enhanced the current test.