### PR TITLE
Avoid indenting after endless method definition

### DIFF
--- a/vscode/languages/ruby.json
+++ b/vscode/languages/ruby.json
@@ -1,5 +1,5 @@
 {
   "indentationRules": {
-    "decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif)\\b)|((in|when)\\s)"
+    "increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def(?!\\s+[\\w.]+[!?=]?(?:\\([^)]*\\))?\\s*=[^=~>])|def(?!\\s+[\\w.]+[!?=]?(?:\\([^)]*\\))?\\s*=[^=~>])|else|elsif|ensure|for|if|module|rescue|unless|until|when|in|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^#\\{;]|(\"|'|\/).*\\4)*(#.*)?$"
   }
 }


### PR DESCRIPTION
### Motivation

Closes #3997

The automatic [indentation rules that are bundled in VS Code](https://github.com/microsoft/vscode/blob/main/extensions/ruby/language-configuration.json) don't account for endless method definitions and end up advancing the indentation when you break the line (which isn't what you'd expect).

This PR adds our own indentation rules to validate the fix first. Once we know this works correctly, we can contribute the improvement to VS Code and get rid of this.

### Implementation

The rules become more complicated because we now need a negative lookahead that can catch and endless method definition without confusing it with a setter name. Using a setter name with an endless method definition is actually a syntax error, but we don't want to indent anyway.

Example:

```ruby
# No indent
def foo = 42
def self.foo = 42
def Foo.foo = 42
def foo=(foo) = 42 # invalid, but we don't want to indent
def self.foo=(foo) = 42 # invalid, but we don't want to indent
def Foo.foo=(foo) = 42 # invalid, but we don't want to indent

# Indent
def foo
def self.foo
def Foo.foo
def foo=(foo)
def self.foo=(foo)
def Foo.foo=(foo)
```