### PR TITLE
Fix Windows test reporter path lookup (#3881)

### DIFF
--- a/lib/ruby_lsp/test_reporters/lsp_reporter.rb
+++ b/lib/ruby_lsp/test_reporters/lsp_reporter.rb
@@ -37,6 +37,24 @@ module RubyLsp
         zero_based_line = line ? line - 1 : nil
         [uri, zero_based_line]
       end
+
+      # VS Code stores uri.fsPath keys; Dir.pwd may differ in separators / drive case (#3881).
+      #: (String) -> String
+      def normalize_path(path)
+        path.tr("\\", "/").sub(/\A([A-Za-z]):/) { "#{Regexp.last_match(1).downcase}:" }
+      end
+
+      #: (Hash[String, String], ?String) -> String?
+      def resolve_reporter_port(db, working_directory = Dir.pwd)
+        return db[working_directory] if db.key?(working_directory)
+
+        normalized_pwd = normalize_path(working_directory)
+        db.each do |stored_path, port|
+          return port if normalize_path(stored_path) == normalized_pwd
+        end
+
+        nil
+      end
     end
 
     # https://code.visualstudio.com/api/references/vscode-api#Position
@@ -64,8 +82,11 @@ module RubyLsp
         if port
           socket(port)
         elsif File.exist?(port_db_path)
-          db = JSON.load_file(port_db_path)
-          socket(db[Dir.pwd])
+          db = JSON.load_file(port_db_path) #: Hash[String, String]
+          resolved_port = self.class.resolve_reporter_port(db)
+          raise "No reporter port for #{Dir.pwd}" unless resolved_port
+
+          socket(resolved_port)
         else
           # For tests that don't spawn the TCP server
           require "stringio"

--- a/test/test_reporters/lsp_reporter_test.rb
+++ b/test/test_reporters/lsp_reporter_test.rb
@@ -168,5 +168,47 @@ module RubyLsp
 
       assert_equal(one_based_line - 1, line)
     end
+
+    def test_resolve_reporter_port_matches_windows_path_variants
+      db = { "d:\\source\\repos\\myproject" => "12345" }
+
+      assert_equal(
+        "12345",
+        LspReporter.resolve_reporter_port(db, "D:/source/repos/myproject"),
+      )
+      assert_equal(
+        "12345",
+        LspReporter.resolve_reporter_port(db, "d:\\source\\repos\\myproject"),
+      )
+      assert_nil(LspReporter.resolve_reporter_port(db, "D:/other/project"))
+    end
+
+    def test_socket_connects_using_port_db_despite_windows_path_mismatch
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.addr[1].to_s
+      thread = Thread.new { server.accept }
+      io = nil #: Socket?
+
+      Dir.mktmpdir("ruby-lsp-3881-") do |tmpdir|
+        ENV.delete("RUBY_LSP_REPORTER_PORT")
+        Dir.stubs(:tmpdir).returns(tmpdir)
+        Dir.stubs(:pwd).returns("D:/source/repos/myproject")
+
+        port_db_path = File.join(tmpdir, "ruby-lsp", "test_reporter_port_db.json")
+        FileUtils.mkdir_p(File.dirname(port_db_path))
+        File.write(port_db_path, { "d:\\source\\repos\\myproject" => port }.to_json)
+
+        reporter = LspReporter.new
+        io = reporter.instance_variable_get(:@io)
+
+        assert_kind_of(Socket, io)
+
+        accepted = thread.join(1)&.value #: untyped
+        accepted&.close
+      end
+    ensure
+      io&.close
+      server.close
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Fixes #3881.

On Windows, VS Code stores Test Explorer reporter DB keys using `uri.fsPath`, while Ruby's `Dir.pwd` can represent the same path with different separators and drive-letter casing. The exact hash lookup then misses, causing the reporter to fall back to `StringIO` and leaving Test Explorer waiting for results even though the tests finished.

### Implementation

Normalize path separators and drive-letter casing when resolving the reporter port in `LspReporter`.

The change is reader-only: the VS Code writer continues storing native `uri.fsPath` values, while the Ruby reporter tolerates equivalent Windows path representations.

### Automated Tests

- Added coverage for equivalent Windows path representations.
- Added a socket-level regression test verifying that the reporter connects successfully when the DB contains `d:\...` and `Dir.pwd` returns `D:/...`.
- `bundle exec ruby -Itest test/test_reporters/lsp_reporter_test.rb` — 12 runs, 0 failures.
- Indexer suite — 318 runs, 0 failures.

### Manual Tests

Tested against a small RSpec project on Windows:

1. Published gem: Test Explorer remained spinning after the test completed (~81s, still 0/1).
2. This branch via local gem path: 1/1 test reported green in ~1.3s.

**Before (published gem):**

![Before: Test Explorer spinning at 0/1](https://raw.githubusercontent.com/trippyogi/ruby-lsp/pr-4191-manual-screenshots/manual-tests/before-test-explorer-spinning.png)

**After (this branch):**

![After: Test Explorer green 1/1](https://raw.githubusercontent.com/trippyogi/ruby-lsp/pr-4191-manual-screenshots/manual-tests/after-test-explorer-green.png)