### PR TITLE
Fix document link gem paths when `to_spec` returns nil

### DIFF
--- a/lib/ruby_lsp/listeners/document_link.rb
+++ b/lib/ruby_lsp/listeners/document_link.rb
@@ -21,6 +21,8 @@ module RubyLsp
 
             Gem::Specification.stubs.each do |stub|
               spec = stub.to_spec
+              next unless spec
+
               lookup[spec.name] = {}
               lookup[spec.name][spec.version.to_s] = {}
 
@@ -31,6 +33,8 @@ module RubyLsp
 
             Gem::Specification.default_stubs.each do |stub|
               spec = stub.to_spec
+              next unless spec
+
               lookup[spec.name] = {}
               lookup[spec.name][spec.version.to_s] = {}
               prefix_matchers = Regexp.union(spec.require_paths.map do |rp|

--- a/test/requests/document_link_expectations_test.rb
+++ b/test/requests/document_link_expectations_test.rb
@@ -116,6 +116,19 @@ class DocumentLinkExpectationsTest < ExpectationsTestRunner
     refute_empty(links, "Expected document link for source comment above multi-line sig block")
   end
 
+  def test_does_not_fail_if_to_spec_returns_nil
+    # Guarantee that the cache is reset
+    RubyLsp::Listeners::DocumentLink.instance_variable_set(:@gem_paths, nil)
+
+    Gem::Specification.any_instance.stubs(:to_spec).returns(nil)
+
+    result = RubyLsp::Listeners::DocumentLink.gem_paths
+    refute_nil(result)
+  ensure
+    # Reset the cache again since we stubbed `to_spec` to return nil
+    RubyLsp::Listeners::DocumentLink.instance_variable_set(:@gem_paths, nil)
+  end
+
   def test_package_url_links_with_invalid_uris
     source = <<~RUBY
       # pkg:gem/rubocop$1.78.0#:99


### PR DESCRIPTION
### Motivation

`Gem::Specification#to_spec` may return `nil` under certain situations. For example, if the gem installation is missing because the current platform is not supported. We had a few cases of this happening in telemetry.

### Implementation

We just need to skip if `to_spec` returns `nil` since we have no way of inspecting any other information about that gem.

### Automated Tests

Added a test using a simple stub. Creating a super realistic test scenario involves a lot of setup.