### PR TITLE
Start indexing and resolving Rubydex graph

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -30,6 +30,9 @@ module RubyLsp
     #: RubyIndexer::Index
     attr_reader :index
 
+    #: Rubydex::Graph
+    attr_reader :graph
+
     #: Encoding
     attr_reader :encoding
 
@@ -58,6 +61,7 @@ module RubyLsp
       @test_library = "minitest" #: String
       @has_type_checker = true #: bool
       @index = RubyIndexer::Index.new #: RubyIndexer::Index
+      @graph = Rubydex::Graph.new #: Rubydex::Graph
       @supported_formatters = {} #: Hash[String, Requests::Support::Formatter]
       @type_inferrer = TypeInferrer.new(@index) #: TypeInferrer
       @addon_settings = {} #: Hash[String, untyped]
@@ -117,6 +121,7 @@ module RubyLsp
       all_dependencies = gather_direct_and_indirect_dependencies
       workspace_uri = options.dig(:workspaceFolders, 0, :uri)
       @workspace_uri = URI(workspace_uri) if workspace_uri
+      @graph.workspace_path = workspace_path
 
       specified_formatter = options.dig(:initializationOptions, :formatter)
       rubocop_has_addon = defined?(::RuboCop::Version::STRING) &&
@@ -189,12 +194,16 @@ module RubyLsp
 
       encodings = options.dig(:capabilities, :general, :positionEncodings)
       @encoding = if !encodings || encodings.empty?
+        @graph.encoding = "utf16"
         Encoding::UTF_16LE
       elsif encodings.include?(Constant::PositionEncodingKind::UTF8)
+        @graph.encoding = "utf8"
         Encoding::UTF_8
       elsif encodings.include?(Constant::PositionEncodingKind::UTF16)
+        @graph.encoding = "utf16"
         Encoding::UTF_16LE
       else
+        @graph.encoding = "utf32"
         Encoding::UTF_32
       end
       @index.configuration.encoding = @encoding

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -1228,12 +1228,18 @@ module RubyLsp
 
     #: -> void
     def perform_initial_indexing
+      progress("indexing-progress", message: "Indexing workspace...")
+      @global_state.graph.index_workspace
+
+      progress("indexing-progress", message: "Resolving graph...")
+      @global_state.graph.resolve
+
       # The begin progress invocation happens during `initialize`, so that the notification is sent before we are
       # stuck indexing files
       Thread.new do
         begin
           @global_state.index.index_all do |percentage|
-            progress("indexing-progress", percentage)
+            progress("indexing-progress", percentage: percentage)
             true
           rescue ClosedQueueError
             # Since we run indexing on a separate thread, it's possible to kill the server before indexing is complete.
@@ -1287,11 +1293,13 @@ module RubyLsp
       send_message(Notification.progress_begin(id, title, percentage: percentage, message: "#{percentage}% completed"))
     end
 
-    #: (String id, Integer percentage) -> void
-    def progress(id, percentage)
+    #: (String, ?message: String?, ?percentage: Integer?) -> void
+    def progress(id, message: nil, percentage: nil)
       return unless @global_state.client_capabilities.supports_progress
 
-      send_message(Notification.progress_report(id, percentage: percentage, message: "#{percentage}% completed"))
+      message ||= "#{percentage}% completed" if percentage
+
+      send_message(Notification.progress_report(id, percentage: percentage, message: message))
     end
 
     #: (String id) -> void

--- a/lib/ruby_lsp/test_helper.rb
+++ b/lib/ruby_lsp/test_helper.rb
@@ -30,6 +30,9 @@ module RubyLsp
         })
 
         server.global_state.index.index_single(uri, source)
+        graph = server.global_state.graph
+        graph.index_source(uri.to_s, source, "ruby")
+        graph.resolve
       end
 
       server.load_addons(include_project_addons: false) if load_addons


### PR DESCRIPTION
### Motivation

This PR starts indexing and resolving the Rubydex graph on boot and for tests. Note that consuming incremental changes is not yet a part of the API, so this PR doesn't address that yet.

Our strategy, for smaller and easier to review PRs, will be to maintain both indexing mechanisms while we migrate each request one by one. That way, we don't have to review a massive amount of changes and we can rely on CI.

### Implementation

The implementation makes sure we're:

- Instantiating the graph and configuring the encoding and workspace path
- Indexing and resolving on boot and tests