### PR TITLE
Ensure bundle is re-composed when CLI arguments change

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -61,7 +61,7 @@ module RubyLsp
       @custom_dir = Pathname.new(".ruby-lsp").expand_path(@project_path) #: Pathname
       @custom_gemfile = @custom_dir + @gemfile_name #: Pathname
       @custom_lockfile = @custom_dir + (@lockfile&.basename || "Gemfile.lock") #: Pathname
-      @lockfile_hash_path = @custom_dir + "main_lockfile_hash" #: Pathname
+      @freshness_hash_path = @custom_dir + "freshness_hash" #: Pathname
       @last_updated_path = @custom_dir + "last_updated" #: Pathname
       @error_path = @custom_dir + "install_error" #: Pathname
       @already_composed_path = @custom_dir + "bundle_is_composed" #: Pathname
@@ -120,8 +120,14 @@ module RubyLsp
         return run_bundle_install(@custom_gemfile)
       end
 
-      if @lockfile_hash && @custom_lockfile.exist? && @lockfile_hash_path.exist? &&
-          @lockfile_hash_path.read == @lockfile_hash
+      # Our freshness hash determines if we need to copy the lockfile from the main app again and run bundle install
+      # from scratch. We use a combination of the main app's lockfile and the composed Gemfile. The goal is to
+      # automatically account for CLI arguments which can change the Gemfile we compose. If the CLI arguments or the
+      # main lockfile change, we need to make sure we're re-composing.
+      freshness_digest = Digest::SHA256.hexdigest("#{@lockfile_hash}#{@custom_gemfile.read}")
+
+      if @lockfile_hash && @custom_lockfile.exist? && @freshness_hash_path.exist? &&
+          @freshness_hash_path.read == freshness_digest
         $stderr.puts(
           "Ruby LSP> Skipping composed bundle setup since #{@custom_lockfile} already exists and is up to date",
         )
@@ -131,7 +137,7 @@ module RubyLsp
       @needs_update_path.delete if @needs_update_path.exist?
       FileUtils.cp(@lockfile.to_s, @custom_lockfile.to_s)
       correct_relative_remote_paths
-      @lockfile_hash_path.write(@lockfile_hash)
+      @freshness_hash_path.write(freshness_digest)
       run_bundle_install(@custom_gemfile)
     end
 

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -74,7 +74,7 @@ class SetupBundlerTest < Minitest::Test
           assert_path_exists(".ruby-lsp")
           assert_path_exists(".ruby-lsp/Gemfile")
           assert_path_exists(".ruby-lsp/Gemfile.lock")
-          assert_path_exists(".ruby-lsp/main_lockfile_hash")
+          assert_path_exists(".ruby-lsp/freshness_hash")
           assert_match("ruby-lsp", File.read(".ruby-lsp/Gemfile"))
           assert_match("debug", File.read(".ruby-lsp/Gemfile"))
           refute_match("ruby-lsp-rails", File.read(".ruby-lsp/Gemfile"))
@@ -101,7 +101,7 @@ class SetupBundlerTest < Minitest::Test
           assert_path_exists(".ruby-lsp")
           assert_path_exists(".ruby-lsp/Gemfile")
           assert_path_exists(".ruby-lsp/Gemfile.lock")
-          assert_path_exists(".ruby-lsp/main_lockfile_hash")
+          assert_path_exists(".ruby-lsp/freshness_hash")
           assert_match("ruby-lsp", File.read(".ruby-lsp/Gemfile"))
           assert_match("debug", File.read(".ruby-lsp/Gemfile"))
           assert_match("ruby-lsp-rails", File.read(".ruby-lsp/Gemfile"))
@@ -538,42 +538,24 @@ class SetupBundlerTest < Minitest::Test
 
   def test_recovers_from_stale_lockfiles
     in_temp_dir do |dir|
-      custom_dir = File.join(dir, ".ruby-lsp")
-      FileUtils.mkdir_p(custom_dir)
-
-      # Write the main Gemfile and lockfile with valid versions
       File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
         source "https://rubygems.org"
         gem "stringio"
       GEMFILE
 
-      lockfile_contents = <<~LOCKFILE
-        GEM
-          remote: https://rubygems.org/
-          specs:
-            stringio (3.1.0)
+      capture_subprocess_io do
+        Bundler.with_unbundled_env do
+          system("bundle install")
 
-        PLATFORMS
-          arm64-darwin-23
-          ruby
+          # First run to set up the composed bundle correctly, including the freshness hash
+          run_script(dir)
+        end
+      end
 
-        DEPENDENCIES
-          stringio
-
-        BUNDLED WITH
-          2.5.7
-      LOCKFILE
-      File.write(File.join(dir, "Gemfile.lock"), lockfile_contents)
-
-      # Write the lockfile hash based on the valid file
-      File.write(File.join(custom_dir, "main_lockfile_hash"), Digest::SHA256.hexdigest(lockfile_contents))
-
-      # Write the composed bundle's lockfile using a fake version that doesn't exist to force bundle install to fail
-      File.write(File.join(custom_dir, "Gemfile"), <<~GEMFILE)
-        source "https://rubygems.org"
-        gem "stringio"
-      GEMFILE
-      File.write(File.join(custom_dir, "Gemfile.lock"), <<~LOCKFILE)
+      # Tamper with the composed lockfile using a fake version that doesn't exist to force bundle install to fail.
+      # The freshness hash from the first run still matches (main lockfile and composed Gemfile are unchanged), so
+      # the stale lockfile will NOT be re-copied and bundle install will encounter the bad version.
+      File.write(File.join(dir, ".ruby-lsp", "Gemfile.lock"), <<~LOCKFILE)
         GEM
           remote: https://rubygems.org/
           specs:
@@ -590,8 +572,10 @@ class SetupBundlerTest < Minitest::Test
           2.5.7
       LOCKFILE
 
-      Bundler.with_unbundled_env do
-        run_script(dir)
+      capture_subprocess_io do
+        Bundler.with_unbundled_env do
+          run_script(dir)
+        end
       end
 
       # Verify that the script recovered and re-generated the composed bundle from scratch
@@ -1165,6 +1149,43 @@ class SetupBundlerTest < Minitest::Test
 
       gemfile_content = File.read(File.join(dir, ".ruby-lsp", "Gemfile"))
       refute_match(/gem "ruby-lsp", ">= 0.a", require: false, group: :development/, gemfile_content)
+    end
+  end
+
+  def test_composed_lockfile_is_recopied_when_cli_options_change
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "Gemfile"), <<~GEMFILE)
+        source "https://rubygems.org"
+        gem "rdoc"
+      GEMFILE
+
+      capture_subprocess_io do
+        Bundler.with_unbundled_env do
+          system("bundle install")
+
+          # First run with --beta creates composed bundle
+          run_script(dir, beta: true)
+        end
+      end
+
+      assert_match(/>= 0\.a/, File.read(".ruby-lsp/Gemfile"))
+      assert_valid_gemfile(File.join(dir, ".ruby-lsp", "Gemfile"))
+
+      # Second run without --beta. The main lockfile hasn't changed, but the composed Gemfile will change. The freshness
+      # check should detect this and re-copy the lockfile from main, NOT skip it.
+      _stdout, stderr = capture_subprocess_io do
+        Bundler.with_unbundled_env do
+          RubyLsp::SetupBundler.new(File.realpath(dir)).setup!
+        end
+      end
+
+      refute_match(/>= 0\.a/, File.read(".ruby-lsp/Gemfile"))
+      assert_valid_gemfile(File.join(dir, ".ruby-lsp", "Gemfile"))
+      refute_match(
+        /Skipping composed bundle setup/,
+        stderr,
+        "Composed lockfile was not refreshed when CLI options changed",
+      )
     end
   end
 


### PR DESCRIPTION
### Motivation

Another bug fix prompted by #3976. CLI arguments to the LSP executable may change the generated `.ruby-lsp/Gemfile`. For example, `--beta` or `--branch=main` mutate the contents of the Gemfile.

If the user then re-boots the server with different CLI arguments (by changing settings) and without any other modifications, the composed Gemfile needs to be invalidated. We weren't doing this, so this is a bug.

Example scenario:

- Use the `branch` setting to point `ruby-lsp` to main
- We generate a Gemfile with `branch: "main"`
- Remove the setting
- The Gemfile should be re-generated without the `branch` option, but instead we just reuse the existing one

### Implementation

Instead of having a lockfile hash, what we need is a freshness hash, which indicates if the bundle must be recomposed based on multiple signals.

This PR changes the signals on the freshness check to include:

- The state of the main application's lockfile: if a gem gets updated/downgraded, we need to recompose
- The state of the composed Gemfile: if CLI arguments change, the composed Gemfile might change too. If it did, we want to recompose

### Automated Tests

Added tests.