### PR TITLE
Fix stack StackLevelError during self referential constant resolution

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -903,6 +903,7 @@ module RubyIndexer
       return entry if seen_names.include?(alias_name)
 
       seen_names << alias_name
+
       target = resolve(entry.target, entry.nesting, seen_names)
       return entry unless target
 

--- a/lib/ruby_indexer/test/constant_test.rb
+++ b/lib/ruby_indexer/test/constant_test.rb
@@ -318,28 +318,6 @@ module RubyIndexer
       assert_instance_of(Entry::Constant, constant)
     end
 
-    def test_self_referential_constant_alias
-      index(<<~RUBY)
-        module RealClass
-          CONSTANT = {}
-        end
-
-        module Foo
-          SomeClass = ::SomeClass
-          RealClass = ::RealClass
-
-          UNRESOLVED = SomeClass::CONSTANT
-          CONSTANT = RealClass::CONSTANT
-        end
-      RUBY
-
-      assert_entry("RealClass", Entry::Module, "/fake/path/foo.rb:0-0:2-3")
-      assert_no_entry("SomeClass")
-      assert_entry("Foo", Entry::Module, "/fake/path/foo.rb:4-0:10-3")
-      assert_entry("RealClass::CONSTANT", Entry::Constant, "/fake/path/foo.rb:1-2:1-15")
-      assert_entry("Foo::UNRESOLVED", Entry::UnresolvedConstantAlias, "/fake/path/foo.rb:8-2:8-34")
-    end
-
     def test_indexing_or_and_operator_nodes
       index(<<~RUBY)
         A ||= 1


### PR DESCRIPTION
### Motivation

Closes #3798

Following code snipper is going to cause StackLevelError and will kill RubyLSP process

### Implementation

`ruby-lsp` is trying to create ConstantAlias from UnresolvedConstantAlias during constant resolution, I am checking if the target matches entry in cases when unresolved entry is same as target entry we should bail out from resolution because thats the same unresolved entry.

### Automated Tests

I've created `RubyIndexer::ConstantTest#test_self_referential_constant_alias` that is giving coverage for this case

### Manual Tests
1. Bootstrap VS Code ruby-lsp from this branch
2. Paste following code into editor
```Ruby
module RealClass
  CONSTANT = {}
end

module Foo
  SomeClass = ::SomeClass
  RealClass = ::RealClass

  UNRESOLVED = SomeClass::CONSTANT
  CONSTANT = RealClass::CONSTANT
end


RealClass
Foo::UNRESOLVED
```
3. Working on the file should not cause any errors on Ruby LSP in the output


