### PR TITLE
Do not index documents excluded from indexing when they are opened

### DIFF
--- a/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
+++ b/lib/ruby_indexer/lib/ruby_indexer/configuration.rb
@@ -12,7 +12,7 @@ module RubyIndexer
     }.freeze #: Hash[String, untyped]
 
     #: String
-    attr_writer :workspace_path
+    attr_reader :workspace_path
 
     #: Encoding
     attr_accessor :encoding
@@ -29,9 +29,13 @@ module RubyIndexer
         "**/fixtures/**/*",
       ] #: Array[String]
 
+      @absolute_excluded_patterns = nil #: Array[String]?
+
+      # Substitute Windows backslashes into forward slashes, which are used in glob patterns
       path = Bundler.settings["path"]
+      @bundle_path = path&.gsub(/[\\]+/, "/") #: String?
+
       if path
-        # Substitute Windows backslashes into forward slashes, which are used in glob patterns
         glob = path.gsub(/[\\]+/, "/")
         glob.delete_suffix!("/")
         @excluded_patterns << "#{glob}/**/*.rb"
@@ -53,6 +57,14 @@ module RubyIndexer
         "coding:",
         "warn_past_scope:",
       ] #: Array[String]
+    end
+
+    # Changing the workspace path changes what the relative exclusion patterns resolve to, so the memoized absolute
+    # patterns have to be discarded
+    #: (String path) -> void
+    def workspace_path=(path)
+      @workspace_path = path
+      @absolute_excluded_patterns = nil
     end
 
     #: -> Array[URI::Generic]
@@ -81,24 +93,8 @@ module RubyIndexer
         end
       end
 
-      # If the patterns are relative, we make it relative to the workspace path. If they are absolute, then we shouldn't
-      # concatenate anything
-      excluded_patterns = @excluded_patterns.map do |pattern|
-        if File.absolute_path?(pattern)
-          pattern
-        else
-          File.join(@workspace_path, pattern)
-        end
-      end
-
       # Remove user specified patterns
-      bundle_path = Bundler.settings["path"]&.gsub(/[\\]+/, "/")
-      uris.reject! do |indexable|
-        path = indexable.full_path #: as !nil
-        next false if test_files_ignored_from_exclusion?(path, bundle_path)
-
-        excluded_patterns.any? { |pattern| File.fnmatch?(pattern, path, flags) }
-      end
+      uris.reject! { |indexable| excluded?(indexable.full_path) }
 
       # Add default gems to the list of files to be indexed
       Dir.glob(File.join(RbConfig::CONFIG["rubylibdir"], "*")).each do |default_path|
@@ -166,6 +162,20 @@ module RubyIndexer
       uris
     end
 
+    # Whether `path` is excluded from indexing by the configured patterns. Note that this only takes the exclusion
+    # patterns into account. Files that are simply not covered by the inclusion patterns (like a Ruby file in a
+    # directory that is never traversed) are not considered excluded by this method
+    #: (String? path) -> bool
+    def excluded?(path)
+      return false unless path
+
+      return false if test_files_ignored_from_exclusion?(path, @bundle_path)
+
+      flags = File::FNM_PATHNAME | File::FNM_EXTGLOB
+
+      absolute_excluded_patterns.any? { |pattern| File.fnmatch?(pattern, path, flags) }
+    end
+
     #: -> Regexp
     def magic_comment_regex
       @magic_comment_regex ||= /^#\s*#{@excluded_magic_comments.join("|")}/ #: Regexp?
@@ -177,12 +187,28 @@ module RubyIndexer
 
       @excluded_gems.concat(config["excluded_gems"]) if config["excluded_gems"]
       @included_gems.concat(config["included_gems"]) if config["included_gems"]
-      @excluded_patterns.concat(config["excluded_patterns"]) if config["excluded_patterns"]
+      if config["excluded_patterns"]
+        @excluded_patterns.concat(config["excluded_patterns"])
+        @absolute_excluded_patterns = nil
+      end
       @included_patterns.concat(config["included_patterns"]) if config["included_patterns"]
       @excluded_magic_comments.concat(config["excluded_magic_comments"]) if config["excluded_magic_comments"]
     end
 
     private
+
+    # If the patterns are relative, we make them relative to the workspace path. If they are absolute, then we
+    # shouldn't concatenate anything. Memoized because exclusion is checked once per indexable file
+    #: -> Array[String]
+    def absolute_excluded_patterns
+      @absolute_excluded_patterns ||= @excluded_patterns.map do |pattern|
+        if File.absolute_path?(pattern)
+          pattern
+        else
+          File.join(@workspace_path, pattern)
+        end
+      end
+    end
 
     #: (Hash[String, untyped] config) -> void
     def validate_config!(config)

--- a/lib/ruby_indexer/test/configuration_test.rb
+++ b/lib/ruby_indexer/test/configuration_test.rb
@@ -24,6 +24,34 @@ module RubyIndexer
       assert(uris.none? { |uri| uri.full_path == __FILE__ })
     end
 
+    def test_excluded_reports_paths_matching_the_exclusion_patterns
+      @config.apply_config({ "excluded_patterns" => ["lib/ruby_indexer/**/*"] })
+
+      assert(@config.excluded?(File.join(@workspace_path, "lib", "ruby_indexer", "lib", "ruby_indexer.rb")))
+      refute(@config.excluded?(File.join(@workspace_path, "lib", "ruby_lsp", "server.rb")))
+    end
+
+    def test_excluded_accepts_absolute_patterns
+      @config.apply_config({ "excluded_patterns" => [File.join(@workspace_path, "lib", "**", "*")] })
+
+      assert(@config.excluded?(File.join(@workspace_path, "lib", "ruby_lsp", "server.rb")))
+    end
+
+    def test_excluded_handles_nil_paths
+      refute(@config.excluded?(nil))
+    end
+
+    def test_excluded_is_invalidated_when_the_workspace_path_changes
+      @config.apply_config({ "excluded_patterns" => ["ignored/**/*"] })
+
+      assert(@config.excluded?(File.join(@workspace_path, "ignored", "foo.rb")))
+
+      @config.workspace_path = File.join(@workspace_path, "other")
+
+      refute(@config.excluded?(File.join(@workspace_path, "ignored", "foo.rb")))
+      assert(@config.excluded?(File.join(@workspace_path, "other", "ignored", "foo.rb")))
+    end
+
     def test_indexable_uris_have_expanded_full_paths
       @config.apply_config({ "included_patterns" => ["**/*.rb"] })
       uris = @config.indexable_uris

--- a/lib/ruby_lsp/server.rb
+++ b/lib/ruby_lsp/server.rb
@@ -492,7 +492,11 @@ module RubyLsp
       # the dispatcher's state
       code_lens = nil #: Requests::CodeLens?
 
-      if document.is_a?(RubyDocument) && document.should_index?
+      # Documents excluded from indexing must not be indexed when the editor opens them either. Otherwise, in
+      # multi-root setups where a parent workspace overlaps a nested one, both language servers end up indexing the
+      # same document and every request that reads the index (go to definition, for example) returns duplicate results
+      if document.is_a?(RubyDocument) && document.should_index? &&
+          !@global_state.index.configuration.excluded?(uri.to_standardized_path)
         # Re-index the file as it is modified. This mode of indexing updates entries only. Require path trees are only
         # updated on save
         @global_state.synchronize do

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1424,6 +1424,42 @@ class ServerTest < Minitest::Test
     end
   end
 
+  def test_opening_an_excluded_document_does_not_index_it
+    path = File.join(Dir.pwd, "lib", "excluded_from_indexing.rb")
+    source = <<~RUBY
+      class ExcludedFromIndexing
+      end
+    RUBY
+    File.write(path, source)
+    uri = URI::Generic.from_path(path: path)
+
+    begin
+      @server.global_state.index.configuration.apply_config({ "excluded_patterns" => ["lib/**/*"] })
+
+      @server.process_message({
+        method: "textDocument/didOpen",
+        params: {
+          textDocument: {
+            uri: uri,
+            text: source,
+            version: 1,
+            languageId: "ruby",
+          },
+        },
+      })
+
+      # The editor fires a document symbol request right after opening, which is what triggers indexing the document
+      @server.process_message({
+        method: "textDocument/documentSymbol",
+        params: { textDocument: { uri: uri } },
+      })
+
+      assert_nil(@server.global_state.index["ExcludedFromIndexing"])
+    ensure
+      FileUtils.rm(path) if File.exist?(path)
+    end
+  end
+
   def test_diagnose_state
     @server.process_message({
       method: "textDocument/didOpen",


### PR DESCRIPTION
### Motivation

`excludedPatterns` is applied only while collecting `indexable_uris`. When the editor opens a document, the combined requests path indexes it unconditionally — `RubyDocument#should_index?` returns `true` for any freshly opened document and never consults the index configuration — so an excluded file lands in the index as soon as somebody looks at it.

That is surprising on its own, but it is most visible in **multi-root workspaces where one folder contains another**, which is the normal shape of a monorepo. Both the parent folder and the nested folder spawn a language server, both match the document selector for the same file (`${fsPath}/**/*`), and both index it on open. Every request that reads the index then answers twice, and the editor merges the responses, so `Go to Definition` opens a peek view titled `Definitions (2)` listing the same location twice.

Concretely, with a workspace whose folders are the repo root plus every app and component nested under it, opening `apps/billing/app/models/application_record.rb` logs this, 5ms apart:

```
[info] (root) Determined that document should be indexed: file:///…/apps/billing/app/models/application_record.rb
[info] (billing) Determined that document should be indexed: file:///…/apps/billing/app/models/application_record.rb
```

and `Go to Definition` on any constant in that file offers two identical locations. Configuring the root workspace with

```json
"rubyLsp.indexing": { "excludedPatterns": ["apps/**/*", "components/**/*"] }
```

correctly shrinks the root server's initial index (7,300 files down to 2,083 in the workspace I reproduced this on), but has no effect on documents once they are opened, so the duplicates come back for exactly the files you are working in.

This is related to #3639, but distinct: that issue is about one index gaining duplicate entries, whereas this is two servers each holding one entry for the same declaration.

### Implementation

- Extract the exclusion check out of `indexable_uris` into a public `Configuration#excluded?(path)`, so there is one definition of "excluded" rather than a check inlined in the collection loop.
- Consult it before indexing an opened document in the combined requests path.
- Memoize the absolutized exclusion patterns, since exclusion is now evaluated once per indexable file rather than once per `indexable_uris` call, and invalidate that memo when either the patterns (`apply_config`) or the workspace path change. `@bundle_path` moves to the initializer for the same reason.

`excluded?` deliberately only accounts for the *exclusion* patterns. A file that is merely not covered by the inclusion patterns is not reported as excluded, which keeps the semantics of the didOpen check the same as the semantics of `indexable_uris`.

### Automated Tests

- `Configuration#excluded?`: relative patterns, absolute patterns, `nil` paths, and memo invalidation when `workspace_path` changes.
- `Server`: opening a document that matches `excludedPatterns` and then firing the document symbol request the editor sends on open leaves the index empty. Verified that this test fails without the `server.rb` change and passes with it.

`bundle exec rake test` (18,542 runs, 0 failures, 0 errors), `bundle exec rake test:indexer` (322 runs, 0 failures), `bundle exec rubocop` and `bundle exec srb tc` are all clean locally.

### Manual verification

Reproduced against a fixture with the same shape as the workspace this came from — a folder rooted at the repo root with `excludedPatterns: ["apps/**/*"]`, containing `apps/billing/app/models/{application_record,invoice}.rb` — driving the server through `didOpen`, the `documentSymbol` request the editor sends on open, and then `textDocument/definition` on the superclass:

| | root server indexes `ApplicationRecord` | definitions returned |
| --- | --- | --- |
| `main` | yes | 1 |
| this branch | no | 0 |

The location the root server returned on `main` is identical to the one the nested `billing` server returns, which is what the editor renders as two entries. Note that reproducing this requires the file *declaring* the constant to be open, since that is what gets force-indexed — opening only the referencing file is not enough.

I would still be happy to be redirected if you would rather fix this on the extension side by narrowing each client's document selector so that the closest workspace folder owns a file. That would also cover multi-root users who have not configured `excludedPatterns` at all, which this change does not.
