### PR TITLE
Prevent workspace_dependencies failing if directory gets removed during execution

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1211,7 +1211,7 @@ module RubyLsp
             }
           end
         end
-      rescue Bundler::GemNotFound, Bundler::GemfileNotFound
+      rescue Bundler::GemNotFound, Bundler::GemfileNotFound, Errno::ENOENT
         []
       end
 

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -383,6 +383,24 @@ class ServerTest < Minitest::Test
     assert_empty(@server.pop_response.response)
   end
 
+  def test_workspace_dependencies_returns_empty_response_when_cwd_is_deleted
+    original_dir = Dir.pwd
+
+    begin
+      parent = Dir.mktmpdir
+      workspace = File.join(parent, "workspace")
+      Dir.mkdir(workspace)
+      Dir.chdir(workspace)
+      FileUtils.rm_rf(parent)
+
+      @server.process_message({ id: 1, method: "rubyLsp/workspace/dependencies" })
+
+      assert_empty(@server.pop_response.response)
+    ensure
+      Dir.chdir(original_dir)
+    end
+  end
+
   def test_workspace_dependencies_returns_empty_list_when_there_is_no_bundle
     @server.global_state.expects(:top_level_bundle).returns(false)
     @server.process_message({ id: 1, method: "rubyLsp/workspace/dependencies" })


### PR DESCRIPTION
### Motivation

We got some cases in telemetry of this scenario:

- User starts running the LSP on a directory
- User goes on the terminal and deletes the directory where the LSP is running

This makes `Dir.pwd` crash deep inside Bundler on `workspace_dependencies`.

### Implementation

The fix is simple, we just rescue in this case. There's not much we can do if the user deleted the workspace other than avoid crashing.

### Automated Tests

Added a test that reproduces the issue.