### PR TITLE
Add rbs to composed bundle update commands

### DIFF
--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -176,7 +176,7 @@ class SetupBundlerTest < Minitest::Test
         Bundler.with_unbundled_env do
           stub_bundle_with_env(
             bundle_env(dir, ".ruby-lsp/Gemfile"),
-            /((bundle _[\d\.]+_ check && bundle _[\d\.]+_ update ruby-lsp debug) || bundle _[\d\.]+_ install) 1>&2/,
+            /((bundle _[\d\.]+_ check && bundle _[\d\.]+_ update ruby-lsp debug rbs) || bundle _[\d\.]+_ install) 1>&2/,
           )
 
           FileUtils.expects(:cp).never
@@ -732,7 +732,7 @@ class SetupBundlerTest < Minitest::Test
           require "bundler/cli/update"
           Bundler::CLI::Update.expects(:new).with(
             { conservative: true },
-            ["ruby-lsp", "debug", "prism"],
+            ["ruby-lsp", "debug", "prism", "rbs"],
           ).returns(mock_update)
 
           FileUtils.touch(File.join(dir, ".ruby-lsp", "needs_update"))


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/3937

### Implementation

I added `rbs` to the gems array for the `bundle update` command in both the launcher and non-launcher paths.

> [!NOTE]
> Should `prism` be in both of these places? And should `--conservative` be consistent in both places? 

### Automated Tests

I updated existing tests to expect rbs in the bundle update commands:
- test_uses_custom_bundle_path_when_no_gemfile_lock_is_present
- test_update_using_bundler_internals

### Manual Tests

I suspect this fixes the issue based on the manual workaround I found and documented in  https://github.com/Shopify/ruby-lsp/issues/3937

1. Create a project with a Gemfile that does NOT include rbs as a direct dependency
2. Trigger an auto-update
4. Observe that the `bundle update` command now includes rbs and that ruby-lsp is not downgraded