### PR TITLE
[VS Code] Resolve ruby path correctly with chruby

### DIFF
--- a/vscode/chruby_activation.rb
+++ b/vscode/chruby_activation.rb
@@ -8,12 +8,10 @@ user_dir = Gem.user_dir
 paths = Gem.path
 default_dir = Gem.default_dir
 
-if paths.length > 2
-  paths.delete(default_dir)
-  paths.delete(user_dir)
-  first_path = paths[0]
-  user_dir = first_path if first_path && Dir.exist?(first_path)
-end
+paths.delete(default_dir)
+paths.delete(user_dir)
+first_path = paths[0]
+user_dir = first_path if first_path && Dir.exist?(first_path)
 
 newer_gem_home = File.join(File.dirname(user_dir), ARGV.first)
 gems = Dir.exist?(newer_gem_home) ? newer_gem_home : user_dir


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

In VS Code and its forks (like ~Curser~ Cursor) **Ruby LSP** doesn't work as intended (if I did interpret the comment in `vscode/chruby_activation.rb` correctly LOL).

There is sentence in the comment:
> In our activation script, we check if a directory using the patch exists and then prefer that over the default one.

I read this as: if we have ruby path with patch version (e.g. `"/home/user/.gem/ruby/3.2.3"`) we should use it instead of no-patch one (e.g. `"/home/user/.gem/ruby/3.2.0"`).

But look at the snippet output below:

```ruby
irb(main):011> Gem.path
=> ["/home/user/.gem/ruby/3.2.3", "/home/user/.rubies/ruby-3.2.3/lib/ruby/gems/3.2.0"]
irb(main):012> Gem.user_dir
=> "/home/user/.gem/ruby/3.2.0"
```

Maybe it's just my setup, but I have exactly 2 paths. And condition never resolves, leaving me with gems installed by **Ruby LSP** in the wrong directory (the default one, that we tried to avoid).

### Implementation

Path size checking condition is not needed, as `Array#delete` is safe for misses, and `first_path`'s existence is checked anyways. So in case of any troubles (aka the only ruby version I have is the one without patch, and thus `Gem.path` returns exactly one path) - we still fall back to `Gem.user_dir`.

### Automated Tests

N/A

### Manual Tests

- Removed `$MY_PROJECT_DIR/.ruby-lsp`
- Removed `/home/user/.gem/ruby/3.2.0`
- Restarted VS Code
- Checked **Output** of **Ruby LSP**
- Paths are resolved properly 🎉
