### PR TITLE
Fix syntax highlighting for line-ending forward slashes

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -540,7 +540,7 @@
       ]
     },
     {
-      "begin": "(?x)\n(?<![\\w)])((/))(?![?*+])\n(?=\n  (?:\\\\/|[^/])*+          # Do NOT change the order\n  /[eimnosux]*\\s*\n  (?:\n    [)\\]}#.,?:]|\\|\\||&&|<=>|=>|==|=~|!~|!=|;|$|\n    if|else|elsif|then|do|end|unless|while|until|or|and\n  )\n  |\n  $\n)",
+      "begin": "(?x)\n(?<![\\w)])((/))(?![?*+])(?!\\s*$)\n(?=\n  (?:\\\\/|[^/])*+          # Do NOT change the order\n  /[eimnosux]*\\s*\n  (?:\n    [)\\]}#.,?:]|\\|\\||&&|<=>|=>|==|=~|!~|!=|;|$|\n    if|else|elsif|then|do|end|unless|while|until|or|and\n  )\n)",
       "captures": {
         "1": {
           "name": "string.regexp.interpolated.ruby"

--- a/vscode/src/test/suite/grammars.test.ts
+++ b/vscode/src/test/suite/grammars.test.ts
@@ -586,6 +586,95 @@ suite("Grammars", () => {
       });
     });
 
+    suite("regex", () => {
+      test("division at end of line is not treated as regex", () => {
+        const ruby = "a = 1 /\n  2\nb = 3";
+        const expectedTokens = [
+          ["a", ["source.ruby", "variable.ruby"]],
+          [" ", ["source.ruby"]],
+          ["=", ["source.ruby", "keyword.operator.assignment.ruby"]],
+          [" ", ["source.ruby"]],
+          ["1", ["source.ruby", "constant.numeric.ruby"]],
+          [" ", ["source.ruby"]],
+          ["/", ["source.ruby", "keyword.operator.arithmetic.ruby"]],
+          ["  ", ["source.ruby"]],
+          ["2", ["source.ruby", "constant.numeric.ruby"]],
+          ["b", ["source.ruby", "variable.ruby"]],
+          [" ", ["source.ruby"]],
+          ["=", ["source.ruby", "keyword.operator.assignment.ruby"]],
+          [" ", ["source.ruby"]],
+          ["3", ["source.ruby", "constant.numeric.ruby"]],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+
+      test("regex literal is still recognized", () => {
+        const ruby = "a = /foo/";
+        const expectedTokens = [
+          ["a", ["source.ruby", "variable.ruby"]],
+          [" ", ["source.ruby"]],
+          ["=", ["source.ruby", "keyword.operator.assignment.ruby"]],
+          [" ", ["source.ruby"]],
+          ["/", ["source.ruby", "string.regexp.interpolated.ruby", "punctuation.section.regexp.ruby"]],
+          ["foo", ["source.ruby", "string.regexp.interpolated.ruby"]],
+          ["/", ["source.ruby", "string.regexp.interpolated.ruby", "punctuation.section.regexp.ruby"]],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+
+      test("regex with flags is still recognized", () => {
+        const ruby = "a = /foo/i";
+        const expectedTokens = [
+          ["a", ["source.ruby", "variable.ruby"]],
+          [" ", ["source.ruby"]],
+          ["=", ["source.ruby", "keyword.operator.assignment.ruby"]],
+          [" ", ["source.ruby"]],
+          ["/", ["source.ruby", "string.regexp.interpolated.ruby", "punctuation.section.regexp.ruby"]],
+          ["foo", ["source.ruby", "string.regexp.interpolated.ruby"]],
+          ["/i", ["source.ruby", "string.regexp.interpolated.ruby", "punctuation.section.regexp.ruby"]],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+
+      test("regex followed by keyword is still recognized", () => {
+        const ruby = "a = /foo/ if bar";
+        const expectedTokens = [
+          ["a", ["source.ruby", "variable.ruby"]],
+          [" ", ["source.ruby"]],
+          ["=", ["source.ruby", "keyword.operator.assignment.ruby"]],
+          [" ", ["source.ruby"]],
+          ["/", ["source.ruby", "string.regexp.interpolated.ruby", "punctuation.section.regexp.ruby"]],
+          ["foo", ["source.ruby", "string.regexp.interpolated.ruby"]],
+          ["/", ["source.ruby", "string.regexp.interpolated.ruby", "punctuation.section.regexp.ruby"]],
+          [" ", ["source.ruby"]],
+          ["if", ["source.ruby", "keyword.control.ruby"]],
+          [" bar", ["source.ruby"]],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+
+      test("string containing slash does not break subsequent highlighting", () => {
+        const ruby = '"foo /\nbar"\nb = 3';
+        const expectedTokens = [
+          ['"', ["source.ruby", "string.quoted.double.interpolated.ruby", "punctuation.definition.string.begin.ruby"]],
+          ["foo /", ["source.ruby", "string.quoted.double.interpolated.ruby"]],
+          ["bar", ["source.ruby", "string.quoted.double.interpolated.ruby"]],
+          ['"', ["source.ruby", "string.quoted.double.interpolated.ruby", "punctuation.definition.string.end.ruby"]],
+          ["b", ["source.ruby", "variable.ruby"]],
+          [" ", ["source.ruby"]],
+          ["=", ["source.ruby", "keyword.operator.assignment.ruby"]],
+          [" ", ["source.ruby"]],
+          ["3", ["source.ruby", "constant.numeric.ruby"]],
+        ];
+        const actualTokens = tokenizeRuby(ruby);
+        assert.deepStrictEqual(actualTokens, expectedTokens);
+      });
+    });
+
     function tokenizeRBS(rbs: string): [string, string[]][] {
       if (!rbsGrammar) {
         throw new Error("RBS grammar not loaded");


### PR DESCRIPTION
### Motivation

Closes #1786

This fixes an issue with syntax highlighting where slashes at the end of lines, such as for division across lines, strings with slashes at the end of lines, etc. were being read as regex contents. This would cause many lines of the source to be rendered in the same color, essentially removing any practical syntax highlighting. This would continue until another backslash was seen.

### Implementation

This change makes two changes to the regex grammar. The first (the addition of `(?!\\s*$)`) is a negative lookahead to reject `/` when followed only by whitespace until end of line. The second change removed the `| $` alternative that incorrectly allowed matching at end of line without a closing `/`.

### Automated Tests

See the added automated tests.

### Manual Tests

I opened up a VSCode window with these changes.

Before ❌ 

<img width="163" height="209" alt="Screenshot 2026-01-15 at 1 07 19 PM" src="https://github.com/user-attachments/assets/88ee6048-aa82-495b-814e-9a8bf13e8e16" />


After ✅ 

<img width="162" height="183" alt="Screenshot 2026-01-15 at 1 07 57 PM" src="https://github.com/user-attachments/assets/c6b4357d-2f40-4062-a99b-e8cd0f941103" />
