### PR TITLE
Fix Bundler::GemNotFound error introduced in 0.26.5

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -126,6 +126,7 @@ module RubyLsp
         return run_bundle_install(@custom_gemfile)
       end
 
+      @needs_update_path.delete if @needs_update_path.exist?
       FileUtils.cp(@lockfile.to_s, @custom_lockfile.to_s)
       correct_relative_remote_paths
       @lockfile_hash_path.write(@lockfile_hash)


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

- Fixes: https://github.com/shop/issues/issues/8978

### Implementation

- delete `needs_update_path` prior to copying updated lockfile

### Automated Tests

- test added

### Manual Tests

- N/A