### PR TITLE
Don't include test files in the gem package

### DIFF
--- a/ruby-lsp.gemspec
+++ b/ruby-lsp.gemspec
@@ -13,7 +13,9 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/Shopify/ruby-lsp"
   s.license = "MIT"
 
-  s.files = Dir.glob("lib/**/*.rb") + ["README.md", "VERSION", "LICENSE.txt"] + Dir.glob("static_docs/**/*.md")
+  s.files = Dir.glob("lib/**/*.rb").grep_v(%r{^lib/ruby_indexer/test/}) +
+    ["README.md", "VERSION", "LICENSE.txt"] +
+    Dir.glob("static_docs/**/*.md")
   s.bindir = "exe"
   s.executables = ["ruby-lsp", "ruby-lsp-check", "ruby-lsp-launcher", "ruby-lsp-test-exec"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
The ruby-indexer tests were being included in the gem package.