### PR TITLE
Add addon example for zed configuration

### DIFF
--- a/jekyll/editors.markdown
+++ b/jekyll/editors.markdown
@@ -325,6 +325,22 @@ Zed has support for the Ruby LSP through the [Ruby extension](https://github.com
 
 Documentation can be found in [Setting up Ruby LSP](https://zed.dev/docs/languages/ruby#setting-up-ruby-lsp).
 
+To configure an add-on, add the `addonSettings` configuration within `initialization_options`, for example:
+
+```json
+"lsp": {
+  "ruby-lsp": {
+    "initialization_options": {
+      "addonSettings": {
+        "Ruby LSP Rails": {
+          "enablePendingMigrationsPrompt": false
+        }
+      }
+    }
+  }
+}
+```
+
 ## RubyMine
 
 You can use the Ruby LSP with RubyMine (or IntelliJ IDEA Ultimate) through the following plugin.


### PR DESCRIPTION
### Motivation

It took me a bit of experimentation to figure out how to configure `addonSettings` in zed given the mixed cases and lack of examples. So I added an example.

### Automated Tests

None. Text change only.

### Manual Tests

I verified that this setting does take effect once the LSP is restarted. I rolled back a migration, restarted the server, restarted the LSP the alert showed up. Then I added the config, restarted the server, and saw no alert.
