### PR TITLE
Fix semantic token `defaultLibrary` modifier casing

### DIFF
--- a/jekyll/semantic-highlighting.markdown
+++ b/jekyll/semantic-highlighting.markdown
@@ -43,7 +43,7 @@ contained in the default list.
 | Method calls with any syntax  | method | |
 | Constant references (including classes and modules)  | namespace | We don't yet differentiate between module and class references |
 | Method definition  | method.declaration | |
-| self  | variable.default_library | |
+| self  | variable.defaultLibrary | |
 | Method, block and lambda arguments | parameter | |
 | Class declaration | class.declaration | |
 | Module declaration | class.declaration | |

--- a/lib/ruby_lsp/listeners/semantic_highlighting.rb
+++ b/lib/ruby_lsp/listeners/semantic_highlighting.rb
@@ -162,7 +162,7 @@ module RubyLsp
 
       #: (Prism::SelfNode node) -> void
       def on_self_node_enter(node)
-        @response_builder.add_token(node.location, :variable, [:default_library])
+        @response_builder.add_token(node.location, :variable, [:defaultLibrary])
       end
 
       #: (Prism::LocalVariableWriteNode node) -> void

--- a/lib/ruby_lsp/response_builders/semantic_highlighting.rb
+++ b/lib/ruby_lsp/response_builders/semantic_highlighting.rb
@@ -43,7 +43,7 @@ module RubyLsp
         async: 6,
         modification: 7,
         documentation: 8,
-        default_library: 9,
+        defaultLibrary: 9,
       }.freeze #: Hash[Symbol, Integer]
 
       #: ((^(Integer arg0) -> Integer | Prism::CodeUnitsCache) code_units_cache) -> void
@@ -184,8 +184,8 @@ module RubyLsp
         end
 
         # Encode an array of modifiers to positions onto a bit flag
-        # For example, [:default_library] will be encoded as
-        # 0b1000000000, as :default_library is the 10th bit according
+        # For example, [:defaultLibrary] will be encoded as
+        # 0b1000000000, as :defaultLibrary is the 10th bit according
         # to the token modifiers index map.
         #: (Array[Integer] modifiers) -> Integer
         def encode_modifiers(modifiers)

--- a/test/requests/semantic_highlighting_expectations_test.rb
+++ b/test/requests/semantic_highlighting_expectations_test.rb
@@ -82,6 +82,15 @@ class SemanticHighlightingExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_provider_uses_lsp_default_library_modifier_casing
+    token_modifiers = JSON.parse(
+      RubyLsp::Requests::SemanticHighlighting.provider.to_json,
+    ).dig("legend", "tokenModifiers")
+
+    assert_includes(token_modifiers, "defaultLibrary")
+    refute_includes(token_modifiers, "default_library")
+  end
+
   private
 
   def create_semantic_highlighting_addon


### PR DESCRIPTION

### Motivation

Ruby LSP currently emits the semantic token modifier as `default_library`, but the LSP standard modifier name is `defaultLibrary` (camelCase).  From the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokenModifiers):
```typescript
export enum SemanticTokenModifiers {
	...
	defaultLibrary = 'defaultLibrary'
}
```

The [Ruby LSP docs](https://shopify.github.io/ruby-lsp/semantic-highlighting.html) state:
> Currently, the Ruby LSP does not contribute any new semantic tokens and only uses the ones contained in the default list.

But `default_library` is not in the default list.

I noticed this because I was using Ruby LSP with Zed, which has [default semantic token rules](https://github.com/zed-industries/zed/blob/main/assets/settings/default_semantic_token_rules.json) to map semantic token types and modifiers to syntax theme styles.  But these default semantic token rules do not support `default_library`; they only support `defaultLibrary`.

This means that, when using Zed, in order to get semantic token syntax highlighting for `self`, you need to define your own custom semantic token rules for `default_library`.

This would also apply to any other clients or themes expecting the semantic token types/modifiers from the specification in order to determine syntax theme styles.

In short - using the non-standard modifier `default_library` breaks protocol compatibility for clients/themes expecting the standard modifier `defaultLibrary`.

### Related PR

See: https://github.com/Shopify/vscode-shopify-ruby/pull/754

That PR updates the Spinel themes to apply the same formatting to `variable.defaultLibrary` as it does to `variable.default_library`.
That PR should ideally be merged and released before this PR, so that VSCode users of the Spinel theme don't notice any changes.

### Implementation

- Updated semantic token modifier key from `default_library` to `defaultLibrary` in:
  - `lib/ruby_lsp/response_builders/semantic_highlighting.rb`
- Updated the `self` token emission to use the new modifier symbol:
  - `lib/ruby_lsp/listeners/semantic_highlighting.rb`
- Updated documentation to reflect the correct selector:
  - `jekyll/semantic-highlighting.markdown` (`variable.defaultLibrary`)
- Added a regression test to verify provider legend serialization uses `defaultLibrary` and not `default_library`:
  - `test/requests/semantic_highlighting_expectations_test.rb`

### Automated Tests

Yes, I added tests!

### Manual Tests

1. In VSCode, open a Ruby file containing `self`, for example:

   ```ruby
   class Post
     def title
       self
     end
   end
   ```

2. Run **Developer: Inspect Editor Tokens and Scopes**.
3. Place cursor on `self`.
3. Verify semantic token shows:
   - semantic token type: `variable`
   - modifiers: `defaultLibrary`
   - and does **not** show `default_library`.
