### PR TITLE
Add Entry#in_dependencies? and refactor dependency checks

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/entry.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/entry.rb
@@ -41,20 +41,31 @@ module RubyIndexer
       @visibility == :private
     end
 
+    #: -> bool?
+    def in_dependencies?
+      @in_dependencies ||= if file_path
+        !RubyLsp.not_in_dependencies?(
+          file_path, #: as String
+        )
+      else
+        false
+      end #: bool?
+    end
+
     #: -> String
     def file_name
-      if @uri.scheme == "untitled"
+      @file_name ||= if @uri.scheme == "untitled"
         @uri.opaque #: as !nil
       else
         File.basename(
           file_path, #: as !nil
         )
-      end
+      end #: String?
     end
 
     #: -> String?
     def file_path
-      @uri.full_path
+      @file_path ||= @uri.full_path #: String?
     end
 
     #: -> String

--- a/lib/ruby_lsp/listeners/definition.rb
+++ b/lib/ruby_lsp/listeners/definition.rb
@@ -316,8 +316,8 @@ module RubyLsp
 
         methods.each do |target_method|
           uri = target_method.uri
-          full_path = uri.full_path
-          next if @sorbet_level.true_or_higher? && (!full_path || not_in_dependencies?(full_path))
+
+          next if @sorbet_level.true_or_higher? && !target_method.in_dependencies?
 
           @response_builder << Interface::LocationLink.new(
             target_uri: uri.to_s,
@@ -390,9 +390,8 @@ module RubyLsp
           # additional behavior on top of jumping to RBIs. The only sigil where Sorbet cannot handle constants is typed
           # ignore
           uri = entry.uri
-          full_path = uri.full_path
 
-          if !@sorbet_level.ignore? && (!full_path || not_in_dependencies?(full_path))
+          if !@sorbet_level.ignore? && !entry.in_dependencies?
             next
           end
 

--- a/lib/ruby_lsp/requests/support/common.rb
+++ b/lib/ruby_lsp/requests/support/common.rb
@@ -49,15 +49,6 @@ module RubyLsp
           )
         end
 
-        #: (String file_path) -> bool?
-        def not_in_dependencies?(file_path)
-          BUNDLE_PATH &&
-            !file_path.start_with?(
-              BUNDLE_PATH, #: as !nil
-            ) &&
-            !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])
-        end
-
         #: (Prism::CallNode node) -> bool
         def self_receiver?(node)
           receiver = node.receiver

--- a/lib/ruby_lsp/requests/workspace_symbol.rb
+++ b/lib/ruby_lsp/requests/workspace_symbol.rb
@@ -22,11 +22,9 @@ module RubyLsp
       def perform
         @index.fuzzy_search(@query).filter_map do |entry|
           uri = entry.uri
-          file_path = uri.full_path
 
           # We only show symbols declared in the workspace
-          in_dependencies = file_path && !not_in_dependencies?(file_path)
-          next if in_dependencies
+          next if entry.in_dependencies?
 
           # We should never show private symbols when searching the entire workspace
           next if entry.private?

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -21,6 +21,17 @@ module RubyLsp
   GUESSED_TYPES_URL = "https://shopify.github.io/ruby-lsp/#guessed-types"
   TEST_PATH_PATTERN = "**/{test,spec,features}/**/{*_test.rb,test_*.rb,*_spec.rb,*.feature}"
 
+  class << self
+    #: (String file_path) -> bool?
+    def not_in_dependencies?(file_path)
+      BUNDLE_PATH &&
+        !file_path.start_with?(
+          BUNDLE_PATH, #: as !nil
+        ) &&
+        !file_path.start_with?(RbConfig::CONFIG["rubylibdir"])
+    end
+  end
+
   # Request delegation for embedded languages is not yet standardized into the language server specification. Here we
   # use this custom error class as a way to return a signal to the client that the request should be delegated to the
   # language server for the host language. The support for delegation is custom built on the client side, so each editor


### PR DESCRIPTION
### Motivation

Related #2660

This simple caching of uri path, file_name and dependency check on entry level provides significant performance improvements and on workspace/symbol makes it faster by 60.616 %

### Implementation

This commit introduces a new method `Entry#in_dependencies?` to encapsulate dependency path checks within the `Entry` class and refactors existing dependency checks across the codebase to use it. The logic for determining whether a file is inside dependencies was moved from `RubyLsp::Requests::Support::Common` into `RubyLsp::Utils`.

### Automated Tests

I wasn't sure if I should introduce any entry testing above what is being used now. If this will be required and change is considering useful for the project looking forward for recommendation how this should be tested on unit level (entry.rb does have its direct tests)
