### PR TITLE
Restart the server when the Ruby version file changes

### DIFF
--- a/vscode/src/ruby.ts
+++ b/vscode/src/ruby.ts
@@ -84,6 +84,11 @@ export class Ruby implements RubyInterface {
     }
   }
 
+  // Files watched to restart the server when the project's Ruby version changes.
+  get versionDefinitionFiles(): string[] {
+    return [".ruby-version", ".tool-versions", "mise.toml", ".mise.toml"];
+  }
+
   get env() {
     return this._env;
   }

--- a/vscode/src/test/suite/workspace.test.ts
+++ b/vscode/src/test/suite/workspace.test.ts
@@ -132,4 +132,22 @@ suite("Workspace", () => {
     assert.strictEqual(startStub.callCount, 0);
     assert.strictEqual(restartSpy.callCount, 0);
   }).timeout(10000);
+
+  test("restarts when the Ruby version file is modified", async () => {
+    const versionFileUri = vscode.Uri.file(path.join(workspacePath, ".ruby-version"));
+    await vscode.workspace.fs.writeFile(versionFileUri, Buffer.from("3.3.0"));
+
+    await workspace.activate();
+
+    const startStub = sandbox.stub(workspace, "start");
+    const restartSpy = sandbox.spy(workspace, "restart");
+
+    await vscode.workspace.fs.writeFile(versionFileUri, Buffer.from("3.4.0"));
+
+    // Give enough time for the watcher to fire and the debounce to run off
+    await new Promise((resolve) => setTimeout(resolve, 6000));
+
+    assert.strictEqual(startStub.callCount, 1);
+    assert.strictEqual(restartSpy.callCount, 1);
+  }).timeout(10000);
 });

--- a/vscode/src/workspace.ts
+++ b/vscode/src/workspace.ts
@@ -86,7 +86,7 @@ export class Workspace implements WorkspaceInterface {
     this.registerRestarts();
 
     // Eagerly calculate SHAs for the watched files to avoid unnecessary restarts
-    for (const file of WATCHED_FILES) {
+    for (const file of [...WATCHED_FILES, ...this.ruby.versionDefinitionFiles]) {
       const uri = vscode.Uri.joinPath(this.workspaceFolder.uri, file);
       const currentSha = await this.fileContentsSha(uri);
 
@@ -345,6 +345,7 @@ export class Workspace implements WorkspaceInterface {
 
   private registerRestarts() {
     this.createRestartWatcher(`{${WATCHED_FILES.join(",")}}`);
+    this.createRestartWatcher(`{${this.ruby.versionDefinitionFiles.join(",")}}`);
 
     // If a configuration that affects the Ruby LSP has changed, update the client options using the latest
     // configuration and restart the server


### PR DESCRIPTION
### Motivation

Closes #2583. The extension already restarts the language server when the bundle lockfile changes, but not when the file that selects the Ruby version changes. After editing `.ruby-version` (or `.tool-versions` / `mise.toml`), the server keeps running the old Ruby until the window is reloaded by hand.

### Implementation

`Ruby` exposes `versionDefinitionFiles` and `Workspace` watches those files in `registerRestarts`, the same way it already watches the lockfile. The eager SHA pass in `activate` covers them too, so touching a file without changing its contents does not restart. `versionDefinitionFiles` returns the set rather than a single path, covering `.ruby-version`, `.tool-versions`, `mise.toml`, and `.mise.toml`.

### Automated Tests

Added a test in `workspace.test.ts` that writes `.ruby-version`, activates the workspace, rewrites the file, and asserts the server restarts once. It mirrors the existing lockfile watcher tests.

### Manual Tests

1. Open a Ruby project managed by chruby, rbenv, asdf, or mise.
2. Change the Ruby version in `.ruby-version` (or `.tool-versions` / `mise.toml`).
3. The server restarts on its own, without reloading the window.
