### PR TITLE
Filter GemNotFound and GitError setup errors from telemetry

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -3,6 +3,8 @@
 
 module RubyLsp
   class Server < BaseServer
+    NON_REPORTABLE_SETUP_ERRORS = [Bundler::GemNotFound, Bundler::GitError].freeze #: Array[singleton(StandardError)]
+
     # Only for testing
     #: GlobalState
     attr_reader :global_state
@@ -315,7 +317,7 @@ module RubyLsp
 
       global_state_notifications.each { |notification| send_message(notification) }
 
-      if @setup_error
+      if @setup_error && NON_REPORTABLE_SETUP_ERRORS.none? { |error_class| @setup_error.is_a?(error_class) }
         send_message(Notification.telemetry(
           type: "error",
           errorMessage: @setup_error.message,

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -647,6 +647,21 @@ class ServerTest < Minitest::Test
     assert_match("mocha/exception_raiser.rb", data[:backtrace])
   end
 
+  def test_gem_not_found_setup_error_does_not_send_telemetry
+    RubyLsp::Notification.expects(:telemetry).never
+    run_initialize_server_with_setup_error(Bundler::GemNotFound.new("Could not find gem 'foo'"))
+  end
+
+  def test_git_error_setup_error_does_not_send_telemetry
+    RubyLsp::Notification.expects(:telemetry).never
+    run_initialize_server_with_setup_error(Bundler::GitError.new("Revision abc123 does not exist"))
+  end
+
+  def test_other_setup_errors_are_reported_to_telemetry
+    RubyLsp::Notification.expects(:telemetry).once
+    run_initialize_server_with_setup_error(StandardError.new("something unexpected"))
+  end
+
   def test_handles_editor_indexing_settings
     capture_io do
       @server.process_message({
@@ -1713,6 +1728,22 @@ class ServerTest < Minitest::Test
   end
 
   private
+
+  def run_initialize_server_with_setup_error(error)
+    server = RubyLsp::Server.new(test_mode: true, setup_error: error)
+    capture_subprocess_io do
+      server.process_message({
+        id: 1,
+        method: "initialize",
+        params: {
+          initializationOptions: { enabledFeatures: [] },
+          capabilities: { general: { positionEncodings: ["utf-8"] } },
+        },
+      })
+    end
+  ensure
+    server&.run_shutdown
+  end
 
   def wait_for_indexing
     message = @server.pop_response


### PR DESCRIPTION
When Bundler.setup fails with GemNotFound or GitError, the server already recovers gracefully into degraded mode. Reporting them creates noise since they are user environment issues (missing gems or bad git refs in Gemfile).