### PR TITLE
Use URI instead of path for read more keyword read more links

### DIFF
--- a/lib/ruby_lsp/listeners/hover.rb
+++ b/lib/ruby_lsp/listeners/hover.rb
@@ -283,10 +283,10 @@ module RubyLsp
         content = KEYWORD_DOCS[keyword]
         return unless content
 
-        doc_path = File.join(STATIC_DOCS_PATH, "#{keyword}.md")
+        doc_uri = URI::Generic.from_path(path: File.join(STATIC_DOCS_PATH, "#{keyword}.md"))
 
         @response_builder.push("```ruby\n#{keyword}\n```", category: :title)
-        @response_builder.push("[Read more](#{doc_path})", category: :links)
+        @response_builder.push("[Read more](#{doc_uri})", category: :links)
         @response_builder.push(content, category: :documentation)
       end
 

--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -84,7 +84,7 @@ module RubyLsp
         content = KEYWORD_DOCS[keyword]
 
         if content
-          doc_path = File.join(STATIC_DOCS_PATH, "#{keyword}.md")
+          doc_uri = URI::Generic.from_path(path: File.join(STATIC_DOCS_PATH, "#{keyword}.md"))
 
           @item[:documentation] = Interface::MarkupContent.new(
             kind: "markdown",
@@ -93,7 +93,7 @@ module RubyLsp
               #{keyword}
               ```
 
-              [Read more](#{doc_path})
+              [Read more](#{doc_uri})
 
               #{content}
             MARKDOWN

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -204,7 +204,8 @@ class CompletionResolveTest < Minitest::Test
         RubyLsp::KEYWORD_DOCS["yield"], #: as !nil
         contents,
       )
-      assert_match("[Read more](#{RubyLsp::STATIC_DOCS_PATH}/yield.md)", contents)
+      expected_uri = URI::Generic.from_path(path: File.join(RubyLsp::STATIC_DOCS_PATH, "yield.md"))
+      assert_match("[Read more](#{expected_uri})", contents)
     end
   end
 end

--- a/test/requests/hover_expectations_test.rb
+++ b/test/requests/hover_expectations_test.rb
@@ -965,7 +965,9 @@ class HoverExpectationsTest < ExpectationsTestRunner
           RubyLsp::KEYWORD_DOCS[keyword] || "No documentation found for #{keyword}",
           contents,
         )
-        assert_match("[Read more](#{RubyLsp::STATIC_DOCS_PATH}/#{keyword}.md)", contents)
+
+        expected_uri = URI::Generic.from_path(path: File.join(RubyLsp::STATIC_DOCS_PATH, "#{keyword}.md"))
+        assert_match("[Read more](#{expected_uri})", contents)
       end
     end
   end


### PR DESCRIPTION
### Motivation

I noticed that the read more links weren't working. The reason is because Markdown links always need to use URIs and not file paths.

### Implementation

Corrected the links to use URIs.

### Automated Tests

Updated the tests, which were asserting the wrong behaviour.