### PR TITLE
Revert "Reuse the prism result again"

### DIFF
--- a/lib/ruby_lsp/requests/support/rubocop_runner.rb
+++ b/lib/ruby_lsp/requests/support/rubocop_runner.rb
@@ -61,14 +61,6 @@ module RubyLsp
           "RuboCop::Formatter::BaseFormatter", # Suppress any output by using the base formatter
         ] #: Array[String]
 
-        # Functionality was introduced in 1.75.0 but had issues with autocorrect
-        REUSE_PRISM_RESULT = begin
-          gem("rubocop", ">= 1.80.1")
-          true
-        rescue LoadError
-          false
-        end #: bool
-
         #: Array[::RuboCop::Cop::Offense]
         attr_reader :offenses
 
@@ -89,7 +81,7 @@ module RubyLsp
           @offenses = [] #: Array[::RuboCop::Cop::Offense]
           @errors = [] #: Array[String]
           @warnings = [] #: Array[String]
-          @prism_result = nil #: Prism::ParseLexResult?
+          # @prism_result = nil #: Prism::ParseLexResult?
 
           args += DEFAULT_ARGS
           rubocop_options = ::RuboCop::Options.new.parse(args).first
@@ -109,7 +101,11 @@ module RubyLsp
           @warnings = []
           @offenses = []
           @options[:stdin] = contents
-          @prism_result = prism_result if REUSE_PRISM_RESULT
+
+          # Setting the Prism result before running the RuboCop runner makes it reuse the existing AST and avoids
+          # double-parsing. Unfortunately, this leads to a bunch of cops failing to execute properly under LSP mode.
+          # Uncomment this once reusing the Prism result is more stable
+          # @prism_result = prism_result
 
           super([path])
 


### PR DESCRIPTION
Closes #3809

Unfortunately, we continue to receive reports of issues related to trying to reuse the Prism result for RuboCop. Let's revert this for now and make time to investigate in more detail.