### PR TITLE
Suppress version manager environment errors from extension telemetry

### DIFF
--- a/vscode/src/ruby/asdf.ts
+++ b/vscode/src/ruby/asdf.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 import * as vscode from "vscode";
 
-import { VersionManager, ActivationResult } from "./versionManager";
+import { VersionManager, ActivationResult, NonReportableError } from "./versionManager";
 
 // A tool to manage multiple runtime versions with a single CLI tool
 //
@@ -82,7 +82,9 @@ export class Asdf extends VersionManager {
       this.outputChannel.info(`Using configured ASDF executable path: ${asdfPath}`);
       return configuredPath.fsPath;
     } catch (_error: any) {
-      throw new Error(`ASDF executable configured as ${configuredPath.fsPath}, but that file doesn't exist`);
+      throw new NonReportableError(
+        `ASDF executable configured as ${configuredPath.fsPath}, but that file doesn't exist`,
+      );
     }
   }
 }

--- a/vscode/src/ruby/chruby.ts
+++ b/vscode/src/ruby/chruby.ts
@@ -5,7 +5,13 @@ import * as vscode from "vscode";
 
 import { WorkspaceChannel } from "../workspaceChannel";
 
-import { ActivationResult, MissingRubyError, VersionManager, ACTIVATION_SEPARATOR } from "./versionManager";
+import {
+  ActivationResult,
+  MissingRubyError,
+  NonReportableError,
+  VersionManager,
+  ACTIVATION_SEPARATOR,
+} from "./versionManager";
 
 interface RubyVersion {
   engine?: string;
@@ -248,13 +254,13 @@ export class Chruby extends VersionManager {
       }
 
       if (version === "") {
-        throw new Error(`Ruby version file ${rubyVersionUri.fsPath} is empty`);
+        throw new NonReportableError(`Ruby version file ${rubyVersionUri.fsPath} is empty`);
       }
 
       const match = /((?<engine>[A-Za-z]+)-)?(?<version>\d+\.\d+(\.\d+)?(-[A-Za-z0-9]+)?)/.exec(version);
 
       if (!match?.groups) {
-        throw new Error(
+        throw new NonReportableError(
           `Ruby version file ${rubyVersionUri.fsPath} contains invalid format. Expected (engine-)?version, got ${version}`,
         );
       }
@@ -433,7 +439,7 @@ export class Chruby extends VersionManager {
   }
 
   private rubyVersionError() {
-    return new Error(
+    return new NonReportableError(
       `Cannot find .ruby-version file. Please specify the Ruby version in a
            .ruby-version either in ${this.bundleUri.fsPath} or in a parent directory`,
     );

--- a/vscode/src/ruby/custom.ts
+++ b/vscode/src/ruby/custom.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { VersionManager, ActivationResult } from "./versionManager";
+import { VersionManager, ActivationResult, NonReportableError } from "./versionManager";
 
 // Custom
 //
@@ -24,7 +24,7 @@ export class Custom extends VersionManager {
     const customCommand: string | undefined = configuration.get("customRubyCommand");
 
     if (customCommand === undefined) {
-      throw new Error(
+      throw new NonReportableError(
         "The customRubyCommand configuration must be set when 'custom' is selected as the version manager. \
         See the [README](https://shopify.github.io/ruby-lsp/version-managers.html) for instructions.",
       );

--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -2,7 +2,7 @@ import os from "os";
 
 import * as vscode from "vscode";
 
-import { VersionManager, ActivationResult } from "./versionManager";
+import { VersionManager, ActivationResult, NonReportableError } from "./versionManager";
 
 // Mise (mise en place) is a manager for dev tools, environment variables and tasks
 //
@@ -33,7 +33,9 @@ export class Mise extends VersionManager {
         await vscode.workspace.fs.stat(configuredPath);
         return configuredPath;
       } catch (_error: any) {
-        throw new Error(`Mise executable configured as ${configuredPath.fsPath}, but that file doesn't exist`);
+        throw new NonReportableError(
+          `Mise executable configured as ${configuredPath.fsPath}, but that file doesn't exist`,
+        );
       }
     }
 
@@ -57,7 +59,7 @@ export class Mise extends VersionManager {
       }
     }
 
-    throw new Error(
+    throw new NonReportableError(
       `The Ruby LSP version manager is configured to be Mise, but could not find Mise installation. Searched in
         ${possiblePaths.join(", ")}`,
     );

--- a/vscode/src/ruby/rbenv.ts
+++ b/vscode/src/ruby/rbenv.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { VersionManager, ActivationResult } from "./versionManager";
+import { VersionManager, ActivationResult, NonReportableError } from "./versionManager";
 
 // Seamlessly manage your app’s Ruby environment with rbenv.
 //
@@ -36,7 +36,9 @@ export class Rbenv extends VersionManager {
 
       return path;
     } catch (_error: any) {
-      throw new Error(`The Ruby LSP version manager is configured to be rbenv, but ${path} does not exist`);
+      throw new NonReportableError(
+        `The Ruby LSP version manager is configured to be rbenv, but ${path} does not exist`,
+      );
     }
   }
 }

--- a/vscode/src/ruby/rv.ts
+++ b/vscode/src/ruby/rv.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { VersionManager, ActivationResult } from "./versionManager";
+import { VersionManager, ActivationResult, NonReportableError } from "./versionManager";
 
 // Manage your Ruby environment with rv
 //
@@ -40,7 +40,7 @@ export class Rv extends VersionManager {
       await vscode.workspace.fs.stat(vscode.Uri.file(path));
       return path;
     } catch (_error: any) {
-      throw new Error(`The Ruby LSP version manager is configured to be rv, but ${path} does not exist`);
+      throw new NonReportableError(`The Ruby LSP version manager is configured to be rv, but ${path} does not exist`);
     }
   }
 }

--- a/vscode/src/ruby/rvm.ts
+++ b/vscode/src/ruby/rvm.ts
@@ -2,7 +2,7 @@ import os from "os";
 
 import * as vscode from "vscode";
 
-import { ActivationResult, VersionManager } from "./versionManager";
+import { ActivationResult, NonReportableError, VersionManager } from "./versionManager";
 
 // Ruby enVironment Manager. It manages Ruby application environments and enables switching between them.
 // Learn more:
@@ -43,7 +43,7 @@ export class Rvm extends VersionManager {
       }
     }
 
-    throw new Error(
+    throw new NonReportableError(
       `Cannot find RVM installation directory. Searched in ${possiblePaths.map((uri) => uri.fsPath).join(",")}`,
     );
   }

--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -15,7 +15,7 @@ export class Shadowenv extends VersionManager {
     try {
       await vscode.workspace.fs.stat(vscode.Uri.joinPath(this.bundleUri, ".shadowenv.d"));
     } catch (_error: any) {
-      throw new Error(
+      throw new NonReportableError(
         "The Ruby LSP version manager is configured to be shadowenv, \
         but no .shadowenv.d directory was found in the workspace",
       );
@@ -58,7 +58,7 @@ export class Shadowenv extends VersionManager {
       try {
         await asyncExec("shadowenv --version");
       } catch (_error: any) {
-        throw new Error(
+        throw new NonReportableError(
           `Shadowenv executable not found. Ensure it is installed and available in the PATH.
            This error may happen if your shell configuration is failing to be sourced from the editor or if
            another extension is mutating the process PATH.`,
@@ -66,7 +66,7 @@ export class Shadowenv extends VersionManager {
       }
 
       // If it failed for some other reason, present the error to the user
-      throw new Error(`Failed to activate Ruby environment with Shadowenv: ${error.message}`);
+      throw new NonReportableError(`Failed to activate Ruby environment with Shadowenv: ${error.message}`);
     }
   }
 }


### PR DESCRIPTION
Version manager activation errors (missing executables, misconfigured paths, absent .ruby-version files) are usually user environment issues. They are still surfaced to the user for troubleshooting, but reporting them to telemetry is noise since there is nothing actionable on the Ruby LSP side.