### PR TITLE
Use Rubydex for method completion resolve

### DIFF
--- a/lib/ruby_lsp/requests/completion_resolve.rb
+++ b/lib/ruby_lsp/requests/completion_resolve.rb
@@ -53,9 +53,10 @@ module RubyLsp
         guessed_type = @item.dig(:data, :guessed_type)
         title = @item[:label].dup
 
-        # TODO: when Rubydex exposes method signatures via `Rubydex::MethodDefinition#signatures`, append the formatted
-        # parameter list and overload count to the title here (see the legacy `decorated_parameters` /
-        # `formatted_signatures` rendering on `RubyIndexer::Entry::Member`).
+        if declaration.is_a?(Rubydex::Method)
+          title << declaration.decorated_parameters
+          title << declaration.formatted_signatures
+        end
 
         extra_links = if guessed_type
           title << "\n\nGuessed receiver: #{guessed_type}"

--- a/test/requests/completion_resolve_test.rb
+++ b/test/requests/completion_resolve_test.rb
@@ -89,8 +89,6 @@ class CompletionResolveTest < Minitest::Test
   end
 
   def test_inserts_method_parameters_in_label_details
-    skip("[RUBYDEX] needs method signatures")
-
     source = +<<~RUBY
       class Bar
         def foo(a, b, c)
@@ -116,13 +114,24 @@ class CompletionResolveTest < Minitest::Test
   end
 
   def test_indicates_signature_count_in_label_details
-    skip("[RUBYDEX] needs method signatures. Change this test to index an RBS document with overloaded signatures")
+    rbs = <<~RBS
+      class Foo
+        def try_convert: (Object object) -> String?
+                       | (String s) -> String
+                       | (Symbol s) -> String
+      end
+    RBS
+    rbs_uri = URI::Generic.from_path(path: "/fake/path/foo.rbs").to_s
 
-    with_server("String.try_convert", stub_no_typechecker: true) do |server, _uri|
+    with_server("Foo.new.try_convert", stub_no_typechecker: true) do |server, _uri|
+      graph = server.global_state.graph
+      graph.index_source(rbs_uri, rbs, "rbs")
+      graph.resolve
+
       existing_item = {
         label: "try_convert",
         kind: RubyLsp::Constant::CompletionItemKind::METHOD,
-        data: { owner_name: "String::<String>" },
+        data: { owner_name: "Foo" },
       }
 
       server.process_message(id: 1, method: "completionItem/resolve", params: existing_item)


### PR DESCRIPTION
### Motivation

Almost exactly the same change as we did for hover, but this time for completion resolve. We show documentation for methods including their signatures.

### Implementation

Just used the created helpers to show the method's signature.

### Automated Tests

Simplified the RBS test, but kept the rest the same.