### PR TITLE
Don't crash on document URIs with an invalid scheme

### DIFF
--- a/lib/ruby_lsp/base_server.rb
+++ b/lib/ruby_lsp/base_server.rb
@@ -74,6 +74,8 @@ module RubyLsp
                   )
                 end
               end
+            rescue URI::Error
+              # A client can send a document URI with a scheme Ruby's URI parser rejects, so we don't want to fail
             rescue Store::NonExistingDocumentError
               # If we receive a request for a file that no longer exists, we don't want to fail
             end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1749,6 +1749,36 @@ class ServerTest < Minitest::Test
     assert_equal("Method not found: #{non_existent_method}", error.message)
   end
 
+  def test_does_not_crash_when_a_document_uri_cannot_be_parsed
+    # A document URI with a scheme Ruby's URI parser rejects must not crash the server
+    body = {
+      id: 1,
+      method: "textDocument/hover",
+      params: {
+        textDocument: { uri: "_diff_view:/path/to/file.rb" },
+        position: { line: 0, character: 0 },
+      },
+    }.to_json
+    server = RubyLsp::Server.new(
+      test_mode: true,
+      reader: StringIO.new("Content-Length: #{body.bytesize}\r\n\r\n#{body}"),
+      writer: StringIO.new,
+    )
+
+    error = nil #: StandardError?
+    capture_subprocess_io do
+      server.start
+    rescue StandardError => e
+      error = e
+    end
+
+    assert_nil(error, "server crashed on an unparseable document URI: #{error&.message}")
+    # The request still gets an error response instead of hanging
+    assert_instance_of(RubyLsp::Error, server.pop_response)
+  ensure
+    server&.run_shutdown
+  end
+
   private
 
   def run_initialize_server_with_setup_error(error)


### PR DESCRIPTION
### Motivation

Closes #4067. A client can send a `textDocument` message whose URI uses a scheme Ruby's `URI()` parser rejects, which crashes the server and drops the connection. The Claude Code extension does this with its `_claude_fs_right:` and `_claude_fs_left:` inline-diff schemes, where the leading underscore is invalid under RFC 3986. `BaseServer#start` wraps the `URI(uri)` call only in `rescue Store::NonExistingDocumentError`, so `URI::InvalidURIError` escapes the reader loop.

### Implementation

Rescue `URI::Error` next to the existing `Store::NonExistingDocumentError` rescue. The message then continues to normal dispatch, where `process_message` already returns an error response for requests and logs notifications, so a URI Ruby cannot parse no longer crashes the reader loop.

### Automated Tests

Added a test that drives `start` with an invalid-scheme document URI and asserts the server stays up and still answers the request with an error.
