### PR TITLE
Handle missing Gemfile in project add-on loading

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -56,9 +56,16 @@ module RubyLsp
         addon_files = Gem.find_files("ruby_lsp/**/addon.rb")
 
         if include_project_addons
-          bundle_path = Bundler.bundle_path.to_s
+          bundle_path = begin
+            Bundler.bundle_path.to_s
+          rescue Bundler::GemfileNotFound
+            nil
+          end
+
           project_addons = Dir.glob("#{global_state.workspace_path}/**/ruby_lsp/**/addon.rb")
-          project_addons.reject! { |path| path.start_with?(bundle_path) || gem_installation_path?(path) }
+          project_addons.reject! do |path|
+            (bundle_path && path.start_with?(bundle_path)) || gem_installation_path?(path)
+          end
 
           addon_files.concat(project_addons)
         end

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -191,6 +191,39 @@ module RubyLsp
       end
     end
 
+    def test_loading_project_addons_when_the_project_has_no_gemfile
+      Dir.mktmpdir do |dir|
+        addon_dir = File.join(dir, "lib", "ruby_lsp", "test_addon")
+        FileUtils.mkdir_p(addon_dir)
+        File.write(File.join(addon_dir, "addon.rb"), <<~RUBY)
+          class NoGemfileProjectAddon < RubyLsp::Addon
+            def activate(global_state, outgoing_queue)
+            end
+
+            def name
+              "No Gemfile Project Addon"
+            end
+
+            def version
+              "0.1.0"
+            end
+          end
+        RUBY
+
+        @global_state.apply_options({
+          workspaceFolders: [{ uri: URI::Generic.from_path(path: dir).to_s }],
+        })
+
+        # Projects without a Gemfile have no bundle path at all and asking Bundler for one raises
+        Bundler.stubs(:bundle_path).raises(Bundler::GemfileNotFound)
+
+        Addon.load_addons(@global_state, @outgoing_queue)
+
+        addon = Addon.get("No Gemfile Project Addon", "0.1.0")
+        assert_equal("No Gemfile Project Addon", addon.name)
+      end
+    end
+
     def test_loading_project_addons_ignores_bundle_path
       Dir.mktmpdir do |dir|
         addon_dir = File.join(dir, "vendor", "bundle", "ruby_lsp", "test_addon")


### PR DESCRIPTION
### Motivation

We were unconditionally invoking `Bundler.bundle_path` to filter project add-ons, but that actually raises when opening the LSP in a project with no Gemfile.

### Implementation

We need to rescue and ensure that we don't crash when loading project add-ons.

### Automated Tests

Added a test to avoid regressions.