### PR TITLE
Avoid sending invalid location errors to telemetry

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -126,8 +126,12 @@ module RubyLsp
       if message[:id]
         # If a document is deleted before we are able to process all of its enqueued requests, we will try to read it
         # from disk and it raise this error. This is expected, so we don't include the `data` attribute to avoid
-        # reporting these to our telemetry
-        if e.is_a?(Store::NonExistingDocumentError)
+        # reporting these to our telemetry.
+        #
+        # Similarly, if we receive a location for an invalid position in the
+        # document, we don't report it to telemetry
+        case e
+        when Store::NonExistingDocumentError, Document::InvalidLocationError
           send_message(Error.new(
             id: message[:id],
             code: Constant::ErrorCodes::INVALID_PARAMS,


### PR DESCRIPTION
### Motivation

With the changes to position scanners being released for a while, we received no reports that indicate corrupted documents, but we do see the server receiving requests for invalid positions on occasion. This has no actual impact on features because if the document state changed, the editor will request for the features again and successfully get a response the second time.

I think it's safe to ignore these errors from telemetry.

### Implementation

Added the invalid location error to our special case that doesn't include the `data` attribute, which makes the error be ignored by telemetry.

### Automated Tests

Added a test.