### PR TITLE
Add a timeout to the test method `pop_response`

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -103,7 +103,7 @@ module RubyLsp
     # This method is only intended to be used in tests! Pops the latest response that would be sent to the client
     #: -> untyped
     def pop_response
-      @outgoing_queue.pop
+      @outgoing_queue.pop(timeout: 20) || raise("No message received from server")
     end
 
     # This method is only intended to be used in tests! Pushes a message to the incoming queue directly


### PR DESCRIPTION
### Motivation

I'm currently looking into running ruby lsp tests against the buildin rubocop addon to check for differences. It looks like there are some, and one test doesn't terminate because no response is provided. Is was harder than necessary to find out which test it actually was.

20 seconds is quite long but I don't want to make it too short

### Implementation

return nil on timeout and raise if that is the case

### Automated Tests

None

### Manual Tests

It does indeed raise for a test that used to hang because no messages were provided
