### PR TITLE
Support IPv4 and IPv6 for LSP reporter connection

### DIFF
--- a/lib/ruby_lsp/test_reporters/lsp_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/lsp_reporter.rb
@@ -213,12 +213,9 @@ module RubyLsp
 
     private
 
-    #: (String) -> TCPSocket
+    #: (String) -> Socket
     def socket(port)
-      # Connect to 127.0.0.1 (IPv4) explicitly since the extension listens on IPv4 only
-      # Using "localhost" hostname can cause connection failures on systems where it resolves
-      # to IPv6 first, but the server is only listening on IPv4
-      socket = TCPSocket.new("127.0.0.1", port)
+      socket = Socket.tcp("localhost", port)
       socket.binmode
       socket.sync = true
       socket

--- a/test/test_reporters/minitest_reporter_test.rb
+++ b/test/test_reporters/minitest_reporter_test.rb
@@ -173,7 +173,7 @@ module RubyLsp
     def gather_events(uri, output: :stdout)
       plugin_path = File.expand_path("lib/ruby_lsp/test_reporters/minitest_reporter.rb")
 
-      server = TCPServer.new("127.0.0.1", 0)
+      server = TCPServer.new("localhost", 0)
       port = server.addr[1].to_s
       events = []
       socket = nil #: Socket?

--- a/test/test_reporters/test_unit_reporter_test.rb
+++ b/test/test_reporters/test_unit_reporter_test.rb
@@ -97,7 +97,7 @@ module RubyLsp
     def gather_events(uri, output: :stdout)
       reporter_path = File.expand_path(File.join("lib", "ruby_lsp", "test_reporters", "test_unit_reporter.rb"))
 
-      server = TCPServer.new("127.0.0.1", 0)
+      server = TCPServer.new("localhost", 0)
       port = server.addr[1].to_s
       events = []
       socket = nil #: Socket?

--- a/vscode/src/streamingRunner.ts
+++ b/vscode/src/streamingRunner.ts
@@ -188,7 +188,7 @@ export class StreamingRunner implements vscode.Disposable {
       server.unref();
 
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      server.listen(0, "127.0.0.1", async () => {
+      server.listen(0, "localhost", async () => {
         const address = server.address();
 
         if (!address) {


### PR DESCRIPTION
### Motivation

Closes #3868

The changes in #3953 force using IPv4 to connect to the extension. I believe we can go a different direction and use `Socket.tcp`. My understanding is that using that will try to connect to either IPv4 or IPv6, whatever is available.

This also eliminates the change to the extension side, which #3953 does not coordinate. If users got a new version of the extension, but old version of the server (or vice versa), the LSP test reporter would fail to connect.

### Implementation

Switched the extension back to `localhost` and used `Socket.tcp` to connect to it instead.

### Automated Tests

Added tests to verify that we can connect to both IPv4 and IPv6.