### PR TITLE
[DOC] Add security documentation

### DIFF
--- a/jekyll/security.markdown
+++ b/jekyll/security.markdown
@@ -10,7 +10,7 @@ This page documents potential risks when using the Ruby LSP VS Code extension an
 
 ## Trust Model
 
-**Ruby LSP assumes that all code in your workspace is trusted.**
+**Ruby LSP assumes that all code in your workspace (including dependencies) is trusted.**
 
 When you open a project with Ruby LSP, the extension and language server will execute code from that project as part of
 normal operation. This is fundamentally similar to running `bundle install` in that project directory.


### PR DESCRIPTION
### Motivation

Ruby LSP, by design, can execute code (e.g. run `bundle install`) when the user simply opening the project in VS Code under trusted mode. This is necessary for usability and it's a common practice among language servers and their extensions. But the risk should be clearly communicated with users.

### Implementation

Add a page to document known (but not exhaustive) code executions that could be performed by Ruby LSP so users can be aware of the potential risks.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
