### PR TITLE
Use `find_latest_files` for loading add-ons

### DIFF
--- a/lib/ruby_lsp/addon.rb
+++ b/lib/ruby_lsp/addon.rb
@@ -53,7 +53,7 @@ module RubyLsp
         # Require all add-ons entry points, which should be placed under
         # `some_gem/lib/ruby_lsp/your_gem_name/addon.rb` or in the workspace under
         # `your_project/ruby_lsp/project_name/addon.rb`
-        addon_files = Gem.find_files("ruby_lsp/**/addon.rb")
+        addon_files = Gem.find_latest_files("ruby_lsp/**/addon.rb")
 
         if include_project_addons
           bundle_path = begin

--- a/test/addon_test.rb
+++ b/test/addon_test.rb
@@ -378,7 +378,7 @@ module RubyLsp
         })
 
         expected_addon_path = File.join(dir, "vendor", "bundle", "rubocop-1.73.0", "lib", "ruby_lsp", "rubocop", "addon.rb")
-        Gem.stubs(:find_files).with("ruby_lsp/**/addon.rb").returns([expected_addon_path])
+        Gem.stubs(:find_latest_files).with("ruby_lsp/**/addon.rb").returns([expected_addon_path])
         Bundler.stubs(:bundle_path).returns(Pathname.new(File.join(dir, "vendor", "bundle")))
         Addon.load_addons(@global_state, @outgoing_queue)
 


### PR DESCRIPTION
### Motivation

We had a few bugs in the past related to loading multiple versions of the same add-on. We already added some guard rails, but I just discovered that RubyGems actually has a better API we can use.

### Implementation

`Gem.find_latest_files` will only find once for each gem, using the latest possible version according to the Bundle.