### PR TITLE
Add BBEdit to editor support page

### DIFF
--- a/jekyll/editors.markdown
+++ b/jekyll/editors.markdown
@@ -107,7 +107,6 @@ new H2 header in this file containing the instructions. -->
 - [Helix](#helix)
 - [BBEdit](#bbedit)
 
-
 ## Emacs Eglot
 
 [Eglot](https://github.com/joaotavora/eglot) runs solargraph server by default. To set it up with ruby-lsp you need to


### PR DESCRIPTION
Fixes #3754 

Adds BBEdit to the list of editors that support Ruby LSP and links to the official BBEdit documentation for configuring language server support. 