### PR TITLE
Restore window scope for several workspace specific settings

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -440,7 +440,7 @@
         "rubyLsp.customRubyCommand": {
           "description": "A shell command to activate the right Ruby version or add a custom Ruby bin folder to the PATH. Only used if rubyVersionManager is set to 'custom'",
           "type": "string",
-          "scope": "machine"
+          "scope": "machine-overridable"
         },
         "rubyLsp.formatter": {
           "description": "Which tool the Ruby LSP should use for formatting files",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -131,7 +131,7 @@
       {
         "command": "rubyLsp.selectRubyVersionManager",
         "title": "Select Ruby version manager",
-        "category": "Ruby LSP"
+        "category": "Ruby LSP",
       },
       {
         "command": "rubyLsp.toggleFeatures",
@@ -389,6 +389,7 @@
         },
         "rubyLsp.rubyVersionManager": {
           "type": "object",
+          "scope": "window",
           "properties": {
             "identifier": {
               "description": "The Ruby version manager to use",
@@ -440,7 +441,7 @@
         "rubyLsp.customRubyCommand": {
           "description": "A shell command to activate the right Ruby version or add a custom Ruby bin folder to the PATH. Only used if rubyVersionManager is set to 'custom'",
           "type": "string",
-          "scope": "machine-overridable"
+          "scope": "window"
         },
         "rubyLsp.formatter": {
           "description": "Which tool the Ruby LSP should use for formatting files",
@@ -478,7 +479,7 @@
         "rubyLsp.bundleGemfile": {
           "description": "Relative or absolute path to the Gemfile to use for bundling the Ruby LSP server. Do not use this if you're working on a monorepo or your project's Gemfile is in a subdirectory (look into multiroot workspaces instead). Only necessary when using a separate Gemfile for the Ruby LSP",
           "type": "string",
-          "scope": "machine",
+          "scope": "window",
           "default": ""
         },
         "rubyLsp.testTimeout": {
@@ -509,7 +510,7 @@
         "rubyLsp.rubyExecutablePath": {
           "description": "Path to the Ruby installation. This is used as a fallback if version manager activation fails",
           "type": "string",
-          "scope": "machine"
+          "scope": "window"
         },
         "rubyLsp.indexing": {
           "description": "Indexing configurations. Modifying these will impact which declarations are available for definition, completion and other features",

--- a/vscode/src/ruby/custom.ts
+++ b/vscode/src/ruby/custom.ts
@@ -21,8 +21,10 @@ export class Custom extends VersionManager {
 
   customCommand() {
     const configuration = vscode.workspace.getConfiguration("rubyLsp");
-    const customCommand: string | undefined = configuration.get("customRubyCommand");
-
+    const inspectedCustomRubyCommand = configuration.inspect("customRubyCommand");
+    const customCommand = inspectedCustomRubyCommand.globalValue
+      ?? inspectedCustomRubyCommand.workspaceValue
+      ?? inspectedCustomRubyCommand.workspaceFolderValue
     if (customCommand === undefined) {
       throw new NonReportableError(
         "The customRubyCommand configuration must be set when 'custom' is selected as the version manager. \


### PR DESCRIPTION
### Motivation
~With capabilities.untrustedWorkspaces.restrictedConfigurations~ It seems impossible to set customRubyCommand at workspace level because VS Code prevents the extension from reading the machine scope options in workspace's .vscode/settings.json.

It fails with `Automatic Ruby environment activation with custom failed: Command failed: && ruby -EUTF-8:UTF-8 '/path/to/.vscode/extensions/shopify.ruby-lsp-0.10.4/activation.rb' zsh:1: parse error near &&' ` because the command here becomes ` && ruby - ...`.

https://github.com/Shopify/ruby-lsp/blob/4c109e356e3ece372b51be8866dce841ff1f487f/vscode/src/ruby/custom.ts#L12

It is sometimes case with me to find two ruby projects use different tools to manage ruby.
It is also quite likely that different projects have bundleGemfile in different locations.

This change allows users to change some workspace specific settings for each workspace.

Related to
- https://github.com/Shopify/ruby-lsp/issues/4119
- https://github.com/Shopify/ruby-lsp/issues/4114

### Implementation
Change option scope from "machine" to "machine-configurable"

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests
Add the following .vscode/settings.json to your workspace  and enable the extension.

```json
{
  "rubyLsp.rubyVersionManager": {
    "identifier": "custom"
  },
  "rubyLsp.customRubyCommand": "{any command of your choice}"
}
```

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
