### PR TITLE
docs: Update Sublime Text installation docs

### DIFF
--- a/jekyll/editors.markdown
+++ b/jekyll/editors.markdown
@@ -210,7 +210,7 @@ return {
   cmd = { "ruby-lsp" } -- or { "bundle", "exec", "ruby-lsp" },
 
   root_markers = { "Gemfile", ".git" },
-  
+
   init_options = {
     formatter = 'standard',
     linters = { 'standard' },
@@ -305,11 +305,8 @@ To configure the Ruby LSP using [LSP for Sublime Text](https://github.com/sublim
     "command": [
       "ruby-lsp"
     ],
-    "selector": "source.ruby",
+    "selector": "source.ruby | text.html.rails",
     "initializationOptions": {
-      "enabledFeatures": {
-        "diagnostics": false
-      },
       "experimentalFeaturesEnabled": true
     }
   }


### PR DESCRIPTION
### Motivation

The Sublime Text documentation is slightly outdated on two points:

1. The recommendation for disabling diagnostics. I couldn't find a reason why it was this way, but diagnostics work fine with current versions of the editor and the LSP plugin.
2. The selector on which files to use ruby-lsp for. Since ruby-lsp now supports ERB files, I have extended it to include them.

### Dependencies

The LSP plugin needs to be at least on version `4070-2.6.0` ([link](https://github.com/sublimelsp/LSP/releases/tag/4070-2.6.0)) for ERB to be supported properly. In earlier versions, the file doesn't have the right `language_id` in the request and the LSP server errors out in parsing it. See https://github.com/sublimelsp/LSP/pull/2642
