### PR TITLE
Switch singleton class names to new style

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/declaration_listener.rb
@@ -129,7 +129,7 @@ module RubyIndexer
 
       if current_owner
         expression = node.expression
-        name = (expression.is_a?(Prism::SelfNode) ? "<Class:#{last_name_in_stack}>" : "<Class:#{expression.slice}>")
+        name = (expression.is_a?(Prism::SelfNode) ? "<#{last_name_in_stack}>" : "<#{expression.slice}>")
         real_nesting = Index.actual_nesting(@stack, name)
 
         existing_entries = @index[real_nesting.join("::")] #: as Array[Entry::SingletonClass]?
@@ -577,7 +577,7 @@ module RubyIndexer
 
       # set the class variable's owner to the attached context when defined within a singleton scope.
       if owner.is_a?(Entry::SingletonClass)
-        owner = @owner_stack.reverse.find { |entry| !entry.name.include?("<Class:") }
+        owner = @owner_stack.reverse.find { |entry| !entry.name.include?("<") }
       end
 
       @index.add(Entry::ClassVariable.new(

--- a/lib/ruby_indexer/lib/ruby_indexer/index.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/index.rb
@@ -507,7 +507,7 @@ module RubyIndexer
       singleton_levels = 0
 
       parts.reverse_each do |part|
-        break unless part.include?("<Class:")
+        break unless part.start_with?("<")
 
         singleton_levels += 1
         parts.pop
@@ -551,7 +551,7 @@ module RubyIndexer
 
       if nesting.any?
         singleton_levels.times do
-          nesting << "<Class:#{nesting.last}>"
+          nesting << "<#{nesting.last}>"
         end
       end
 
@@ -616,7 +616,7 @@ module RubyIndexer
       if class_variables.any?
         name_parts = owner_name.split("::")
 
-        if name_parts.last&.start_with?("<Class:")
+        if name_parts.last&.start_with?("<")
           attached_name = name_parts[0..-2] #: as !nil
             .join("::")
           attached_ancestors = linearized_ancestors_of(attached_name)
@@ -707,7 +707,7 @@ module RubyIndexer
     #: (String name) -> Entry::SingletonClass
     def existing_or_new_singleton_class(name)
       *_namespace, unqualified_name = name.split("::")
-      full_singleton_name = "#{name}::<Class:#{unqualified_name}>"
+      full_singleton_name = "#{name}::<#{unqualified_name}>"
       singleton = self[full_singleton_name]&.first #: as Entry::SingletonClass?
 
       unless singleton
@@ -744,7 +744,7 @@ module RubyIndexer
     def linearized_attached_ancestors(name)
       name_parts = name.split("::")
 
-      if name_parts.last&.start_with?("<Class:")
+      if name_parts.last&.start_with?("<")
         attached_name = name_parts[0..-2] #: as !nil
           .join("::")
         linearized_ancestors_of(attached_name)
@@ -866,7 +866,7 @@ module RubyIndexer
 
           parent_name_parts = parent_class_name.split("::")
           singleton_levels.times do
-            parent_name_parts << "<Class:#{parent_name_parts.last}>"
+            parent_name_parts << "<#{parent_name_parts.last}>"
           end
 
           ancestors.concat(linearized_ancestors_of(parent_name_parts.join("::")))
@@ -878,7 +878,7 @@ module RubyIndexer
           class_class_name_parts = ["Class"]
 
           (singleton_levels - 1).times do
-            class_class_name_parts << "<Class:#{class_class_name_parts.last}>"
+            class_class_name_parts << "<#{class_class_name_parts.last}>"
           end
 
           ancestors.concat(linearized_ancestors_of(class_class_name_parts.join("::")))
@@ -892,7 +892,7 @@ module RubyIndexer
           module_class_name_parts = ["Module"]
 
           (singleton_levels - 1).times do
-            module_class_name_parts << "<Class:#{module_class_name_parts.last}>"
+            module_class_name_parts << "<#{module_class_name_parts.last}>"
           end
 
           ancestors.concat(linearized_ancestors_of(module_class_name_parts.join("::")))

--- a/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/reference_finder.rb
@@ -134,7 +134,7 @@ module RubyIndexer
       expression = node.expression
       return unless expression.is_a?(Prism::SelfNode)
 
-      @stack << "<Class:#{@stack.last}>"
+      @stack << "<#{@stack.last}>"
     end
 
     #: (Prism::SingletonClassNode node) -> void
@@ -239,7 +239,7 @@ module RubyIndexer
       end
 
       if node.receiver.is_a?(Prism::SelfNode)
-        @stack << "<Class:#{@stack.last}>"
+        @stack << "<#{@stack.last}>"
       end
     end
 

--- a/lib/ruby_indexer/test/classes_and_modules_test.rb
+++ b/lib/ruby_indexer/test/classes_and_modules_test.rb
@@ -489,15 +489,15 @@ module RubyIndexer
         end
       RUBY
 
-      foo = @index["Foo::<Class:Foo>"] #: as !nil
+      foo = @index["Foo::<Foo>"] #: as !nil
         .first #: as Entry::Class
       assert_equal(["A1", "A2", "A3", "A4", "A5", "A6"], foo.mixin_operation_module_names)
 
-      qux = @index["Foo::Qux::<Class:Qux>"] #: as !nil
+      qux = @index["Foo::Qux::<Qux>"] #: as !nil
         .first #: as Entry::Class
       assert_equal(["Corge", "Corge", "Baz"], qux.mixin_operation_module_names)
 
-      constant_path_references = @index["ConstantPathReferences::<Class:ConstantPathReferences>"] #: as !nil
+      constant_path_references = @index["ConstantPathReferences::<ConstantPathReferences>"] #: as !nil
         .first #: as Entry::Class
       assert_equal(["Foo::Bar", "Foo::Bar2"], constant_path_references.mixin_operation_module_names)
     end
@@ -512,7 +512,7 @@ module RubyIndexer
         end
       RUBY
 
-      foo = @index["Foo::<Class:Foo>"] #: as !nil
+      foo = @index["Foo::<Foo>"] #: as !nil
         .first #: as Entry::SingletonClass
       assert_equal(4, foo.location.start_line)
       assert_equal("Some extra comments", foo.comments)
@@ -527,7 +527,7 @@ module RubyIndexer
         end
       RUBY
 
-      singleton = @index["Foo::<Class:bar>"] #: as !nil
+      singleton = @index["Foo::<bar>"] #: as !nil
         .first #: as Entry::SingletonClass
 
       # Even though this is not correct, we consider any dynamic singleton class block as a regular singleton class.
@@ -547,7 +547,7 @@ module RubyIndexer
         end
       RUBY
 
-      assert_entry("Foo::<Class:Foo>::Bar", Entry::Class, "/fake/path/foo.rb:2-4:3-7")
+      assert_entry("Foo::<Foo>::Bar", Entry::Class, "/fake/path/foo.rb:2-4:3-7")
     end
 
     def test_name_location_points_to_constant_path_location
@@ -614,10 +614,10 @@ module RubyIndexer
       entries = @index.instance_variable_get(:@entries)
       refute(entries.key?("::Foo"))
       refute(entries.key?("::Foo::Bar"))
-      refute(entries.key?("::Foo::Bar::<Class:Bar>"))
+      refute(entries.key?("::Foo::Bar::<Bar>"))
       assert_entry("Foo", Entry::Module, "/fake/path/foo.rb:0-0:5-3")
       assert_entry("Foo::Bar", Entry::Class, "/fake/path/foo.rb:1-2:4-5")
-      assert_entry("Foo::Bar::<Class:Bar>", Entry::SingletonClass, "/fake/path/foo.rb:2-4:3-7")
+      assert_entry("Foo::Bar::<Bar>", Entry::SingletonClass, "/fake/path/foo.rb:2-4:3-7")
     end
 
     def test_indexing_namespaces_inside_nested_top_level_references
@@ -683,13 +683,13 @@ module RubyIndexer
       RUBY
 
       # Verify we didn't index the incorrect name
-      assert_nil(@index["Foo::Bar::<Class:Foo::Bar>"])
+      assert_nil(@index["Foo::Bar::<Foo::Bar>"])
 
       # Verify we indexed the correct name
-      assert_entry("Foo::Bar::<Class:Bar>", Entry::SingletonClass, "/fake/path/foo.rb:1-2:3-5")
+      assert_entry("Foo::Bar::<Bar>", Entry::SingletonClass, "/fake/path/foo.rb:1-2:3-5")
 
       method = @index["baz"]&.first #: as Entry::Method
-      assert_equal("Foo::Bar::<Class:Bar>", method.owner&.name)
+      assert_equal("Foo::Bar::<Bar>", method.owner&.name)
     end
 
     def test_lazy_comments_with_spaces_are_properly_attributed

--- a/lib/ruby_indexer/test/enhancements_test.rb
+++ b/lib/ruby_indexer/test/enhancements_test.rb
@@ -76,18 +76,18 @@ module RubyIndexer
 
       assert_equal(
         [
-          "User::<Class:User>",
-          "ActiveRecord::Base::<Class:Base>",
+          "User::<User>",
+          "ActiveRecord::Base::<Base>",
           "ActiveRecord::Associations::ClassMethods",
-          "Object::<Class:Object>",
-          "BasicObject::<Class:BasicObject>",
+          "Object::<Object>",
+          "BasicObject::<BasicObject>",
           "Class",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("User::<Class:User>"),
+        @index.linearized_ancestors_of("User::<User>"),
       )
 
       assert_entry("new_method", Entry::Method, "/fake/path/foo.rb:10-4:10-33")
@@ -271,20 +271,20 @@ module RubyIndexer
 
       assert_equal(
         [
-          "User::<Class:User>",
+          "User::<User>",
           "MyConcern::ClassMethods",
-          "Object::<Class:Object>",
-          "BasicObject::<Class:BasicObject>",
+          "Object::<Object>",
+          "BasicObject::<BasicObject>",
           "Class",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("User::<Class:User>"),
+        @index.linearized_ancestors_of("User::<User>"),
       )
 
-      refute_nil(@index.resolve_method("foo", "User::<Class:User>"))
+      refute_nil(@index.resolve_method("foo", "User::<User>"))
     end
 
     def test_creating_anonymous_classes_from_enhancement

--- a/lib/ruby_indexer/test/index_test.rb
+++ b/lib/ruby_indexer/test/index_test.rb
@@ -1386,7 +1386,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index.resolve_method("found_me!", "Foo::Bar::<Class:Bar>::Baz::<Class:Baz>")&.first #: as !nil
+      entry = @index.resolve_method("found_me!", "Foo::Bar::<Bar>::Baz::<Baz>")&.first #: as !nil
       refute_nil(entry)
       assert_equal("found_me!", entry.name)
     end
@@ -1411,7 +1411,7 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index.resolve("CONST", ["Foo", "Bar", "<Class:Bar>", "Baz", "<Class:Baz>"])&.first #: as !nil
+      entry = @index.resolve("CONST", ["Foo", "Bar", "<Bar>", "Baz", "<Baz>"])&.first #: as !nil
       refute_nil(entry)
       assert_equal(9, entry.location.start_line)
     end
@@ -1433,15 +1433,15 @@ module RubyIndexer
         end
       RUBY
 
-      entry = @index.resolve_instance_variable("@a", "Foo::Bar::<Class:Bar>")&.first #: as !nil
+      entry = @index.resolve_instance_variable("@a", "Foo::Bar::<Bar>")&.first #: as !nil
       refute_nil(entry)
       assert_equal("@a", entry.name)
 
-      entry = @index.resolve_instance_variable("@b", "Foo::Bar::<Class:Bar>")&.first #: as !nil
+      entry = @index.resolve_instance_variable("@b", "Foo::Bar::<Bar>")&.first #: as !nil
       refute_nil(entry)
       assert_equal("@b", entry.name)
 
-      entry = @index.resolve_instance_variable("@c", "Foo::Bar::<Class:Bar>::<Class:<Class:Bar>>")&.first #: as !nil
+      entry = @index.resolve_instance_variable("@c", "Foo::Bar::<Bar>::<<Bar>>")&.first #: as !nil
       refute_nil(entry)
       assert_equal("@c", entry.name)
     end
@@ -1463,7 +1463,7 @@ module RubyIndexer
         end
       RUBY
 
-      entries = @index.instance_variable_completion_candidates("@", "Foo::Bar::<Class:Bar>").map(&:name)
+      entries = @index.instance_variable_completion_candidates("@", "Foo::Bar::<Bar>").map(&:name)
       assert_includes(entries, "@a")
       assert_includes(entries, "@b")
     end
@@ -1724,37 +1724,37 @@ module RubyIndexer
 
       assert_equal(
         [
-          "Baz::<Class:Baz>::<Class:<Class:Baz>>",
-          "Bar::<Class:Bar>::<Class:<Class:Bar>>",
-          "Foo::<Class:Foo>::<Class:<Class:Foo>>",
-          "Object::<Class:Object>::<Class:<Class:Object>>",
-          "BasicObject::<Class:BasicObject>::<Class:<Class:BasicObject>>",
-          "Class::<Class:Class>",
-          "Module::<Class:Module>",
-          "Object::<Class:Object>",
-          "BasicObject::<Class:BasicObject>",
+          "Baz::<Baz>::<<Baz>>",
+          "Bar::<Bar>::<<Bar>>",
+          "Foo::<Foo>::<<Foo>>",
+          "Object::<Object>::<<Object>>",
+          "BasicObject::<BasicObject>::<<BasicObject>>",
+          "Class::<Class>",
+          "Module::<Module>",
+          "Object::<Object>",
+          "BasicObject::<BasicObject>",
           "Class",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("Baz::<Class:Baz>::<Class:<Class:Baz>>"),
+        @index.linearized_ancestors_of("Baz::<Baz>::<<Baz>>"),
       )
     end
 
     def test_linearizing_singleton_object
       assert_equal(
         [
-          "Object::<Class:Object>",
-          "BasicObject::<Class:BasicObject>",
+          "Object::<Object>",
+          "BasicObject::<BasicObject>",
           "Class",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("Object::<Class:Object>"),
+        @index.linearized_ancestors_of("Object::<Object>"),
       )
     end
 
@@ -1771,7 +1771,7 @@ module RubyIndexer
         end
       RUBY
 
-      ["bar", "baz"].product(["Foo", "Foo::<Class:Foo>"]).each do |method, receiver|
+      ["bar", "baz"].product(["Foo", "Foo::<Foo>"]).each do |method, receiver|
         entry = @index.resolve_method(method, receiver)&.first #: as !nil
         refute_nil(entry)
         assert_equal(method, entry.name)
@@ -1779,14 +1779,14 @@ module RubyIndexer
 
       assert_equal(
         [
-          "Foo::<Class:Foo>",
+          "Foo::<Foo>",
           "Foo",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("Foo::<Class:Foo>"),
+        @index.linearized_ancestors_of("Foo::<Foo>"),
       )
     end
 
@@ -1816,18 +1816,18 @@ module RubyIndexer
 
       assert_equal(
         [
-          "Foo::Bar::<Class:Bar>::Baz::<Class:Baz>",
+          "Foo::Bar::<Bar>::Baz::<Baz>",
           "Second",
           "First",
-          "Object::<Class:Object>",
-          "BasicObject::<Class:BasicObject>",
+          "Object::<Object>",
+          "BasicObject::<BasicObject>",
           "Class",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("Foo::Bar::<Class:Bar>::Baz::<Class:Baz>"),
+        @index.linearized_ancestors_of("Foo::Bar::<Bar>::Baz::<Baz>"),
       )
     end
 
@@ -1846,18 +1846,18 @@ module RubyIndexer
 
       assert_equal(
         [
-          "Baz::<Class:Baz>",
-          "Bar::<Class:Bar>",
-          "Foo::<Class:Foo>",
-          "Object::<Class:Object>",
-          "BasicObject::<Class:BasicObject>",
+          "Baz::<Baz>",
+          "Bar::<Bar>",
+          "Foo::<Foo>",
+          "Object::<Object>",
+          "BasicObject::<BasicObject>",
           "Class",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("Baz::<Class:Baz>"),
+        @index.linearized_ancestors_of("Baz::<Baz>"),
       )
     end
 
@@ -1868,19 +1868,19 @@ module RubyIndexer
 
       assert_equal(
         [
-          "A::<Class:A>",
+          "A::<A>",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("A::<Class:A>"),
+        @index.linearized_ancestors_of("A::<A>"),
       )
     end
 
     def test_linearizing_a_singleton_class_with_no_attached
       assert_raises(Index::NonExistingNamespaceError) do
-        @index.linearized_ancestors_of("A::<Class:A>")
+        @index.linearized_ancestors_of("A::<A>")
       end
     end
 
@@ -1894,17 +1894,17 @@ module RubyIndexer
 
       assert_equal(
         [
-          "User::<Class:User>",
-          "ActiveRecord::Base::<Class:Base>",
-          "Object::<Class:Object>",
-          "BasicObject::<Class:BasicObject>",
+          "User::<User>",
+          "ActiveRecord::Base::<Base>",
+          "Object::<Object>",
+          "BasicObject::<BasicObject>",
           "Class",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("User::<Class:User>"),
+        @index.linearized_ancestors_of("User::<User>"),
       )
     end
 
@@ -1926,18 +1926,18 @@ module RubyIndexer
 
       assert_equal(
         [
-          "Foo::Child::<Class:Child>",
-          "Foo::Namespace::Parent::<Class:Parent>",
+          "Foo::Child::<Child>",
+          "Foo::Namespace::Parent::<Parent>",
           "Bar",
-          "Object::<Class:Object>",
-          "BasicObject::<Class:BasicObject>",
+          "Object::<Object>",
+          "BasicObject::<BasicObject>",
           "Class",
           "Module",
           "Object",
           "Kernel",
           "BasicObject",
         ],
-        @index.linearized_ancestors_of("Foo::Child::<Class:Child>"),
+        @index.linearized_ancestors_of("Foo::Child::<Child>"),
       )
     end
 
@@ -1972,13 +1972,13 @@ module RubyIndexer
       RUBY
 
       entries = @index.entries_for("file:///fake/path/foo.rb", Entry) #: as !nil
-      assert_equal(["Foo", "Bar", "my_def", "Bar::<Class:Bar>", "my_singleton_def"], entries.map(&:name))
+      assert_equal(["Foo", "Bar", "my_def", "Bar::<Bar>", "my_singleton_def"], entries.map(&:name))
 
       entries = @index.entries_for("file:///fake/path/foo.rb", RubyIndexer::Entry::Namespace) #: as !nil
-      assert_equal(["Foo", "Bar", "Bar::<Class:Bar>"], entries.map(&:name))
+      assert_equal(["Foo", "Bar", "Bar::<Bar>"], entries.map(&:name))
 
       entries = @index.entries_for("file:///fake/path/foo.rb") #: as !nil
-      assert_equal(["Foo", "Bar", "my_def", "Bar::<Class:Bar>", "my_singleton_def"], entries.map(&:name))
+      assert_equal(["Foo", "Bar", "my_def", "Bar::<Bar>", "my_singleton_def"], entries.map(&:name))
     end
 
     def test_entries_for_returns_nil_if_no_matches
@@ -2204,7 +2204,7 @@ module RubyIndexer
         end
       RUBY
 
-      adf, abc = @index.instance_variable_completion_candidates("@", "Child::<Class:Child>")
+      adf, abc = @index.instance_variable_completion_candidates("@", "Child::<Child>")
 
       refute_nil(abc)
       refute_nil(adf)
@@ -2223,7 +2223,7 @@ module RubyIndexer
         end
       RUBY
 
-      candidates = @index.class_variable_completion_candidates("@@", "Foo::<Class:Foo>")
+      candidates = @index.class_variable_completion_candidates("@@", "Foo::<Foo>")
       refute_empty(candidates)
 
       assert_equal("@@hello", candidates.first&.name)
@@ -2236,7 +2236,7 @@ module RubyIndexer
         end
       RUBY
 
-      candidates = @index.resolve_class_variable("@@hello", "Foo::<Class:Foo>") #: as !nil
+      candidates = @index.resolve_class_variable("@@hello", "Foo::<Foo>") #: as !nil
       refute_empty(candidates)
 
       assert_equal("@@hello", candidates.first&.name)

--- a/lib/ruby_indexer/test/instance_variables_test.rb
+++ b/lib/ruby_indexer/test/instance_variables_test.rb
@@ -159,21 +159,21 @@ module RubyIndexer
       entry = @index["@a"]&.first #: as Entry::InstanceVariable
       owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::Bar::<Class:Bar>", owner&.name)
+      assert_equal("Foo::Bar::<Bar>", owner&.name)
 
       assert_entry("@b", Entry::InstanceVariable, "/fake/path/foo.rb:6-8:6-10")
 
       entry = @index["@b"]&.first #: as Entry::InstanceVariable
       owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::Bar::<Class:Bar>", owner&.name)
+      assert_equal("Foo::Bar::<Bar>", owner&.name)
 
       assert_entry("@c", Entry::InstanceVariable, "/fake/path/foo.rb:9-6:9-8")
 
       entry = @index["@c"]&.first #: as Entry::InstanceVariable
       owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::Bar::<Class:Bar>::<Class:<Class:Bar>>", owner&.name)
+      assert_equal("Foo::Bar::<Bar>::<<Bar>>", owner&.name)
     end
 
     def test_top_level_instance_variables
@@ -197,7 +197,7 @@ module RubyIndexer
       entry = @index["@a"]&.first #: as Entry::InstanceVariable
       owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::<Class:Foo>", owner&.name)
+      assert_equal("Foo::<Foo>", owner&.name)
     end
 
     def test_instance_variable_inside_dynamic_method_declaration
@@ -234,7 +234,7 @@ module RubyIndexer
       entry = @index["@a"]&.first #: as Entry::InstanceVariable
       owner = entry.owner
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("Foo::<Class:Foo>", owner&.name)
+      assert_equal("Foo::<Foo>", owner&.name)
     end
 
     def test_class_instance_variable_comments

--- a/lib/ruby_indexer/test/method_test.rb
+++ b/lib/ruby_indexer/test/method_test.rb
@@ -49,7 +49,7 @@ module RubyIndexer
 
       entry = @index["bar"]&.first #: as Entry::Method
       owner = entry.owner
-      assert_equal("Foo::<Class:Foo>", owner&.name)
+      assert_equal("Foo::<Foo>", owner&.name)
       assert_instance_of(Entry::SingletonClass, owner)
     end
 
@@ -145,7 +145,7 @@ module RubyIndexer
         assert_instance_of(Entry::Module, first_entry&.owner)
         assert_predicate(first_entry, :private?)
         # The second entry points to the public singleton method
-        assert_equal("Test::<Class:Test>", second_entry&.owner&.name)
+        assert_equal("Test::<Test>", second_entry&.owner&.name)
         assert_instance_of(Entry::SingletonClass, second_entry&.owner)
         assert_equal(:public, second_entry&.visibility)
       end
@@ -873,7 +873,7 @@ module RubyIndexer
       assert_equal("Foo", instance_baz&.owner&.name)
 
       assert_predicate(singleton_baz, :public?)
-      assert_equal("Foo::<Class:Foo>", singleton_baz&.owner&.name)
+      assert_equal("Foo::<Foo>", singleton_baz&.owner&.name)
 
       # After invoking `public`, the state of `module_function` is reset
       instance_qux, singleton_qux = @index["qux"] #: as Array[Entry::Method]

--- a/lib/ruby_indexer/test/rbs_indexer_test.rb
+++ b/lib/ruby_indexer/test/rbs_indexer_test.rb
@@ -89,7 +89,7 @@ module RubyIndexer
 
       owner = entries.first&.owner #: as Entry::SingletonClass
       assert_instance_of(Entry::SingletonClass, owner)
-      assert_equal("File::<Class:File>", owner.name)
+      assert_equal("File::<File>", owner.name)
     end
 
     def test_location_and_name_location_are_the_same
@@ -122,7 +122,7 @@ module RubyIndexer
 
     def test_rbs_method_with_unnamed_required_positionals
       entries = @index["try_convert"] #: as Array[Entry::Method]
-      entry = entries.find { |entry| entry.owner&.name == "Array::<Class:Array>" } #: as Entry::Method
+      entry = entries.find { |entry| entry.owner&.name == "Array::<Array>" } #: as Entry::Method
 
       parameters = entry.signatures[0]&.parameters #: as Array[Entry::Parameter]
 
@@ -132,7 +132,7 @@ module RubyIndexer
 
     def test_rbs_method_with_optional_positionals
       entries = @index["polar"] #: as Array[Entry::Method]
-      entry = entries.find { |entry| entry.owner&.name == "Complex::<Class:Complex>" } #: as Entry::Method
+      entry = entries.find { |entry| entry.owner&.name == "Complex::<Complex>" } #: as Entry::Method
 
       # def self.polar: (Numeric, ?Numeric) -> Complex
 
@@ -190,7 +190,7 @@ module RubyIndexer
 
     def test_rbs_anonymous_block_parameter
       entries = @index["open"] #: as Array[Entry::Method]
-      entry = entries.find { |entry| entry.owner&.name == "File::<Class:File>" } #: as Entry::Method
+      entry = entries.find { |entry| entry.owner&.name == "File::<File>" } #: as Entry::Method
 
       assert_equal(2, entry.signatures.length)
 
@@ -227,7 +227,7 @@ module RubyIndexer
 
     def test_rbs_method_with_trailing_positionals
       entries = @index["select"] #: as Array[Entry::Method]
-      entry = entries.find { |entry| entry.owner&.name == "IO::<Class:IO>" } #: as !nil
+      entry = entries.find { |entry| entry.owner&.name == "IO::<IO>" } #: as !nil
 
       signatures = entry.signatures
       assert_equal(2, signatures.length)

--- a/lib/ruby_indexer/test/reference_finder_test.rb
+++ b/lib/ruby_indexer/test/reference_finder_test.rb
@@ -28,7 +28,7 @@ module RubyIndexer
     end
 
     def test_finds_constant_references_inside_singleton_contexts
-      refs = find_const_references("Foo::<Class:Foo>::Bar", <<~RUBY)
+      refs = find_const_references("Foo::<Foo>::Bar", <<~RUBY)
         class Foo
           class << self
             class Bar

--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -266,7 +266,7 @@ module RubyLsp
         # We only support regular Minitest tests. The declarative syntax provided by ActiveSupport is handled by the
         # Rails add-on
         name_parts = fully_qualified_name.split("::")
-        singleton_name = "#{name_parts.join("::")}::<Class:#{name_parts.last}>"
+        singleton_name = "#{name_parts.join("::")}::<#{name_parts.last}>"
         !@index.linearized_ancestors_of(singleton_name).include?("ActiveSupport::Testing::Declarative")
       rescue RubyIndexer::Index::NonExistingNamespaceError
         true

--- a/lib/ruby_lsp/node_context.rb
+++ b/lib/ruby_lsp/node_context.rb
@@ -62,12 +62,12 @@ module RubyLsp
         when Prism::ClassNode, Prism::ModuleNode
           nesting << node.constant_path.slice
         when Prism::SingletonClassNode
-          nesting << "<Class:#{nesting.flat_map { |n| n.split("::") }.last}>"
+          nesting << "<#{nesting.flat_map { |n| n.split("::") }.last}>"
         when Prism::DefNode
           surrounding_method = node.name.to_s
           next unless node.receiver.is_a?(Prism::SelfNode)
 
-          nesting << "<Class:#{nesting.flat_map { |n| n.split("::") }.last}>"
+          nesting << "<#{nesting.flat_map { |n| n.split("::") }.last}>"
         end
       end
 

--- a/lib/ruby_lsp/type_inferrer.rb
+++ b/lib/ruby_lsp/type_inferrer.rb
@@ -86,9 +86,9 @@ module RubyLsp
         return unless name
 
         *parts, last = name.split("::")
-        return Type.new("#{last}::<Class:#{last}>") if parts.empty?
+        return Type.new("#{last}::<#{last}>") if parts.empty?
 
-        Type.new("#{parts.join("::")}::#{last}::<Class:#{last}>")
+        Type.new("#{parts.join("::")}::#{last}::<#{last}>")
       when Prism::CallNode
         raw_receiver = receiver.message
 
@@ -142,7 +142,7 @@ module RubyLsp
       # If the class/module definition is using compact style (e.g.: `class Foo::Bar`), then we need to split the name
       # into its individual parts to build the correct singleton name
       parts = nesting.flat_map { |part| part.split("::") }
-      Type.new("#{parts.join("::")}::<Class:#{parts.last}>")
+      Type.new("#{parts.join("::")}::<#{parts.last}>")
     end
 
     #: (NodeContext node_context) -> Type?
@@ -152,7 +152,7 @@ module RubyLsp
       return Type.new("Object") if nesting_parts.empty?
 
       nesting_parts.reverse_each do |part|
-        break unless part.include?("<Class:")
+        break unless part.start_with?("<")
 
         nesting_parts.pop
       end
@@ -174,7 +174,7 @@ module RubyLsp
         @name = name
       end
 
-      # Returns the attached version of this type by removing the `<Class:...>` part from its name
+      # Returns the attached version of this type by removing the `<...>` part from its name
       #: -> Type
       def attached
         Type.new(

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -122,7 +122,7 @@ class CompletionResolveTest < Minitest::Test
       existing_item = {
         label: "try_convert",
         kind: RubyLsp::Constant::CompletionItemKind::METHOD,
-        data: { owner_name: "String::<Class:String>" },
+        data: { owner_name: "String::<String>" },
       }
 
       server.process_message(id: 1, method: "completionItem/resolve", params: existing_item)

--- a/test/ruby_document_test.rb
+++ b/test/ruby_document_test.rb
@@ -953,15 +953,15 @@ class RubyDocumentTest < Minitest::Test
     assert_nil(node_context.surrounding_method)
 
     node_context = document.locate_node({ line: 4, character: 4 })
-    assert_equal(["Foo", "<Class:Foo>"], node_context.nesting)
+    assert_equal(["Foo", "<Foo>"], node_context.nesting)
     assert_equal("bar", node_context.surrounding_method)
 
     node_context = document.locate_node({ line: 8, character: 4 })
-    assert_equal(["Foo", "<Class:Foo>"], node_context.nesting)
+    assert_equal(["Foo", "<Foo>"], node_context.nesting)
     assert_nil(node_context.surrounding_method)
 
     node_context = document.locate_node({ line: 11, character: 6 })
-    assert_equal(["Foo", "<Class:Foo>"], node_context.nesting)
+    assert_equal(["Foo", "<Foo>"], node_context.nesting)
     assert_equal("baz", node_context.surrounding_method)
 
     node_context = document.locate_node({ line: 16, character: 6 })

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1057,7 +1057,7 @@ class ServerTest < Minitest::Test
       params: { textDocument: { uri: uri } },
     })
 
-    assert_equal(["Foo::<Class:Foo>", "Bar"], index.linearized_ancestors_of("Foo::<Class:Foo>"))
+    assert_equal(["Foo::<Foo>", "Bar"], index.linearized_ancestors_of("Foo::<Foo>"))
 
     # Delete the extend
     @server.process_message({
@@ -1096,7 +1096,7 @@ class ServerTest < Minitest::Test
     result = find_message(RubyLsp::Result, id: 2)
     refute_nil(result)
 
-    assert_equal(["Foo::<Class:Foo>"], index.linearized_ancestors_of("Foo::<Class:Foo>"))
+    assert_equal(["Foo::<Foo>"], index.linearized_ancestors_of("Foo::<Foo>"))
   end
 
   def test_edits_outside_of_declarations_do_not_trigger_indexing

--- a/test/type_inferrer_test.rb
+++ b/test/type_inferrer_test.rb
@@ -29,7 +29,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo::<Class:Foo>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::<Foo>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_self_inside_singleton_method
@@ -41,7 +41,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo::<Class:Foo>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::<Foo>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_self_inside_singleton_block_body
@@ -53,7 +53,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo::<Class:Foo>::<Class:<Class:Foo>>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::<Foo>::<<Foo>>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_self_inside_singleton_block_method
@@ -67,7 +67,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo::<Class:Foo>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::<Foo>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_constant
@@ -79,7 +79,7 @@ module RubyLsp
         Foo.bar
       RUBY
 
-      assert_equal("Foo::<Class:Foo>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::<Foo>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_constant_path
@@ -93,7 +93,7 @@ module RubyLsp
         Foo::Bar.baz
       RUBY
 
-      assert_equal("Foo::Bar::<Class:Bar>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::Bar::<Bar>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_top_level_receiver
@@ -111,7 +111,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo::<Class:Foo>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::<Foo>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_instance_variables_in_singleton_method
@@ -123,7 +123,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo::<Class:Foo>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::<Foo>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_instance_variables_in_singleton_block_body
@@ -135,7 +135,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo::<Class:Foo>::<Class:<Class:Foo>>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::<Foo>::<<Foo>>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_in_namespaced_singleton_method
@@ -148,7 +148,7 @@ module RubyLsp
       RUBY
 
       result = @type_inferrer.infer_receiver_type(node_context).name
-      assert_equal("Foo::Bar::<Class:Bar>", result)
+      assert_equal("Foo::Bar::<Bar>", result)
     end
 
     def test_infer_receiver_type_instance_variables_in_singleton_block_method
@@ -162,7 +162,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Foo::<Class:Foo>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Foo::<Foo>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_instance_variables_in_instance_method
@@ -376,7 +376,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Admin::User::<Class:User>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Admin::User::<User>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_self_type_for_compact_namespace_inside_method
@@ -400,7 +400,7 @@ module RubyLsp
         end
       RUBY
 
-      assert_equal("Admin::User::<Class:User>", @type_inferrer.infer_receiver_type(node_context).name)
+      assert_equal("Admin::User::<User>", @type_inferrer.infer_receiver_type(node_context).name)
     end
 
     def test_infer_receiver_type_class_variables_in_class_body


### PR DESCRIPTION
### Motivation

The Ruby LSP indexer currently represents singleton class names as `Foo::<Class:Foo>`, but Rubydex uses the shorter `Foo::<Foo>`.

A lot of places in the code build names with that convention, so it's not possible to migrate requests one by one while maintaining the current functionality without changing the representation first.

### Implementation

This PR just changes all singleton names and logic to use the new names.