### PR TITLE
Fix send_log_message ignoring type parameter

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -197,7 +197,7 @@ module RubyLsp
 
     #: (String message, ?type: Integer) -> void
     def send_log_message(message, type: Constant::MessageType::LOG)
-      send_message(Notification.window_log_message(message, type: Constant::MessageType::LOG))
+      send_message(Notification.window_log_message(message, type: type))
     end
   end
 end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -412,6 +412,21 @@ class ServerTest < Minitest::Test
     end
   end
 
+  def test_send_log_message_passes_type_parameter
+    @server.expects(:workspace_dependencies).raises(StandardError, "boom")
+
+    capture_io do
+      @server.process_message({
+        id: 1,
+        method: "rubyLsp/workspace/dependencies",
+        params: {},
+      })
+    end
+
+    log = find_message(RubyLsp::Notification, "window/logMessage")
+    assert_equal(RubyLsp::Constant::MessageType::ERROR, log.params.type)
+  end
+
   def test_changed_file_only_indexes_ruby
     path = File.join(Dir.pwd, "lib", "foo.rb")
     File.write(path, "class Foo\nend")


### PR DESCRIPTION
### Motivation

The `type` parameter was being silently ignored, which makes our warn and error log messages all appear as info.