### PR TITLE
vscode: Detect mise via shell PATH like other version managers

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -17,25 +17,6 @@ import { Custom } from "./ruby/custom";
 import { Asdf } from "./ruby/asdf";
 import { Rv } from "./ruby/rv";
 
-async function detectMise() {
-  const possiblePaths = [
-    vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin", "mise"),
-    vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin", "mise"),
-    vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "bin", "mise"),
-  ];
-
-  for (const possiblePath of possiblePaths) {
-    try {
-      await vscode.workspace.fs.stat(possiblePath);
-      return true;
-    } catch (_error: any) {
-      // Continue looking
-    }
-  }
-
-  return false;
-}
-
 export enum ManagerIdentifier {
   Asdf = "asdf",
   Auto = "auto",
@@ -374,6 +355,7 @@ export class Ruby implements RubyInterface {
       ManagerIdentifier.Rvm,
       ManagerIdentifier.Asdf,
       ManagerIdentifier.Rv,
+      ManagerIdentifier.Mise,
     ];
 
     for (const tool of managers) {
@@ -383,11 +365,6 @@ export class Ruby implements RubyInterface {
         this.versionManager = tool;
         return;
       }
-    }
-
-    if (await detectMise()) {
-      this.versionManager = ManagerIdentifier.Mise;
-      return;
     }
 
     if (os.platform() === "win32") {

--- a/vscode/src/ruby/mise.ts
+++ b/vscode/src/ruby/mise.ts
@@ -9,10 +9,10 @@ import { VersionManager, ActivationResult, NonReportableError } from "./versionM
 // Learn more: https://github.com/jdx/mise
 export class Mise extends VersionManager {
   async activate(): Promise<ActivationResult> {
-    const miseUri = await this.findMiseUri();
+    const miseExec = await this.findMise();
 
     // The exec command in Mise is called `x`
-    const parsedResult = await this.runEnvActivationScript(`${miseUri.fsPath} x -- ruby`);
+    const parsedResult = await this.runEnvActivationScript(`${miseExec} x -- ruby`);
 
     return {
       env: { ...process.env, ...parsedResult.env },
@@ -22,46 +22,37 @@ export class Mise extends VersionManager {
     };
   }
 
-  async findMiseUri(): Promise<vscode.Uri> {
+  async findMise(): Promise<string> {
     const config = vscode.workspace.getConfiguration("rubyLsp");
-    const misePath = config.get<string | undefined>("rubyVersionManager.miseExecutablePath");
+    const configuredMisePath = config.get<string | undefined>("rubyVersionManager.miseExecutablePath");
 
-    if (misePath) {
-      const configuredPath = vscode.Uri.file(misePath);
-
-      try {
-        await vscode.workspace.fs.stat(configuredPath);
-        return configuredPath;
-      } catch (_error: any) {
-        throw new NonReportableError(
-          `Mise executable configured as ${configuredPath.fsPath}, but that file doesn't exist`,
-        );
-      }
+    if (configuredMisePath) {
+      return this.ensureMiseExistsAt(configuredMisePath);
     }
 
-    // Possible mise installation paths
+    // Possible mise installation directories. If none match, fall back to the PATH.
     //
     // 1. Installation from curl | sh (per mise.jdx.dev Getting Started)
     // 2. Homebrew M series
-    // 3. Installation from `apt install mise`
+    // 3. Homebrew Intel / Linuxbrew
+    // 4. Linuxbrew (legacy)
+    // 5. Installation from `apt install mise`
     const possiblePaths = [
-      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin", "mise"),
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin", "mise"),
-      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "bin", "mise"),
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "bin"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "home", "linuxbrew", ".linuxbrew", "bin"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "bin"),
     ];
+    return this.findExec(possiblePaths, "mise");
+  }
 
-    for (const possiblePath of possiblePaths) {
-      try {
-        await vscode.workspace.fs.stat(possiblePath);
-        return possiblePath;
-      } catch (_error: any) {
-        // Continue looking
-      }
+  private async ensureMiseExistsAt(path: string): Promise<string> {
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.file(path));
+      return path;
+    } catch (_error: any) {
+      throw new NonReportableError(`The Ruby LSP version manager is configured to be Mise, but ${path} does not exist`);
     }
-
-    throw new NonReportableError(
-      `The Ruby LSP version manager is configured to be Mise, but could not find Mise installation. Searched in
-        ${possiblePaths.join(", ")}`,
-    );
   }
 }

--- a/vscode/src/test/suite/ruby/mise.test.ts
+++ b/vscode/src/test/suite/ruby/mise.test.ts
@@ -35,7 +35,7 @@ suite("Mise", () => {
     context.dispose();
   });
 
-  test("Finds Ruby only binary path is appended to PATH", async () => {
+  test("Activates with auto-detected mise", async () => {
     const workspacePath = process.env.PWD!;
     const workspaceFolder = {
       uri: vscode.Uri.from({ scheme: "file", path: workspacePath }),
@@ -51,31 +51,25 @@ suite("Mise", () => {
       stdout: "",
       stderr: `${ACTIVATION_SEPARATOR}${envStub}${ACTIVATION_SEPARATOR}`,
     });
-    const findStub = sandbox
-      .stub(mise, "findMiseUri")
-      .resolves(vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin", "mise"));
+
+    // Stub findMise to return the executable name, simulating PATH fallback
+    sandbox.stub(mise, "findMise" as any).resolves("mise");
 
     const { env, version, yjit } = await mise.activate();
 
     assert.ok(
-      execStub.calledOnceWithExactly(
-        `${os.homedir()}/.local/bin/mise x -- ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`,
-        {
-          cwd: workspacePath,
-          shell: vscode.env.shell,
+      execStub.calledOnceWithExactly(`mise x -- ruby -EUTF-8:UTF-8 '${activationPath.fsPath}'`, {
+        cwd: workspacePath,
+        shell: vscode.env.shell,
 
-          env: process.env,
-          encoding: "utf-8",
-        },
-      ),
+        env: process.env,
+        encoding: "utf-8",
+      }),
     );
 
     assert.strictEqual(version, "3.0.0");
     assert.strictEqual(yjit, true);
     assert.deepStrictEqual(env.ANY, "true");
-
-    execStub.restore();
-    findStub.restore();
   });
 
   test("Allows configuring where Mise is installed", async () => {


### PR DESCRIPTION
### Motivation

Previously mise was the only version manager whose detection and executable resolution relied solely on a hardcoded list of installation directories. Users who installed mise outside of `~/.local/bin`, `/opt/homebrew/bin`, or `/usr/bin` had to set `miseExecutablePath` explicitly, even when `mise` was already on their shell `PATH`.

### Implementation

Align mise with rbenv, rv, and asdf:

- Replace `detectMise()` with the standard `toolExists("mise")` probe, which runs `mise --version` through the user's interactive shell so any `PATH` is honored.
- Rewrite `Mise#findMiseUri` as `Mise#findMise` using `findExec`, so installations under the well-known directories are still preferred while unknown locations fall back to the shell `PATH`.
- Add `/usr/local/bin` and `/home/linuxbrew/.linuxbrew/bin` to the candidate list to cover Homebrew Intel and Linuxbrew installations that were previously missed.

### Automated Tests

vscode/src/ruby/mise.ts
