### PR TITLE
Add missing kinds for indexer entries

### DIFF
--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -140,21 +140,25 @@ module RubyLsp
           end
         end
 
-        #: (RubyIndexer::Entry entry) -> Integer?
+        #: (RubyIndexer::Entry entry) -> Integer
         def kind_for_entry(entry)
           case entry
           when RubyIndexer::Entry::Class
             Constant::SymbolKind::CLASS
           when RubyIndexer::Entry::Module
             Constant::SymbolKind::NAMESPACE
-          when RubyIndexer::Entry::Constant
+          when RubyIndexer::Entry::Constant, RubyIndexer::Entry::UnresolvedConstantAlias, RubyIndexer::Entry::ConstantAlias
             Constant::SymbolKind::CONSTANT
-          when RubyIndexer::Entry::Method
+          when RubyIndexer::Entry::Method, RubyIndexer::Entry::UnresolvedMethodAlias, RubyIndexer::Entry::MethodAlias
             entry.name == "initialize" ? Constant::SymbolKind::CONSTRUCTOR : Constant::SymbolKind::METHOD
           when RubyIndexer::Entry::Accessor
             Constant::SymbolKind::PROPERTY
-          when RubyIndexer::Entry::InstanceVariable
+          when RubyIndexer::Entry::InstanceVariable, RubyIndexer::Entry::ClassVariable
             Constant::SymbolKind::FIELD
+          when RubyIndexer::Entry::GlobalVariable
+            Constant::SymbolKind::VARIABLE
+          else
+            Constant::SymbolKind::NULL
           end
         end
       end

--- a/test/requests/support/common_test.rb
+++ b/test/requests/support/common_test.rb
@@ -1,0 +1,21 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module RubyLsp
+  class CommonTest < Minitest::Test
+    include Requests::Support::Common
+
+    def test_kinds_are_defined_for_every_entry
+      index = RubyIndexer::Index.new
+      index.index_all
+
+      entries = index.instance_variable_get(:@entries).values.flatten
+      entries.each do |entry|
+        kind = kind_for_entry(entry)
+        refute_equal(kind, Constant::SymbolKind::NULL, "Kind not defined for entry: #{entry.inspect}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

Closes #3781

We were missing some possible entries and returning a `nil` kind can cause trouble for editors. 

### Implementation

I added a fallback with `NULL` and a test that indexes our own codebase and checks that no kinds are `NULL`. This should help us prevent regressions.