### PR TITLE
Add initialization option bypassTypechecker

### DIFF
--- a/jekyll/troubleshooting.markdown
+++ b/jekyll/troubleshooting.markdown
@@ -129,6 +129,26 @@ and are working on a codebase that uses Sorbet, then this may indicate the
 To avoid duplicate/conflicting behavior, Ruby LSP disables some features when a Sorbet codebase is detected, with the
 intention that Sorbet can provide better accuracy.
 
+When working on the Ruby LSP repository itself, you may want to disable Sorbet detection so that Ruby LSP provides all features directly.
+
+You can do this by setting the **bypassTypechecker** option during initialization:
+
+- **In VS Code:**
+
+  Set the `rubyLsp.bypassTypechecker` option in your workspace settings, or open the project using the provided ruby-lsp.code-workspace file.
+
+- **In other editors:**
+
+  Add the following to your editor’s LSP client configuration.
+
+  ```json
+  {
+    "initializationOptions": {
+      "bypassTypechecker": true
+    }
+  }
+  ````
+
 ### Gem installation locations and permissions
 
 To launch the Ruby LSP server, the `ruby-lsp` gem must be installed. And in order to automatically index your project's

--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -155,7 +155,8 @@ module RubyLsp
       @test_library = detect_test_library(direct_dependencies)
       notifications << Notification.window_log_message("Detected test library: #{@test_library}")
 
-      @has_type_checker = detect_typechecker(all_dependencies)
+      bypass_typechecker = options.dig(:initializationOptions, :bypassTypechecker) || ENV["RUBY_LSP_BYPASS_TYPECHECKER"]
+      @has_type_checker = bypass_typechecker ? false : detect_typechecker(all_dependencies)
       if @has_type_checker
         notifications << Notification.window_log_message(
           "Ruby LSP detected this is a Sorbet project and will defer to the Sorbet LSP for some functionality",
@@ -277,8 +278,6 @@ module RubyLsp
 
     #: (Array[String] dependencies) -> bool
     def detect_typechecker(dependencies)
-      return false if ENV["RUBY_LSP_BYPASS_TYPECHECKER"]
-
       dependencies.any?(/^sorbet-static/)
     rescue Bundler::GemfileNotFound
       false

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -199,6 +199,16 @@ module RubyLsp
       assert_predicate(state, :has_type_checker)
     end
 
+    def test_type_checker_is_bypassed_based_on_initialization_options
+      state = GlobalState.new
+
+      Bundler.locked_gems.stubs(dependencies: {})
+      stub_all_dependencies("sorbet-static")
+      state.apply_options({ initializationOptions: { bypassTypechecker: true } })
+
+      refute(state.has_type_checker)
+    end
+
     def test_addon_settings_are_stored
       global_state = GlobalState.new
 

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -84,11 +84,10 @@ function getLspExecutables(workspaceFolder: vscode.WorkspaceFolder, env: NodeJS.
   const branch: string = config.get("branch")!;
   const customBundleGemfile: string = config.get("bundleGemfile")!;
   const useBundlerCompose: boolean = config.get("useBundlerCompose")!;
-  const bypassTypechecker: boolean = config.get("bypassTypechecker")!;
 
   const executableOptions: ExecutableOptions = {
     cwd: workspaceFolder.uri.fsPath,
-    env: bypassTypechecker ? { ...env, RUBY_LSP_BYPASS_TYPECHECKER: "true" } : env,
+    env: env,
     shell: true,
   };
 
@@ -239,6 +238,7 @@ function collectClientOptions(
       addonSettings: configuration.get("addonSettings"),
       enabledFeatureFlags: enabledFeatureFlags(),
       telemetryMachineId: vscode.env.machineId,
+      bypassTypechecker: configuration.get("bypassTypechecker"),
     },
   };
 }


### PR DESCRIPTION
### Motivation

Currently, when working on the `ruby-lsp` repository in editors that support the Language Server Protocol (LSP) but do **not** support workspace configuration (such as Zed), developers are required to use the `RUBY_LSP_BYPASS_TYPECHECKER` environment variable. However, this approach can be problematic, as not all editors provide a straightforward way to define or persist environment variables for LSP servers.

Additionally, in VS Code extension, the `rubyLsp.bypassTypechecker` workspace configuration is used to set the `RUBY_LSP_BYPASS_TYPECHECKER` environment variable, which is then passed to the LSP executable. While this works well for VS Code, it introduces unnecessary indirection and editor-specific handling.

By supporting this configuration directly through `initializationOptions`, we can simplify the setup and make the behavior consistent across all editors. The `initializationOptions` field is part of the LSP specification and is supported by all compliant editors, making this a more portable and standard solution.


Closes #2856 

### Implementation

The change introduces support for the `bypassTypechecker` option in the LSP `initializationOptions`.  Previously, this behavior could only be controlled through the `RUBY_LSP_BYPASS_TYPECHECKER` environment variable or the VS Code workspace configuration.  Now, the option can be passed directly during LSP initialization, making it editor-agnostic and compliant with the LSP specification.  

The implementation updates `GlobalState` to respect `initializationOptions[:bypassTypechecker]`, adjusts the VS Code client to forward this setting through initialization options instead of environment variables, and adds a dedicated test to verify the new behavior.  Reviewers should confirm that backward compatibility with the environment variable remains intact and that the change does not affect Sorbet detection in normal use.

### Automated Tests

A new unit test was added to verify that `bypassTypechecker` correctly disables type checker detection when provided through `initializationOptions`. Existing tests continue to cover the environment variable path, ensuring backward compatibility.  
All tests pass locally.

### Manual Tests

Below are step-by-step instructions to validate the new `bypassTypechecker` initialization option in VS Code when working in the `ruby-lsp` repo.

#### Prerequisites
- Open the repository using the provided workspace: **File → Open Workspace… → `ruby-lsp.code-workspace`**.
- Ensure dependencies are installed (`bundle install`) and the Ruby LSP VS Code extension is enabled.
- (Optional) Install Sorbet LSP extension to observe deferral behavior when `bypassTypechecker` is **off**.

#### 1) Verify behavior with `bypassTypechecker: true`
1. Open **Settings** (Workspace) and set:  
   `rubyLsp.bypassTypechecker = true`
2. Reload the window (**Developer: Reload Window**).
3. Enable LSP tracing (optional but helpful): set `rubyLsp.trace.server = "verbose"`.
4. Open any Ruby file in the repo (e.g., `lib/ruby_lsp/global_state.rb`).
5. **Expected:**
   - In **Output → Ruby LSP**, **no** message like “Ruby LSP detected this is a Sorbet project…” appears.
   - “Go to Definition”, “Find References”, etc., are provided directly by Ruby LSP.
   - If tracing is enabled, the `initialize` payload contains:
     ```json
     "initializationOptions": { "bypassTypechecker": true }
     ```

#### 2) Verify behavior with `bypassTypechecker: false`
1. Set `rubyLsp.bypassTypechecker = false` (or remove it).
2. Reload the window.
3. **Expected:**
   - In **Output → Ruby LSP**, you see a log similar to:  
     “Ruby LSP detected this is a Sorbet project and will defer to the Sorbet LSP for some functionality.”
   - If Sorbet LSP extension is installed/active, those features are handled by Sorbet; if not, some features appear disabled (as documented).
