### PR TITLE
Fix yjit RUBYOPT concatenation for Ruby 3.2

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -273,7 +273,7 @@ export class Ruby implements RubyInterface {
       // RUBYOPT may be empty or it may contain bundler paths. In the second case, we must concat to avoid accidentally
       // removing the paths from the env variable
       if (this._env.RUBYOPT) {
-        this._env.RUBYOPT.concat(" --yjit");
+        this._env.RUBYOPT += " --yjit";
       } else {
         this._env.RUBYOPT = "--yjit";
       }


### PR DESCRIPTION
### Motivation

JavaScript `concat` works differently than Ruby's. It does not mutate the string, it concatenates and returns a copy. Which means, that branch of the code was not doing anything.

This PR ensures that we're actually concatenating.