### PR TITLE
Cache RBS core index in indexer test setup

### DIFF
--- a/lib/ruby_indexer/test/test_case.rb
+++ b/lib/ruby_indexer/test/test_case.rb
@@ -5,9 +5,21 @@ require "test_helper"
 
 module RubyIndexer
   class TestCase < Minitest::Test
+    class << self
+      #: String?
+      attr_accessor :core_index_data
+    end
+
     def setup
-      @index = Index.new
-      RBSIndexer.new(@index).index_ruby_core
+      self.class.core_index_data ||= begin
+        index = Index.new
+        RBSIndexer.new(index).index_ruby_core
+        Marshal.dump(index)
+      end
+
+      core_data = self.class.core_index_data #: as !nil
+      loaded_index = Marshal.load(core_data) #: as Index
+      @index = loaded_index
       @default_indexed_entries = @index.instance_variable_get(:@entries).dup
     end
 


### PR DESCRIPTION
## Summary

- Cache the `RBSIndexer#index_ruby_core` result using `Marshal.dump`/`Marshal.load` in `RubyIndexer::TestCase#setup`, so it's built once per test class instead of once per test method
- Previously, every indexer test method (~264 across 9 test classes) rebuilt the entire Ruby core type index from scratch, adding ~2 minutes of pure setup overhead

## Benchmarks

Local (`bundle exec rake test:indexer`, Apple Silicon, Ruby 3.4.7, 3 runs each):

| | Run 1 | Run 2 | Run 3 | Avg |
|---|---|---|---|---|
| **Before** | 166.1s | 124.3s | 111.5s | **133.9s** |
| **After** | 21.8s | 21.5s | 23.2s | **22.1s** |