### PR TITLE
Refresh diagnostics on .rubocop_todo.yml change

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -303,7 +303,7 @@ module RubyLsp
           @current_request_id,
           Interface::RelativePattern.new(
             base_uri: @global_state.workspace_uri.to_s,
-            pattern: "{.rubocop.yml,.rubocop}",
+            pattern: "{.rubocop.yml,.rubocop,.rubocop_todo.yml}",
           ),
           registration_id: "rubocop-watcher",
         ))
@@ -1045,7 +1045,7 @@ module RubyLsp
 
         file_name = File.basename(file_path)
 
-        if file_name == ".rubocop.yml" || file_name == ".rubocop"
+        if file_name == ".rubocop.yml" || file_name == ".rubocop" || file_name == ".rubocop_todo.yml"
           handle_rubocop_config_change(uri)
         end
       end


### PR DESCRIPTION
### Motivation

Closes #3609

We weren't refreshing diagnostics when the `.rubocop_todo.yml` file changed, leading to stale diagnostics.

### Implementation

We just need to ensure it's handled as part of the file names we already do.

### Automated Tests

Made sure we're testing all 3 files.