### PR TITLE
Ensure binmode and sync on LSP reporter socket

### DIFF
--- a/lib/ruby_lsp/test_reporters/lsp_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/lsp_reporter.rb
@@ -35,10 +35,10 @@ module RubyLsp
       @io = begin
         # The environment variable is only used for tests. The extension always writes to the temporary file
         if port
-          TCPSocket.new("localhost", port)
+          socket(port)
         elsif File.exist?(port_db_path)
           db = JSON.load_file(port_db_path)
-          TCPSocket.new("localhost", db[Dir.pwd])
+          socket(db[Dir.pwd])
         else
           # For tests that don't spawn the TCP server
           require "stringio"
@@ -208,6 +208,14 @@ module RubyLsp
     end
 
     private
+
+    #: (String) -> TCPSocket
+    def socket(port)
+      socket = TCPSocket.new("localhost", port)
+      socket.binmode
+      socket.sync = true
+      socket
+    end
 
     #: (String?, **untyped) -> void
     def send_message(method_name, **params)

--- a/test/test_reporters/minitest_reporter_test.rb
+++ b/test/test_reporters/minitest_reporter_test.rb
@@ -181,6 +181,8 @@ module RubyLsp
       receiver = Thread.new do
         socket = server.accept
         socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
+        socket.binmode
+        socket.sync = true
 
         loop do
           headers = socket.gets("\r\n\r\n")

--- a/test/test_reporters/test_unit_reporter_test.rb
+++ b/test/test_reporters/test_unit_reporter_test.rb
@@ -105,6 +105,8 @@ module RubyLsp
       receiver = Thread.new do
         socket = server.accept
         socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
+        socket.binmode
+        socket.sync = true
 
         loop do
           headers = socket.gets("\r\n\r\n")


### PR DESCRIPTION
### Motivation

I believe this will close #3760

Since we're using JSON RPC to communicate test results between server and extension, we have to turn on

- binmode: so that Windows preserves the `\r\n\r\n` sequences that are the key request separators
- sync: so that the content of the pipe is not buffered, but immediately flushed

We already do this one very stdio we use and we forgot to do the same for the socket used for tests.

### Implementation

Added `binmode` and `sync` to our LSP reporter socket.

### Automated Tests

I believe that turning `binmode` on our fake test client would've been enough to catch this.