### PR TITLE
Escape URIs like the editor does and harden Dir.glob against metacharacters in paths

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/uri.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/uri.rb
@@ -15,10 +15,14 @@ module URI
     class << self
       #: (path: String, ?fragment: String?, ?scheme: String, ?load_path_entry: String?) -> URI::Generic
       def from_path(path:, fragment: nil, scheme: "file", load_path_entry: nil)
-        # This unsafe regex is the same one used in the URI::RFC2396_REGEXP class with the exception of the fact that we
-        # do not include colon as a safe character. VS Code URIs always escape colons and we need to ensure we do the
-        # same to avoid inconsistencies in our URIs, which are used to identify resources
-        unsafe_regex = %r{[^\-_.!~*'()a-zA-Z\d;/?@&=+$,\[\]]}
+        # Our URIs are used to identify resources, so they must be escaped exactly the way the editor escapes them.
+        # Otherwise the same file ends up tracked under two different URIs: one built here during indexing and one
+        # received from the editor, which results in duplicate index entries (see Shopify/ruby-lsp#3639).
+        #
+        # VS Code's `vscode-uri` only leaves the RFC 3986 unreserved characters unescaped (`A-Za-z0-9-._~`), plus the
+        # forward slash in paths. Everything else, including characters that RFC 2396 considers safe such as `(`, `)`,
+        # `!`, `'`, `*`, `$`, `&`, `+`, `,`, `;`, `=`, `@`, `[`, `]` and `:`, is percent-encoded
+        unsafe_regex = %r{[^\-_.~a-zA-Z\d/]}
 
         # On Windows, if the path begins with the disk name, we need to add a leading slash to make it a valid URI
         escaped_path = if /^[A-Z]:/i.match?(path)

--- a/lib/ruby_indexer/test/uri_test.rb
+++ b/lib/ruby_indexer/test/uri_test.rb
@@ -81,5 +81,100 @@ module RubyIndexer
       assert_equal(path, uri.to_standardized_path)
       assert_equal("file:///path/with/unicode/%E6%96%87%E4%BB%B6.rb", uri.to_s)
     end
+
+    def test_from_path_with_brackets
+      uri = URI::Generic.from_path(path: "/some/path/[id].rb")
+      assert_equal("file:///some/path/%5Bid%5D.rb", uri.to_s)
+    end
+
+    def test_from_path_with_braces
+      uri = URI::Generic.from_path(path: "/some/path/{slug}.rb")
+      assert_equal("file:///some/path/%7Bslug%7D.rb", uri.to_s)
+    end
+
+    def test_round_trip_with_brackets
+      path = "/some/path/[id].rb"
+      uri = URI::Generic.from_path(path: path)
+      assert_equal(path, uri.to_standardized_path)
+    end
+
+    def test_round_trip_with_braces
+      path = "/some/path/{slug}.rb"
+      uri = URI::Generic.from_path(path: path)
+      assert_equal(path, uri.to_standardized_path)
+    end
+
+    def test_from_path_with_parentheses
+      uri = URI::Generic.from_path(path: "/some/path/(id).rb")
+      assert_equal("file:///some/path/%28id%29.rb", uri.to_s)
+    end
+
+    def test_round_trip_with_parentheses
+      path = "/some/path/(id).rb"
+      uri = URI::Generic.from_path(path: path)
+      assert_equal(path, uri.to_standardized_path)
+    end
+
+    def test_round_trip_with_spaces_inside_brackets
+      path = "/some/path/[id page].rb"
+      uri = URI::Generic.from_path(path: path)
+      assert_equal(path, uri.to_standardized_path)
+      assert_equal("file:///some/path/%5Bid%20page%5D.rb", uri.to_s)
+    end
+
+    def test_round_trip_with_spaces_inside_braces
+      path = "/some/path/{slug name}.rb"
+      uri = URI::Generic.from_path(path: path)
+      assert_equal(path, uri.to_standardized_path)
+      assert_equal("file:///some/path/%7Bslug%20name%7D.rb", uri.to_s)
+    end
+
+    def test_round_trip_with_spaces_inside_parentheses
+      path = "/some/path/file (copy).rb"
+      uri = URI::Generic.from_path(path: path)
+      assert_equal(path, uri.to_standardized_path)
+      assert_equal("file:///some/path/file%20%28copy%29.rb", uri.to_s)
+    end
+
+    # The editor and the server must escape paths identically, otherwise the same file is tracked under two different
+    # URIs and the index ends up with duplicate entries (Shopify/ruby-lsp#3639). These expectations were captured from
+    # the `vscode-uri` package, which is what VS Code uses to build the URIs it sends us
+    def test_from_path_escapes_every_character_the_editor_escapes
+      {
+        "/some/path/[id].rb" => "file:///some/path/%5Bid%5D.rb",
+        "/some/path/{slug}.rb" => "file:///some/path/%7Bslug%7D.rb",
+        "/some/path/(id).rb" => "file:///some/path/%28id%29.rb",
+        "/some/path/a&b.rb" => "file:///some/path/a%26b.rb",
+        "/some/path/a,b.rb" => "file:///some/path/a%2Cb.rb",
+        "/some/path/a+b.rb" => "file:///some/path/a%2Bb.rb",
+        "/some/path/a=b.rb" => "file:///some/path/a%3Db.rb",
+        "/some/path/a@b.rb" => "file:///some/path/a%40b.rb",
+        "/some/path/a;b.rb" => "file:///some/path/a%3Bb.rb",
+        "/some/path/a!b.rb" => "file:///some/path/a%21b.rb",
+        "/some/path/a*b.rb" => "file:///some/path/a%2Ab.rb",
+        "/some/path/a$b.rb" => "file:///some/path/a%24b.rb",
+        "/some/path/it's.rb" => "file:///some/path/it%27s.rb",
+        "/some/path/with space.rb" => "file:///some/path/with%20space.rb",
+      }.each do |path, expected|
+        uri = URI::Generic.from_path(path: path)
+        assert_equal(expected, uri.to_s)
+        assert_equal(path, uri.to_standardized_path)
+      end
+    end
+
+    def test_from_path_does_not_escape_unreserved_characters
+      path = "/some/path/a-b_c.d~e.rb"
+      uri = URI::Generic.from_path(path: path)
+      assert_equal("file:///some/path/a-b_c.d~e.rb", uri.to_s)
+      assert_equal(path, uri.to_standardized_path)
+    end
+
+    def test_from_path_with_question_mark
+      # A question mark used to be treated as safe, which made `URI::Generic.build` reject the escaped path for not
+      # being a valid absolute path component
+      uri = URI::Generic.from_path(path: "/some/path/what?.rb")
+      assert_equal("file:///some/path/what%3F.rb", uri.to_s)
+      assert_equal("/some/path/what?.rb", uri.to_standardized_path)
+    end
   end
 end

--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -62,7 +62,9 @@ module RubyLsp
             nil
           end
 
-          project_addons = Dir.glob("#{global_state.workspace_path}/**/ruby_lsp/**/addon.rb")
+          project_addons = Dir.glob("**/ruby_lsp/**/addon.rb", base: global_state.workspace_path).map! do |relative_path|
+            File.join(global_state.workspace_path, relative_path)
+          end
           project_addons.reject! do |path|
             (bundle_path && path.start_with?(bundle_path)) || gem_installation_path?(path)
           end

--- a/lib/ruby_lsp/listeners/completion.rb
+++ b/lib/ruby_lsp/listeners/completion.rb
@@ -457,10 +457,11 @@ module RubyLsp
         # if the path is not a directory, glob all possible next characters
         # for example ../somethi| (where | is the cursor position)
         # should find files for ../somethi*/
+        escaped_content = RubyLsp.escape_glob_metacharacters(content)
         path_query = if content.end_with?("/") || content.empty?
-          "#{content}**/*.rb"
+          "#{escaped_content}**/*.rb"
         else
-          "{#{content}*/**/*.rb,**/#{content}*.rb}"
+          "{#{escaped_content}*/**/*.rb,**/#{escaped_content}*.rb}"
         end
 
         Dir.glob(path_query, File::FNM_PATHNAME | File::FNM_EXTGLOB, base: origin_dir).sort!.each do |path|

--- a/lib/ruby_lsp/listeners/test_style.rb
+++ b/lib/ruby_lsp/listeners/test_style.rb
@@ -35,9 +35,10 @@ module RubyLsp
               if children.empty?
                 full_files.concat(
                   Dir.glob(
-                    "#{path}/**/{*_test,test_*,*_spec}.rb",
+                    "**/{*_test,test_*,*_spec}.rb",
                     File::Constants::FNM_EXTGLOB | File::Constants::FNM_PATHNAME,
-                  ).map! { |p| Shellwords.escape(p) },
+                    base: path,
+                  ).map! { |p| Shellwords.escape(File.join(path, p)) },
                 )
               end
             elsif tags.include?("test_file")

--- a/lib/ruby_lsp/requests/go_to_relevant_file.rb
+++ b/lib/ruby_lsp/requests/go_to_relevant_file.rb
@@ -36,9 +36,10 @@ module RubyLsp
       #: -> Array[String]
       def find_relevant_paths
         patterns = relevant_filename_patterns
+        root = search_root
 
         candidate_paths = patterns.flat_map do |pattern|
-          Dir.glob(File.join(search_root, "**", pattern))
+          Dir.glob(File.join("**", pattern), base: root).map! { |p| File.join(root, p) }
         end
 
         return [] if candidate_paths.empty?
@@ -89,22 +90,25 @@ module RubyLsp
           # Test file -> find implementation
           base = input_basename.gsub(TEST_PATTERN, "")
           parent_dir = File.basename(File.dirname(@path))
+          escaped_base = RubyLsp.escape_glob_metacharacters(base)
+          escaped_parent_dir = RubyLsp.escape_glob_metacharacters(parent_dir)
 
           # If test file is in a directory matching the implementation name
           # (e.g., go_to_relevant_file/test_go_to_relevant_file_a.rb)
           # return patterns for both the base file name and the parent directory name
           if base.include?(parent_dir) && base != parent_dir
-            ["#{base}#{extension}", "#{parent_dir}#{extension}"]
+            ["#{escaped_base}#{extension}", "#{escaped_parent_dir}#{extension}"]
           else
-            ["#{base}#{extension}"]
+            ["#{escaped_base}#{extension}"]
           end
         else
           # Implementation file -> find tests (including in matching directory)
+          escaped_basename = RubyLsp.escape_glob_metacharacters(input_basename)
           [
-            "{#{TEST_PREFIX_GLOB}}#{input_basename}#{extension}",
-            "#{input_basename}{#{TEST_SUFFIX_GLOB}}#{extension}",
-            "#{input_basename}/{#{TEST_PREFIX_GLOB}}*#{extension}",
-            "#{input_basename}/*{#{TEST_SUFFIX_GLOB}}#{extension}",
+            "{#{TEST_PREFIX_GLOB}}#{escaped_basename}#{extension}",
+            "#{escaped_basename}{#{TEST_SUFFIX_GLOB}}#{extension}",
+            "#{escaped_basename}/{#{TEST_PREFIX_GLOB}}*#{extension}",
+            "#{escaped_basename}/*{#{TEST_SUFFIX_GLOB}}#{extension}",
           ]
         end
       end

--- a/lib/ruby_lsp/requests/references.rb
+++ b/lib/ruby_lsp/requests/references.rb
@@ -60,7 +60,8 @@ module RubyLsp
         reference_target = create_reference_target(target, node_context)
         return @locations unless reference_target
 
-        Dir.glob(File.join(@global_state.workspace_path, "**/*.rb")).each do |path|
+        Dir.glob("**/*.rb", base: @global_state.workspace_path).each do |relative_path|
+          path = File.join(@global_state.workspace_path, relative_path)
           uri = URI::Generic.from_path(path: path)
           # If the document is being managed by the client, then we should use whatever is present in the store instead
           # of reading from disk

--- a/lib/ruby_lsp/requests/rename.rb
+++ b/lib/ruby_lsp/requests/rename.rb
@@ -129,7 +129,8 @@ module RubyLsp
       def collect_text_edits(target, name)
         changes = {}
 
-        Dir.glob(File.join(@global_state.workspace_path, "**/*.rb")).each do |path|
+        Dir.glob("**/*.rb", base: @global_state.workspace_path).each do |relative_path|
+          path = File.join(@global_state.workspace_path, relative_path)
           uri = URI::Generic.from_path(path: path)
           # If the document is being managed by the client, then we should use whatever is present in the store instead
           # of reading from disk

--- a/lib/ruby_lsp/utils.rb
+++ b/lib/ruby_lsp/utils.rb
@@ -21,6 +21,21 @@ module RubyLsp
   GUESSED_TYPES_URL = "https://shopify.github.io/ruby-lsp/#guessed-types"
   TEST_PATH_PATTERN = "**/{test,spec,features}/**/{*_test.rb,test_*.rb,*_spec.rb,*.feature}"
 
+  class << self
+    # Escape characters that have special meaning in Dir.glob patterns. The comma is included because callers may
+    # interpolate the result into a brace group, where an unescaped comma would split the alternation
+    #
+    # This only takes effect on POSIX. `Dir.glob` does not support backslash escaping on Windows, where the backslash
+    # is a path separator, so there a path containing metacharacters still fails to match. Nothing regresses because
+    # of it, since the substitution is a no-op for the metacharacter-free paths that are the common case. Prefer
+    # `Dir.glob`'s `base:` parameter whenever the value is a path rather than a fragment interpolated into a pattern,
+    # because that treats the path literally on every platform
+    #: (String str) -> String
+    def escape_glob_metacharacters(str)
+      str.gsub(/[\[\]{}*?,\\]/) { |c| "\\#{c}" }
+    end
+  end
+
   # Request delegation for embedded languages is not yet standardized into the language server specification. Here we
   # use this custom error class as a way to return a signal to the client that the request should be delegated to the
   # language server for the host language. The support for delegation is custom built on the client side, so each editor

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -191,6 +191,38 @@ module RubyLsp
       end
     end
 
+    def test_project_specific_addons_in_a_workspace_path_with_glob_metacharacters
+      Dir.mktmpdir do |dir|
+        # Routing conventions like Rails or Next.js produce directory names such as `[id]` or `{slug}`, which are
+        # `Dir.glob` metacharacters. They must be treated as literal path segments
+        workspace = File.join(dir, "[id]", "{slug}")
+        addon_dir = File.join(workspace, "lib", "ruby_lsp", "test_addon")
+        FileUtils.mkdir_p(addon_dir)
+        File.write(File.join(addon_dir, "addon.rb"), <<~RUBY)
+          class GlobMetacharacterProjectAddon < RubyLsp::Addon
+            def activate(global_state, outgoing_queue)
+            end
+
+            def name
+              "Glob Metacharacter Project Addon"
+            end
+
+            def version
+              "0.1.0"
+            end
+          end
+        RUBY
+
+        @global_state.apply_options({
+          workspaceFolders: [{ uri: URI::Generic.from_path(path: workspace).to_s }],
+        })
+        Addon.load_addons(@global_state, @outgoing_queue)
+
+        addon = Addon.get("Glob Metacharacter Project Addon", "0.1.0") #: as untyped
+        assert_equal("Glob Metacharacter Project Addon", addon.name)
+      end
+    end
+
     def test_loading_project_addons_when_the_project_has_no_gemfile
       Dir.mktmpdir do |dir|
         addon_dir = File.join(dir, "lib", "ruby_lsp", "test_addon")

--- a/test/expectations/code_lens/minitest_nested_classes_and_modules.exp.json
+++ b/test/expectations/code_lens/minitest_nested_classes_and_modules.exp.json
@@ -15,9 +15,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::FooTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::FooTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::FooTest(#|::)/\"",
           {
             "start_line": 1,
             "start_column": 2,
@@ -49,9 +49,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::FooTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::FooTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::FooTest(#|::)/\"",
           {
             "start_line": 1,
             "start_column": 2,
@@ -83,9 +83,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::FooTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::FooTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::FooTest(#|::)/\"",
           {
             "start_line": 1,
             "start_column": 2,
@@ -117,9 +117,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::FooTest#test_foo",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo",
           {
             "start_line": 2,
             "start_column": 4,
@@ -150,9 +150,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::FooTest#test_foo",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo",
           {
             "start_line": 2,
             "start_column": 4,
@@ -183,9 +183,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::FooTest#test_foo",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo",
           {
             "start_line": 2,
             "start_column": 4,
@@ -216,9 +216,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::FooTest#test_foo_2",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo_2",
           {
             "start_line": 4,
             "start_column": 4,
@@ -249,9 +249,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::FooTest#test_foo_2",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo_2",
           {
             "start_line": 4,
             "start_column": 4,
@@ -282,9 +282,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::FooTest#test_foo_2",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::FooTest#test_foo_2",
           {
             "start_line": 4,
             "start_column": 4,
@@ -315,9 +315,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest(#|::)/\"",
           {
             "start_line": 8,
             "start_column": 4,
@@ -349,9 +349,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest(#|::)/\"",
           {
             "start_line": 8,
             "start_column": 4,
@@ -383,9 +383,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest(#|::)/\"",
           {
             "start_line": 8,
             "start_column": 4,
@@ -417,9 +417,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest#test_bar",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest#test_bar",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest#test_bar",
           {
             "start_line": 9,
             "start_column": 6,
@@ -450,9 +450,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest#test_bar",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest#test_bar",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest#test_bar",
           {
             "start_line": 9,
             "start_column": 6,
@@ -483,9 +483,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest#test_bar",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest#test_bar",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest#test_bar",
           {
             "start_line": 9,
             "start_column": 6,
@@ -516,9 +516,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest::Baz::BazTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest::Baz::BazTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest::Baz::BazTest(#|::)/\"",
           {
             "start_line": 12,
             "start_column": 8,
@@ -550,9 +550,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest::Baz::BazTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest::Baz::BazTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest::Baz::BazTest(#|::)/\"",
           {
             "start_line": 12,
             "start_column": 8,
@@ -584,9 +584,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest::Baz::BazTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest::Baz::BazTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::BarTest::Baz::BazTest(#|::)/\"",
           {
             "start_line": 12,
             "start_column": 8,
@@ -618,9 +618,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest::Baz::BazTest#test_baz",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz",
           {
             "start_line": 13,
             "start_column": 10,
@@ -651,9 +651,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest::Baz::BazTest#test_baz",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz",
           {
             "start_line": 13,
             "start_column": 10,
@@ -684,9 +684,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest::Baz::BazTest#test_baz",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz",
           {
             "start_line": 13,
             "start_column": 10,
@@ -717,9 +717,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
           {
             "start_line": 15,
             "start_column": 10,
@@ -750,9 +750,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
           {
             "start_line": 15,
             "start_column": 10,
@@ -783,9 +783,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::BarTest::Baz::BazTest#test_baz_2",
           {
             "start_line": 15,
             "start_column": 10,
@@ -816,9 +816,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Baz::BazTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Baz::BazTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Baz::BazTest(#|::)/\"",
           {
             "start_line": 22,
             "start_column": 4,
@@ -850,9 +850,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Baz::BazTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Baz::BazTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Baz::BazTest(#|::)/\"",
           {
             "start_line": 22,
             "start_column": 4,
@@ -884,9 +884,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Baz::BazTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Baz::BazTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Baz::BazTest(#|::)/\"",
           {
             "start_line": 22,
             "start_column": 4,
@@ -918,9 +918,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Baz::BazTest#test_baz",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Baz::BazTest#test_baz",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Baz::BazTest#test_baz",
           {
             "start_line": 23,
             "start_column": 6,
@@ -951,9 +951,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Baz::BazTest#test_baz",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Baz::BazTest#test_baz",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Baz::BazTest#test_baz",
           {
             "start_line": 23,
             "start_column": 6,
@@ -984,9 +984,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Baz::BazTest#test_baz",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Baz::BazTest#test_baz",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Baz::BazTest#test_baz",
           {
             "start_line": 23,
             "start_column": 6,
@@ -1017,9 +1017,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBarTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBarTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBarTest(#|::)/\"",
           {
             "start_line": 29,
             "start_column": 2,
@@ -1051,9 +1051,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBarTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBarTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBarTest(#|::)/\"",
           {
             "start_line": 29,
             "start_column": 2,
@@ -1085,9 +1085,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBarTest",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBarTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBarTest(#|::)/\"",
           {
             "start_line": 29,
             "start_column": 2,
@@ -1119,9 +1119,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBarTest#test_foo_bar",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar",
           {
             "start_line": 30,
             "start_column": 4,
@@ -1152,9 +1152,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBarTest#test_foo_bar",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar",
           {
             "start_line": 30,
             "start_column": 4,
@@ -1185,9 +1185,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBarTest#test_foo_bar",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar",
           {
             "start_line": 30,
             "start_column": 4,
@@ -1218,9 +1218,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBarTest#test_foo_bar_2",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar_2",
           {
             "start_line": 32,
             "start_column": 4,
@@ -1251,9 +1251,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBarTest#test_foo_bar_2",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar_2",
           {
             "start_line": 32,
             "start_column": 4,
@@ -1284,9 +1284,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBarTest#test_foo_bar_2",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBarTest#test_foo_bar_2",
           {
             "start_line": 32,
             "start_column": 4,
@@ -1317,9 +1317,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBar::Test",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBar::Test(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBar::Test(#|::)/\"",
           {
             "start_line": 38,
             "start_column": 2,
@@ -1351,9 +1351,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBar::Test",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBar::Test(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBar::Test(#|::)/\"",
           {
             "start_line": 38,
             "start_column": 2,
@@ -1385,9 +1385,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBar::Test",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBar::Test(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name \"/^Foo::Bar::FooBar::Test(#|::)/\"",
           {
             "start_line": 38,
             "start_column": 2,
@@ -1419,9 +1419,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBar::Test#test_foo_bar_baz",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBar::Test#test_foo_bar_baz",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBar::Test#test_foo_bar_baz",
           {
             "start_line": 39,
             "start_column": 4,
@@ -1452,9 +1452,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBar::Test#test_foo_bar_baz",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBar::Test#test_foo_bar_baz",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBar::Test#test_foo_bar_baz",
           {
             "start_line": 39,
             "start_column": 4,
@@ -1485,9 +1485,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_nested_classes_and_modules.rb",
+          "/test/fixtures/minitest_nested_classes_and_modules.rb",
           "Foo::Bar::FooBar::Test#test_foo_bar_baz",
-          "bundle exec ruby /fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBar::Test#test_foo_bar_baz",
+          "bundle exec ruby -Itest /test/fixtures/minitest_nested_classes_and_modules.rb --name Foo::Bar::FooBar::Test#test_foo_bar_baz",
           {
             "start_line": 39,
             "start_column": 4,

--- a/test/expectations/code_lens/minitest_spec_tests.exp.json
+++ b/test/expectations/code_lens/minitest_spec_tests.exp.json
@@ -15,9 +15,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -49,9 +49,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -83,9 +83,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -117,9 +117,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo#test_0001_it_level_one",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
           {
             "start_line": 1,
             "start_column": 2,
@@ -150,9 +150,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo#test_0001_it_level_one",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
           {
             "start_line": 1,
             "start_column": 2,
@@ -183,9 +183,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo#test_0001_it_level_one",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0001_it_level_one$/\"",
           {
             "start_line": 1,
             "start_column": 2,
@@ -216,9 +216,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
@@ -250,9 +250,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
@@ -284,9 +284,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested(#|::)/\"",
           {
             "start_line": 3,
             "start_column": 2,
@@ -318,9 +318,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested#test_0001_it_nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
           {
             "start_line": 4,
             "start_column": 4,
@@ -351,9 +351,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested#test_0001_it_nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
           {
             "start_line": 4,
             "start_column": 4,
@@ -384,9 +384,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested#test_0001_it_nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0001_it_nested$/\"",
           {
             "start_line": 4,
             "start_column": 4,
@@ -417,9 +417,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested::deep_nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
@@ -451,9 +451,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested::deep_nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
@@ -485,9 +485,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested::deep_nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested(#|::)/\"",
           {
             "start_line": 6,
             "start_column": 4,
@@ -519,9 +519,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested::deep_nested#test_0001_it_deep_nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
           {
             "start_line": 7,
             "start_column": 6,
@@ -552,9 +552,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested::deep_nested#test_0001_it_deep_nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
           {
             "start_line": 7,
             "start_column": 6,
@@ -585,9 +585,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested::deep_nested#test_0001_it_deep_nested",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested::deep_nested#test_0001_it_deep_nested$/\"",
           {
             "start_line": 7,
             "start_column": 6,
@@ -618,9 +618,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested#test_0002_it_nested_again",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
           {
             "start_line": 10,
             "start_column": 4,
@@ -651,9 +651,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested#test_0002_it_nested_again",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
           {
             "start_line": 10,
             "start_column": 4,
@@ -684,9 +684,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::nested#test_0002_it_nested_again",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::nested#test_0002_it_nested_again$/\"",
           {
             "start_line": 10,
             "start_column": 4,
@@ -717,9 +717,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo#test_0003_it_level_one_again",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
           {
             "start_line": 13,
             "start_column": 2,
@@ -750,9 +750,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo#test_0003_it_level_one_again",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
           {
             "start_line": 13,
             "start_column": 2,
@@ -783,9 +783,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo#test_0003_it_level_one_again",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo#test_0003_it_level_one_again$/\"",
           {
             "start_line": 13,
             "start_column": 2,
@@ -816,9 +816,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::Bar",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
           {
             "start_line": 16,
             "start_column": 0,
@@ -850,9 +850,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::Bar",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
           {
             "start_line": 16,
             "start_column": 0,
@@ -884,9 +884,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::Bar",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar(#|::)/\"",
           {
             "start_line": 16,
             "start_column": 0,
@@ -918,9 +918,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::Bar#test_0001_it_class_constant_path",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
           {
             "start_line": 17,
             "start_column": 2,
@@ -951,9 +951,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::Bar#test_0001_it_class_constant_path",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
           {
             "start_line": 17,
             "start_column": 2,
@@ -984,9 +984,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Foo::Bar#test_0001_it_class_constant_path",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Foo::Bar#test_0001_it_class_constant_path$/\"",
           {
             "start_line": 17,
             "start_column": 2,
@@ -1017,9 +1017,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz(#|::)/\"",
           {
             "start_line": 20,
             "start_column": 0,
@@ -1051,9 +1051,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz(#|::)/\"",
           {
             "start_line": 20,
             "start_column": 0,
@@ -1085,9 +1085,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz(#|::)/\"",
           {
             "start_line": 20,
             "start_column": 0,
@@ -1119,9 +1119,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#foo",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
           {
             "start_line": 21,
             "start_column": 2,
@@ -1153,9 +1153,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#foo",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
           {
             "start_line": 21,
             "start_column": 2,
@@ -1187,9 +1187,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#foo",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo(#|::)/\"",
           {
             "start_line": 21,
             "start_column": 2,
@@ -1221,9 +1221,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#foo#test_0001_works",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
           {
             "start_line": 22,
             "start_column": 4,
@@ -1254,9 +1254,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#foo#test_0001_works",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
           {
             "start_line": 22,
             "start_column": 4,
@@ -1287,9 +1287,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#foo#test_0001_works",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#foo#test_0001_works$/\"",
           {
             "start_line": 22,
             "start_column": 4,
@@ -1320,9 +1320,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#bar",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
           {
             "start_line": 25,
             "start_column": 2,
@@ -1354,9 +1354,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#bar",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
           {
             "start_line": 25,
             "start_column": 2,
@@ -1388,9 +1388,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#bar",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar(#|::)/\"",
           {
             "start_line": 25,
             "start_column": 2,
@@ -1422,9 +1422,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#bar#test_0001_works",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
           {
             "start_line": 26,
             "start_column": 4,
@@ -1455,9 +1455,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#bar#test_0001_works",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
           {
             "start_line": 26,
             "start_column": 4,
@@ -1488,9 +1488,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_spec_tests.rb",
+          "/test/fixtures/minitest_spec_tests.rb",
           "Baz::#bar#test_0001_works",
-          "bundle exec ruby /fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_spec_tests.rb --name \"/^Baz::\\#bar#test_0001_works$/\"",
           {
             "start_line": 26,
             "start_column": 4,

--- a/test/expectations/code_lens/minitest_tests.exp.json
+++ b/test/expectations/code_lens/minitest_tests.exp.json
@@ -15,9 +15,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name \"/^Test(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name \"/^Test(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -49,9 +49,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name \"/^Test(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name \"/^Test(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -83,9 +83,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name \"/^Test(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name \"/^Test(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -117,9 +117,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_public",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_public",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_public",
           {
             "start_line": 5,
             "start_column": 2,
@@ -150,9 +150,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_public",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_public",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_public",
           {
             "start_line": 5,
             "start_column": 2,
@@ -183,9 +183,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_public",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_public",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_public",
           {
             "start_line": 5,
             "start_column": 2,
@@ -216,9 +216,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_public_command",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_public_command",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_public_command",
           {
             "start_line": 9,
             "start_column": 9,
@@ -249,9 +249,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_public_command",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_public_command",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_public_command",
           {
             "start_line": 9,
             "start_column": 9,
@@ -282,9 +282,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_public_command",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_public_command",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_public_command",
           {
             "start_line": 9,
             "start_column": 9,
@@ -315,9 +315,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_another_public",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_another_public",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_another_public",
           {
             "start_line": 11,
             "start_column": 9,
@@ -348,9 +348,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_another_public",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_another_public",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_another_public",
           {
             "start_line": 11,
             "start_column": 9,
@@ -381,9 +381,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_another_public",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_another_public",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_another_public",
           {
             "start_line": 11,
             "start_column": 9,
@@ -414,9 +414,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_public_vcall",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_public_vcall",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_public_vcall",
           {
             "start_line": 17,
             "start_column": 2,
@@ -447,9 +447,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_public_vcall",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_public_vcall",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_public_vcall",
           {
             "start_line": 17,
             "start_column": 2,
@@ -480,9 +480,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_public_vcall",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_public_vcall",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_public_vcall",
           {
             "start_line": 17,
             "start_column": 2,
@@ -513,9 +513,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_with_q?",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_with_q\\?",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_with_q\\?",
           {
             "start_line": 19,
             "start_column": 2,
@@ -546,9 +546,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_with_q?",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_with_q\\?",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_with_q\\?",
           {
             "start_line": 19,
             "start_column": 2,
@@ -579,9 +579,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "Test#test_with_q?",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name Test#test_with_q\\?",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name Test#test_with_q\\?",
           {
             "start_line": 19,
             "start_column": 2,
@@ -612,9 +612,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "AnotherTest",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name \"/^AnotherTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name \"/^AnotherTest(#|::)/\"",
           {
             "start_line": 24,
             "start_column": 0,
@@ -646,9 +646,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "AnotherTest",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name \"/^AnotherTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name \"/^AnotherTest(#|::)/\"",
           {
             "start_line": 24,
             "start_column": 0,
@@ -680,9 +680,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "AnotherTest",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name \"/^AnotherTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name \"/^AnotherTest(#|::)/\"",
           {
             "start_line": 24,
             "start_column": 0,
@@ -714,9 +714,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "AnotherTest#test_public",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name AnotherTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name AnotherTest#test_public",
           {
             "start_line": 25,
             "start_column": 2,
@@ -747,9 +747,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "AnotherTest#test_public",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name AnotherTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name AnotherTest#test_public",
           {
             "start_line": 25,
             "start_column": 2,
@@ -780,9 +780,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "AnotherTest#test_public",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name AnotherTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name AnotherTest#test_public",
           {
             "start_line": 25,
             "start_column": 2,
@@ -813,9 +813,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "AnotherTest#test_public_2",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name AnotherTest#test_public_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name AnotherTest#test_public_2",
           {
             "start_line": 31,
             "start_column": 2,
@@ -846,9 +846,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "AnotherTest#test_public_2",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name AnotherTest#test_public_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name AnotherTest#test_public_2",
           {
             "start_line": 31,
             "start_column": 2,
@@ -879,9 +879,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_tests.rb",
+          "/test/fixtures/minitest_tests.rb",
           "AnotherTest#test_public_2",
-          "bundle exec ruby /fixtures/minitest_tests.rb --name AnotherTest#test_public_2",
+          "bundle exec ruby -Itest /test/fixtures/minitest_tests.rb --name AnotherTest#test_public_2",
           {
             "start_line": 31,
             "start_column": 2,

--- a/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
+++ b/test/expectations/code_lens/minitest_with_dynamic_constant_path.exp.json
@@ -15,9 +15,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
           {
             "start_line": 9,
             "start_column": 2,
@@ -49,9 +49,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
           {
             "start_line": 9,
             "start_column": 2,
@@ -83,9 +83,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test(#|::)/\"",
           {
             "start_line": 9,
             "start_column": 2,
@@ -117,9 +117,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test#test_something",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something$/",
           {
             "start_line": 10,
             "start_column": 4,
@@ -150,9 +150,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test#test_something",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something$/",
           {
             "start_line": 10,
             "start_column": 4,
@@ -183,9 +183,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test#test_something",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something$/",
           {
             "start_line": 10,
             "start_column": 4,
@@ -216,9 +216,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test#test_something_else",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something_else$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something_else$/",
           {
             "start_line": 12,
             "start_column": 4,
@@ -249,9 +249,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test#test_something_else",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something_else$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something_else$/",
           {
             "start_line": 12,
             "start_column": 4,
@@ -282,9 +282,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test#test_something_else",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something_else$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::Test#test_something_else$/",
           {
             "start_line": 12,
             "start_column": 4,
@@ -315,9 +315,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test::NestedTest",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
           {
             "start_line": 14,
             "start_column": 4,
@@ -349,9 +349,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test::NestedTest",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
           {
             "start_line": 14,
             "start_column": 4,
@@ -383,9 +383,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test::NestedTest",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name \"/::Test::NestedTest(#|::)/\"",
           {
             "start_line": 14,
             "start_column": 4,
@@ -417,9 +417,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test::NestedTest#test_nested",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest#test_nested$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest#test_nested$/",
           {
             "start_line": 15,
             "start_column": 6,
@@ -450,9 +450,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test::NestedTest#test_nested",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest#test_nested$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest#test_nested$/",
           {
             "start_line": 15,
             "start_column": 6,
@@ -483,9 +483,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::Test::NestedTest#test_nested",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest#test_nested$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::Test::NestedTest#test_nested$/",
           {
             "start_line": 15,
             "start_column": 6,
@@ -516,9 +516,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::SomeOtherTest",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
           {
             "start_line": 19,
             "start_column": 2,
@@ -550,9 +550,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::SomeOtherTest",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
           {
             "start_line": 19,
             "start_column": 2,
@@ -584,9 +584,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::SomeOtherTest",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name \"/::SomeOtherTest(#|::)/\"",
           {
             "start_line": 19,
             "start_column": 2,
@@ -618,9 +618,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::SomeOtherTest#test_stuff",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_stuff$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_stuff$/",
           {
             "start_line": 20,
             "start_column": 4,
@@ -651,9 +651,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::SomeOtherTest#test_stuff",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_stuff$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_stuff$/",
           {
             "start_line": 20,
             "start_column": 4,
@@ -684,9 +684,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::SomeOtherTest#test_stuff",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_stuff$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_stuff$/",
           {
             "start_line": 20,
             "start_column": 4,
@@ -717,9 +717,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::SomeOtherTest#test_other_stuff",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_other_stuff$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_other_stuff$/",
           {
             "start_line": 22,
             "start_column": 4,
@@ -750,9 +750,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::SomeOtherTest#test_other_stuff",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_other_stuff$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_other_stuff$/",
           {
             "start_line": 22,
             "start_column": 4,
@@ -783,9 +783,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/minitest_with_dynamic_constant_path.rb",
+          "/test/fixtures/minitest_with_dynamic_constant_path.rb",
           "<dynamic_reference>::SomeOtherTest#test_other_stuff",
-          "bundle exec ruby /fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_other_stuff$/",
+          "bundle exec ruby -Itest /test/fixtures/minitest_with_dynamic_constant_path.rb --name /::SomeOtherTest#test_other_stuff$/",
           {
             "start_line": 22,
             "start_column": 4,

--- a/test/expectations/code_lens/nested_minitest_tests.exp.json
+++ b/test/expectations/code_lens/nested_minitest_tests.exp.json
@@ -15,9 +15,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name \"/^ParentTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name \"/^ParentTest(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -49,9 +49,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name \"/^ParentTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name \"/^ParentTest(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -83,9 +83,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name \"/^ParentTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name \"/^ParentTest(#|::)/\"",
           {
             "start_line": 0,
             "start_column": 0,
@@ -117,9 +117,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest#test_public",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest#test_public",
           {
             "start_line": 1,
             "start_column": 2,
@@ -150,9 +150,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest#test_public",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest#test_public",
           {
             "start_line": 1,
             "start_column": 2,
@@ -183,9 +183,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest#test_public",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest#test_public",
           {
             "start_line": 1,
             "start_column": 2,
@@ -216,9 +216,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::FirstChildTest",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::FirstChildTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name \"/^ParentTest::FirstChildTest(#|::)/\"",
           {
             "start_line": 5,
             "start_column": 2,
@@ -250,9 +250,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::FirstChildTest",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::FirstChildTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name \"/^ParentTest::FirstChildTest(#|::)/\"",
           {
             "start_line": 5,
             "start_column": 2,
@@ -284,9 +284,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::FirstChildTest",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::FirstChildTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name \"/^ParentTest::FirstChildTest(#|::)/\"",
           {
             "start_line": 5,
             "start_column": 2,
@@ -318,9 +318,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::FirstChildTest#test_public",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest::FirstChildTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest::FirstChildTest#test_public",
           {
             "start_line": 6,
             "start_column": 4,
@@ -351,9 +351,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::FirstChildTest#test_public",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest::FirstChildTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest::FirstChildTest#test_public",
           {
             "start_line": 6,
             "start_column": 4,
@@ -384,9 +384,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::FirstChildTest#test_public",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest::FirstChildTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest::FirstChildTest#test_public",
           {
             "start_line": 6,
             "start_column": 4,
@@ -417,9 +417,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::SecondChildTest",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::SecondChildTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name \"/^ParentTest::SecondChildTest(#|::)/\"",
           {
             "start_line": 13,
             "start_column": 2,
@@ -451,9 +451,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::SecondChildTest",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::SecondChildTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name \"/^ParentTest::SecondChildTest(#|::)/\"",
           {
             "start_line": 13,
             "start_column": 2,
@@ -485,9 +485,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::SecondChildTest",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name \"/^ParentTest::SecondChildTest(#|::)/\"",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name \"/^ParentTest::SecondChildTest(#|::)/\"",
           {
             "start_line": 13,
             "start_column": 2,
@@ -519,9 +519,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::SecondChildTest#test_public",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest::SecondChildTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest::SecondChildTest#test_public",
           {
             "start_line": 14,
             "start_column": 4,
@@ -552,9 +552,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::SecondChildTest#test_public",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest::SecondChildTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest::SecondChildTest#test_public",
           {
             "start_line": 14,
             "start_column": 4,
@@ -585,9 +585,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest::SecondChildTest#test_public",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest::SecondChildTest#test_public",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest::SecondChildTest#test_public",
           {
             "start_line": 14,
             "start_column": 4,
@@ -618,9 +618,9 @@
         "title": "▶ Run",
         "command": "rubyLsp.runTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest#test_public_again",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest#test_public_again",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest#test_public_again",
           {
             "start_line": 19,
             "start_column": 2,
@@ -651,9 +651,9 @@
         "title": "▶ Run In Terminal",
         "command": "rubyLsp.runTestInTerminal",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest#test_public_again",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest#test_public_again",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest#test_public_again",
           {
             "start_line": 19,
             "start_column": 2,
@@ -684,9 +684,9 @@
         "title": "Debug",
         "command": "rubyLsp.debugTest",
         "arguments": [
-          "/fixtures/nested_minitest_tests.rb",
+          "/test/fixtures/nested_minitest_tests.rb",
           "ParentTest#test_public_again",
-          "bundle exec ruby /fixtures/nested_minitest_tests.rb --name ParentTest#test_public_again",
+          "bundle exec ruby -Itest /test/fixtures/nested_minitest_tests.rb --name ParentTest#test_public_again",
           {
             "start_line": 19,
             "start_column": 2,

--- a/test/fixtures/[id].rb
+++ b/test/fixtures/[id].rb
@@ -1,0 +1,8 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Routing conventions such as Rails' or Next.js' dynamic segments produce file names like `[id].rb`. Brackets are
+# `Dir.glob` metacharacters and are percent-encoded in URIs, so this fixture keeps the expectations test runner honest
+# about both.
+module DynamicSegment
+end

--- a/test/requests/code_lens_expectations_test.rb
+++ b/test/requests/code_lens_expectations_test.rb
@@ -8,7 +8,7 @@ class CodeLensExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::CodeLens, "code_lens"
 
   def run_expectations(source)
-    uri = URI("file://#{@_path}")
+    uri = URI::Generic.from_path(path: File.join("/", @_path.to_s))
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new

--- a/test/requests/completion_test.rb
+++ b/test/requests/completion_test.rb
@@ -1761,6 +1761,94 @@ class CompletionTest < Minitest::Test
     end
   end
 
+  def test_relative_completion_with_a_comma_in_the_typed_path
+    # A prefix without a trailing slash is interpolated into a brace group, so an unescaped comma splits the
+    # alternation and the pattern silently matches nothing
+    prefix = "a,b"
+    source = <<~RUBY
+      require_relative "#{prefix}"
+    RUBY
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
+    end_position = { line: 0, character: end_char }
+
+    with_server(source) do |server|
+      Dir.mktmpdir("path_completion_comma_test") do |tmpdir|
+        FileUtils.mkdir_p(File.join(tmpdir, "foo"))
+        FileUtils.touch(File.join(tmpdir, "foo", "a,b.rb"))
+
+        uri = URI("file://#{tmpdir}/foo/fake.rb")
+        server.process_message({
+          method: "textDocument/didOpen",
+          params: {
+            textDocument: {
+              uri: uri,
+              text: source,
+              version: 1,
+              languageId: "ruby",
+            },
+          },
+        })
+
+        server.process_message(id: 1, method: "textDocument/completion", params: {
+          textDocument: { uri: uri },
+          position: { line: 0, character: end_char },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [path_completion("a,b", start_position, end_position)].to_json,
+          result.to_json,
+        )
+      end
+    end
+  end
+
+  def test_relative_completion_with_glob_metacharacters_in_the_typed_path
+    prefix = "[id]/"
+    source = <<~RUBY
+      require_relative "#{prefix}"
+    RUBY
+    start_char = source.index('"') #: as !nil
+    end_char = source.rindex('"') #: as !nil
+    start_position = { line: 0, character: start_char + 1 }
+    end_position = { line: 0, character: end_char }
+
+    with_server(source) do |server|
+      Dir.mktmpdir("path_completion_metacharacters_test") do |tmpdir|
+        # `[id]` is a `Dir.glob` character class, so without escaping the typed content it matches "i" or "d" rather
+        # than the literal directory name and no completion is offered
+        FileUtils.mkdir_p(File.join(tmpdir, "foo", "[id]"))
+        FileUtils.touch(File.join(tmpdir, "foo", "[id]", "bar.rb"))
+
+        uri = URI("file://#{tmpdir}/foo/fake.rb")
+        server.process_message({
+          method: "textDocument/didOpen",
+          params: {
+            textDocument: {
+              uri: uri,
+              text: source,
+              version: 1,
+              languageId: "ruby",
+            },
+          },
+        })
+
+        server.process_message(id: 1, method: "textDocument/completion", params: {
+          textDocument: { uri: uri },
+          position: { line: 0, character: end_char },
+        })
+
+        result = server.pop_response.response
+        assert_equal(
+          [path_completion("[id]/bar", start_position, end_position)].to_json,
+          result.to_json,
+        )
+      end
+    end
+  end
+
   def test_require_relative_returns_empty_result_for_unsaved_files
     prefix = "support/"
     source = <<~RUBY

--- a/test/requests/document_highlight_expectations_test.rb
+++ b/test/requests/document_highlight_expectations_test.rb
@@ -8,7 +8,7 @@ class DocumentHighlightExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::DocumentHighlight, "document_highlight"
 
   def run_expectations(source)
-    uri = URI("file://#{@_path}")
+    uri = URI::Generic.from_path(path: File.join("/", @_path.to_s))
     params = @__params&.any? ? @__params : default_args
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -21,7 +21,7 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
   end
 
   def run_expectations(source)
-    uri = URI("file://#{@_path}")
+    uri = URI::Generic.from_path(path: File.join("/", @_path.to_s))
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new

--- a/test/requests/document_symbol_expectations_test.rb
+++ b/test/requests/document_symbol_expectations_test.rb
@@ -110,7 +110,7 @@ class DocumentSymbolExpectationsTest < ExpectationsTestRunner
   end
 
   def run_expectations(source)
-    uri = URI("file://#{@_path}")
+    uri = URI::Generic.from_path(path: File.join("/", @_path.to_s))
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new

--- a/test/requests/folding_ranges_expectations_test.rb
+++ b/test/requests/folding_ranges_expectations_test.rb
@@ -8,7 +8,7 @@ class FoldingRangesExpectationsTest < ExpectationsTestRunner
   expectations_tests RubyLsp::Requests::FoldingRanges, "folding_ranges"
 
   def run_expectations(source)
-    uri = URI("file://#{@_path}")
+    uri = URI::Generic.from_path(path: File.join("/", @_path.to_s))
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new

--- a/test/requests/go_to_relevant_file_test.rb
+++ b/test/requests/go_to_relevant_file_test.rb
@@ -118,6 +118,58 @@ class GoToRelevantFileTest < Minitest::Test
     end
   end
 
+  def test_when_implementation_file_name_contains_glob_metacharacters
+    Dir.chdir(@workspace) do
+      # `[id].rb` is a routing convention, but `[id]` is also a `Dir.glob` character class matching "i" or "d"
+      lib_dir = File.join(@workspace, "app/models")
+      test_dir = File.join(@workspace, "test/models")
+      FileUtils.mkdir_p(lib_dir)
+      FileUtils.mkdir_p(test_dir)
+
+      impl_file = File.join(lib_dir, "[id].rb")
+      test_file = File.join(test_dir, "[id]_test.rb")
+      FileUtils.touch(impl_file)
+      FileUtils.touch(test_file)
+
+      result = RubyLsp::Requests::GoToRelevantFile.new(impl_file, @workspace).perform
+      assert_equal([test_file], result)
+    end
+  end
+
+  def test_when_test_file_name_contains_glob_metacharacters
+    Dir.chdir(@workspace) do
+      lib_dir = File.join(@workspace, "app/models")
+      test_dir = File.join(@workspace, "test/models")
+      FileUtils.mkdir_p(lib_dir)
+      FileUtils.mkdir_p(test_dir)
+
+      impl_file = File.join(lib_dir, "{slug}.rb")
+      test_file = File.join(test_dir, "{slug}_test.rb")
+      FileUtils.touch(impl_file)
+      FileUtils.touch(test_file)
+
+      result = RubyLsp::Requests::GoToRelevantFile.new(test_file, @workspace).perform
+      assert_equal([impl_file], result)
+    end
+  end
+
+  def test_when_a_parent_directory_contains_glob_metacharacters
+    Dir.chdir(@workspace) do
+      lib_dir = File.join(@workspace, "app/[id]/models")
+      test_dir = File.join(@workspace, "app/[id]/test")
+      FileUtils.mkdir_p(lib_dir)
+      FileUtils.mkdir_p(test_dir)
+
+      impl_file = File.join(lib_dir, "user.rb")
+      test_file = File.join(test_dir, "user_test.rb")
+      FileUtils.touch(impl_file)
+      FileUtils.touch(test_file)
+
+      result = RubyLsp::Requests::GoToRelevantFile.new(impl_file, @workspace).perform
+      assert_equal([test_file], result)
+    end
+  end
+
   def test_finds_tests_in_matching_subdirectory
     Dir.chdir(@workspace) do
       lib_dir = File.join(@workspace, "lib")

--- a/test/requests/inlay_hints_expectations_test.rb
+++ b/test/requests/inlay_hints_expectations_test.rb
@@ -9,7 +9,7 @@ class InlayHintsExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     params = @__params&.any? ? @__params : default_args
-    uri = URI("file://#{@_path}")
+    uri = URI::Generic.from_path(path: File.join("/", @_path.to_s))
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
 
     dispatcher = Prism::Dispatcher.new

--- a/test/requests/prepare_rename_expectations_test.rb
+++ b/test/requests/prepare_rename_expectations_test.rb
@@ -9,7 +9,7 @@ class PrepareRenameExpectationsTest < ExpectationsTestRunner
 
   def run_expectations(source)
     position = @__params&.any? ? @__params[:position] : default_position
-    uri = URI("file://#{@_path}")
+    uri = URI::Generic.from_path(path: File.join("/", @_path.to_s))
     document = RubyLsp::RubyDocument.new(source: source, version: 1, uri: uri, global_state: @global_state)
     RubyLsp::Requests::PrepareRename.new(document, position).perform
   end

--- a/test/requests/references_test.rb
+++ b/test/requests/references_test.rb
@@ -12,6 +12,48 @@ class ReferencesTest < Minitest::Test
     assert_equal([0, 3], refs)
   end
 
+  def test_finds_references_in_a_workspace_path_with_glob_metacharacters
+    Dir.mktmpdir do |dir|
+      # `[id]` and `{slug}` are `Dir.glob` metacharacters, so interpolating the workspace path into the pattern
+      # silently matches nothing and no reference is ever collected from disk
+      workspace = File.join(dir, "[id]", "{slug}")
+      FileUtils.mkdir_p(workspace)
+
+      declaration_path = File.join(workspace, "article.rb")
+      reference_path = File.join(workspace, "consumer.rb")
+      File.write(declaration_path, "class Article\nend\n")
+      File.write(reference_path, "Article\n")
+
+      global_state = RubyLsp::GlobalState.new
+      global_state.apply_options({
+        workspaceFolders: [{ uri: URI::Generic.from_path(path: workspace).to_s }],
+      })
+
+      source = File.read(declaration_path)
+      uri = URI::Generic.from_path(path: declaration_path)
+      global_state.index.index_single(uri, source)
+
+      document = RubyLsp::RubyDocument.new(
+        source: source,
+        version: 1,
+        uri: uri,
+        global_state: global_state,
+      )
+
+      locations = RubyLsp::Requests::References.new(
+        global_state,
+        RubyLsp::Store.new(global_state),
+        document,
+        { position: { line: 0, character: 6 } },
+      ).perform
+
+      assert_includes(
+        locations.map(&:uri),
+        URI::Generic.from_path(path: reference_path).to_s,
+      )
+    end
+  end
+
   private
 
   def find_references(fixture_path, position)

--- a/test/requests/rename_test.rb
+++ b/test/requests/rename_test.rb
@@ -105,6 +105,47 @@ class RenameTest < Minitest::Test
     assert_equal("NewMe", untitled_change.edits[0].new_text)
   end
 
+  def test_collects_text_edits_in_a_workspace_path_with_glob_metacharacters
+    Dir.mktmpdir do |dir|
+      # `[id]` and `{slug}` are `Dir.glob` metacharacters, so interpolating the workspace path into the pattern
+      # silently matches nothing and references in other files are never renamed
+      workspace = File.join(dir, "[id]", "{slug}")
+      FileUtils.mkdir_p(workspace)
+
+      declaration_path = File.join(workspace, "article.rb")
+      reference_path = File.join(workspace, "consumer.rb")
+      File.write(declaration_path, "class Article\nend\n")
+      File.write(reference_path, "Article\n")
+
+      global_state = RubyLsp::GlobalState.new
+      global_state.apply_options({
+        workspaceFolders: [{ uri: URI::Generic.from_path(path: workspace).to_s }],
+      })
+
+      source = File.read(declaration_path)
+      uri = URI::Generic.from_path(path: declaration_path)
+      global_state.index.index_single(uri, source)
+
+      document = RubyLsp::RubyDocument.new(
+        source: source,
+        version: 1,
+        uri: uri,
+        global_state: global_state,
+      )
+
+      workspace_edit = RubyLsp::Requests::Rename.new(
+        global_state,
+        RubyLsp::Store.new(global_state),
+        document,
+        { position: { line: 0, character: 6 }, newName: "Post" },
+      ).perform #: as !nil
+
+      reference_uri = URI::Generic.from_path(path: reference_path).to_s
+      assert_includes(workspace_edit.changes.keys, reference_uri)
+      assert_equal("Post", workspace_edit.changes[reference_uri].first.new_text)
+    end
+  end
+
   private
 
   def expect_renames(fixture_path, new_fixture_path, expected, position, new_name)

--- a/test/requests/resolve_test_commands_test.rb
+++ b/test/requests/resolve_test_commands_test.rb
@@ -223,7 +223,7 @@ module RubyLsp
 
     def test_resolve_test_command_entire_directories
       with_server do |server|
-        Dir.stubs(:glob).returns(["/other/test/fake_test.rb", "/other/test/fake_test2.rb"])
+        Dir.stubs(:glob).returns(["fake_test.rb", "fake_test2.rb"])
         server.process_message({
           id: 1,
           method: "rubyLsp/resolveTestCommands",
@@ -539,7 +539,7 @@ module RubyLsp
 
     def test_resolve_test_command_mix_of_directories_and_examples
       with_server do |server|
-        Dir.stubs(:glob).returns(["/test/unit/fake_test.rb", "/test/unit/fake_test2.rb"])
+        Dir.stubs(:glob).returns(["fake_test.rb", "fake_test2.rb"])
         server.process_message({
           id: 1,
           method: "rubyLsp/resolveTestCommands",
@@ -637,7 +637,7 @@ module RubyLsp
 
     def test_resolve_test_command_for_minitest_spec_directory
       with_server do |server|
-        Dir.stubs(:glob).returns(["/other/spec/fake_spec.rb", "/other/spec/fake2_spec.rb"])
+        Dir.stubs(:glob).returns(["fake_spec.rb", "fake2_spec.rb"])
         server.process_message({
           id: 1,
           method: "rubyLsp/resolveTestCommands",
@@ -782,7 +782,7 @@ module RubyLsp
 
     def test_resolve_properly_escapes_file_paths_within_directories
       with_server do |server|
-        Dir.stubs(:glob).returns(["/other/test/fake(v2)_test.rb"])
+        Dir.stubs(:glob).returns(["fake(v2)_test.rb"])
         server.process_message({
           id: 1,
           method: "rubyLsp/resolveTestCommands",
@@ -834,6 +834,43 @@ module RubyLsp
           ["#{COMMAND} -Itest /test/server\\(v2\\)_test.rb --name \"/^ServerTest(#|::)/\""],
           result[:commands],
         )
+      end
+    end
+
+    # Unlike the other directory tests, this one hits the real file system instead of stubbing `Dir.glob`, so that the
+    # expansion of a `test_dir` item is actually exercised against a path holding glob metacharacters
+    def test_resolve_test_command_entire_directory_with_glob_metacharacters_in_the_path
+      Dir.mktmpdir do |dir|
+        test_dir = File.join(dir, "[id]", "test")
+        FileUtils.mkdir_p(test_dir)
+        FileUtils.touch(File.join(test_dir, "fake_test.rb"))
+
+        with_server do |server|
+          server.process_message({
+            id: 1,
+            method: "rubyLsp/resolveTestCommands",
+            params: {
+              items: [
+                {
+                  id: URI::Generic.from_path(path: test_dir).to_s,
+                  uri: URI::Generic.from_path(path: test_dir).to_s,
+                  label: test_dir,
+                  tags: ["test_dir", "framework:minitest"],
+                  children: [],
+                },
+              ],
+            },
+          })
+
+          result = server.pop_response.response
+          assert_equal(
+            [
+              "#{COMMAND} -Itest -e \"ARGV.each { |f| require f }\" " \
+                "#{Shellwords.escape(File.join(test_dir, "fake_test.rb"))}",
+            ],
+            result[:commands],
+          )
+        end
       end
     end
   end
@@ -1298,7 +1335,7 @@ module RubyLsp
 
     def test_resolve_test_command_mix_of_directories_and_examples
       with_server do |server|
-        Dir.stubs(:glob).returns(["/test/unit/fake_test.rb", "/test/unit/fake_test2.rb"])
+        Dir.stubs(:glob).returns(["fake_test.rb", "fake_test2.rb"])
         server.process_message({
           id: 1,
           method: "rubyLsp/resolveTestCommands",
@@ -1366,7 +1403,7 @@ module RubyLsp
 
     def test_resolve_properly_escapes_file_paths_within_directories
       with_server do |server|
-        Dir.stubs(:glob).returns(["/other/test/fake(v2)_test.rb"])
+        Dir.stubs(:glob).returns(["fake(v2)_test.rb"])
         server.process_message({
           id: 1,
           method: "rubyLsp/resolveTestCommands",

--- a/test/requests/support/expectations_test_runner.rb
+++ b/test/requests/support/expectations_test_runner.rb
@@ -50,16 +50,21 @@ class ExpectationsTestRunner < Minitest::Test
           raise "Expectations directory #{expectations_dir} does not exist"
         end
 
-        expectation_glob = Dir.glob(File.join(expectations_dir, "#{test_name}.exp.{rb,json}"))
-        if expectation_glob.size == 1
-          expectation_path = expectation_glob.first
-        elsif expectation_glob.size > 1
+        json_path = File.join(expectations_dir, "#{test_name}.exp.json")
+        rb_path = File.join(expectations_dir, "#{test_name}.exp.rb")
+        if File.file?(json_path) && File.file?(rb_path)
           raise "multiple expectations for #{test_name}"
+        elsif File.file?(json_path)
+          expectation_path = json_path
+        elsif File.file?(rb_path)
+          expectation_path = rb_path
         end
+
+        sanitized_name = test_name.gsub(/[^\w]/, "_")
 
         if expectation_path && File.file?(expectation_path)
           class_eval(<<~RB, __FILE__, __LINE__ + 1)
-            def test_#{expectation_suffix}__#{test_name}
+            def test_#{expectation_suffix}__#{sanitized_name}
               @_path = "#{path}"
               @_expectation_path = "#{expectation_path}"
               source = File.read(@_path)
@@ -70,7 +75,7 @@ class ExpectationsTestRunner < Minitest::Test
           RB
         else
           class_eval(<<~RB, __FILE__, __LINE__ + 1)
-            def test_#{expectation_suffix}__#{test_name}__does_not_raise
+            def test_#{expectation_suffix}__#{sanitized_name}__does_not_raise
               @_path = "#{path}"
               source = File.read(@_path)
               run_expectations(source)

--- a/test/store_test.rb
+++ b/test/store_test.rb
@@ -64,6 +64,23 @@ class StoreTest < Minitest::Test
     )
   end
 
+  # The editor percent-encodes brackets and braces, so a document opened by the client must resolve to the same key
+  # the server builds from the file path. Otherwise the same file is tracked under two different URIs
+  def test_handling_uris_with_glob_metacharacters
+    {
+      "/foo/[id].rb" => "file:///foo/%5Bid%5D.rb",
+      "/foo/{slug}.rb" => "file:///foo/%7Bslug%7D.rb",
+    }.each do |path, client_uri_string|
+      server_uri = URI::Generic.from_path(path: path)
+      assert_equal(client_uri_string, server_uri.to_s)
+
+      @store.set(uri: URI(client_uri_string), source: "def foo; end", version: 1, language_id: :ruby)
+
+      assert(@store.key?(server_uri), "expected the store to find #{path} under the URI built from its path")
+      assert_equal("def foo; end", @store.get(server_uri).source)
+    end
+  end
+
   def test_handling_uris_for_unsaved_files
     uri = URI("untitled:Untitled-1")
     @store.set(uri: uri, source: "def foo; end", version: 1, language_id: :ruby)


### PR DESCRIPTION
Fixes #3503. Contributes to #3639.

## The problem

The server and the editor have to agree on how a file is spelled. A URI identifies a resource, so if indexing builds `file:///a/%5Bid%5D.rb` for a file the editor calls `file:///a/[id].rb`, the same file is tracked under two identities: indexed twice, reported twice, and never resolved to the document the editor has open.

There are two independent ways that agreement breaks today, and both are fixed here.

**1. Our escaping did not match the editor's.** `URI::Generic.from_path` used the RFC 2396 safe set. VS Code builds its URIs with `vscode-uri`, which only leaves the RFC 3986 unreserved set (`A-Za-z0-9-._~`) plus `/` unescaped. Checked against the package directly, **12 of 17 sample paths disagreed** — not just on brackets, but on `(`, `)`, `!`, `'`, `*`, `$`, `&`, `+`, `,`, `;`, `=` and `@`. Every one of those is a standing source of the duplication tracked in #3639.

**2. Paths were interpolated into glob patterns.** `Dir.glob` reads `[id]` as a character class and `{a,b}` as an alternation, so a workspace or file path containing them silently matches nothing.

When both bite, every feature fails for the affected file: indexing, definition, references, hover, completion, diagnostics, code lens. The reporter in #3503 hit it on a generated path they could not control (`/home/streetp/index[0]/example.rb`); the names are also routine under routing conventions (`app/models/[id].rb`, `{slug}.rb`).

## Related reports

This is one failure class with several faces. Fixing the spelling mismatch is what they have in common:

| Issue | Symptom |
|---|---|
| #3503 | Bracketed paths fail to index |
| #3639 | Duplicate entries when a `didOpen` races indexing |
| #3842 | Duplicate definitions in Neovim, `//` vs `/` |
| #3285 | Duplicate definitions on Windows, `c%3A` vs `C%3A` |
| #4024 | A bracketed workspace root indexes zero files |

#896 sketches the structural end state — URI identity based on components rather than on the exact string. This PR does not go there, but narrowing the encoding is a prerequisite either way: component-based equality still needs the components to agree.

## Changes

### URI escaping

Narrowing the safe set to `[^\-_.~a-zA-Z\d/]` brings the sample from 12 of 17 disagreeing to **17 of 17 matching**, with every round trip intact. It also fixes `from_path` raising `URI::InvalidComponentError` for a path containing `?`, which used to be treated as safe and produced a string `URI::Generic.build` rejected.

### Glob hardening

- `Dir.glob`'s `base:` parameter in `references.rb`, `rename.rb`, `addon.rb`, `test_style.rb` and `go_to_relevant_file.rb`, so workspace and file paths are passed as literal paths rather than as patterns. This also works on Windows, where backslash escaping is unavailable.
- `RubyLsp.escape_glob_metacharacters` for user-provided content interpolated into a pattern: `require_relative` content in the completion listener, and file names in `go_to_relevant_file.rb`. The comma is escaped too, because `complete_require_relative` interpolates into a brace group where an unescaped comma splits the alternation.

### Expectation test harness

Adding a bracketed fixture surfaced a pre-existing bug. Seven expectation test classes built their URI as `URI("file://#{@_path}")` from a **relative** path, so `file://test/fixtures/foo.rb` parsed `test` as the URI authority and the path came out as `/fixtures/foo.rb` — the `test/` segment silently dropped.

`CodeLens` appends `-Itest` when the path matches `**/test/**/*`, so with that segment missing **five committed expectations asserted commands without `-Itest`**, the opposite of what a user gets for a file genuinely under `test/`. Those are regenerated here; across all 324 modified lines the only changes are the restored `/test/` segment and the flag it enables.

The runner also now looks expectation files up with `File.file?` instead of a glob, and sanitises fixture names when generating test method names.

## Tests

Every test below was verified to **fail when its fix is reverted**, not merely to pass with it.

| Test | Covers |
|---|---|
| `uri_test` — parity, unreserved characters, `?` | escaping matches `vscode-uri` |
| `store_test` — client-encoded URI vs server-built URI | the reported failure |
| `addon_test` — add-ons under `[id]/{slug}/` | `addon.rb` (escaping and glob in one path) |
| `references_test`, `rename_test` — bracketed workspace | `references.rb`, `rename.rb` |
| `resolve_test_commands_test` — real directory, unstubbed | `test_style.rb` `test_dir` expansion |
| `go_to_relevant_file_test` ×3 | file name either direction, and parent directory |
| `completion_test` ×2 | brackets and commas in `require_relative` |
| `test/fixtures/[id].rb` | the expectations runner |

The pre-existing `test_dir` tests stub `Dir.glob`, which bypasses the `base:` behaviour under test, so the new one hits the real file system. Without the sanitised method name, the fixture makes every expectation suite fail to parse with `def test_hover__[id]__does_not_raise`.

## Deliberately not included

**Windows drive letter case.** `vscode-uri` normalises the drive to lower case regardless of input; `from_path` preserves whatever it is given, so indexing (upper case, from `Dir.pwd`) and the editor (lower case) still disagree. That is #3285, which is currently closed but only half fixed — evidence and a repro are [in this comment](https://github.com/Shopify/ruby-lsp/issues/3285#issuecomment-5148209336). It is left out because two committed tests assert the current behaviour, and `server.rb` has case-sensitive `path.start_with?(@global_state.workspace_path)` guards that would have to change at the same time. Normalising only `from_path` would trade one Windows bug for another.

**Bracketed workspace roots.** `configuration.rb` still interpolates the workspace path, so a bracketed **root** indexes zero files. Converting it to `base:` triggers a `Dir.glob` bug: when `top_level_directories` is empty the pattern becomes `{}/**/*.rb`, and with `base:` that escapes the base and walks the file system from `/` — reproduced on Ruby 4.0.1 as `Errno::EPERM` on `/Library/Application Support/com.apple.TCC`. Tracked in #4024, which was auto-closed as stale and should be reopened. A follow-up branch fixes it by guarding the empty case.

**`//` normalisation** (#3842) is not addressed; this only covers URIs we build.

## Test plan

- [x] `bundle exec rake` — 330 + 18,565 runs, 0 failures, 0 errors
- [x] `bundle exec srb tc` — no errors
- [x] `bin/rubocop` — no offenses
- [x] `bin/tapioca check-shims` — no duplicates
- [x] Escaping compared against the `vscode-uri` package directly — 17/17
