### PR TITLE
Apply lower bound `ruby-lsp` version constraint in composed bundle

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -34,6 +34,7 @@ module RubyLsp
     # Gems that should be kept up to date in the composed bundle. When updating, any of these gems that are not
     # already in the user's Gemfile will be updated together.
     GEMS_TO_UPDATE = ["ruby-lsp", "debug", "prism", "rbs"].freeze #: Array[String]
+    RUBY_LSP_MIN_VERSION = "0.18.0" #: String
 
     #: (String project_path, **untyped options) -> void
     def initialize(project_path, **options)
@@ -170,9 +171,8 @@ module RubyLsp
       end
 
       unless @dependencies["ruby-lsp"]
-        ruby_lsp_entry = +'gem "ruby-lsp"'
-        ruby_lsp_entry << ", \">= 0.a\"" if @beta
-        ruby_lsp_entry << ", require: false, group: :development"
+        version = @beta ? "0.a" : RUBY_LSP_MIN_VERSION
+        ruby_lsp_entry = +"gem \"ruby-lsp\", \">= #{version}\", require: false, group: :development"
         ruby_lsp_entry << ", github: \"Shopify/ruby-lsp\", branch: \"#{@branch}\"" if @branch
         parts << ruby_lsp_entry
       end


### PR DESCRIPTION
### Motivation

Without this constraint, Bundler could resolve to very old versions that cause errors. Reasons for choosing 0.18.0:

- Fixes resolution to versions like 0.11.2 which cause `NameError: uninitialized constant RubyLsp::RuboCop::Cop`
- First version with stable Prism 1.0 dependency (`~> 1.0`) — earlier versions used narrow pre-1.0 pins that caused dependency resolution issues
- Includes `rbs >= 3` dependency (added in v0.17.3) needed for core class indexing
- Not overly restrictive — v0.18.0 is from September 2024, leaving ~18 months of versions available

### Implementation

When the composed `.ruby-lsp/Gemfile` is generated for users who don't have `ruby-lsp` in their own Gemfile, apply a `>= 0.18.0` lower bound.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
