### PR TITLE
Fix UTF-32 encoding in global state

### DIFF
--- a/lib/ruby_lsp/global_state.rb
+++ b/lib/ruby_lsp/global_state.rb
@@ -204,7 +204,7 @@ module RubyLsp
         Encoding::UTF_16LE
       else
         @graph.encoding = "utf32"
-        Encoding::UTF_32
+        Encoding::UTF_32LE
       end
       @index.configuration.encoding = @encoding
 

--- a/test/global_state_test.rb
+++ b/test/global_state_test.rb
@@ -219,6 +219,22 @@ module RubyLsp
       global_state.supports_watching_files
     end
 
+    def test_utf32_negotiation_yields_encoding_compatible_with_prism_code_units_cache
+      state = GlobalState.new
+      state.apply_options(capabilities: { general: { positionEncodings: ["utf-32"] } })
+
+      source = "class Foo; end\n\"🙂\"; Foo\n"
+      result = Prism.parse(source)
+      cache = result.code_units_cache(state.encoding)
+      foo_ref = result.value.statements.body.last #: as !nil
+
+      # `Foo` on line 1 starts at byte 23 (`class Foo; end\n` = 15 bytes + `"🙂"; ` = 8 bytes).
+      # In UTF-32 code units that same position is codepoint 20 (15 + 5). If `state.encoding`
+      # returns the dummy `Encoding::UTF_32`, the cache cannot translate past `🙂` and this
+      # assertion fails with a non-20 value.
+      assert_equal(20, foo_ref.location.cached_start_code_units_offset(cache))
+    end
+
     def test_feature_flags_are_processed_by_apply_options
       state = GlobalState.new
 


### PR DESCRIPTION
### Motivation

Encoding::UTF_32 doesn't actually encodes strings correctly and we were calculating code points with a wrong encoding. It's UTF_32LE that encodes the string and provides us the right locations back.

### Implementation

Started using `Encoding::UTF_32LE`, which applies the correct encoding to the string. It's easy to verify that it was previously wrong by doing this:

```ruby
# The length should be based on codepoints (42)

# Using the wrong encoding
"class Foo; end\n\"🙂\"; Foo\n".encode(Encoding::UTF_32).length
# => 100

# Using the right encoding
"class Foo; end\n\"🙂\"; Foo\n".encode(Encoding::UTF_32LE).length
# => 24
```

### Automated Tests

Added a test.