### PR TITLE
Add VS Code rubyLsp.serverPath configuration

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -29,6 +29,13 @@ parser = OptionParser.new do |opts|
     options[:branch] = branch
   end
 
+  opts.on(
+    "--path [PATH]",
+    "Launch the Ruby LSP using a local PATH rather than the release version",
+  ) do |path|
+    options[:path] = path
+  end
+
   opts.on("--doctor", "Run troubleshooting steps") do
     options[:doctor] = true
   end
@@ -51,6 +58,11 @@ rescue OptionParser::InvalidOption => e
   warn(e)
   warn("")
   warn(parser.help)
+  exit(1)
+end
+
+if options[:branch] && options[:path]
+  warn('Invalid options: --branch and --path cannot both be set.')
   exit(1)
 end
 

--- a/jekyll/contributing.markdown
+++ b/jekyll/contributing.markdown
@@ -58,6 +58,20 @@ with a debugger. Note that the debug mode applies only until the editor is close
 Caveat: since you are debugging the language server instance that is currently running in your own editor, features will
 not be available if the execution is currently suspended at a breakpoint.
 
+#### Configuring the server version
+
+When developing the Ruby LSP server, you may want to test your changes in your own Ruby projects to ensure they work correctly in real-world scenarios.
+
+The running server, even in debug mode, will default to the installed release version*. You can use the `rubyLsp.serverPath` configuration setting in the target workspace to start your local copy instead. Make sure to restart the language server after making changes to pick up your updates.
+
+```jsonc
+{
+  "rubyLsp.serverPath": "/path/to/your/ruby-lsp-clone"
+}
+```
+
+*Note: There are some exceptions to this. Most notably, when the ruby-lsp repository is opened in VS Code with the extension active, it will run the server contained within the repository.
+
 #### Understanding Prism ASTs
 
 The Ruby LSP uses Prism to parse and understand Ruby code. When working on a feature, it's very common to need to

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -35,7 +35,13 @@ module RubyLsp
     def initialize(project_path, **options)
       @project_path = project_path
       @branch = options[:branch] #: String?
+      @path = options[:path] #: String?
       @launcher = options[:launcher] #: bool?
+
+      if @branch && !@branch.empty? && @path && !@path.empty?
+        raise ArgumentError, "Branch and path options are mutually exclusive. Please specify only one."
+      end
+
       patch_thor_to_print_progress_to_stderr! if @launcher
 
       # Regular bundle paths
@@ -165,7 +171,13 @@ module RubyLsp
 
       unless @dependencies["ruby-lsp"]
         ruby_lsp_entry = +'gem "ruby-lsp", require: false, group: :development'
-        ruby_lsp_entry << ", github: \"Shopify/ruby-lsp\", branch: \"#{@branch}\"" if @branch
+        if @branch && !@branch.empty?
+          ruby_lsp_entry << ", github: \"Shopify/ruby-lsp\", branch: \"#{@branch}\""
+        end
+        if @path && !@path.empty?
+          absolute_path = File.expand_path(@path, @project_path)
+          ruby_lsp_entry << ", path: \"#{absolute_path}\""
+        end
         parts << ruby_lsp_entry
       end
 

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -280,6 +280,38 @@ class SetupBundlerTest < Minitest::Test
     end
   end
 
+  def test_creates_composed_bundle_with_specified_path
+    Dir.mktmpdir do |dir|
+      local_path = "local-ruby-lsp"
+      FileUtils.mkdir_p(File.join(dir, local_path, "lib"))
+      
+      Dir.chdir(dir) do
+        bundle_gemfile = Pathname.new(".ruby-lsp").expand_path(Dir.pwd) + "Gemfile"
+        Bundler.with_unbundled_env do
+          stub_bundle_with_env(bundle_env(dir, bundle_gemfile.to_s))
+          run_script(File.realpath(dir), path: local_path)
+        end
+  
+        assert_path_exists(".ruby-lsp")
+        assert_path_exists(".ruby-lsp/Gemfile")
+        expected_absolute_path = File.expand_path(local_path, File.realpath(dir))
+        assert_match(%r{ruby-lsp.*path: "#{Regexp.escape(expected_absolute_path)}"}, File.read(".ruby-lsp/Gemfile"))
+        assert_match("debug", File.read(".ruby-lsp/Gemfile"))
+      end
+    end
+  end  
+
+  def test_raises_error_when_both_branch_and_path_are_specified
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        error = assert_raises(ArgumentError) do
+          RubyLsp::SetupBundler.new(dir, branch: "test-branch", path: "local-path")
+        end
+        assert_equal("Branch and path options are mutually exclusive. Please specify only one.", error.message)
+      end
+    end
+  end
+
   def test_returns_bundle_app_config_if_there_is_local_config
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -467,6 +467,11 @@
           "type": "string",
           "default": ""
         },
+        "rubyLsp.serverPath": {
+          "description": "Absolute or workspace-relative path to a local ruby-lsp repository or its ruby-lsp executable. Only supported if not using bundleGemfile",
+          "type": "string",
+          "default": ""
+        },
         "rubyLsp.pullDiagnosticsOn": {
           "description": "When to pull diagnostics from the server (on change, save or both). Selecting 'save' may significantly improve performance on large files",
           "type": "string",


### PR DESCRIPTION
### Motivation

Closes  #3709 

### Implementation

#### VS Code Extension
- Added a `serverPath` configuration setting to package.json
- when `serverPath` configuration is present in `getLspExecutables`, set `--path` as an arg to the `ruby-lsp` executable
- The serverPath option supports relative and absolute paths to both the ruby-lsp repo root directory as well as the executable file

#### Ruby LSP Server
- Capture `--path` arg as an option on `ruby-lsp` execution
- When setting up the Gemfile in `setup_bundler.rb`, add the configured absolute path to `gem 'ruby-lsp', path: "..."`

In every location where the path is considered an error is raised if the branch is also set.

### Automated Tests

I followed the test pattern for the `--branch` option when determining what to test. I have added tests for Bundler setup, but not for VS Code nor for option parsing in the ruby-lsp executable. I would be happy to add additional testing if I missed anything.

### Manual Tests

1. Modify the VS Code "Run Extension" launch configuration to set the target workspace to a ruby project of your choice.
    ```json
    {
	    "name": "Run Extension",
	    "type": "extensionHost",
	    "request": "launch",
	    "args": [
                    "/path/to/your/target/workspace",
		    "--extensionDevelopmentPath=${workspaceFolder}"
	    ],
	    "outFiles": [
		    "${workspaceFolder}/out/**/*.js"
	    ],
	    "preLaunchTask": "${defaultBuildTask}"
    }
    ```
2. From the "Run and Debug" side bar, run the extension
3. In the newly opened debug VS Code instance
     1.  In the settings you should be able to see the new option: `rubyLsp.serverPath`.
     2. Set the`serverPath` to your local ruby-lsp repo
     3. *Restart the entire debug instance to properly pick up on the changes
     4. Inspect the [path/to/target/workspace]/.ruby-lsp/Gemfile
         1. You should see the `path:` designation
     5. It's a little more challenging to fully verify that your code is actually running. You may need to modify some code, add some output or change the version number so that you can inspect it in the status bar
     6. Repeat the above with relative vs absolute paths, the ruby-lsp root path vs executable path, and simultaneously setting the branch.

*There are multiple existing issues with the config file watcher and auto-reload when a configuration setting is changed
1. In current production (v0.26.1), the server restarts but does not respect `rubyLsp.branch` nor `rubyLsp.serverPath`
2. In current development (v0.26.2), the server either does not restart at all or at least, the output is not shown for a restart
3. Changing back and forth from a server that supports serverPath to a server that does not while running a vscode instance that does support serverPath likely would not work well anyhow due to the feature mismatch