### PR TITLE
Run bundle update only on the composed bundle

### DIFF
--- a/project-words
+++ b/project-words
@@ -109,7 +109,9 @@ testresult
 testrunner
 testrunnermediator
 truffleruby
+tsort
 unaliased
+ucrt
 unindexed
 unparser
 unresolve


### PR DESCRIPTION
### Motivation

Closes #3687, closes #3730

The method `should_update_bundle?` can only be correctly executed _before_ we merge the custom environment into `ENV`. However, we need the custom environment to be merged before we actually run the update.

We were not doing that, which explains why we accidentally modified the main bundle in the application (as the ENV was still pointing to that).

### Implementation

I started computing the `should_update_bundle?` check ahead of time, but then ensuring the ENV is merged before updating or installing.

### Automated Tests

I was able to reproduce and verify that the fix works. Unfortunately, creating a test for this is quite troublesome because inside our tests, Bundler has already activated the Ruby LSP's local gemspec, which makes the updates quite odd (like trying to update to the local version that hasn't been pushed to rubygems yet).