### PR TITLE
Restore request cancellation with correct implementation

### DIFF
--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -828,7 +828,7 @@ class ServerTest < Minitest::Test
     end
   end
 
-  def test_cancelling_requests_returns_nil
+  def test_cancelling_requests_returns_expected_error_code
     uri = URI("file:///foo.rb")
 
     @server.process_message({
@@ -868,8 +868,9 @@ class ServerTest < Minitest::Test
     mutex.unlock
     thread.join
 
-    result = find_message(RubyLsp::Result)
-    assert_nil(result.response)
+    error = find_message(RubyLsp::Error)
+    assert_equal(RubyLsp::Constant::ErrorCodes::REQUEST_CANCELLED, error.code)
+    assert_equal("Request 1 was cancelled", error.message)
   end
 
   def test_unsaved_changes_are_indexed_when_computing_automatic_features


### PR DESCRIPTION
### Motivation

Closes #3063

The project symbol search is currently slow in Zed, because it sends a `workspace/symbol` request for every new letter typed in, and attempts to cancel previous requests aren't successful, as Ruby LSP currently doesn't actually cancel requests (it enqueues `$/cancelRequest` messages instead of processing them synchronously).

### Implementation

Fix for request cancellation was already attempted in https://github.com/Shopify/ruby-lsp/issues/3063, but it caused issues with Neovim (https://github.com/Shopify/ruby-lsp/issues/3019), so it was ultimately reverted.

The problem wasn't actually in the new error responses, it was that the attempted fix contained a bug, where **it was returning a regular response *in addition to* the error response**. So, request cancellation would result in *two* responses being returned for the same request, which rightfully tripped Neovim up.

The bug was in attempting to skip the regular response using `next`. In addition to advancing iteration of nearest loop, `next` also breaks out of the nearest closure, whichever comes first. In this case, the surrounding `Mutex#synchronize` block was the nearest, so it broke out of that, and proceeded to execute `#process_message`. This resulted in regular response being sent back even if the cancelled response was previously sent.

To avoid introducing a boolean local variable, I extracted the handling logic into a method, so that I can break out using `return`.

### Automated Tests

I updated the tests to match the original implementation. However, I didn't know how to reliably assert that the 2nd response isn't getting sent, because I don't know how to wait until the worker becomes idle. I feel like I don't have enough control over the concurrency.

### Manual Tests

I tested this in Zed, and everything looked correct in the RCP message log.
