### PR TITLE
Disable spring when running tests through the explorer

### DIFF
--- a/vscode/src/streamingRunner.ts
+++ b/vscode/src/streamingRunner.ts
@@ -142,6 +142,7 @@ export class StreamingRunner implements vscode.Disposable {
       terminal = vscode.window.createTerminal({
         name,
         cwd,
+        env: { DISABLE_SPRING: "1" },
       });
     }
 
@@ -155,7 +156,7 @@ export class StreamingRunner implements vscode.Disposable {
   private spawnTestProcess(command: string, env: NodeJS.ProcessEnv, cwd: string, abortController: AbortController) {
     const promise = new Promise<void>((resolve, _reject) => {
       const testProcess = spawn(command, {
-        env,
+        env: { ...env, DISABLE_SPRING: "1" },
         stdio: ["pipe", "pipe", "pipe"],
         shell: true,
         signal: abortController.signal,


### PR DESCRIPTION
### Motivation

We stopped requiring our custom LSP reporters through `RUBYOPT` because the environment variable caused child processes to accidentally require it too, which leads to unexpected events being received by the explorer.

Unfortunately, when using Spring, the `-r` argument we are now using isn't passed down to the server. When running `bin/rails test`, the Spring server that will run the test doesn't have the reporters required and so the results are not sent to the explorer.

The ideal solution would be to have Spring support some form of environment injection through something other than `RUBYOPT`, so that we can continue to not mess up with child processes while requiring what we need. For now, I think it's fair to disable spring. It's better to have tests run a little slower than not have the reporting work.

### Implementation

Started disabling spring for now.