### PR TITLE
Add information on enabling the Ruby LSP using builtin vim.lsp instea…

### DIFF
--- a/jekyll/editors.markdown
+++ b/jekyll/editors.markdown
@@ -192,6 +192,42 @@ folder is used.
 
 See [this issue][mason-abi] for further information.
 
+### Built-In vim.lsp
+
+**Note**: Ensure that you are using Neovim 0.11 or newer.
+
+You can also configure the Ruby LSP without the nvim-lspconfig plugin.
+Create an `lsp` directory inside your config directory and create a file `ruby-lsp.lua` inside it
+with the following content:
+
+```lua
+-- on Linux and macOS the default location is ~/.config/nvim/lsp/ruby-lsp.lua
+return {
+
+  filetypes = { "ruby" },
+
+  cmd = { "ruby-lsp" } -- or { "bundle", "exec", "ruby-lsp" },
+
+  root_markers = { "Gemfile", ".git" },
+  
+  init_options = {
+    formatter = 'standard',
+    linters = { 'standard' },
+    addonSettings = {
+      ["Ruby LSP Rails"] = {
+        enablePendingMigrationsPrompt = false,
+      },
+    },
+  },
+}
+```
+
+Then you need to enable it, e.g., inside `init.lua`:
+
+```lua
+vim.lsp.enable("ruby-lsp")
+```
+
 ### Additional setup (optional)
 
 `rubyLsp/workspace/dependencies` is a custom method currently supported only in the VS Code plugin.

--- a/jekyll/editors.markdown
+++ b/jekyll/editors.markdown
@@ -194,7 +194,8 @@ See [this issue][mason-abi] for further information.
 
 ### Built-In vim.lsp
 
-**Note**: Ensure that you are using Neovim 0.11 or newer.
+{ .note }
+Ensure that you are using NeoVim 0.11 or newer.
 
 You can also configure the Ruby LSP without the nvim-lspconfig plugin.
 Create an `lsp` directory inside your config directory and create a file `ruby-lsp.lua` inside it


### PR DESCRIPTION
**Background**

With the release of Neovim 0.11, more and more users move away from the nvim-lspconfig plugin in favor of the built-in method of enabling LSP. This method can be quite confusing for new users:
- where to put the LSP config table within my nvim config?
- what should the LSP config table contain?

**Summary**

Add information on how to enable the Ruby LSP using the built-in method
- provide a config example of enabling the LSP that should work out of the box if users have `ruby-lsp` installed
- align the example with the example in the nvim-lspconfig section so users can compare the two ways