### PR TITLE
Suppress Bundler::InstallError from telemetry

### DIFF
--- a/lib/ruby_lsp/setup_bundler.rb
+++ b/lib/ruby_lsp/setup_bundler.rb
@@ -242,7 +242,7 @@ module RubyLsp
         # If no error occurred, then clear previous errors
         @error_path.delete if @error_path.exist?
         $stderr.puts("Ruby LSP> Composed bundle installation complete")
-      rescue Errno::EPIPE, Bundler::HTTPError
+      rescue Errno::EPIPE, Bundler::HTTPError, Bundler::InstallError
         # There are cases where we expect certain errors to happen occasionally, and we don't want to write them to
         # a file, which would report to telemetry on the next launch.
         #
@@ -250,6 +250,7 @@ module RubyLsp
         # install. This situation may happen because, while running bundle install, the server is not yet ready to
         # receive shutdown requests and we may continue doing work until the process is killed.
         # - Bundler might also encounter a network error.
+        # - Native extension build failures (InstallError) are user environment issues that Ruby LSP cannot resolve.
         @error_path.delete if @error_path.exist?
       rescue => e
         # Write the error object to a file so that we can read it from the parent process

--- a/test/setup_bundler_test.rb
+++ b/test/setup_bundler_test.rb
@@ -1067,6 +1067,29 @@ class SetupBundlerTest < Minitest::Test
     end
   end
 
+  def test_does_not_report_native_extension_build_failures_to_telemetry
+    in_temp_dir do |dir|
+      File.write(File.join(dir, "gems.rb"), <<~GEMFILE)
+        source "https://rubygems.org"
+        gem "irb"
+      GEMFILE
+
+      Bundler.with_unbundled_env do
+        capture_subprocess_io do
+          system("bundle install")
+
+          compose = RubyLsp::SetupBundler.new(dir, launcher: true)
+          compose.expects(:run_bundle_install_directly).raises(
+            Bundler::InstallError,
+            "Gem::Ext::BuildError: ERROR: Failed to build gem native extension",
+          )
+          compose.setup!
+          refute_path_exists(File.join(dir, ".ruby-lsp", "install_error"))
+        end
+      end
+    end
+  end
+
   def test_beta_adds_prerelease_constraint_to_composed_gemfile
     in_temp_dir do |dir|
       File.write(File.join(dir, "Gemfile"), <<~GEMFILE)


### PR DESCRIPTION
Native extension build failures (e.g., missing libyaml for psych) are user environment issues that Ruby LSP cannot resolve. Stop writing them to the error file so they don't get reported on next launch.