### PR TITLE
Expand `${workspaceFolder}` in `bundleGemfile` setting

### DIFF
--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -88,12 +88,6 @@ export const FEATURE_FLAGS = {
 
 type FeatureFlagConfigurationKey = keyof typeof FEATURE_FLAGS | "all";
 
-// Expands VS Code predefined variables (e.g., `${workspaceFolder}`) in a configuration string, since VS Code does not
-// automatically expand variables in extension settings retrieved via `getConfiguration()`
-export function expandPath(value: string, workspaceFolder: vscode.WorkspaceFolder): string {
-  return value.replace(/\$\{workspaceFolder\}/g, workspaceFolder.uri.fsPath);
-}
-
 // Creates a debounced version of a function with the specified delay. If the function is invoked before the delay runs
 // out, then the previous invocation of the function gets cancelled and a new one is scheduled.
 //

--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -28,8 +28,9 @@ export class Chruby extends VersionManager {
     outputChannel: WorkspaceChannel,
     context: vscode.ExtensionContext,
     manuallySelectRuby: () => Promise<void>,
+    customBundleGemfile?: string,
   ) {
-    super(workspaceFolder, outputChannel, context, manuallySelectRuby);
+    super(workspaceFolder, outputChannel, context, manuallySelectRuby, customBundleGemfile);
 
     const configuredRubies = vscode.workspace
       .getConfiguration("rubyLsp")

--- a/vscode/src/ruby/none.ts
+++ b/vscode/src/ruby/none.ts
@@ -21,8 +21,9 @@ export class None extends VersionManager {
     context: vscode.ExtensionContext,
     manuallySelectRuby: () => Promise<void>,
     rubyPath?: string,
+    customBundleGemfile?: string,
   ) {
-    super(workspaceFolder, outputChannel, context, manuallySelectRuby);
+    super(workspaceFolder, outputChannel, context, manuallySelectRuby, customBundleGemfile);
     this.rubyPath = rubyPath ?? "ruby";
   }
 

--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -4,7 +4,7 @@ import os from "os";
 import * as vscode from "vscode";
 
 import { WorkspaceChannel } from "../workspaceChannel";
-import { asyncExec, expandPath } from "../common";
+import { asyncExec } from "../common";
 
 export interface ActivationResult {
   env: NodeJS.ProcessEnv;
@@ -31,19 +31,13 @@ export abstract class VersionManager {
     outputChannel: WorkspaceChannel,
     context: vscode.ExtensionContext,
     manuallySelectRuby: () => Promise<void>,
+    customBundleGemfile?: string,
   ) {
     this.workspaceFolder = workspaceFolder;
     this.outputChannel = outputChannel;
     this.context = context;
     this.manuallySelectRuby = manuallySelectRuby;
-    const rawBundleGemfile: string = vscode.workspace.getConfiguration("rubyLsp").get("bundleGemfile")!;
-    const customBundleGemfile = expandPath(rawBundleGemfile, this.workspaceFolder);
-
-    if (customBundleGemfile.length > 0) {
-      this.customBundleGemfile = path.isAbsolute(customBundleGemfile)
-        ? customBundleGemfile
-        : path.resolve(path.join(this.workspaceFolder.uri.fsPath, customBundleGemfile));
-    }
+    this.customBundleGemfile = customBundleGemfile;
 
     this.bundleUri = this.customBundleGemfile
       ? vscode.Uri.file(path.dirname(this.customBundleGemfile))

--- a/vscode/src/test/suite/common.test.ts
+++ b/vscode/src/test/suite/common.test.ts
@@ -3,37 +3,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import sinon from "sinon";
 
-import { expandPath, featureEnabled, FEATURE_FLAGS } from "../../common";
-
-suite("expandPath", () => {
-  const workspaceFolder: vscode.WorkspaceFolder = {
-    uri: vscode.Uri.file("/home/user/project"),
-    name: "project",
-    index: 0,
-  };
-
-  // eslint-disable-next-line no-template-curly-in-string
-  test("replaces ${workspaceFolder} with the workspace folder path", () => {
-    // eslint-disable-next-line no-template-curly-in-string
-    const result = expandPath("${workspaceFolder}/Gemfile", workspaceFolder);
-    assert.strictEqual(result, "/home/user/project/Gemfile");
-  });
-
-  // eslint-disable-next-line no-template-curly-in-string
-  test("replaces multiple occurrences of ${workspaceFolder}", () => {
-    // eslint-disable-next-line no-template-curly-in-string
-    const result = expandPath("${workspaceFolder}/a:${workspaceFolder}/b", workspaceFolder);
-    assert.strictEqual(result, "/home/user/project/a:/home/user/project/b");
-  });
-
-  test("returns the string unchanged when there is no variable", () => {
-    assert.strictEqual(expandPath("Gemfile", workspaceFolder), "Gemfile");
-  });
-
-  test("returns empty string unchanged", () => {
-    assert.strictEqual(expandPath("", workspaceFolder), "");
-  });
-});
+import { featureEnabled, FEATURE_FLAGS } from "../../common";
 
 suite("featureEnabled", () => {
   let sandbox: sinon.SinonSandbox;


### PR DESCRIPTION
Also validates `bundleGemfile` existence early in `activateRuby` so we can givee users a clear error message upfront instead of a confusing shell error later.

Fixes #3829.