### PR TITLE
Account for module wrapping Minitest specs

### DIFF
--- a/lib/ruby_lsp/listeners/spec_style.rb
+++ b/lib/ruby_lsp/listeners/spec_style.rb
@@ -58,13 +58,11 @@ module RubyLsp
 
       #: (Prism::CallNode) -> void
       def on_call_node_enter(node) # rubocop:disable RubyLsp/UseRegisterWithHandlerMethod
-        return unless in_spec_context?
-
         case node.name
         when :describe
           handle_describe(node)
         when :it, :specify
-          handle_example(node)
+          handle_example(node) if in_spec_context?
         end
       end
 
@@ -208,12 +206,13 @@ module RubyLsp
         end
 
         # Specs only using describes
-        first_group = @spec_group_id_stack.find { |i| i.is_a?(DescribeGroup) }
-        return unless first_group
+        first_group_index = @spec_group_id_stack.index { |i| i.is_a?(DescribeGroup) }
+        return unless first_group_index
 
+        first_group = @spec_group_id_stack[first_group_index] #: as !nil
         item = @response_builder[first_group.id] #: as !nil
 
-        @spec_group_id_stack[1..] #: as !nil
+        @spec_group_id_stack[first_group_index + 1..] #: as !nil
           .each do |group|
           next unless group.is_a?(DescribeGroup)
 

--- a/test/requests/discover_tests_test.rb
+++ b/test/requests/discover_tests_test.rb
@@ -792,6 +792,36 @@ module RubyLsp
       end
     end
 
+    def test_specs_defined_inside_modules
+      source = <<~RUBY
+        module MyNamespace
+          describe "this thing" do
+            it "does something" do
+            end
+          end
+
+          module OtherNamespace
+            describe "other test" do
+              it "does something else" do
+              end
+            end
+          end
+        end
+      RUBY
+
+      with_minitest_spec_configured(source) do |items|
+        assert_equal(["this thing", "other test"], items.map { |i| i[:id] })
+        assert_equal(
+          ["this thing#test_0002_does something"],
+          items.dig(0, :children).map { |i| i[:id] },
+        )
+        assert_equal(
+          ["other test#test_0008_does something else"],
+          items.dig(1, :children).map { |i| i[:id] },
+        )
+      end
+    end
+
     private
 
     def create_test_discovery_addon


### PR DESCRIPTION
### Motivation

Closes #3712

When we find no test classes, we were considering the describe groups to start at index 1 in our stack of test groups. If you have a module wrapping those specs, that won't be true as there will be a corresponding `nil` entry in the stack (which we use to balance the stack).

We need to search for what is actually the first index to account for this possibility.

### Implementation

Started searching for what is the first spec group, rather than assuming that it's always the first one. I also moved our `in_spec_context?` check since we want to allow the `describe` to be discovered even if the nesting is not empty and we haven't yet found a spec group (which is what happens when there's only a top level module).

### Automated Tests

Added a test that reproduces the scenario.