### PR TITLE
Add collect_file_renames addon hook for rename requests

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -273,5 +273,12 @@ module RubyLsp
     def resolve_test_commands(items)
       []
     end
+
+    # Allows add-ons to add additional file rename operations during a rename request. This is invoked after the
+    # standard file rename logic and allows add-ons to handle cases where file naming conventions differ from the
+    # default (e.g., Rails migration files with timestamp prefixes)
+    # @overridable
+    #: (String fully_qualified_name, String new_name, Array[(Interface::RenameFile | Interface::TextDocumentEdit)] document_changes) -> void
+    def collect_file_renames(fully_qualified_name, new_name, document_changes); end
   end
 end

--- a/lib/ruby_lsp/requests/rename.rb
+++ b/lib/ruby_lsp/requests/rename.rb
@@ -84,6 +84,11 @@ module RubyLsp
         end
 
         collect_file_renames(fully_qualified_name, document_changes)
+
+        Addon.addons.each do |addon|
+          addon.collect_file_renames(fully_qualified_name, @new_name, document_changes)
+        end
+
         Interface::WorkspaceEdit.new(document_changes: document_changes)
       end
 


### PR DESCRIPTION
### Motivation

This adds an addon hook so that add-ons can participate in file renames during `textDocument/rename`.

Right now, `collect_file_renames` only renames files that exactly match the constant's snake_case name (e.g. Foo → foo.rb). This doesn't cover cases where file naming conventions include prefixes or other patterns. For example, Rails migration files like `20241030120000_create_users.rb`.

Closes https://github.com/Shopify/ruby-lsp-rails/issues/497 (the ruby-lsp-rails side will follow in a separate PR)

### Implementation

- Added `collect_file_renames(fully_qualified_name, new_name, document_changes)` to the Addon class
- Add-ons can push `Interface::RenameFile` entries into `document_changes`

### Automated Tests

No tests added here since the hook is a no-op by default. The ruby-lsp-rails PR will have tests covering the actual behavior.

### Manual Tests

\-
