### PR TITLE
Allow running tests without a bundle

### DIFF
--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -145,7 +145,7 @@ module RubyLsp
       MINITEST_REPORTER_PATH = File.expand_path("../test_reporters/minitest_reporter.rb", __dir__) #: String
       TEST_UNIT_REPORTER_PATH = File.expand_path("../test_reporters/test_unit_reporter.rb", __dir__) #: String
       BASE_COMMAND = begin
-        Bundler.with_original_env { Bundler.default_lockfile }
+        Bundler.with_unbundled_env { Bundler.default_lockfile }
         "bundle exec ruby"
       rescue Bundler::GemfileNotFound
         "ruby"


### PR DESCRIPTION
### Motivation

Closes #3561

It's not uncommon for Rubyists to have unit tests for some scripts that do not have any dependencies (no bundle). There were two issues preventing us from running tests:

1. Because there's no bundle, we never index the parent class (e.g.: `Minitest::Test`) and so the linearized ancestors the class only end up including itself
2. We were using an incorrect Bundler helper to determine the base command

### Implementation

For 1, I started checking if there's only the class itself in the list of ancestors, which indicates that we're hitting this scenario. In that case, I started including the parent class if available, which allows us to discover tests. 

Note that there's one limitation: if the user introduces an intermediate parent class, we won't be able to discover the tests.

For 2, the method we should've been using is `with_unbundled_env`, which removes Bundler related variables and allows us to discover if there's a main bundle in the project.

### Automated Tests

Added a test that reproduces.