### PR TITLE
Add localfs and localfsMap to the debugger configuration schema

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -631,6 +631,14 @@
                 "additionalProperties": {
                   "type": "string"
                 }
+              },
+              "localfs": {
+                "type": "boolean",
+                "description": "Whether VS Code and the debuggee run on the same machine"
+              },
+              "localfsMap": {
+                "type": "string",
+                "description": "Pairs of remote and local root paths, written as remote:local (for example /remote_dir:/local_dir)"
               }
             }
           },
@@ -647,6 +655,14 @@
               "debugHost": {
                 "type": "string",
                 "description": "The host to use to connect to the debugger"
+              },
+              "localfs": {
+                "type": "boolean",
+                "description": "Whether VS Code and the debuggee run on the same machine"
+              },
+              "localfsMap": {
+                "type": "string",
+                "description": "Pairs of remote and local root paths, written as remote:local (for example /remote_dir:/local_dir)"
               }
             }
           }


### PR DESCRIPTION
### Motivation

Closes #3597. Setting `localfsMap` (or `localfs`) in a `ruby_lsp` debug configuration shows a "Property not allowed" warning in VS Code, even though the option works. The extension forwards the launch configuration to the Ruby `debug` gem, which reads these keys, but they were never declared in the debugger schema, so VS Code treated them as unknown.

### Implementation

Declare `localfs` and `localfsMap` under both `launch` and `attach` in the debugger `configurationAttributes`. The gem's DAP server reads both keys for both request types in `server_dap.rb`, so VS Code no longer flags them.

### Automated Tests

None. The new entries are declarations in the `contributes.debuggers` schema in `package.json`, which VS Code validates against `launch.json` at runtime. The extension does not have tests covering its `package.json` contributions.

### Manual Tests

1. Open a Ruby project and add a `launch.json` with a `ruby_lsp` attach configuration containing `"localfsMap": "/remote:/local"` (or `"localfs": true`).
2. On `main`, VS Code flags the property with "Property localfsMap not allowed".
3. With this branch, the warning is gone and the property is accepted.
