### PR TITLE
Avoid failing if `needs_update` file is deleted by concurrent process

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -340,7 +340,7 @@ module RubyLsp
 
       Bundler::CLI::Update.new({ conservative: true }, gems).run
       correct_relative_remote_paths if @custom_lockfile.exist?
-      @needs_update_path.delete
+      @needs_update_path.delete if @needs_update_path.exist?
       @last_updated_path.write(Time.now.iso8601)
       env
     end


### PR DESCRIPTION
### Motivation

We sometimes see this error in telemetry, where we try to delete the `needs_update` file and it's no longer there. This scenario can happen if running `bundle update` takes a long time and we trigger a restart before it is finished, which may delete the file.

### Implementation

This scenario is not really a bug as we want to be able to restart even during an update, but we don't want to crash and send the error to telemetry. We can just check if the file is still there at the end.

### Automated Tests

Added a test that reproduces the scenario.