### PR TITLE
Support multiple test file matches in go to relevant file

### DIFF
--- a/test/requests/go_to_relevant_file_test.rb
+++ b/test/requests/go_to_relevant_file_test.rb
@@ -117,4 +117,51 @@ class GoToRelevantFileTest < Minitest::Test
       )
     end
   end
+
+  def test_finds_tests_in_matching_subdirectory
+    Dir.chdir(@workspace) do
+      lib_dir = File.join(@workspace, "lib")
+      test_root = File.join(@workspace, "test")
+      test_subdir = File.join(test_root, "user")
+
+      FileUtils.mkdir_p(lib_dir)
+      FileUtils.mkdir_p(test_subdir)
+
+      impl_file = File.join(lib_dir, "user.rb")
+      test_file1 = File.join(test_subdir, "create_user_test.rb")
+      test_file2 = File.join(test_subdir, "test_update_user.rb")
+
+      FileUtils.touch(impl_file)
+      FileUtils.touch(test_file1)
+      FileUtils.touch(test_file2)
+
+      result = RubyLsp::Requests::GoToRelevantFile.new(impl_file, @workspace).perform
+
+      assert_equal(
+        [test_file1, test_file2].sort,
+        result.sort,
+      )
+    end
+  end
+
+  def test_finds_implementation_from_nested_test_file
+    Dir.chdir(@workspace) do
+      lib_dir = File.join(@workspace, "lib")
+      test_root = File.join(@workspace, "test")
+      test_subdir = File.join(test_root, "go_to_relevant_file")
+
+      FileUtils.mkdir_p(lib_dir)
+      FileUtils.mkdir_p(test_subdir)
+
+      impl_file = File.join(lib_dir, "go_to_relevant_file.rb")
+      test_file = File.join(test_subdir, "go_to_relevant_file_a_test.rb")
+
+      FileUtils.touch(impl_file)
+      FileUtils.touch(test_file)
+
+      result = RubyLsp::Requests::GoToRelevantFile.new(test_file, @workspace).perform
+
+      assert_equal([impl_file], result)
+    end
+  end
 end


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

Closes #3789

"Go to relevant file" currently fails when tests for an implementation file are split into multiple test files within a subdirectory (e.g., `user.rb` having tests like `user/creation_test.rb`). This makes it harder to discover and maintain these split tests. This PR extends the feature to find all associated tests within a matching subdirectory.

Instead of opening all found files at once, we present a list for the developer to select from. This gives developers control over which file to open rather than flooding their editor with tabs.

<details><summary>Example image</summary>
 
<img width="512" height="130" alt="image" src="https://github.com/user-attachments/assets/416c3a26-9eeb-45a7-86f8-cd0972145153" />

</details> 

### Implementation

The implementation was changed to search using multiple glob patterns instead of just one. This involved refactoring the old `relevant_filename_pattern` method into `relevant_filename_patterns` to return an array of patterns.

This enables two key improvements:

**1. Finding tests in matching subdirectories:**

When triggering "Go to relevant file" on `app/models/user.rb`, the search now includes patterns that look inside a `user/` subdirectory, finding files like:

- `test/models/user_test.rb` (existing behavior)
- `test/models/user/create_user_test.rb` (**new**)
- `test/models/user/test_update_user.rb` (**new**)

**2. Navigating back from nested tests:**

The reverse navigation now also works for nested files. For example, from `test/requests/go_to_relevant_file/go_to_relevant_file_a_test.rb`, it will correctly find `lib/requests/go_to_relevant_file.rb`. This is done by checking if the parent directory's name is included in the test file's name.

 ### Automated Tests 

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

New tests have been added to cover these scenarios.

 ### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

1.  In a test project, create the following file structure:

		.
		├── app
		│	└── models
		│		└── user.rb
		└── test
			└── models
				└── user
					├── create_user_test.rb
					└── update_user_test.rb
                
2.  Open `app/models/user.rb`.
3.  Click on the "Go to relevant file" button.
4.  **Expected:** A VS Code quick pick should appear with both `create_user_test.rb` and `update_user_test.rb` as options.
5.  Now open `test/models/user/create_user_test.rb`.
6.  Click on the "Go to relevant file" button.
7.  **Expected:** The editor should navigate directly to `app/models/user.rb`.