### PR TITLE
Fix bare heredoc syntax highlighting

### DIFF
--- a/vscode/grammars/ruby.cson.json
+++ b/vscode/grammars/ruby.cson.json
@@ -1616,13 +1616,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)HTML)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)HTML)\\b\\1))",
       "comment": "Heredoc with embedded HTML",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.html",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)HTML)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)HTML)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1653,13 +1653,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)HAML)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)HAML)\\b\\1))",
       "comment": "Heredoc with embedded HAML",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.haml",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)HAML)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)HAML)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1690,13 +1690,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)XML)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)XML)\\b\\1))",
       "comment": "Heredoc with embedded XML",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.xml",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)XML)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)XML)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1727,13 +1727,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)SQL)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)SQL)\\b\\1))",
       "comment": "Heredoc with embedded SQL",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.sql",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)SQL)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)SQL)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1764,13 +1764,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:GRAPHQL|GQL))\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)(?:GRAPHQL|GQL))\\b\\1))",
       "comment": "Heredoc with embedded GraphQL",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.graphql",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:GRAPHQL|GQL))\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)(?:GRAPHQL|GQL))\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1801,13 +1801,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)CSS)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)CSS)\\b\\1))",
       "comment": "Heredoc with embedded CSS",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.css",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)CSS)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)CSS)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1838,13 +1838,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)CPP)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)CPP)\\b\\1))",
       "comment": "Heredoc with embedded C++",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.cpp",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)CPP)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)CPP)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1875,13 +1875,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)C)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)C)\\b\\1))",
       "comment": "Heredoc with embedded C",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.c",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)C)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)C)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1912,13 +1912,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1))",
       "comment": "Heredoc with embedded Javascript",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.js",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)(?:JS|JAVASCRIPT))\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1949,13 +1949,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)JQUERY)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)JQUERY)\\b\\1))",
       "comment": "Heredoc with embedded jQuery Javascript",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.js.jquery",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)JQUERY)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)JQUERY)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -1986,13 +1986,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1))",
       "comment": "Heredoc with embedded Shell",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.shell",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)(?:SH|SHELL))\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -2023,13 +2023,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)LUA)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)LUA)\\b\\1))",
       "comment": "Heredoc with embedded Lua",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.lua",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)LUA)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)LUA)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -2060,13 +2060,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)RUBY)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)RUBY)\\b\\1))",
       "comment": "Heredoc with embedded Ruby",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.ruby",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)RUBY)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)RUBY)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -2097,13 +2097,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:YAML|YML))\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)(?:YAML|YML))\\b\\1))",
       "comment": "Heredoc with embedded YAML",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.yaml",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:YAML|YML))\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)(?:YAML|YML))\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -2134,13 +2134,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)SLIM)\\b\\1))",
+      "begin": "(?=(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)SLIM)\\b\\1))",
       "comment": "Heredoc with embedded Slim",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.slim",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)SLIM)\\b\\1)",
+          "begin": "(?><<[-~]?([\"'`]?)((?:[_\\w]+_|)SLIM)\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "string.definition.begin.ruby"
@@ -2197,7 +2197,7 @@
       ]
     },
     {
-      "begin": "(?>((<<[-~]([\"'`]?)(\\w+)\\3,\\s?)*<<[-~]([\"'`]?)(\\w+)\\5))(.*)",
+      "begin": "(?>((<<[-~]?([\"'`]?)(\\w+)\\3,\\s?)*<<[-~]?([\"'`]?)(\\w+)\\5))(.*)",
       "beginCaptures": {
         "1": {
           "name": "string.definition.begin.ruby"


### PR DESCRIPTION
### Motivation

Closes #3908 

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation

The primary change is changing the grammar to use `<<[-~]?` instead of `<<[-~]`, since heredocs don't strictly require a dash or tilde. This is changed in a number of places, as there are specific regexes for each language-specific heredoc type (e.g. `<<SQL`), but it's all the same change.

### Automated Tests

See the included automated tests.

### Manual Tests

I started a new VSCode window with this change and confirmed that it was highlighted as expected with both regular heredocs and language-specific tags.

Highlighting works:
<img width="279" height="256" alt="Screenshot 2026-01-20 at 3 42 21 PM" src="https://github.com/user-attachments/assets/9a5b24e0-4628-4380-bda1-e3ec3afb4a8d" />

Token types look correct:
<img width="587" height="366" alt="Screenshot 2026-01-20 at 3 42 42 PM" src="https://github.com/user-attachments/assets/d786b0de-1f32-45a7-abeb-ef09e6c2eae0" />

<img width="587" height="525" alt="Screenshot 2026-01-20 at 3 42 52 PM" src="https://github.com/user-attachments/assets/ced9541a-255e-4687-9dae-2b6c1db66d6e" />




