### PR TITLE
Fix incompatible addon version activation when Bundler.setup fails after retry

### DIFF
--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -101,7 +101,7 @@ begin
     Bundler.setup
     $stderr.puts("Composed Bundle set up successfully")
   end
-rescue Bundler::GemNotFound, Bundler::GitError
+rescue Bundler::GemNotFound, Bundler::GitError => e
   # Sometimes, we successfully set up the bundle, but users either change their Gemfile or uninstall gems from an
   # external process. If there's no install error, but the gem is still not found, then we need to attempt to start from
   # scratch
@@ -113,6 +113,10 @@ rescue Bundler::GemNotFound, Bundler::GitError
       exec(Gem.ruby, __FILE__, *ARGV, "--retry")
     end
   end
+
+  setup_error = e
+  $stderr.puts("Failed to set up composed Bundle\n#{e.full_message}")
+  $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 rescue StandardError => e
   setup_error = e
   $stderr.puts("Failed to set up composed Bundle\n#{e.full_message}")


### PR DESCRIPTION
When Bundler.setup raises GemNotFound or GitError and the retry has already been attempted (or install_error is set), the rescue block fell through without setting setup_error. This caused the server to boot thinking setup succeeded, bypassing the load_addons guard. Without Bundler constraining Gem.find_files, every installed version of every addon gem was discovered, leading to version mismatches (e.g., ruby-lsp-rails 0.4.2 loaded with ruby-lsp 0.26.5) and ArgumentError crashes.

The StandardError rescue already handled this correctly - this aligns the GemNotFound/GitError rescue to do the same.

<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
Resolves errors that may occur from activating incorrect add-on versions. Instead of getting error reports we can not load the add-ons in the first place.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Set `setup_error` and adjust the `LOAD_PATH` similar to `StandardError` case.
### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
