### PR TITLE
Search for shadowenv in ~/.local/bin too

### DIFF
--- a/vscode/src/ruby/shadowenv.ts
+++ b/vscode/src/ruby/shadowenv.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-
+import os from "os";
 import { asyncExec } from "../common";
 
 import { VersionManager, ActivationResult, NonReportableError } from "./versionManager";
@@ -21,7 +21,10 @@ export class Shadowenv extends VersionManager {
       );
     }
 
-    const shadowenvExec = await this.findExec([vscode.Uri.file("/opt/homebrew/bin")], "shadowenv");
+    const shadowenvExec = await this.findExec(
+      [vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin"), vscode.Uri.file("/opt/homebrew/bin")],
+      "shadowenv",
+    );
 
     try {
       const parsedResult = await this.runEnvActivationScript(`${shadowenvExec} exec -- ruby`);


### PR DESCRIPTION
### Motivation

Start searching for the `shadowenv` executable under `~/.local/bin` as well as the Homebrew path.