### PR TITLE
Stop preferring /opt/homebrew/bin/shadowenv

### DIFF
--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -21,7 +21,7 @@ export class Shadowenv extends VersionManager {
       );
     }
 
-    const shadowenvExec = await this.findExec([vscode.Uri.file("/opt/homebrew/bin")], "shadowenv");
+    const shadowenvExec = await this.findExec([], "shadowenv");
 
     try {
       const parsedResult = await this.runEnvActivationScript(`${shadowenvExec} exec -- ruby`);


### PR DESCRIPTION
We distribute shadowenv via Nix, but at least one person still has an old version installed on their machine via Homebrew. The version at the front of their $PATH and the one in Homebrew were far enough out of sync that they were incompatible. By just looking for shadowenv on $PATH we should be able to locate the correct version.

It looks like this was added to help with cases where $PATH is broken[1]. We could keep something as a fallback, but at least at Shopify, /opt/homebrew/bin isn't a good fallback anymore.

[1] b7dc6d2ca44781b68b47a0a574c319e5154f3e56