### PR TITLE
Disable stale workflow on forks

### DIFF
--- a/.github/workflows/stale_check.yml
+++ b/.github/workflows/stale_check.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: github.repository == 'Shopify/ruby-lsp'
     steps:
       - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10.1.1
         with:


### PR DESCRIPTION
To avoid contributors receiving these kinds of notifications:

> The "Close stale issues & pull requests" workflow in andyw8/ruby-lsp has been disabled