### PR TITLE
Suppress missing Ruby version errors from extension telemetry

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -5,9 +5,9 @@ import * as vscode from "vscode";
 
 import { asyncExec, RubyInterface } from "./common";
 import { WorkspaceChannel } from "./workspaceChannel";
-import { Shadowenv, UntrustedWorkspaceError } from "./ruby/shadowenv";
+import { Shadowenv } from "./ruby/shadowenv";
 import { Chruby } from "./ruby/chruby";
-import { VersionManager } from "./ruby/versionManager";
+import { NonReportableError, VersionManager } from "./ruby/versionManager";
 import { Mise } from "./ruby/mise";
 import { RubyInstaller } from "./ruby/rubyInstaller";
 import { Rbenv } from "./ruby/rbenv";
@@ -151,7 +151,7 @@ export class Ruby implements RubyInterface {
       try {
         await this.runManagerActivation();
       } catch (error: any) {
-        if (!(error instanceof UntrustedWorkspaceError)) {
+        if (!(error instanceof NonReportableError)) {
           this.telemetry.logError(error, {
             appType: "extension",
             appVersion: this.context.extension.packageJSON.version,

--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
 
 import { WorkspaceChannel } from "../workspaceChannel";
 
-import { ActivationResult, VersionManager, ACTIVATION_SEPARATOR } from "./versionManager";
+import { ActivationResult, MissingRubyError, VersionManager, ACTIVATION_SEPARATOR } from "./versionManager";
 
 interface RubyVersion {
   engine?: string;
@@ -226,7 +226,7 @@ export class Chruby extends VersionManager {
       return closest;
     }
 
-    throw new Error("Cannot find any Ruby installations");
+    throw new MissingRubyError("Cannot find any Ruby installations");
   }
 
   // Returns the Ruby version information including version and engine. E.g.: ruby-3.3.0, truffleruby-21.3.0
@@ -425,11 +425,11 @@ export class Chruby extends VersionManager {
       }
     }
 
-    throw new Error("Cannot find any Ruby installations");
+    throw new MissingRubyError("Cannot find any Ruby installations");
   }
 
   private missingRubyError(version: string) {
-    return new Error(`Cannot find Ruby installation for version ${version}`);
+    return new MissingRubyError(`Cannot find Ruby installation for version ${version}`);
   }
 
   private rubyVersionError() {

--- a/vscode/src/ruby/rubyInstaller.ts
+++ b/vscode/src/ruby/rubyInstaller.ts
@@ -3,6 +3,7 @@ import os from "os";
 import * as vscode from "vscode";
 
 import { Chruby } from "./chruby";
+import { MissingRubyError } from "./versionManager";
 
 interface RubyVersion {
   engine?: string;
@@ -40,7 +41,7 @@ export class RubyInstaller extends Chruby {
       }
     }
 
-    throw new Error(
+    throw new MissingRubyError(
       `Cannot find installation directory for Ruby version ${rubyVersion.version}.\
          Searched in ${possibleInstallationUris.map((uri) => uri.fsPath).join(", ")}`,
     );

--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -2,13 +2,13 @@ import * as vscode from "vscode";
 
 import { asyncExec } from "../common";
 
-import { VersionManager, ActivationResult } from "./versionManager";
+import { VersionManager, ActivationResult, NonReportableError } from "./versionManager";
 
 // Shadowenv is a tool that allows managing environment variables upon entering a directory. It allows users to manage
 // which Ruby version should be used for each project, in addition to other customizations such as GEM_HOME.
 //
 // Learn more: https://github.com/Shopify/shadowenv
-export class UntrustedWorkspaceError extends Error {}
+export class UntrustedWorkspaceError extends NonReportableError {}
 
 export class Shadowenv extends VersionManager {
   async activate(): Promise<ActivationResult> {

--- a/vscode/src/ruby/versionManager.ts
+++ b/vscode/src/ruby/versionManager.ts
@@ -13,6 +13,9 @@ export interface ActivationResult {
   gemPath: string[];
 }
 
+export class NonReportableError extends Error {}
+export class MissingRubyError extends NonReportableError {}
+
 // Changes to either one of these values have to be synchronized with a corresponding update in `activation.rb`
 export const ACTIVATION_SEPARATOR = "RUBY_LSP_ACTIVATION_SEPARATOR";
 export const VALUE_SEPARATOR = "RUBY_LSP_VS";

--- a/vscode/src/test/suite/ruby.test.ts
+++ b/vscode/src/test/suite/ruby.test.ts
@@ -12,7 +12,8 @@ import { WorkspaceChannel } from "../../workspaceChannel";
 import { LOG_CHANNEL } from "../../common";
 import * as common from "../../common";
 import { Shadowenv, UntrustedWorkspaceError } from "../../ruby/shadowenv";
-import { ACTIVATION_SEPARATOR, FIELD_SEPARATOR, VALUE_SEPARATOR } from "../../ruby/versionManager";
+import { Chruby } from "../../ruby/chruby";
+import { ACTIVATION_SEPARATOR, FIELD_SEPARATOR, MissingRubyError, VALUE_SEPARATOR } from "../../ruby/versionManager";
 
 import { createContext, FakeContext } from "./helpers";
 import { FAKE_TELEMETRY } from "./fakeTelemetry";
@@ -141,6 +142,21 @@ suite("Ruby environment activation", () => {
 
     await assert.rejects(async () => {
       await ruby.activateRuby({ identifier: ManagerIdentifier.Shadowenv });
+    });
+
+    assert.ok(!telemetry.logError.called);
+  });
+
+  test("Ignores missing Ruby version for telemetry", async () => {
+    const telemetry = { ...FAKE_TELEMETRY, logError: sandbox.stub() };
+    const ruby = new Ruby(context, workspaceFolder, outputChannel, telemetry);
+
+    sandbox
+      .stub(Chruby.prototype, "activate")
+      .rejects(new MissingRubyError("Cannot find Ruby installation for version 3.4.0"));
+
+    await assert.rejects(async () => {
+      await ruby.activateRuby({ identifier: ManagerIdentifier.Chruby });
     });
 
     assert.ok(!telemetry.logError.called);


### PR DESCRIPTION
Introduce NonReportableError base class that MissingRubyError and UntrustedWorkspaceError both extend. The telemetry check in ruby.ts now uses a single `instanceof NonReportableError` guard, making it extensible without modifying the check for each new error type.