### PR TITLE
Suppress Bundler::Dsl::DSLError from telemetry

### DIFF
--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -3,7 +3,11 @@
 
 module RubyLsp
   class Server < BaseServer
-    NON_REPORTABLE_SETUP_ERRORS = [Bundler::GemNotFound, Bundler::GitError].freeze #: Array[singleton(StandardError)]
+    NON_REPORTABLE_SETUP_ERRORS = [
+      Bundler::GemNotFound,
+      Bundler::GitError,
+      Bundler::Dsl::DSLError,
+    ].freeze #: Array[singleton(StandardError)]
 
     # Only for testing
     #: GlobalState

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -662,6 +662,16 @@ class ServerTest < Minitest::Test
     run_initialize_server_with_setup_error(StandardError.new("something unexpected"))
   end
 
+  def test_dsl_error_setup_error_does_not_send_telemetry
+    RubyLsp::Notification.expects(:telemetry).never
+
+    run_initialize_server_with_setup_error(Bundler::Dsl::DSLError.new(
+      "There was an error parsing `Gemfile`: syntax errors found",
+      "Gemfile",
+      [],
+    ))
+  end
+
   def test_handles_editor_indexing_settings
     capture_io do
       @server.process_message({


### PR DESCRIPTION
When Bundler raises `Bundler::Dsl::DSLError` during setup, Ruby LSP starts in degraded mode and cannot recover automatically. These failures are caused by invalid `Gemfile` syntax in the project and are not something actionable by us, so reporting them to telemetry is noise.