### PR TITLE
Rollout launcher mode to 30% of users

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -82,7 +82,7 @@ export const SUPPORTED_LANGUAGE_IDS = ["ruby", "erb"];
 // are not impacted by the user's choice of opting into all flags
 export const FEATURE_FLAGS = {
   tapiocaAddon: 1.0,
-  launcher: 0.1,
+  launcher: 0.3,
   fullTestDiscovery: 1.0,
 };
 


### PR DESCRIPTION
### Motivation

We fixed numerous launcher related issues and made the experience more reliable. Let's roll it out to 30% of users to see if we catch any new problems. If not, we can continue rolling it out to 100% and simplify our Bundler integrations.