### PR TITLE
Prevent adding `end` token on endless methods

### DIFF
--- a/lib/ruby_lsp/requests/on_type_formatting.rb
+++ b/lib/ruby_lsp/requests/on_type_formatting.rb
@@ -120,6 +120,10 @@ module RubyLsp
 
         return unless END_REGEXES.any? { |regex| regex.match?(@previous_line) }
 
+        # Endless method definitions (e.g., `def foo = 42`) are complete statements
+        # and should not have `end` added
+        return if @previous_line.match?(/\bdef\s+[\w.]+[!?=]?(\([^)]*\))?\s*=[^=~>]/)
+
         indents = " " * @indentation
         current_line = @lines[@position[:line]]
         next_line = @lines[@position[:line] + 1]

--- a/test/requests/on_type_formatting_test.rb
+++ b/test/requests/on_type_formatting_test.rb
@@ -1122,4 +1122,86 @@ class OnTypeFormattingTest < Minitest::Test
     ]
     assert_equal(expected_edits.to_json, edits.to_json)
   end
+
+  def test_does_not_add_end_for_endless_method
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
+
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "def foo = 42",
+      }],
+      version: 2,
+    )
+    document.parse!
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(
+      document,
+      { line: 1, character: 0 },
+      "\n",
+      "Visual Studio Code",
+    ).perform
+
+    assert_empty(edits)
+  end
+
+  def test_does_not_add_end_for_multiline_endless_method
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
+
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "def hello = puts(",
+      }],
+      version: 2,
+    )
+    document.parse!
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(
+      document,
+      { line: 1, character: 0 },
+      "\n",
+      "Visual Studio Code",
+    ).perform
+
+    assert_empty(edits)
+  end
+
+  def test_does_not_add_end_for_endless_method_with_equals_and_parameters
+    document = RubyLsp::RubyDocument.new(
+      source: +"",
+      version: 1,
+      uri: URI("file:///fake.rb"),
+      global_state: @global_state,
+    )
+
+    # This is actually invalid Ruby. It crashes with a syntax error. But we shouldn't add the `end` token anyway
+    document.push_edits(
+      [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        text: "def foo=(bar) = 42",
+      }],
+      version: 2,
+    )
+    document.parse!
+
+    edits = RubyLsp::Requests::OnTypeFormatting.new(
+      document,
+      { line: 1, character: 0 },
+      "\n",
+      "Visual Studio Code",
+    ).perform
+
+    assert_empty(edits)
+  end
 end


### PR DESCRIPTION
### Motivation

Working on #4041, I realized that we were incorrectly adding the `end` token when breaking the line on endless method definitions. This PR prevents that from happening.

### Implementation

Just added another check to verify that the `def` is not followed by an endless method definition.

### Automated Tests

Added a test for an invalid syntax case and for a valid one.