### PR TITLE
Revert GlobalState caching

### DIFF
--- a/test/requests/support/expectations_test_runner.rb
+++ b/test/requests/support/expectations_test_runner.rb
@@ -8,14 +8,10 @@ class ExpectationsTestRunner < Minitest::Test
   TEST_PRISM_FIXTURES = File.join(TEST_FIXTURES_DIR, "prism/test/prism/fixtures/**", "*.txt")
 
   def setup
-    @global_state = self.class.shared_global_state
+    @global_state = RubyLsp::GlobalState.new
   end
 
   class << self
-    def shared_global_state
-      @shared_global_state ||= RubyLsp::GlobalState.new
-    end
-
     def expectations_tests(handler_class, expectation_suffix)
       class_eval(<<~RB, __FILE__, __LINE__ + 1)
         module ExpectationsRunnerMethods


### PR DESCRIPTION
### Motivation

Right now we have consistent test setup within the same test class, so caching the GlobalState within the same test class doesn't leak state.

But it's not easy to guarantee this for future tests and it can easily become a footgun. So let's revert it for now.
### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
