### PR TITLE
Fix document links for source comments above sig blocks

### DIFF
--- a/lib/ruby_lsp/listeners/document_link.rb
+++ b/lib/ruby_lsp/listeners/document_link.rb
@@ -60,6 +60,7 @@ module RubyLsp
         @lines_to_comments = comments.to_h do |comment|
           [comment.location.end_line, comment]
         end #: Hash[Integer, Prism::Comment]
+        @sig_comments = {} #: Hash[Integer, Prism::Comment]
 
         dispatcher.register(
           self,
@@ -68,7 +69,18 @@ module RubyLsp
           :on_module_node_enter,
           :on_constant_write_node_enter,
           :on_constant_path_write_node_enter,
+          :on_call_node_enter,
         )
+      end
+
+      #: (Prism::CallNode node) -> void
+      def on_call_node_enter(node)
+        return unless node.name == :sig
+
+        comment = @lines_to_comments[node.location.start_line - 1]
+        return unless comment
+
+        @sig_comments[node.location.end_line] = comment
       end
 
       #: (Prism::DefNode node) -> void
@@ -100,7 +112,7 @@ module RubyLsp
 
       #: (Prism::Node node) -> void
       def extract_document_link(node)
-        comment = @lines_to_comments[node.location.start_line - 1]
+        comment = @lines_to_comments[node.location.start_line - 1] || @sig_comments[node.location.start_line - 1]
         return unless comment
 
         match = comment.location.slice.match(%r{(source://.*#\d+|pkg:gem/.*#.*)$})

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -88,6 +88,34 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
     end
   end
 
+  def test_source_link_with_single_line_sig_block
+    source = <<~RUBY
+      # source://syntax_tree//lib/syntax_tree.rb#39
+      sig { returns(String) }
+      def foo
+      end
+    RUBY
+
+    links = run_expectations(source)
+    refute_empty(links, "Expected document link for source comment above single-line sig block")
+  end
+
+  def test_source_link_with_multi_line_sig_block
+    source = <<~RUBY
+      # source://syntax_tree//lib/syntax_tree.rb#39
+      sig do
+        params(
+          x: Integer,
+        ).returns(String)
+      end
+      def foo(x)
+      end
+    RUBY
+
+    links = run_expectations(source)
+    refute_empty(links, "Expected document link for source comment above multi-line sig block")
+  end
+
   def test_package_url_links_with_invalid_uris
     source = <<~RUBY
       # pkg:gem/rubocop$1.78.0#:99


### PR DESCRIPTION
<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->
In RBI files, `# source://` comments above `sig` blocks were not clickable because `extract_document_link` only checked the line immediately before the `def` node. However, when a `sig` block sits between the comment and the `def`, the comment is no longer in the line immediately before.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Register for `on_call_node_enter` to record source comments found above `sig` calls, keyed by the sig's end line. Then in `extract_document_link`, fall back to the stashed sig comment when no direct comment is found. ~It's only registered in RBI files to prevent overhead but still provide value for Tapioca's gem RBIs.~

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
Added

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
I played around with it locally, didn't notice new performance issues.