### PR TITLE
Fix indexing for editors that don't trigger combined requests (Neovim, etc.)

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -18,6 +18,7 @@ module RubyLsp
       @current_request_id = 1 #: Integer
       @global_state = GlobalState.new #: GlobalState
       @store = Store.new(@global_state) #: Store
+      @combined_requests_used = false #: bool
       @outgoing_dispatcher = Thread.new do
         unless @test_mode
           while (message = @outgoing_queue.pop)

--- a/lib/ruby_lsp/document.rb
+++ b/lib/ruby_lsp/document.rb
@@ -44,6 +44,7 @@ module RubyLsp
       @uri = uri #: URI::Generic
       @needs_parsing = true #: bool
       @last_edit = nil #: Edit?
+      @needs_indexing = true #: bool
 
       # Workaround to be able to type parse_result properly. It is immediately set when invoking parse!
       @parse_result = ( # rubocop:disable Style/RedundantParentheses
@@ -117,6 +118,8 @@ module RubyLsp
       else
         Replace.new(last_edit_range)
       end
+
+      @needs_indexing = true
     end
 
     # Returns `true` if the document was parsed and `false` if nothing needed parsing
@@ -143,6 +146,11 @@ module RubyLsp
       start_index = scanner.find_char_position(start_pos)
       end_index = scanner.find_char_position(end_pos) if end_pos
       [start_index, end_index]
+    end
+
+    #: -> void
+    def mark_as_indexed!
+      @needs_indexing = false
     end
 
     private

--- a/lib/ruby_lsp/ruby_document.rb
+++ b/lib/ruby_lsp/ruby_document.rb
@@ -193,6 +193,8 @@ module RubyLsp
 
     #: -> bool
     def should_index?
+      return false unless @needs_indexing
+
       # This method controls when we should index documents. If there's no recent edit and the document has just been
       # opened, we need to index it
       return true unless @last_edit


### PR DESCRIPTION
## Summary

- Editors like Neovim don't send `documentSymbol`/`codeLens`/`foldingRange`/`documentLink` requests, so the combined-request indexing path never fires for open files. This causes the index to go stale after edits, breaking go-to-definition, completion, and other index-dependent features.
- Adds runtime detection of whether the client sends combined requests via a `@combined_requests_used` flag, and indexes documents directly in `textDocument/didChange` when the flag is false.
- A per-document `@needs_indexing` flag prevents double-indexing during the startup window before the first combined request fires.

## Details

Zero overhead for VS Code users: the flag is set on the first combined request, and the `didChange` indexing path is permanently skipped from that point forward.

For non-combined-request editors (Neovim, etc.), indexing on `didChange` reuses the existing `should_index?` heuristic, so only declaration-affecting edits trigger re-indexing. Non-declaration edits (e.g., changes inside a method body) are correctly skipped.

Thread safety is maintained by performing parse + index under `@global_state.synchronize`, matching the existing pattern in `run_combined_requests`.

Closes #3384

## Test plan

- [x] New test: `test_indexing_occurs_on_did_change_without_combined_requests` — verifies indexing happens on `didChange` when no combined request has fired
- [x] New test: `test_did_change_skips_indexing_when_combined_requests_are_used` — verifies `didChange` indexing is skipped when combined requests are active (VS Code path)
- [x] New test: `test_did_change_skips_indexing_for_non_declaration_edits` — verifies non-declaration edits don't trigger indexing even without combined requests
- [x] Existing tests pass: `test_unsaved_changes_are_indexed_when_computing_automatic_features`, `test_does_not_index_on_did_change_watched_files_if_document_is_managed_by_client`, `test_ancestors_are_recomputed_even_on_unsaved_changes`, `test_should_index_for_inserts`, `test_should_index_for_replaces`
- [x] Sorbet type check passes (`bundle exec srb tc`)