### PR TITLE
Refactor rubyLsp configuration for custom commands

### DIFF
--- a/jekyll/version-managers.markdown
+++ b/jekyll/version-managers.markdown
@@ -54,9 +54,9 @@ shell command that will activate the right Ruby version or add the Ruby `bin` fo
   },
 
   // Using a different version manager than the ones included by default
-  "rubyLsp.customRubyCommand": "my_custom_version_manager activate",
+  "rubyLsp": { "customRubyCommand": "my_custom_version_manager activate" },
 
   // Adding a custom Ruby bin folder to the PATH
-  "rubyLsp.customRubyCommand": "PATH=/path/to/ruby/bin:$PATH",
+  "rubyLsp": { "customRubyCommand": "PATH=/path/to/ruby/bin:$PATH" },
 }
 ```


### PR DESCRIPTION
Since some version custmoRubyCommand is searched with `customCommand(){let t=Z_.workspace.getConfiguration("rubyLsp").get("customRubyCommand");` that does not find it if using "rubyLsp.customRubyCommand": "my_custom_version_manager activate",

<!--
NOTE: If you plan to invest significant effort into a large pull request with multiple decisions that may impact the long term maintenance of the Ruby LSP, please open a [discussion](https://github.com/Shopify/ruby-lsp/discussions/new/choose) first to align on the direction.
-->

### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Include links to issues or describe the problem being solved, not the solution. -->

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
