### PR TITLE
Start accepting --beta flag to install beta server version

### DIFF
--- a/exe/ruby-lsp
+++ b/exe/ruby-lsp
@@ -37,6 +37,10 @@ parser = OptionParser.new do |opts|
     options[:launcher] = true
   end
 
+  opts.on("--beta", "Use pre-release server gems") do
+    options[:beta] = true
+  end
+
   opts.on("-h", "--help", "Print this help") do
     puts opts.help
     puts
@@ -66,6 +70,7 @@ if ENV["BUNDLE_GEMFILE"].nil?
   if options[:launcher]
     flags = []
     flags << "--debug" if options[:debug]
+    flags << "--beta" if options[:beta]
     exit exec(Gem.ruby, File.expand_path("ruby-lsp-launcher", __dir__), *flags)
   end
 

--- a/exe/ruby-lsp-launcher
+++ b/exe/ruby-lsp-launcher
@@ -49,16 +49,18 @@ pid = if Gem.win_platform?
     ["-I", File.expand_path(path)]
   end
 
-  Process.spawn(
+  args = [
     Gem.ruby,
     *load_path,
     File.expand_path("../lib/ruby_lsp/scripts/compose_bundle_windows.rb", __dir__),
     raw_initialize,
-  )
+  ]
+  args << "--beta" if ARGV.include?("--beta")
+  Process.spawn(*args)
 else
   fork do
     require_relative "../lib/ruby_lsp/scripts/compose_bundle"
-    compose(raw_initialize)
+    compose(raw_initialize, beta: ARGV.include?("--beta"))
   end
 end
 

--- a/lib/ruby_lsp/scripts/compose_bundle.rb
+++ b/lib/ruby_lsp/scripts/compose_bundle.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-def compose(raw_initialize)
+def compose(raw_initialize, beta: false)
   require_relative "../setup_bundler"
   require "json"
   require "uri"
@@ -12,7 +12,7 @@ def compose(raw_initialize)
   workspace_path = workspace_uri && URI(workspace_uri).to_standardized_path
   workspace_path ||= Dir.pwd
 
-  env = RubyLsp::SetupBundler.new(workspace_path, launcher: true).setup!
+  env = RubyLsp::SetupBundler.new(workspace_path, launcher: true, beta: beta).setup!
 
   File.open(File.join(".ruby-lsp", "bundle_env"), "w") do |f|
     f.flock(File::LOCK_EX)

--- a/lib/ruby_lsp/scripts/compose_bundle_windows.rb
+++ b/lib/ruby_lsp/scripts/compose_bundle_windows.rb
@@ -5,4 +5,4 @@ require_relative "compose_bundle"
 
 # When this is invoked on Windows, we pass the raw initialize as an argument to this script. On other platforms, we
 # invoke the compose method from inside a forked process
-compose(ARGV.first)
+compose(ARGV.first, beta: ARGV.include?("--beta"))

--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -40,6 +40,7 @@ module RubyLsp
       @project_path = project_path
       @branch = options[:branch] #: String?
       @launcher = options[:launcher] #: bool?
+      @beta = options[:beta] #: bool?
       force_output_to_stderr! if @launcher
 
       # Regular bundle paths
@@ -169,7 +170,9 @@ module RubyLsp
       end
 
       unless @dependencies["ruby-lsp"]
-        ruby_lsp_entry = +'gem "ruby-lsp", require: false, group: :development'
+        ruby_lsp_entry = +'gem "ruby-lsp"'
+        ruby_lsp_entry << ", \">= 0.a\"" if @beta
+        ruby_lsp_entry << ", require: false, group: :development"
         ruby_lsp_entry << ", github: \"Shopify/ruby-lsp\", branch: \"#{@branch}\"" if @branch
         parts << ruby_lsp_entry
       end

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -1067,7 +1067,91 @@ class SetupBundlerTest < Minitest::Test
     end
   end
 
+  def test_beta_adds_prerelease_constraint_to_composed_gemfile
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+        source "https://rubygems.org"
+        gem "rdoc"
+      GEMFILE
+
+      capture_subprocess_io do
+        Bundler.with_unbundled_env do
+          system("bundle install")
+          run_script(dir, beta: true)
+        end
+      end
+
+      gemfile_content = File.read(File.join(dir, ".ruby-lsp", "Gemfile"))
+      assert_match(/gem "ruby-lsp", ">= 0.a", require: false, group: :development/, gemfile_content)
+      assert_valid_gemfile(File.join(dir, ".ruby-lsp", "Gemfile"))
+    end
+  end
+
+  def test_beta_adds_prerelease_constraint_to_composed_gemfile_in_launcher_mode
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+        source "https://rubygems.org"
+        gem "rdoc"
+      GEMFILE
+
+      capture_subprocess_io do
+        Bundler.with_unbundled_env do
+          system("bundle install")
+          RubyLsp::SetupBundler.new(dir, launcher: true, beta: true).setup!
+        end
+      end
+
+      gemfile_content = File.read(File.join(dir, ".ruby-lsp", "Gemfile"))
+      assert_match(/gem "ruby-lsp", ">= 0.a", require: false, group: :development/, gemfile_content)
+      assert_valid_gemfile(File.join(dir, ".ruby-lsp", "Gemfile"))
+    end
+  end
+
+  def test_beta_has_no_effect_when_ruby_lsp_is_in_the_bundle_in_launcher_mode
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+        source "https://rubygems.org"
+        gem "ruby-lsp"
+      GEMFILE
+
+      capture_subprocess_io do
+        Bundler.with_unbundled_env do
+          system("bundle install")
+          RubyLsp::SetupBundler.new(dir, launcher: true, beta: true).setup!
+        end
+      end
+
+      gemfile_content = File.read(File.join(dir, ".ruby-lsp", "Gemfile"))
+      refute_match(/gem "ruby-lsp", ">= 0.a", require: false, group: :development/, gemfile_content)
+    end
+  end
+
+  def test_beta_has_no_effect_when_ruby_lsp_is_in_the_bundle
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+        source "https://rubygems.org"
+        gem "ruby-lsp"
+      GEMFILE
+
+      capture_subprocess_io do
+        Bundler.with_unbundled_env do
+          system("bundle install")
+          run_script(dir, beta: true)
+        end
+      end
+
+      gemfile_content = File.read(File.join(dir, ".ruby-lsp", "Gemfile"))
+      refute_match(/gem "ruby-lsp", ">= 0.a", require: false, group: :development/, gemfile_content)
+    end
+  end
+
   private
+
+  def assert_valid_gemfile(gemfile_path)
+    Bundler::Definition.build(gemfile_path, nil, nil)
+  rescue Bundler::GemfileError => e
+    flunk("Composed Gemfile is not valid: #{e.message}")
+  end
 
   def in_temp_dir(&block)
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
### Motivation

Adopting the new indexer will be a process of ironing out bugs, ensuring all APIs are in place and making sure the implementation is robust.

We need a way to ship beta releases of the server to do this without being too disruptive, while at the same time getting feedback from users.

This PR starts accepting a `--beta` flag when launching the Ruby LSP, which makes us install a beta release in the composed bundle.

### Implementation

The idea is to accept the new flag and use a Gemfile constraint to allow installing pre-release versions.

I avoided using the `--pre` flag because that applies to all dependencies and would end up trying to update to pre-releases of `rbs`, `prism`, `ruby-lsp-rails` and so on. This constrains the surface area to just `ruby-lsp`.

### Automated Tests

Added tests to verify that we generate the expected composed Gemfile when beta is on.