### PR TITLE
Fix keyboard shortcut for document symbols in Rails add-on docs

### DIFF
--- a/jekyll/rails-add-on.markdown
+++ b/jekyll/rails-add-on.markdown
@@ -62,7 +62,7 @@ document and to allow for quick navigation.
 Ruby LSP already provides document symbols for Ruby files, such as classes, modules, methods, etc. But the Rails add-on
 provides additional document symbols for Rails specific features.
 
-In VS Code, you can open the document symbols view by pressing `Ctrl + Shift + O`.
+In VS Code, you can open the document symbols view by pressing `Cmd + Shift + O` (Mac) or `Ctrl + Shift + O` (Windows/Linux).
 
 ### Active Record Callbacks, Validations, and Associations
 


### PR DESCRIPTION
## Summary

Updated the keyboard shortcut documentation in the Rails add-on page to include both Mac and Windows/Linux shortcuts for opening the document symbols view, with Mac listed first.

## Changes

- Changed from `Ctrl + Shift + O` only to `Cmd + Shift + O` (Mac) or `Ctrl + Shift + O` (Windows/Linux)

## References

- [VS Code Default Keybindings Reference](https://github.com/microsoft/vscode-docs/blob/main/docs/reference/default-keybindings.md)
- [Default keybindings JSON files](https://github.com/codebling/vs-code-default-keybindings)
- The command is `workbench.action.gotoSymbol` which is bound to Cmd+Shift+O on Mac and Ctrl+Shift+O on Windows/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)