### PR TITLE
Extract GEMS_TO_UPDATE constant and fix missing prism in command path

### DIFF
--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -176,7 +176,7 @@ class SetupBundlerTest < Minitest::Test
         Bundler.with_unbundled_env do
           stub_bundle_with_env(
             bundle_env(dir, ".ruby-lsp/Gemfile"),
-            /((bundle _[\d\.]+_ check && bundle _[\d\.]+_ update ruby-lsp debug rbs) || bundle _[\d\.]+_ install) 1>&2/,
+            /((bundle _[\d\.]+_ check && bundle _[\d\.]+_ update ruby-lsp debug prism rbs) || bundle _[\d\.]+_ install) 1>&2/,
           )
 
           FileUtils.expects(:cp).never


### PR DESCRIPTION
### Motivation

The list of gems to update in the composed bundle was duplicated across `update` and `run_bundle_install_through_command`, and the latter was missing `prism`. Consolidate into a single GEMS_TO_UPDATE constant.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
