### PR TITLE
Skip adding documentation for require completions

### DIFF
--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -68,10 +68,12 @@ module RubyLsp
           "[Learn more about guessed types](#{GUESSED_TYPES_URL})"
         end
 
-        @item[:documentation] = Interface::MarkupContent.new(
-          kind: "markdown",
-          value: markdown_from_index_entries(label, entries, MAX_DOCUMENTATION_ENTRIES, extra_links: extra_links),
-        )
+        unless @item[:kind] == Constant::CompletionItemKind::FILE
+          @item[:documentation] = Interface::MarkupContent.new(
+            kind: "markdown",
+            value: markdown_from_index_entries(label, entries, MAX_DOCUMENTATION_ENTRIES, extra_links: extra_links),
+          )
+        end
 
         @item
       end

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -207,4 +207,23 @@ class CompletionResolveTest < Minitest::Test
       assert_match("[Read more](#{RubyLsp::STATIC_DOCS_PATH}/yield.md)", contents)
     end
   end
+
+  def test_resolve_for_require_completion
+    source = +<<~RUBY
+      require ""
+    RUBY
+
+    with_server(source, stub_no_typechecker: true) do |server, _uri|
+      existing_item = {
+        label: "foo",
+        kind: RubyLsp::Constant::CompletionItemKind::FILE,
+        data: {},
+      }
+
+      server.process_message(id: 1, method: "completionItem/resolve", params: existing_item)
+
+      result = server.pop_response.response
+      assert_nil(result[:documentation])
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

When completing requires, we shouldn't try to add documentation invoking `markdown_from_index_entries`. There are no index entries associated with the file and so the documentation ends up showing `Definitions: ` with an empty list.

### Implementation

Started skipping documentation for file completions.

### Automated Tests

Added a test to prevent regression.