### PR TITLE
Add betaServer feature flag to enable pre-releases

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -562,6 +562,10 @@
             "launcher": {
               "description": "Opt-in/out of the new launcher mode",
               "type": "boolean"
+            },
+            "betaServer": {
+              "description": "Opt-in/out of beta server versions",
+              "type": "boolean"
             }
           },
           "default": {}

--- a/vscode/src/client.ts
+++ b/vscode/src/client.ts
@@ -135,6 +135,10 @@ function getLspExecutables(workspaceFolder: vscode.WorkspaceFolder, env: NodeJS.
       args.push("--use-launcher");
     }
 
+    if (featureEnabled("betaServer")) {
+      args.push("--beta");
+    }
+
     run = { command, args, options: executableOptions };
     debug = {
       command,

--- a/vscode/src/common.ts
+++ b/vscode/src/common.ts
@@ -84,6 +84,7 @@ export const FEATURE_FLAGS = {
   tapiocaAddon: 1.0,
   launcher: 0.3,
   fullTestDiscovery: 1.0,
+  betaServer: -1,
 };
 
 type FeatureFlagConfigurationKey = keyof typeof FEATURE_FLAGS | "all";


### PR DESCRIPTION
### Motivation

This PR adds the `betaServer` feature flag, so that we can easily enable and rollout the server beta to test the new indexer.

### Implementation

Added the new flag with a start value of `-1`. This prevents any users who don't explicitly opt-in from getting the beta versions of the server until we're ready to start rolling out.