### PR TITLE
Fix multiline ERB comment parsing

### DIFF
--- a/lib/ruby_lsp/erb_document.rb
+++ b/lib/ruby_lsp/erb_document.rb
@@ -82,6 +82,7 @@ module RubyLsp
         @ruby = +"" #: String
         @current_pos = 0 #: Integer
         @inside_ruby = false #: bool
+        @inside_erb_comment = false #: bool
       end
 
       #: -> void
@@ -100,12 +101,16 @@ module RubyLsp
 
         case char
         when "<"
-          if next_char == "%"
+          if !@inside_erb_comment && next_char == "%"
             @inside_ruby = true
             @current_pos += 1
             push_char("  ")
 
-            if next_char == "=" && @source[@current_pos + 2] == "="
+            if next_char == "#"
+              @inside_erb_comment = true
+              @current_pos += 1
+              push_char(" ")
+            elsif next_char == "=" && @source[@current_pos + 2] == "="
               @current_pos += 2
               push_char("  ")
             elsif next_char == "=" || next_char == "-"
@@ -121,6 +126,7 @@ module RubyLsp
           if @inside_ruby && next_char == "%" &&
               @source[@current_pos + 2] == ">"
             @current_pos += 2
+            @inside_erb_comment = false
             push_char("   ")
             @inside_ruby = false
           else
@@ -130,9 +136,10 @@ module RubyLsp
           end
         when "%"
           if @inside_ruby && next_char == ">"
-            @inside_ruby = false
             @current_pos += 1
+            @inside_erb_comment = false
             push_char("  ")
+            @inside_ruby = false
           else
             push_char(
               char, #: as !nil
@@ -159,7 +166,10 @@ module RubyLsp
 
       #: (String char) -> void
       def push_char(char)
-        if @inside_ruby
+        if @inside_erb_comment
+          @ruby << " " * char.length
+          @host_language << " " * char.length
+        elsif @inside_ruby
           @ruby << char
           @host_language << " " * char.length
         else

--- a/test/erb_document_test.rb
+++ b/test/erb_document_test.rb
@@ -73,6 +73,53 @@ class ERBDocumentTest < Minitest::Test
     assert_equal("   \r\nbar   ", document.parse_result.source.source)
   end
 
+  def test_multiline_erb_comments_are_excluded_from_virtual_sources
+    source = +"<%# first line\ncomment_method(:argument)\n-%>\n<%= visible_call %>"
+    document = RubyLsp::ERBDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.erb"),
+      global_state: @global_state,
+    )
+
+    document.parse!
+
+    expected_ruby = source.gsub(/[^\r\n]/, " ")
+    visible_call = "visible_call"
+    visible_call_start = source.index(visible_call)
+    expected_ruby[visible_call_start, visible_call.length] = visible_call
+
+    refute_predicate(document, :syntax_error?)
+    assert_equal(expected_ruby, document.parse_result.source.source)
+    assert_equal(source.gsub(/[^\r\n]/, " "), document.host_language_source)
+  end
+
+  def test_multiline_erb_comments_preserve_windows_newlines_and_resume_scanning
+    source = +"<%# first line\r\ncomment_method(:argument) %>\r\n<p>visible</p>\r\n<%= another_call %>"
+    document = RubyLsp::ERBDocument.new(
+      source: source,
+      version: 1,
+      uri: URI("file:///foo.erb"),
+      global_state: @global_state,
+    )
+
+    document.parse!
+
+    expected_ruby = source.gsub(/[^\r\n]/, " ")
+    another_call = "another_call"
+    another_call_start = source.index(another_call)
+    expected_ruby[another_call_start, another_call.length] = another_call
+
+    expected_host = source.gsub(/[^\r\n]/, " ")
+    visible_html = "<p>visible</p>"
+    visible_html_start = source.index(visible_html)
+    expected_host[visible_html_start, visible_html.length] = visible_html
+
+    refute_predicate(document, :syntax_error?)
+    assert_equal(expected_ruby, document.parse_result.source.source)
+    assert_equal(expected_host, document.host_language_source)
+  end
+
   def test_erb_syntax_error_does_not_cause_crash
     [
       "<%=",


### PR DESCRIPTION
### Motivation

Closes #4181.

Multiline `<%# ... %>` comments currently leak every line after the first into
the virtual Ruby source. Prism can then parse prose as method calls, which
produces incorrect semantic highlighting and can affect other features that use
the ERB AST.

### Implementation

- Recognize the `#` marker when opening an ERB tag and track an explicit ERB
  comment state.
- Replace comment content with equal-length spaces in both virtual sources while
  preserving LF and CRLF sequences and source offsets.
- Clear the comment state on both `%>` and `-%>` closing paths, then resume
  normal host-language and Ruby scanning.
- Ignore apparent `<%` openers inside an active ERB comment.

### Automated Tests

Added document-level regression tests for:

- multiline comments with LF and `-%>`, followed by real Ruby;
- multiline comments with CRLF and `%>`, followed by both HTML and real Ruby;
- exact virtual-source masking, newline preservation, syntax validity, and
  scanner recovery after each closing form.

Validation performed locally:

- `bin/test test/erb_document_test.rb`
- `bundle exec rake`
- `bundle exec rubocop`
- `bundle exec srb tc`
- `bin/tapioca check-shims`

### Manual Tests

I did not run a VS Code UI test. To verify manually, open an ERB document with
semantic highlighting enabled, add a multiline `<%# ... %>` block followed by
HTML and `<%= ruby_code %>`, and confirm that the comment remains entirely
comment-colored while highlighting resumes for the following content.
