### PR TITLE
Clean up cancelled requests after processing them

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -165,18 +165,20 @@ module RubyLsp
 
       # Check if the request was cancelled before trying to process it
       @global_state.synchronize do
-        if id && @cancelled_requests.include?(id)
+        if id && @cancelled_requests.delete(id)
           send_message(Error.new(
             id: id,
             code: Constant::ErrorCodes::REQUEST_CANCELLED,
             message: "Request #{id} was cancelled",
           ))
-          @cancelled_requests.delete(id)
+
           return
         end
       end
 
       process_message(message)
+      # Ensure we remove the request if it got cancelled while it was being processed
+      @cancelled_requests.delete(id)
     end
 
     #: ((Result | Error | Notification | Request) message) -> void


### PR DESCRIPTION
### Motivation

We were growing the cancelled requests list indefinitely when the notification came in during process. We only cleaned up if the editor managed to cancel the request before we got to it.

### Implementation

We can fix the unbound memory growth by always ensuring that we delete from the list after processing.

### Automated Tests

Added a test to ensure that the list is always empty after the request got processed.