### PR TITLE
Revert "Fix Ruby 4.0 CI failure on ubuntu-latest (#3940)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,6 @@ jobs:
         with:
           submodules: "recursive"
 
-      # Workaround: The ubuntu-latest runner image (20260126.10+) ships a pre-installed Ruby 4.0.1
-      # that causes native extension builds and bundler operations to fail. Removing it forces
-      # setup-ruby to download a working build from ruby-builder instead.
-      # See https://github.com/ruby/rubygems/issues/9284.
-      - name: Remove pre-installed Ruby 4.0
-        if: matrix.os == 'ubuntu-latest' && matrix.ruby == '4.0'
-        run: rm -rf /opt/hostedtoolcache/Ruby/4.0*
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
         with:


### PR DESCRIPTION
The upstream issue (ruby/rubygems#9284) has been fixed, so the workaround to remove pre-installed Ruby 4.0 from the tool cache is no longer needed.

Closes #3942