### PR TITLE
Exclude bundled gems from test discovery

### DIFF
--- a/jekyll/test_explorer.markdown
+++ b/jekyll/test_explorer.markdown
@@ -56,6 +56,8 @@ To discover all test files in the workspace with decent performance, the Ruby LS
 conventions. For a test file to be discovered, the file path must match this glob:
 `**/{test,spec,features}/**/{*_test.rb,test_*.rb,*_spec.rb,*.feature}`
 
+Tests in certain directories are automatically excluded from discovery: `.bundle`, `vendor/bundle`, `node_modules`, `tmp`, and `log`.
+
 ### Dynamically defined tests
 
 There is limited support for tests defined via meta-programming. Initially, they will not be present in the test


### PR DESCRIPTION
Test discovery was finding tests in .bundle/gems and vendor/bundle directories, which contain bundled gem code. This adds an exclude pattern to prevent these directories from being scanned during test discovery.

Fixes #3949.