### PR TITLE
Fix Ruby 4.0 CI failure on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,14 @@ jobs:
         with:
           submodules: "recursive"
 
+      # Workaround: The ubuntu-latest runner image (20260126.10+) ships a pre-installed Ruby 4.0.1
+      # that causes native extension builds and bundler operations to fail. Removing it forces
+      # setup-ruby to download a working build from ruby-builder instead.
+      # See https://github.com/ruby/rubygems/issues/9284.
+      - name: Remove pre-installed Ruby 4.0
+        if: matrix.os == 'ubuntu-latest' && matrix.ruby == '4.0'
+        run: rm -rf /opt/hostedtoolcache/Ruby/4.0*
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 # v1.286.0
         with:


### PR DESCRIPTION
## Motivation

The `ubuntu-latest` runner image (`20260126.10+`) ships a pre-installed Ruby 4.0.1 that causes native extension builds and bundler operations to fail. The `chmod +t` workaround from https://github.com/ruby/rubygems/issues/9284 is insufficient — the pre-installed Ruby has deeper issues beyond the sticky bit.

## Implementation

Remove the pre-installed Ruby 4.0 from `/opt/hostedtoolcache` before `setup-ruby` runs, forcing it to download a working build from ruby-builder.

## Automated Tests

Existing CI matrix covers this — the Ruby 4.0 on ubuntu-latest job now passes.