### PR TITLE
generated code to offer nix-develop as version manager

### DIFF
--- a/jekyll/version-managers.markdown
+++ b/jekyll/version-managers.markdown
@@ -31,6 +31,32 @@ Ensure Mise is up-to-date: https://mise.jdx.dev/faq.html#mise-is-failing-or-not-
 
 Ensure RVM is up-to-date: https://rvm.io/rvm/upgrading
 
+## Nix Flakes
+
+To use the Ruby LSP with Nix flakes, set the version manager to `nix-develop`.
+
+```jsonc
+{
+  "rubyLsp.rubyVersionManager": {
+    "identifier": "nix-develop"
+  }
+}
+```
+
+By default, this will use `nix develop --command ruby` to activate the environment. If you need to specify a path to a
+flake, you can do so with the `rubyLsp.customRubyCommand` setting.
+
+```jsonc
+{
+  "rubyLsp.rubyVersionManager": {
+    "identifier": "nix-develop"
+  },
+  "rubyLsp.customRubyCommand": "/path/to/dir/containing/flake"
+}
+```
+
+This will result in the activation command `nix develop /path/to/dir/containing/flake --command ruby`.
+
 ## Custom activation
 
 If you're using a different version manager that's not supported by this extension or if you're manually inserting the Ruby

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -390,6 +390,7 @@
                 "rvm",
                 "shadowenv",
                 "mise",
+                "nix-develop",
                 "custom"
               ],
               "default": "auto"

--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -11,6 +11,7 @@ import { VersionManager } from "./ruby/versionManager";
 import { Mise } from "./ruby/mise";
 import { RubyInstaller } from "./ruby/rubyInstaller";
 import { Rbenv } from "./ruby/rbenv";
+import { NixDevelop } from "./ruby/nixDevelop";
 import { Rvm } from "./ruby/rvm";
 import { None } from "./ruby/none";
 import { Custom } from "./ruby/custom";
@@ -44,6 +45,7 @@ export enum ManagerIdentifier {
   Shadowenv = "shadowenv",
   Mise = "mise",
   RubyInstaller = "rubyInstaller",
+  NixDevelop = "nix-develop",
   None = "none",
   Custom = "custom",
 }
@@ -316,6 +318,11 @@ export class Ruby implements RubyInterface {
       case ManagerIdentifier.RubyInstaller:
         await this.runActivation(
           new RubyInstaller(this.workspaceFolder, this.outputChannel, this.context, this.manuallySelectRuby.bind(this)),
+        );
+        break;
+      case ManagerIdentifier.NixDevelop:
+        await this.runActivation(
+          new NixDevelop(this.workspaceFolder, this.outputChannel, this.context, this.manuallySelectRuby.bind(this)),
         );
         break;
       case ManagerIdentifier.Custom:

--- a/vscode/src/ruby/nixDevelop.ts
+++ b/vscode/src/ruby/nixDevelop.ts
@@ -1,0 +1,26 @@
+import * as vscode from "vscode";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+export class NixDevelop extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    const customCommand = this.customCommand();
+    const command = `nix develop ${customCommand} --command ruby`;
+    const parsedResult = await this.runEnvActivationScript(command);
+
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+      gemPath: parsedResult.gemPath,
+    };
+  }
+
+  private customCommand() {
+    const configuration = vscode.workspace.getConfiguration("rubyLsp");
+    const customCommand: string | undefined =
+      configuration.get("customRubyCommand");
+
+    return customCommand || "";
+  }
+}


### PR DESCRIPTION
### Motivation

I was having problem with setting up ruby-lsp with nix develop, and turned to the discussion board for help. After getting some tips from @vinistock I decided to see if I could submit a patch

### Implementation

I am very new to both nix and vscode extension development, so most of the work is done by gemini-cli. From what I can tell, here are some changes:

1. Defining a new version manager type `nix-develop`
2. (possibly need revision) For now, reuse `customRubyCommand` to define the directory holding the flake.nix file
3. By referring to `vscode/src/ruby/custom.ts`, create a version for `nixDevelop.ts`, that fires the command as follows
```
`nix develop /Users/jeffrey04/Projects/home-manager/devenvs/ruby-3.3 --command ruby -EUTF-8:UTF-8 '/Users/jeffrey04/.vscode-oss/extensions/shopify.ruby-lsp-0.9.31/activation.rb'
```

### Automated Tests

I need help on this one

### Manual Tests

this is my flake.nix

```
# flake.nix
{
  description = "A cross-platform Ruby development environment";

  # Define the inputs for this flake, primarily nixpkgs.
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
  };

  # Define the outputs of this flake.
  outputs = { self, nixpkgs }:
    let
      # A list of systems we want to support.
      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];

      # A helper function to generate an attribute set for each system.
      forEachSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
        pkgs = nixpkgs.legacyPackages.${system};
        system = system;
      });

    in
    {
      # Generate a `devShell` for each of the `supportedSystems`.
      devShells = forEachSystem ({ pkgs, system }:
      {
        default = pkgs.mkShell {
          # A name for the shell environment.
          name = "ruby-3.3";

          # List of packages to be available in the development environment.
          buildInputs = with pkgs; [
            # fish is kept so that fish-specific completions from other
            # packages can be made available.
            fish
            # Git is needed for fetching gems from git repositories.
            git
            # The Ruby interpreter.
            ruby
            rubyPackages.psych
            rubyPackages.ruby-lsp
            # Bundler for managing Ruby gems.
            bundler
            # Common dependencies for building native extensions.
            cmake
            findutils
            gcc
            gnumake
            # Libraries often required by gems.
            openssl
            pkg-config
            libmysqlclient
            shared-mime-info
            re2
            readline
            zlib
          ] ++ lib.optionals stdenv.isDarwin [
            # Add macOS-specific dependencies.
            libiconv
          ];

          # This hook now correctly detects the parent shell (e.g., fish)
          # and works for both `nix develop` and `direnv`.
          shellHook = ''
            # Ruby-specific setup
            export FREEDESKTOP_MIME_TYPES_PATH="${pkgs.shared-mime-info}/share/mime/packages/freedesktop.org.xml"

            echo "Ruby dev environment activated for ${system}!"
          '';
        };
      });
    };
}
```
