### PR TITLE
Avoid failing if the git extension is disabled

### DIFF
--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -69,11 +69,15 @@ export class Workspace implements WorkspaceInterface {
 
     // If the git extension is available, use that to find the root of the git repository
     if (gitExtension) {
-      const api = gitExtension.exports.getAPI(1);
-      const repository = await api.openRepository(this.workspaceFolder.uri);
+      try {
+        const api = gitExtension.exports.getAPI(1);
+        const repository = await api.openRepository(this.workspaceFolder.uri);
 
-      if (repository) {
-        rootGitUri = repository.rootUri;
+        if (repository) {
+          rootGitUri = repository.rootUri;
+        }
+      } catch (_error: any) {
+        // Git extension might be disabled
       }
     }
 


### PR DESCRIPTION
### Motivation

Closes #3685

If the git extension is disabled, trying to invoke `getAPI` may throw an error like the one reported in the issue.

### Implementation

We can just wrap that call in a try/catch block since we fall back to the default, which is to consider the git root to be in the same place as the workspace path.